### PR TITLE
Fix Resize-Bug

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/html/line_chart.html
+++ b/name.abuchen.portfolio.ui/META-INF/html/line_chart.html
@@ -11,6 +11,7 @@
 <script src="${/META-INF/js/lib/d3.min.js}"></script>
 <script src="${/META-INF/js/lib/rickshaw.min.js}"></script>
 
+<script src="${/META-INF/js/Rickshaw.Fixtures.PortfolioTime.js}"></script>
 <script src="${/META-INF/js/Rickshaw.Graph.Behavior.MouseWheelZoom.js}"></script>
 <script src="${/META-INF/js/Rickshaw.Graph.Behavior.DragZoomedChart.js}"></script>
 <script src="${/META-INF/js/Rickshaw.Graph.Renderer.DottedLine.js}"></script>

--- a/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Fixtures.PortfolioTime.js
+++ b/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Fixtures.PortfolioTime.js
@@ -1,0 +1,121 @@
+Rickshaw.namespace('Rickshaw.Fixtures.PortfolioTime');
+
+Rickshaw.Fixtures.PortfolioTime = function() {
+
+	var self = this;
+
+	this.months = ['Jan', 'Feb', 'Mrz', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+
+	this.units = [
+		{
+			name: 'decade',
+			seconds: 86400 * 365.25 * 10,
+			formatter: function(d) { return (parseInt(d.getUTCFullYear() / 10, 10) * 10) }
+		}, {
+			name: 'year',
+			seconds: 86400 * 365.25,
+			//formatter: function(d) { return d.getUTCFullYear() }
+			formatter: function(d) { return  d.getUTCFullYear() }
+		},
+		{
+			name: 'semiyear',
+			seconds: 86400 * 182.625,
+			formatter: function(d) { return 'Q'+Math.floor((d.getUTCMonth() + 3) / 3) + '/' + d.getUTCFullYear() }
+		}, {
+			name: 'quarter',
+			seconds: 86400 * 91.3125,
+		formatter: function(d) { return 'Q'+Math.floor((d.getUTCMonth() + 3) / 3) + '/' + d.getUTCFullYear() }
+		}, {
+			name: 'month',
+			seconds: 86400 * 30.5,
+			formatter: function(d) { return self.months[d.getUTCMonth()] + '/' + d.getUTCFullYear() }
+		}, {
+			name: 'week',
+			seconds: 86400 * 7,
+			formatter: function(d) { return d3.time.format('W%W/%Y')(d) } //W%W/%Y
+		}, {
+			name: 'day',
+			seconds: 86400,
+			formatter: function(d) { return d3.time.format('%d.%m.%Y')(d) }
+		}, {
+			name: '6 hour',
+			seconds: 3600 * 6,
+			formatter: function(d) { return self.formatTime(d) }
+		}, {
+			name: 'hour',
+			seconds: 3600,
+			formatter: function(d) { return self.formatTime(d) }
+		}, {
+			name: '15 minute',
+			seconds: 60 * 15,
+			formatter: function(d) { return self.formatTime(d) }
+		}, {
+			name: 'minute',
+			seconds: 60,
+			formatter: function(d) { return d.getUTCMinutes() }
+		}, {
+			name: '15 second',
+			seconds: 15,
+			formatter: function(d) { return d.getUTCSeconds() + 's' }
+		}, {
+			name: 'second',
+			seconds: 1,
+			formatter: function(d) { return d.getUTCSeconds() + 's' }
+		}, {
+			name: 'decisecond',
+			seconds: 1/10,
+			formatter: function(d) { return d.getUTCMilliseconds() + 'ms' }
+		}, {
+			name: 'centisecond',
+			seconds: 1/100,
+			formatter: function(d) { return d.getUTCMilliseconds() + 'ms' }
+		}
+	];
+
+	this.unit = function(unitName) {
+		return this.units.filter( function(unit) { return unitName == unit.name } ).shift();
+	};
+
+	this.formatTime = function(d) {
+		return d.toUTCString().match(/(\d+:\d+):/)[1];
+	};
+
+	this.ceil = function(time, unit) {
+
+		var date, floor, year;
+
+		if (unit.name == 'month') {
+
+			date = new Date(time * 1000);
+
+			floor = Date.UTC(date.getUTCFullYear(), date.getUTCMonth()) / 1000;
+			if (floor == time) return time;
+
+			year = date.getUTCFullYear();
+			var month = date.getUTCMonth();
+
+			if (month == 11) {
+				month = 0;
+				year = year + 1;
+			} else {
+				month += 1;
+			}
+
+			return Date.UTC(year, month) / 1000;
+		}
+
+		if (unit.name == 'year') {
+
+			date = new Date(time * 1000);
+
+			floor = Date.UTC(date.getUTCFullYear(), 0) / 1000;
+			if (floor == time) return time;
+
+			year = date.getUTCFullYear() + 1;
+
+			return Date.UTC(year, 0) / 1000;
+		}
+
+		return Math.ceil(time / unit.seconds) * unit.seconds;
+	};
+};

--- a/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Graph.Behavior.DragZoomedChart.js
+++ b/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Graph.Behavior.DragZoomedChart.js
@@ -63,34 +63,37 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 		}
 	};
 
