### PR TITLE
make capitalGainsOnHoldings sortable

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
@@ -233,7 +233,7 @@ public final class ColumnViewerSorter extends ViewerComparator
     private ViewerColumn viewerColumn;
     private int direction = SWT.DOWN;
 
-    private ColumnViewerSorter(Comparator<Object> comparator)
+    public ColumnViewerSorter(Comparator<Object> comparator)
     {
         this.comparator = comparator;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -493,6 +493,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setVisible(false);
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "capitalGainsOnHoldings")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
         column = new Column("capitalgains%", Messages.ColumnCapitalGainsPercent, SWT.RIGHT, 80); //$NON-NLS-1$
@@ -513,6 +514,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setVisible(false);
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "capitalGainsOnHoldingsPercent")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
         // delta

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
@@ -131,6 +131,16 @@ public final class SecurityPerformanceRecord implements Adaptable
      * periodicity of dividend payments {@link #calculateDividends()}
      */
     private Periodicity periodicity = Periodicity.UNKNOWN;
+    
+    /**
+     * market value - fifo cost of shares held {@link #calculateFifoCosts()}
+     */
+    private Money capitalGainsOnHoldings;
+
+    /**
+     * {@link capitalGainsOnHoldings} in percent
+     */
+    private double capitalGainsOnHoldingsPercent;
 
     /* package */SecurityPerformanceRecord(Security security)
     {
@@ -209,12 +219,14 @@ public final class SecurityPerformanceRecord implements Adaptable
 
     public Money getCapitalGainsOnHoldings()
     {
-        return marketValue.subtract(fifoCost);
+        capitalGainsOnHoldings = marketValue.subtract(fifoCost);
+        return capitalGainsOnHoldings;
     }
 
     public double getCapitalGainsOnHoldingsPercent()
     {
-        return ((double) marketValue.getAmount() / (double) fifoCost.getAmount()) - 1;
+        capitalGainsOnHoldingsPercent = ((double) marketValue.getAmount() / (double) fifoCost.getAmount()) - 1;
+        return capitalGainsOnHoldingsPercent;
     }
 
     public Money getFees()


### PR DESCRIPTION
Ich habe vermisst, dass die beiden Werte capitalGainsOnHoldings und capitalGainsOnHoldingsPercent sortierbar sind.
Mit diesen kleinen Änderungen wäre es möglich.