### PR TITLE
Stack Diagram nach Klassifizierung sortieren

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -273,6 +273,7 @@ public class Messages extends NLS
     public static String LabelNotAvailable;
     public static String LabelOneOfX;
     public static String LabelOther;
+    public static String LabelOrderByTaxonomy;
     public static String LabelPassword;
     public static String LabelPasswordRepeat;
     public static String LabelPerformanceCalculation;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -539,6 +539,8 @@ LabelOneOfX = (1 of {0})
 
 LabelOther = Other...
 
+LabelOrderByTaxonomy = Order by Classification
+
 LabelPassword = Password
 
 LabelPasswordRepeat = Repeat

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -539,6 +539,8 @@ LabelOneOfX = (1 von {0})
 
 LabelOther = Andere...
 
+LabelOrderByTaxonomy = Nach Klassifizierung sortieren
+
 LabelPassword = Passwort
 
 LabelPasswordRepeat = Best\u00E4tigung

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractChartPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractChartPage.java
@@ -30,18 +30,7 @@ public abstract class AbstractChartPage extends Page
                 @Override
                 public void menuAboutToShow(IMenuManager manager)
                 {
-                    Action action = new Action(Messages.LabelIncludeUnassignedCategoryInCharts)
-                    {
-                        @Override
-                        public void run()
-                        {
-                            getModel().setExcludeUnassignedCategoryInCharts(
-                                            !getModel().isUnassignedCategoryInChartsExcluded());
-                            onConfigChanged();
-                        }
-                    };
-                    action.setChecked(!getModel().isUnassignedCategoryInChartsExcluded());
-                    manager.add(action);
+                    initializeConfigMenu(manager);
                 }
             });
 
@@ -49,6 +38,21 @@ public abstract class AbstractChartPage extends Page
         }
 
         configMenu.setVisible(true);
+    }
+    
+    protected void initializeConfigMenu(IMenuManager manager) {
+        Action action = new Action(Messages.LabelIncludeUnassignedCategoryInCharts)
+        {
+            @Override
+            public void run()
+            {
+                getModel().setExcludeUnassignedCategoryInCharts(
+                                !getModel().isUnassignedCategoryInChartsExcluded());
+                onConfigChanged();
+            }
+        };
+        action.setChecked(!getModel().isUnassignedCategoryInChartsExcluded());
+        manager.add(action);
     }
 
     public abstract void onConfigChanged();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -169,7 +169,7 @@ public class StackedChartViewer extends AbstractChartPage
                 onConfigChanged();
             }
         };
-        action.setChecked(!getModel().isOrderByTaxonomyInStackChart());
+        action.setChecked(getModel().isOrderByTaxonomyInStackChart());
         manager.add(action);
     }
     

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -2,10 +2,13 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.InvestmentVehicle;
@@ -22,6 +25,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -151,6 +156,24 @@ public class StackedChartViewer extends AbstractChartPage
     }
 
     @Override
