### PR TITLE
Recognize more comdirect documents

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ComdirectPDFExtractor.java
@@ -169,7 +169,8 @@ public class ComdirectPDFExtractor implements Extractor
                     SecurityItem item = new SecurityItem(security);
                     results.add(item);
                 }
-                int stueckLinePos = text.indexOf("\n", text.indexOf("Zum Kurs von")); //$NON-NLS-1$ //$NON-NLS-2$
+                // Do not use 'Zum Kurs von' as there are tons of other variants ('Zum Preis von', 'Zum comdirect Preis von', ...)
+                int stueckLinePos = text.indexOf('\n', text.indexOf("Nennwert")); //$NON-NLS-2$
                 Number shares = getNextNumber(text, jumpWord(text, stueckLinePos, 1));
                 // Fees need not be present
                 // In case they are a section is present in the file

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ComdirectPDFExtractor.java
@@ -174,11 +174,15 @@ public class ComdirectPDFExtractor implements Extractor
                 // Fees need not be present
                 // In case they are a section is present in the file
                 int provPos = -1;
-                provPos = text.indexOf("Provision", stueckLinePos); //$NON-NLS-1$
+                provPos = text.indexOf("Summe Entgelte", stueckLinePos); //$NON-NLS-1$
+                // Fallback to 'Provision'; perhaps unneeded, but for backward compatability
+                if (provPos <= 0)
+                    provPos = text.indexOf("Provision", stueckLinePos); //$NON-NLS-1$
+
                 BuySellEntry purchase = new BuySellEntry();
                 if (provPos > 0)
                 {
-                    Number fee = getNextNumber(text, jumpWord(text, provPos, 3));
+                    Number fee = getNextNumber(text, getLastWordInLinePos(text, provPos));
                     purchase.setFees(Math.round(fee.doubleValue() * Values.Amount.factor()));
                 }
                 int totalEURPos = text.indexOf("EUR", //$NON-NLS-1$
@@ -271,6 +275,7 @@ public class ComdirectPDFExtractor implements Extractor
         }
     }
 
+
     private int jumpWord(String text, int position, int words)
     {
         for (int i = 0; i < words; i++)
@@ -281,24 +286,39 @@ public class ComdirectPDFExtractor implements Extractor
         return position;
     }
 
+    private int getLastWordInLinePos(String text, int position)
+    {
+        int wordPos;
+
+        wordPos = text.indexOf('\n', position);
+        if (wordPos == 0) // we started at a newline; try again
+            wordPos = text.indexOf('\n', position + 1);
+
+        if (wordPos == 0) // yeah, a bunch of newlines -> just give up
+            return -1;
+
+        if (wordPos < 0) // no newline -> last line
+            wordPos = text.length();
+        
+        wordPos--;
+
+        // possible white space at end of line
+        while (text.charAt(wordPos) == ' ')
+        {
+            wordPos--;
+        }
+
+        // pass over the word
+        wordPos = text.lastIndexOf(' ', wordPos);
+
+        // if wordPos is -1, there was no whitespace, hence 0 is the last word
+        // if wordPos is >=0, then it points to a whitespace -> +1 first char of word
+        return wordPos + 1;
+    }
+
     private String getLastWordInLine(String text, int position)
     {
-        while (text.charAt(position) != '\n')
-        {
-            position++;
-        }
-        position--;
-        while (text.charAt(position) == ' ')
-        {
-            position--;
-        }
-        String result = ""; //$NON-NLS-1$
-        while (text.charAt(position) != ' ')
-        {
-            result = text.charAt(position) + result;
-            position--;
-        }
-        return result;
+        return getNextWord(text, getLastWordInLinePos(text, position));
     }
 
     private String getNextLine(String text, int position)


### PR DESCRIPTION
This (should) fix issue #277. As I did not want to have another counter to see how many words I have to jump, I relied on 'the last word on the line'. As I needed more functionality for that, I took the liberty of replacing some `while charAt incr/decr` loops by calling `indexOf/lastIndexOf` instead.

Additionally it recognizes more documents, where it does not say 'Zum Kurs von' but different things (I've seen 'Zum comdirect Preis von' and 'Zum Preis von' so far). I have achieved that by checking for 'Nennwert' instead. I hope that does not break anything.