### PR TITLE
Bookmark for finanztreff.de (similar to Finanzen.net).

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
@@ -19,6 +19,8 @@ public class ClientSettings
                         "OnVista", "http://www.onvista.de/suche.html?SEARCH_VALUE={isin}&SELECTED_TOOL=ALL_TOOLS")); //$NON-NLS-1$ //$NON-NLS-2$
         bookmarks.add(new Bookmark("Finanzen.net", //$NON-NLS-1$
                         "http://www.finanzen.net/suchergebnis.asp?frmAktiensucheTextfeld={isin}")); //$NON-NLS-1$
+        bookmarks.add(new Bookmark("finanztreff.de", //$NON-NLS-1$
+                        "http://www.finanztreff.de/kurse_einzelkurs_suche.htn?suchbegriff={isin}")); //$NON-NLS-1$
         bookmarks.add(new Bookmark("Ariva.de Fundamentaldaten", //$NON-NLS-1$
                         "http://www.ariva.de/{isin}/bilanz-guv")); //$NON-NLS-1$
         bookmarks.add(new Bookmark("justETF", //$NON-NLS-1$


### PR DESCRIPTION
A default bookmark, which allows browsing additional details on finanztreff.de.
This website is used by some people because it could be connected to ETrade accounts, which were later on taken over by Flatex