### PR TITLE
MaxDD duration: take longest period even if no new peak has been reached

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -482,6 +482,8 @@ public class Messages extends NLS
     public static String TitlePasswordDialog;
     public static String TooltipMaxDrawdown;
     public static String TooltipMaxDrawdownDuration;
+    public static String TooltipMaxDrawdownDurationEndOfPeriod;
+    public static String TooltipMaxDrawdownDurationFromXtoY;
     public static String TooltipSemiVolatility;
     public static String TooltipVolatility;
     public static String WatchlistDelete;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -951,7 +951,11 @@ TitlePasswordDialog = Assign password
 
 TooltipMaxDrawdown = The Maximum Drawdown is the maximum peak to valley loss in a given period.\n\n{0} to {1}
 
-TooltipMaxDrawdownDuration = The Max Drawdown Duration is the worst (the maximum/longest) amount of time an investment has seen between peaks (equity highs).\n\n{0} to {1}
+TooltipMaxDrawdownDuration = The Max Drawdown Duration is the worst (the maximum/longest) amount of time an investment has seen between peaks (equity highs).
+
+TooltipMaxDrawdownDurationEndOfPeriod = Since {0} (until end of reporting period {1})
+
+TooltipMaxDrawdownDurationFromXtoY = {0} to {1}
 
 TooltipSemiVolatility = Semi-volatility only looks at the negative fluctuations of an asset.\n\nIf the negative and postive fluctuations are equal, then the following holds\n\nVolatility (v) = Semi-volatility (s) * \u221A2\n\nIf the current data set is evenly distributed, then the semi-volatiltity is\n\n  s = v \u00F7 \u221A2 = {2} \u00F7 \u221A2 = {0}\n\nCompare that with the actual semi-volatility\n\n  {0} {1} {3}\n  evenly disributed {1} actual semi-volatility\n\n\nThe semi-volatility is calculated using the "accumulated" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -951,7 +951,11 @@ TitlePasswordDialog = Passwort vergeben
 
 TooltipMaxDrawdown = Der maximale Drawdown stellt den maximalen kumulierten Verlust innerhalb der betrachteten Periode dar. Die Berechnung erfolgt aus der Differenz des letzten Hochs und dem tiefsten Punkt seitdem.\n\n{0} bis {1}
 
-TooltipMaxDrawdownDuration = Die Maximum Drawdown Duration stellt den l\u00E4ngsten Zeitraum zwischen zwei H\u00F6chstwerten innerhalb der betrachteten Periode dar. In dieser Dauer muss nicht zwangsl\u00E4fig der maximale Drawdown liegen.\n\n{0} bis {1}
+TooltipMaxDrawdownDuration = Die Maximum Drawdown Duration stellt den l\u00E4ngsten Zeitraum zwischen zwei H\u00F6chstwerten innerhalb der betrachteten Periode dar. In dieser Dauer muss nicht zwangsl\u00E4fig der maximale Drawdown liegen.
+
+TooltipMaxDrawdownDurationEndOfPeriod = Seit dem {0} (bis Ende des Berichtszeitraums am {1})
+
+TooltipMaxDrawdownDurationFromXtoY = {0} bis {1}
 
 TooltipSemiVolatility = Die Semivolatilit\u00E4t betrachtet im Gegensatz zur Volatilit\u00E4t nur die negativen Abweichungen der erzielten Renditen zum arithmetischen Mittelwert der Renditen.\n\nSind die negativen und positiven Abweichungen gleichverteilt, so gilt \n\n  Volatilit\u00E4t (v) = Semivolatilit\u00E4t (s) * \u221A2\n\nBei der aktuellen Datenreihe ist die gleichverteilte Semivolatilit\u00E4t\n\n  s = v \u00F7 \u221A2 = {2} \u00F7 \u221A2 = {0}\n\nDer Vergleich mit der tats\u00E4chlichen Semivolatilit\u00E4t zeigt\n\n  {0} {1} {3}\n  gleichverteilte {1} tats\u00E4chliche Semivolatilit\u00E4t\n\n\nIm Programm wird die Semivolatilit\u00E4t mit der "akkumuliert" Datenreihe errechnet. Performanceneutrale Bewegungen haben keinen Einflu\u00DF. Wochenenden und B\u00F6rsenfeiertage (z.B. Ostern oder Weihnachten) werden ignoriert.
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -32,6 +32,7 @@ import name.abuchen.portfolio.ui.util.SimpleListContentProvider;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
 import name.abuchen.portfolio.ui.util.TreeViewerCSVExporter;
 import name.abuchen.portfolio.ui.util.ViewerHelper;
+import name.abuchen.portfolio.util.Interval;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
@@ -153,11 +154,15 @@ public class PerformanceView extends AbstractHistoricView
                             formatter.format(drawdown.getIntervalOfMaxDrawdown().getStart()),
                             formatter.format(drawdown.getIntervalOfMaxDrawdown().getEnd())));
 
-            maxDrawdownDuration.setText(MessageFormat.format(Messages.LabelXDays, //
-                            drawdown.getMaxDrawdownDuration().getDays()));
-            maxDrawdownDuration.setToolTipText(MessageFormat.format(Messages.TooltipMaxDrawdownDuration,
-                            formatter.format(drawdown.getMaxDrawdownDuration().getStart()),
-                            formatter.format(drawdown.getMaxDrawdownDuration().getEnd())));
+            Interval duration = drawdown.getMaxDrawdownDuration();
+            maxDrawdownDuration.setText(MessageFormat.format(Messages.LabelXDays, duration.getDays()));
+            boolean isUntilEndOfPeriod = duration.getEnd().equals(index.getReportInterval().getEndDate().toInstant());
+            String supplement = isUntilEndOfPeriod ? Messages.TooltipMaxDrawdownDurationEndOfPeriod
+                            : Messages.TooltipMaxDrawdownDurationFromXtoY;
+            maxDrawdownDuration.setToolTipText(Messages.TooltipMaxDrawdownDuration
+                            + "\n\n" //$NON-NLS-1$
+                            + MessageFormat.format(supplement, formatter.format(duration.getStart()),
+                                            formatter.format(duration.getEnd())));
 
             volatility.setText(Values.Percent2.format(index.getVolatility().getStandardDeviation()));
             volatility.setToolTipText(Messages.TooltipVolatility);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -22,7 +22,7 @@ public final class Risk
             Instant lastPeakDate = dates[0].toInstant();
 
             maxDDDuration = Interval.of(lastPeakDate, lastPeakDate);
-            Interval currentDrawdownDuration;
+            Interval currentDrawdownDuration = null;
 
             for (int ii = 0; ii < values.length; ii++)
             {
@@ -47,6 +47,14 @@ public final class Risk
                     }
                 }
             }
+
+            // check if current drawdown duration is longer than the max
+            // drawdown duration currently calculated --> use it because it is
+            // the longest duration even if we do not know how much longer it
+            // will get
+
+            if (currentDrawdownDuration != null && currentDrawdownDuration.isLongerThan(maxDDDuration))
+                maxDDDuration = currentDrawdownDuration;
         }
 
         public double getMaxDrawdown()


### PR DESCRIPTION
This change checks if the drawdown duration at the end of the reporting
interval is longer than the max drawdown duration calculated so far. If
so, then this duration is used because it is the longest duration even
if we do not yet know how much longer it will get.

See also Issue: #240

@simpsus - ich habe den Change jetzt mal geändert wie in #240 diskutiert.