### PR TITLE
exclude metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.metadata/*


### PR DESCRIPTION
this change prevents suggesting to add .metadata/* files under windows