-	this.initRange = {
-		x : {
-			min : undefined,
-			max : undefined
-		},
-		y : {
-			min : undefined,
-			max : undefined
-		}
-	};
-
 	this.graph.onConfigure(function() {
 		self.graph.series.forEach(function(series) {
 			if (series.disabled) {
 				return;
 			}
 			var domain = self.graph.renderer.domain(series);
-			if (self.initRange.x.min === undefined || domain.x[0] < initRange.x.min) {
-				self.initRange.x.min = domain.x[0];
-			}
-			if (self.initRange.x.max === undefined || domain.x[1] > initRange.x.max) {
-				self.initRange.x.max = domain.x[1];
-			}
-			if (self.initRange.y.min === undefined || domain.y[0] < initRange.y.min) {
-				self.initRange.y.min = domain.y[0];
-			}
-			if (self.initRange.y.max === undefined || domain.y[1] > initRange.y.max) {
-				self.initRange.y.max = domain.y[1];
+
+			if (self.initRange === undefined) {
+				self.initRange = {
+					x : {
+						min : domain.x[0],
+						max : domain.x[1]
+					},
+					y : {
+						min : domain.y[0],
+						max : domain.y[1]
+					}
+				};
+			} else {
+				if (self.initRange.x.min === undefined || domain.x[0] < self.initRange.x.min) {
+					self.initRange.x.min = domain.x[0];
+				}
+				if (self.initRange.x.max === undefined || domain.x[1] > self.initRange.x.max) {
+					self.initRange.x.max = domain.x[1];
+				}
+				if (self.initRange.y.min === undefined || domain.y[0] < self.initRange.y.min) {
+					self.initRange.y.min = domain.y[0];
+				}
+				if (self.initRange.y.max === undefined || domain.y[1] > self.initRange.y.max) {
+					self.initRange.y.max = domain.y[1];
+				}
 			}
 		});
 	});
@@ -139,7 +142,8 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 
 	$(self.graph.element).mousemove(function(event) {
 		if (self.isMouseDown && !self.isMoving) {
-			var chartElement, x, y, relX, relY;
+			self.isMoving = true;
+			var chartElement, parentOffset, x, y, relX, relY;
 			chartElement = $(self.graph.element);
 			parentOffset = chartElement.parent().offset();
 			x = (event.pageX - parentOffset.left);
@@ -147,12 +151,11 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 			relX = (x - self.mouseDownPos.x) * -1;
 			relY = (y - self.mouseDownPos.y);
 			if (Math.abs(relX) > self.MIN_MOUSEMOVE_DELTA || Math.abs(relY) > self.MIN_MOUSEMOVE_DELTA) {
-				self.isMoving = true;
 				self.MoveChartViewPort(relX, relY);
 				self.mouseDownPos.x = x;
 				self.mouseDownPos.y = y;
-				self.isMoving = false;
 			}
+			self.isMoving = false;
 		}
 	});
 
@@ -164,7 +167,16 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 	});
 
 	$(self.graph.element).mouseout(function(event) {
-		$(this).mouseup();
+		var chartElement, parentOffset, x, y, relX, relY;
+		chartElement = $(self.graph.element);
+		parentOffset = chartElement.parent().offset();
+		x = (event.pageX - parentOffset.left);
+		y = (event.pageY - parentOffset.top);
+
+		if (x < 0 || x > chartElement.parent().width() || y < 0 || y > chartElement.parent().height()) {
+			$(this).mouseup();
+		}
+
 	});
 
 };

