### PR TITLE
Patch pie chart unassigned calculation

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
@@ -85,6 +85,9 @@ import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
             String name = StringEscapeUtils.escapeJson(node.getName());
             long actual = node.isRoot() ? total.getAmount() : node.getActual().getAmount();
             long base = node.isRoot() ? total.getAmount() : node.getParent().getActual().getAmount();
+            // if 'unassigned category' is excluded adjust the base for the children of the root node 
+            if(getModel().isUnassignedCategoryInChartsExcluded() && node.getParent() !=  null && node.getParent().isRoot())
+                base = total.getAmount();
 
             String totalPercentage = "";
             if (node.getParent() != null && !node.getParent().isRoot())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
@@ -86,7 +86,7 @@ import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
             long actual = node.isRoot() ? total.getAmount() : node.getActual().getAmount();
             long base = node.isRoot() ? total.getAmount() : node.getParent().getActual().getAmount();
             // if 'unassigned category' is excluded adjust the base for the children of the root node 
-            if(getModel().isUnassignedCategoryInChartsExcluded() && node.getParent() !=  null && node.getParent().isRoot())
+            if(getModel().isUnassignedCategoryInChartsExcluded() && node.getParent() != null && node.getParent().isRoot())
                 base = total.getAmount();
 
             String totalPercentage = "";


### PR DESCRIPTION
Der Fix setzt den 'base'-Wert für die erste Ebene auf die übergebene, in einer anderen Funktion schon korrigierte, Basis. Ansonsten wurde immer aus dem Modell der Gesamtamount inkl. "ohne Klassifizierung" ausgelesen.
Alle Berechnungen sollten damit korrekt sein. (Fix #511)

Eventuell wäre eine Refactoring der Funktion sinnvoll, da die derzeitige Einbeziehung der "ohne Klassifizierung"-Option einiges an Komplexität hinzufügt.