### PR TITLE
dab pdf extractor: fixed parsing of newer DAB documents

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
@@ -174,7 +174,7 @@ public class DABPDFExctractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "DAB Bank AG"; //$NON-NLS-1$
+        return "DAB Bank"; //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
Newer documents no longer contain the string "DAB Bank AG" but just "DAB Bank". That's why it didn't work with recent PDFs.