--- a/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Graph.Behavior.DragZoomedChart.js
+++ b/name.abuchen.portfolio.ui/META-INF/js/Rickshaw.Graph.Behavior.DragZoomedChart.js
@@ -143,17 +143,14 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 	$(self.graph.element).mousemove(function(event) {
 		if (self.isMouseDown && !self.isMoving) {
 			self.isMoving = true;
-			var chartElement, parentOffset, x, y, relX, relY;
-			chartElement = $(self.graph.element);
-			parentOffset = chartElement.parent().offset();
-			x = (event.pageX - parentOffset.left);
-			y = (event.pageY - parentOffset.top);
-			relX = (x - self.mouseDownPos.x) * -1;
-			relY = (y - self.mouseDownPos.y);
+			var parentOffset, chartXY, relX, relY;
+			chartXY = self.getMouseXYonChart(event.pageX, event.pageY);
+			relX = (chartXY.x - self.mouseDownPos.x) * -1;
+			relY = (chartXY.y - self.mouseDownPos.y);
 			if (Math.abs(relX) > self.MIN_MOUSEMOVE_DELTA || Math.abs(relY) > self.MIN_MOUSEMOVE_DELTA) {
 				self.MoveChartViewPort(relX, relY);
-				self.mouseDownPos.x = x;
-				self.mouseDownPos.y = y;
+				self.mouseDownPos.x = chartXY.x;
+				self.mouseDownPos.y = chartXY.y;
 			}
 			self.isMoving = false;
 		}
@@ -167,16 +164,22 @@ Rickshaw.Graph.Behavior.DragZoomedChart = function(args) {
 	});
 
 	$(self.graph.element).mouseout(function(event) {
-		var chartElement, parentOffset, x, y, relX, relY;
-		chartElement = $(self.graph.element);
-		parentOffset = chartElement.parent().offset();
-		x = (event.pageX - parentOffset.left);
-		y = (event.pageY - parentOffset.top);
-
-		if (x < 0 || x > chartElement.parent().width() || y < 0 || y > chartElement.parent().height()) {
+		var chartElementParent, chartXY;
+		chartElementParent = $(self.graph.element).parent();
+		chartXY = self.getMouseXYonChart(event.pageX, event.pageY);
+		if (chartXY.x < 0 || chartXY.x > chartElementParent.width() || chartXY.y < 0 || chartXY.y > chartElementParent.height()) {
 			$(this).mouseup();
 		}
-
 	});
+
+	this.getMouseXYonChart = function(pageX, pageY) {
+		var chartElement, parentOffset;
+		chartElement = $(self.graph.element);
+		parentOffset = chartElement.parent().offset();
+		return {
+			x : (event.pageX - parentOffset.left),
+			y : (event.pageY - parentOffset.top)
+		};
+	};
 
 };

--- a/name.abuchen.portfolio.ui/META-INF/js/line_chart.js
+++ b/name.abuchen.portfolio.ui/META-INF/js/line_chart.js
@@ -35,8 +35,10 @@ function LineChart(args) {
 		series : args.series
 	});
 
+	
 	x_axis = new Rickshaw.Graph.Axis.Time({
-		graph : graph
+		graph       : graph,
+		timeFixture : new Rickshaw.Fixtures.PortfolioTime()
 	});
 
 	y_axis = new Rickshaw.Graph.Axis.Y({

--- a/name.abuchen.portfolio.ui/META-INF/testfiles/line_chart_test.html
+++ b/name.abuchen.portfolio.ui/META-INF/testfiles/line_chart_test.html
@@ -11,6 +11,7 @@
 <script src="../js/lib/d3.min.js"></script>
 <script src="../js/lib/rickshaw.min.js"></script>
 
+<script src="../js/Rickshaw.Fixtures.PortfolioTime.js"></script>
 <script src="../js/Rickshaw.Graph.Behavior.MouseWheelZoom.js"></script>
 <script src="../js/Rickshaw.Graph.Behavior.DragZoomedChart.js"></script>
 <script src="../js/Rickshaw.Graph.Renderer.DottedLine.js"></script>


### PR DESCRIPTION
Der IE scheint hier eine andere Ladereihenfolge zu haben. Die Variable initRange war bei der ersten Ausführung von onConfigure noch nicht initialisiert und das JS ist an dieser Stelle abgebrochen.

Habe außerdem das Verhalten angepasst, wenn der User während des Verschiebens die Fläche verlässt. Es sollte dann der Drag-Vorgang abgebrochen werden. Der IE hat allerdings auch ein MouseOut Ereignis ausgelöst, wenn man die Maus über die Fläche einer Area-Line bewegt.