### PR TITLE
Improve Flatex PDF import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexKontoauszug.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexKontoauszug.txt
@@ -1,0 +1,76 @@
+biw AG
+Hausbroicher Str. 222
+47877 Willich
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+biw AG -  Hausbroicher Str. 222 -  47877 Willich
+               Willich, 03.04.2016
+01022620000005000000000
+Herrn
+Max Mustermann
+Musterstraße. 2
+12345 Stadt
+Kontoauszug Nr:    001/2016                              Seite 1 von 2
+Kontonummer :      1111111111  dazugehörige IBAN:  DE00 0000 0000 0000 0000 00
+Kontenart   :      Kontokorrentkonto
+Kontowährung:      EUR
+Alter Saldo vom    31.12.2015                     in EUR             2.000,00+
+Buchungs-  Valuta  Buchungstext                                         Betrag
+datum                                                                   in EUR
+04.01.     06.01.  Ausführung ORDER Kauf   000000000000              1.000,00-
+                   00000000
+04.01.     04.01.  Erträgnisausschüttung XXXXXXXXXXXX                    1,00+
+05.01.     06.01.  Gebühren Ordernummer 00000000 Transnr                 5,90-
+                   000000000
+29.01.     29.01.  Überweisung                                       1.100,00+
+                   Ubertrag Depot
+                   BICBICBICBI
+                   DE00000000000000000000
+                   MAX MUSTERMANN
+                   KREF: XXXXXXXXXXXXXXXXXXXXXXXXXXX
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Willich  -  Amtsgericht Krefeld  (HRB 10867)
+Vorsitzender des Aufsichtsrats: Frank Niehage   -  Vorstand: Lars Lankes, Bernd Würfel
+2000000000000000 0000000000000000
+Kontoauszug Nr:    001/2016                              Seite 2 von 2
+Buchungs-  Valuta  Buchungstext                                         Betrag
+datum                                                                   in EUR
+11.03.     14.03.  Gebühren Ordernummer 00000000 Transnr                 5,90-
+                   0000000000                                                 
+18.03.     22.03.  Ausführung ORDER Verkauf   XXXXXXXXXXXX             500,00+
+                   00000000
+19.03.     22.03.  Gebühren Ordernummer 00000000 Transnr                 5,90-
+                   0000000000                                                 
+30.03.     29.03.  Erträgnisausschüttung 000000000000                    1,00+
+31.03.     31.03.  Zinsabschluss   01.01.2016 - 31.03.2016               0,00+
+Neuer Saldo 31.03.2016 Nr. 001/2016         Währung EUR              1.584,30+
+Der ausgewiesene Kontosaldo kann durch abweichende Wertstellung (Valuta) vom
+wertmäßigen Kontostand abweichen. Die Wertstellung von Buchungen ist auch
+relevant für die Berechnung von Zinsen.
+Gemäß § 11 Außenwirtschaftsgesetz (AWG) in Verbindung mit §§ 67 ff. Außen-
+wirtschaftsverordnung (AWV) haben Inländer (in Deutschland ansässige
+natürliche und juristische Personen) Zahlungen von mehr als 12 500 Euro oder
+Gegenwert zu melden, die sie von Ausländern (im Ausland ansässige natürliche
+und juristische Personen) oder für deren Rechnung von Inländern entgegennehmen
+(eingehende Zahlungen) oder an Ausländer oder für deren Rechnung an Inländer
+leisten (ausgehende Zahlungen). Die Deutsche Bundesbank und ihre Fillialen
+erteilen dazu gern die notwendigen Auskünfte.
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes
+entschädigungsfähig. Nähere Informationen können dem "Informationsbogen für
+den Einleger" entnommen werden.
+Der Rechnungsabschluss wird Ihnen als separates Dokument zur Verfügung
+gestellt.
+Beanstandungen  gegen Rechnungsabschlüsse sind unverzüglich und schriftlich zu
+senden an:
+      biw AG
+      Revision
+      Hausbroicher Str. 222
+      47877 Willich.
+Der Abschlusssaldo gilt als genehmigt, wenn ihm nicht innerhalb von 6 Wochen
+ab Zugang schriftlich widersprochen  wird. Zur Fristwahrung genügt die
+rechtzeitige Absendung der Einwendung.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Willich  -  Amtsgericht Krefeld  (HRB 10867)
+Vorsitzender des Aufsichtsrats: Frank Niehage   -  Vorstand: Lars Lankes, Bernd Würfel
+2000000000000000

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractorTest.java
@@ -264,7 +264,45 @@ public class FlatexPDFExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(99)));
     }
 
