### PR TITLE
Patch save diagram with title and legend

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -198,7 +198,20 @@ import name.abuchen.portfolio.ui.Messages;
                     format = SWT.IMAGE_UNDEFINED;
 
                 if (format != SWT.IMAGE_UNDEFINED)
-                    chart.save(filename, format);
+                    try
+                    {
+                        chart.suspendUpdate(true);
+                        chart.getTitle().setVisible(true);
+                        chart.getLegend().setVisible(true);
+                        chart.getLegend().setPosition(SWT.BOTTOM);
+                        chart.suspendUpdate(false);
+                        chart.save(filename, format);
+                    }finally {
+                        chart.suspendUpdate(true);
+                        chart.getTitle().setVisible(false);
+                        chart.getLegend().setVisible(false);
+                        chart.suspendUpdate(false);
+                    }
             }
         });
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -18,6 +18,8 @@ import name.abuchen.portfolio.ui.Messages;
 
     private Chart chart;
     private Menu contextMenu;
+    
+    private int rememberFileExtension = 0;
 
     public ChartContextMenu(Chart chart)
     {
@@ -184,6 +186,7 @@ import name.abuchen.portfolio.ui.Messages;
                 FileDialog dialog = new FileDialog(chart.getShell(), SWT.SAVE);
                 dialog.setFileName(label);
                 dialog.setFilterExtensions(EXTENSIONS);
+                dialog.setFilterIndex(rememberFileExtension);
 
                 String filename = dialog.open();
                 if (filename == null)
@@ -196,6 +199,10 @@ import name.abuchen.portfolio.ui.Messages;
                     format = SWT.IMAGE_PNG;
                 else
                     format = SWT.IMAGE_UNDEFINED;
+                
+                rememberFileExtension = dialog.getFilterIndex();
+                if(rememberFileExtension == -1)
+                    rememberFileExtension = 0;
 
                 if (format != SWT.IMAGE_UNDEFINED)
                     try

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -25,7 +25,7 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
     private Chart chart;
     private Menu contextMenu;
     
-    private int rememberFileExtension = 0;
+    private static int lastUsedFileExtension = 0;
 
     public ChartContextMenu(Chart chart)
     {
@@ -197,7 +197,7 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
                         FileDialog dialog = new FileDialog(chart.getShell(), SWT.SAVE);
                         dialog.setFileName(label);
                         dialog.setFilterExtensions(EXTENSIONS);
-                        dialog.setFilterIndex(rememberFileExtension);
+                        dialog.setFilterIndex(lastUsedFileExtension);
 
                         String filename = dialog.open();
                         if (filename == null)
@@ -211,9 +211,9 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
                         else
                             format = SWT.IMAGE_UNDEFINED;
                         
-                        rememberFileExtension = dialog.getFilterIndex();
-                        if(rememberFileExtension == -1)
-                            rememberFileExtension = 0;
+                        lastUsedFileExtension = dialog.getFilterIndex();
+                        if(lastUsedFileExtension == -1)
+                            lastUsedFileExtension = 0;
 
                         if (format != SWT.IMAGE_UNDEFINED)
                             try

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -216,6 +216,9 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
                             lastUsedFileExtension = 0;
 
                         if (format != SWT.IMAGE_UNDEFINED)
+                        {
+                            boolean isChartTitleVisible = chart.getTitle().isVisible(); 
+                            boolean isChartLegendVisible = chart.getLegend().isVisible();
                             try
                             {
                                 chart.suspendUpdate(true);
@@ -226,10 +229,11 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
                                 chart.save(filename, format);
                             }finally {
                                 chart.suspendUpdate(true);
-                                chart.getTitle().setVisible(false);
-                                chart.getLegend().setVisible(false);
+                                chart.getTitle().setVisible(isChartTitleVisible);
+                                chart.getLegend().setVisible(isChartLegendVisible);
                                 chart.suspendUpdate(false);
                             }
+                        }
                     }
 
                 };


### PR DESCRIPTION
Hier ist ein Vorschlag, wie man den Titel und die Legende in ein zu speicherndes Diagramm bekommt (see  #263).

Zuerst das weniger Schöne:
- Es wird der Titel und die Legende genutzt, die zum SWT-Chart gehören. Diese sind nicht die in der UI sichtbaren Elemente.
- Durch temporäres Anzeigen von Titel und Legende verändert sich das Diagramm in der Höhe, kurzzeitig im Hintergrund auch für den Nutzer in der UI sichtbar. Das exportierte Bild stimmt somit nicht 100% mit dem Angezeigten überein.
- Der normalerweise nicht angezeigte SWT-Chart-Titel und die -Legende müssen synchron mit den für den Nutzer angezeigten Elementen gehalten werden.

Was wurde gemacht:
- Die von org.swtchart.Chart bereitgestellten Elemente Titel und Legende werden vor dem Speichern angezeigt, anschließend wieder versteckt. Dies wird deshalb gemacht, da die chart.save(...)-Funktion nur die sichtbaren Teile eines Chart in das Bild packt.
- Es wurde eine Variable rememberFileExtension eingeführt, damit der FileDialog die zuletzt gewählte Dateiendung wieder übernimmt. Dies ist reine Usability.
- Das ganze wurde in einen ProgressMonitorDialog gepackt, damit der User währenddessen ist nicht mit dem Chart interagieren kann und trotzdem eine Rückmeldung hat während das Bild erstellt wird.