+    protected void initializeConfigMenu(IMenuManager manager)
+    {
+        super.initializeConfigMenu(manager);
+        Action action = new Action(Messages.LabelOrderByTaxonomy)
+        {
+            @Override
+            public void run()
+            {
+                getModel().setOrderByTaxonomyInStackChart(
+                                !getModel().isOrderByTaxonomyInStackChart());
+                onConfigChanged();
+            }
+        };
+        action.setChecked(!getModel().isOrderByTaxonomyInStackChart());
+        manager.add(action);
+    }
+    
+    @Override
     public void nodeChange(TaxonomyNode node)
     {
         onConfigChanged();
@@ -198,7 +221,7 @@ public class StackedChartViewer extends AbstractChartPage
     private void updateChart()
     {
         final Map<InvestmentVehicle, VehicleBuilder> vehicle2builder = new HashMap<InvestmentVehicle, VehicleBuilder>();
-        final Map<TaxonomyNode, SeriesBuilder> node2series = new HashMap<TaxonomyNode, SeriesBuilder>();
+        final Map<TaxonomyNode, SeriesBuilder> node2series = new LinkedHashMap<>();
 
         getModel().visitAll(new NodeVisitor()
         {
@@ -253,23 +276,27 @@ public class StackedChartViewer extends AbstractChartPage
                 totals[ii] -= unassigned.values[ii];
         }
 
-        final List<SeriesBuilder> series = node2series
+        Stream<SeriesBuilder> seriesStream = node2series
                         .values()
                         .stream()
-                        .filter(s -> s.hasValues())
-                        .filter(s -> !getModel().isUnassignedCategoryInChartsExcluded()
-                                        || !s.node.isUnassignedCategory()) //
-                        .sorted() //
-                        .collect(Collectors.toList());
-
-        Display.getDefault().asyncExec(new Runnable()
+                        .filter(s -> s.hasValues());
+        if (getModel().isUnassignedCategoryInChartsExcluded())
+            seriesStream = seriesStream.filter(s -> !s.node.isUnassignedCategory());
+        
+        List<SeriesBuilder> series = seriesStream.collect(Collectors.toList());
+        
+        if (getModel().isOrderByTaxonomyInStackChart()) 
         {
-            @Override
-            public void run()
-            {
-                rebuildChartSeries(totals, series);
-            }
-        });
+            // reverse because chart is stacked bottom-up
+            Collections.reverse(series);
+        } 
+        else 
+        {
+            Collections.sort(series);
+        }
+
+
+        Display.getDefault().asyncExec(() -> rebuildChartSeries(totals, series));
     }
 
     private void rebuildChartSeries(long[] totals, List<SeriesBuilder> series)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
@@ -45,6 +45,7 @@ public final class TaxonomyModel
     private Map<InvestmentVehicle, Assignment> investmentVehicle2weight = new HashMap<InvestmentVehicle, Assignment>();
 
     private boolean excludeUnassignedCategoryInCharts = false;
+    private boolean orderByTaxonomyInStackChart = false;
 
     private List<TaxonomyModelChangeListener> listeners = new ArrayList<TaxonomyModelChangeListener>();
 
@@ -230,6 +231,16 @@ public final class TaxonomyModel
         this.excludeUnassignedCategoryInCharts = excludeUnassignedCategoryInCharts;
     }
 
+    public boolean isOrderByTaxonomyInStackChart()
+    {
+        return orderByTaxonomyInStackChart;
+    }
+    
+    public void setOrderByTaxonomyInStackChart(boolean orderByTaxonomyInStackChart)
+    {
+        this.orderByTaxonomyInStackChart = orderByTaxonomyInStackChart;
+    }
+    
     public Taxonomy getTaxonomy()
     {
         return taxonomy;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
@@ -26,6 +26,8 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     private String identifierView;
     /** preference key: include unassigned category in charts */
     private String identifierUnassigned;
+    /** preference key: order by taxonomy in stack chart */
+    private String identifierOrderByTaxonomy;
 
     private TaxonomyModel model;
     private Taxonomy taxonomy;
@@ -46,9 +48,11 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
 
         this.identifierView = TaxonomyView.class.getSimpleName() + "-VIEW-" + taxonomy.getId(); //$NON-NLS-1$
         this.identifierUnassigned = TaxonomyView.class.getSimpleName() + "-UNASSIGNED-" + taxonomy.getId(); //$NON-NLS-1$
+        this.identifierOrderByTaxonomy = TaxonomyView.class.getSimpleName() + "-ORDERBYTAXONOMY-" + taxonomy.getId(); //$NON-NLS-1$
 
         this.model = new TaxonomyModel(getClient(), taxonomy);
         this.model.setExcludeUnassignedCategoryInCharts(part.getPreferenceStore().getBoolean(identifierUnassigned));
+        this.model.setOrderByTaxonomyInStackChart(part.getPreferenceStore().getBoolean(identifierOrderByTaxonomy));
 
         this.taxonomy.addPropertyChangeListener(this);
     }
@@ -63,6 +67,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     public void dispose()
     {
         getPreferenceStore().setValue(identifierUnassigned, model.isUnassignedCategoryInChartsExcluded());
+        getPreferenceStore().setValue(identifierOrderByTaxonomy, model.isOrderByTaxonomyInStackChart());
         taxonomy.removePropertyChangeListener(this);
 
         Control[] children = container.getChildren();


### PR DESCRIPTION
Im Stack Diagramm werden die Positionen nach Größe sortiert. Wenn ich eine Klassifizierung über mehrere Hierarchieebenen habe kann das unübersichtlich werden.

Der Pull-Request fügt eine Option hinzu um die Sortierung zu ändern.