-    private String from(String resource)
+     @Test
+    public void testZinsgutschriftInland() throws IOException
+    {
+        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        {
+            @Override
+            String strip(File file) throws IOException
+            {
+                return from("FlatexZinsgutschriftInland.txt");
+            }
+        };
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(Arrays.asList(new File("t")), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("DE1234567890"));
+        assertThat(security.getWkn(), is("AB1234"));
+        assertThat(security.getName(), is("ISH.FOOBAR 12345666 x.EFT"));
+
+        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getSecurity(), is(security));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2016-04-28")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(73.75)));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(1000)));
+    }
+
+   private String from(String resource)
     {
         try (Scanner scanner = new Scanner(getClass().getResourceAsStream(resource), StandardCharsets.UTF_8.name()))
         {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexZinsgutschriftInland.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexZinsgutschriftInland.txt
@@ -1,0 +1,38 @@
+biw AG
+Hausbroicher Str. 222
+47877 Willich
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+biw AG -  Hausbroicher Str. 222 -  47877 Willich
+01022620000005000000000
+Herrn
+M Willich,          15.01.2014ax Mustermann
+Musterstraße. 2
+12345 Stadt
+Zinsgutschrift
+Ihre Depotnummer : 1111111111
+Depotinhaber     : Mustermann, Max
+Nr.111111111                   ISH.FOOBAR 12345666 x.EFT (DE1234567890/AB1234)
+St./Nominale    :       1.000 EUR
+Zinstage        :         365          Ertrag p.a.     :       7,3750 %
+Extag           :  28.04.2016          Ertrag          :       7,3750 %
+Zinstermin      :  28.04.2016          Zinsbetrag      :        73,75 EUR
+Zahlungstag     :  28.04.2016          Faktor          :     1,000000
+Valuta          :  28.04.2016         *Einbeh. Steuer  :         0,00 EUR
+                                       Endbetrag       :        73,75 EUR
+* Einbehaltene Kapitalertragsteuer, ggf. ausländische Quellensteuer zuzüglich
+  Solidaritätszuschlag und ggf. Kirchensteuer. Evtl. Details dazu finden Sie im
+  Steuerreport unter der Transaktion-Nr.: 111111111
+Die Verrechnung des Endbetrages erfolgt über Ihr Konto Nr.:  111111111
+Die  Gutschrift erfolgt  unter Vorbehalt  des  Eingangs.  Einwendungen  müssen
+unverzüglich  nach  Zugang  erhoben  werden.  Die  Unterlassung  rechtzeitiger
+Einwendung gilt als Genehmigung.
+Dieser   Beleg   ist    keine   Steuerbescheinigung.    Kapitalerträge   sind
+einkommensteuerpflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Willich  -  Amtsgericht Krefeld  (HRB 10867)
+Vorsitzender des Aufsichtsrats: Frank Niehage   -  Vorstand: Lars Lankes, Bernd Würfel
+2000000000000000 0000000000000000

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExctractor.java
@@ -187,12 +187,15 @@ public class FlatexPDFExctractor extends AbstractPDFExtractor
     {
         DocumentType type1 = new DocumentType("Dividendengutschrift");
         DocumentType type2 = new DocumentType("Ertragsmitteilung");
+        DocumentType type3 = new DocumentType("Zinsgutschrift");
         this.addDocumentTyp(type1);
         this.addDocumentTyp(type2);
+        this.addDocumentTyp(type3);
 
         Block block = new Block("Ihre Depotnummer.*");
         type1.addBlock(block);
         type2.addBlock(block);
+        type3.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
                         //
                         .subject(() -> {
@@ -202,12 +205,12 @@ public class FlatexPDFExctractor extends AbstractPDFExtractor
                         })
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.(\\d*) * (?<name>[^(]*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)").assign((t, v) -> {
+                        .match("Nr\\.(\\d*) * (?<name>[^(]*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)").assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
                         .section("shares") //
-                        .match("^St. *: *(?<shares>[\\.\\d]+(,\\d*)?).*")
+                        .match("^St\\.[^:]+: *(?<shares>[\\.\\d]+(,\\d*)?).*")
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("amount", "currency") //


### PR DESCRIPTION
Extract deposits and withdrawals from account statements, test for this functionality, extend PDFParser to be able to provide a context, which applies to all blocks in the file like a date or currency definition.
Allow import of bond coupon rates ("Anleihezins") and provide a test for it.

Note: The provided test data has been anonymized were possible.