### PR TITLE
Fix for RegEx in Flatex PDF extractor

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -21,7 +21,7 @@ Balance = Saldo
 
 BaseCurrencyCue = **
 
-BaseCurrencyMigrationPage_Description = Konten und Wertpapiere unterst\u00FCzen nun W\u00E4hrungen.
+BaseCurrencyMigrationPage_Description = Konten und Wertpapiere unterst\u00FCtzen nun W\u00E4hrungen.
 
 BaseCurrencyMigrationPage_ExplanationIndividualCurrency = W\u00E4hlen sie hier die Hauptw\u00E4hrung f\u00FCr ihr Gesamtportfolio, welche auch als Standardwert f\u00FCr neue Konten und Wertpapiere verwendet wird.\n\nWenn die W\u00E4hrung f\u00FCr bestimmte Konten oder Wertpapiere nicht ihrer Hauptw\u00E4hrung entspricht, k\u00F6nnen Sie diese sp\u00E4ter nach Abschluss des Migrations Wizards anpassen.
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExctractor.java
@@ -45,7 +45,7 @@ public class FlatexPDFExctractor extends AbstractPDFExtractor
                         })
 
                         .section("shares", "date")
-                        .match("^davon ausgef.: (?<shares>\\d+,\\d*) St. *Schlusstag *:  (?<date>\\d+.\\d+.\\d{4}+), \\d+:\\d+ Uhr")
+                        .match("^davon ausgef\\. *: (?<shares>[.\\d]+,\\d*) St\\. *Schlusstag *: *(?<date>\\d+\\.\\d+\\.\\d{4}+), \\d+:\\d+ Uhr")
                         .assign((t, v) -> {
                             t.setShares(asShares(v.get("shares")));
                             t.setDate(asDate(v.get("date")));
@@ -91,7 +91,7 @@ public class FlatexPDFExctractor extends AbstractPDFExtractor
                         })
 
                         .section("shares", "date")
-                        .match("^davon ausgef.: (?<shares>\\d+,\\d*) St. *Schlusstag *:  (?<date>\\d+.\\d+.\\d{4}+), \\d+:\\d+ Uhr")
+                        .match("^davon ausgef\\. *: (?<shares>[.\\d]+,\\d*) St\\. *Schlusstag *: *(?<date>\\d+.\\d+.\\d{4}+), \\d+:\\d+ Uhr")
                         .assign((t, v) -> {
                             t.setShares(asShares(v.get("shares")));
                             t.setDate(asDate(v.get("date")));


### PR DESCRIPTION
Fix for RegEx in Flatex PDF extractor resulting in an empty import if the amount stated in the PDF exceeds 1000 and gets noted as "1.000". Additionally escape dot characters correctly and be less strict about spacings.
Fix typo in messages.