### PR TITLE
Max Drawdown Duration Erweiterung

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -482,6 +482,7 @@ public class Messages extends NLS
     public static String TitlePasswordDialog;
     public static String TooltipMaxDrawdown;
     public static String TooltipMaxDrawdownDuration;
+    public static String TooltipMaxDrawdownDurationSupplement;
     public static String TooltipSemiVolatility;
     public static String TooltipVolatility;
     public static String WatchlistDelete;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -951,7 +951,9 @@ TitlePasswordDialog = Passwort vergeben
 
 TooltipMaxDrawdown = Der maximale Drawdown stellt den maximalen kumulierten Verlust innerhalb der betrachteten Periode dar. Die Berechnung erfolgt aus der Differenz des letzten Hochs und dem tiefsten Punkt seitdem.\n\n{0} bis {1}
 
-TooltipMaxDrawdownDuration = Die Maximum Drawdown Duration stellt den l\u00E4ngsten Zeitraum zwischen zwei H\u00F6chstwerten innerhalb der betrachteten Periode dar. In dieser Dauer muss nicht zwangsl\u00E4fig der maximale Drawdown liegen.\n\n{0} bis {1}
+TooltipMaxDrawdownDuration = Die Maximum Drawdown Duration stellt den l\u00E4ngsten Zeitraum zwischen zwei H\u00F6chstwerten innerhalb der betrachteten Periode dar. In dieser Dauer muss nicht zwangsl\u00E4fig der maximale Drawdown liegen.\n\nMomentaner Zeitraum: {0} bis {1}
+
+TooltipMaxDrawdownDurationSupplement = \n\nDer Zeitraum seit dem letzten Hoch ist l\u00E4nger als der bisher l\u00E4ngste Zeitraum zwischen zwei Hochs. Beim n\u00E4chsten Hoch wird eine neue Maximum Drawdown Duration erstellt. Momentane Dauer {0} Tage seit {1}. 
 
 TooltipSemiVolatility = Die Semivolatilit\u00E4t betrachtet im Gegensatz zur Volatilit\u00E4 nur die negativen Abweichungen der erzielten Renditen zum arithmetischen Mittelwert der Renditen.\n\nHier wird die Semivolatilit\u00E4t mit der "akkumuliert" Datenreihe errechnet. Performanceneutrale Bewegungen haben keinen Einflu\u00DF. Wochenenden und B\u00F6rsenfeiertage (z.B. Ostern oder Weihnachten) werden ignoriert.
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -153,9 +153,15 @@ public class PerformanceView extends AbstractHistoricView
 
             maxDrawdownDuration.setText(MessageFormat.format(Messages.LabelXDays, //
                             drawdown.getMaxDrawdownDuration().getDays()));
-            maxDrawdownDuration.setToolTipText(MessageFormat.format(Messages.TooltipMaxDrawdownDuration,
+            String maxDurationTooltip = MessageFormat.format(Messages.TooltipMaxDrawdownDuration,
                             formatter.format(drawdown.getMaxDrawdownDuration().getStart()),
-                            formatter.format(drawdown.getMaxDrawdownDuration().getEnd())));
+                            formatter.format(drawdown.getMaxDrawdownDuration().getEnd()));
+            if (drawdown.isInMaxDrawdownDuration()) {
+                maxDurationTooltip += MessageFormat.format(Messages.TooltipMaxDrawdownDurationSupplement, 
+                                drawdown.getIntervalSinceLastPeak().getDays(),
+                                formatter.format(drawdown.getIntervalSinceLastPeak().getStart()));
+            }
+            maxDrawdownDuration.setToolTipText(maxDurationTooltip);
 
             volatility.setText(Values.Percent2.format(index.getVolatility().getStandardDeviation()));
             semiVolatility.setText(Values.Percent2.format(index.getVolatility().getSemiDeviation()));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -15,7 +15,8 @@ public final class Risk
         private double maxDD;
         private Interval maxDDDuration;
         private Interval intervalMaxDD;
-
+        private Interval intervalSinceLastPeak;
+        
         public Drawdown(double[] values, Date[] dates)
         {
             double peak = values[0] + 1;
@@ -47,6 +48,7 @@ public final class Risk
                     }
                 }
             }
+            intervalSinceLastPeak = Interval.of(lastPeakDate, dates[dates.length-1].toInstant());
         }
 
         public double getMaxDrawdown()
@@ -62,6 +64,14 @@ public final class Risk
         public Interval getMaxDrawdownDuration()
         {
             return maxDDDuration;
+        }
+        
+        public Interval getIntervalSinceLastPeak() {
+            return intervalSinceLastPeak;
+        }
+        
+        public boolean isInMaxDrawdownDuration() {
+            return intervalSinceLastPeak.isLongerThan(intervalMaxDD);
         }
     }
 


### PR DESCRIPTION
Wenn die Zeit seit dem letzten Hoch länger ist als die max drawdown duration dann wird ein neues hoch auch einen neue max drawdown duration nach sich ziehen. Das Tal in dem man momentan ist ist schon länger als das längste, aber die berechnung kann es noch nicht anzeigen, da es noch nicht vorbei ist. 

Dieser Change zeigt diese Situation im Tooltip an, wenn sie denn vorliegt. Die neue Information ist dann
a) die max drawdown duration ist eigentlich schon veraltet
b) würde jetzt ein neues hoch passieren wäre die max drawdown duration X
c) das letzte Hoch war an Y