### PR TITLE
Feature filter inactive securities

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -555,6 +555,8 @@ public class Messages extends NLS
     public static String SecurityFilter;
     public static String SecurityFilterSharesHeldEqualZero;
     public static String SecurityFilterSharesHeldGreaterZero;
+    public static String SecurityListFilter;
+    public static String SecurityListFilterHideInactive;
     public static String SecurityMenuAddNewSecurity;
     public static String SecurityMenuAddNewSecurityDescription;
     public static String SecurityMenuAddPrice;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1101,6 +1101,10 @@ SecurityFilterSharesHeldEqualZero = Shares held = 0
 
 SecurityFilterSharesHeldGreaterZero = Shares held > 0
 
+SecurityListFilter = Filter securities
+
+SecurityListFilterHideInactive = Hide inactive securities
+
 SecurityMenuAddNewSecurity = Add new investment instrument
 
 SecurityMenuAddNewSecurityDescription = Search Yahoo Finance by ticker symbol, ISIN, or name\n(using your web browser might find more).

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1101,6 +1101,10 @@ SecurityFilterSharesHeldEqualZero = Bestand = 0
 
 SecurityFilterSharesHeldGreaterZero = Bestand > 0
 
+SecurityListFilter = Wertpapiere filtern
+
+SecurityListFilterHideInactive = Inaktive Wertpapiere ausblenden
+
 SecurityMenuAddNewSecurity = Wertpapier hinzuf\u00FCgen
 
 SecurityMenuAddNewSecurityDescription = Auf Yahoo Finance anhand Ticker Symbol, ISIN, oder Name nach\nWertpapieren suchen (direkt im Browser findet man evtl. mehr).

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -692,7 +692,21 @@ public final class SecuritiesTable implements ModificationListener
             markDirty();
             if (!securities.getControl().isDisposed())
             {
-                securities.refresh(security, true);
+                // the check if the security gets filtered after the change. 
+                // Since it is unknown which property of the security has
+                // been changed, filter.isFilterProperty(...) can't be used.
+                boolean areFiltersAffected = false;
+                for(ViewerFilter filter : securities.getFilters())
+                {
+                    if(!filter.select(securities, security, security));
+                        areFiltersAffected = true;
+                }
+                
+                if(areFiltersAffected)
+                    securities.refresh();
+                else
+                    securities.refresh(security, true);
+                
                 securities.setSelection(securities.getSelection());
             }
         }


### PR DESCRIPTION
Ich habe für die Wertpapieransicht einen Filter hinzugefügt um inaktive Wertpapiere auszublenden.
Die Implementierung ist ähnlich der Filter in der "Performance-Werpapierliste". (Setzt Idee von #519 und #363 um)
Weitere Filter könnten also _einfach_ hinzuprogrammiert werden. 

Der zweite Commit verändert die Aktualisierung der Tabelle nach dem Edit eines Wertpapieres. Da ich im Code nichts gefunden habe, wie man das Delta der Änderung herausbekommt, werden alle Filter der Tabelle durchlaufen, ob das Wertpapier nun gefiltert werden sollte. Dies betrifft z. B. auch den Suchfilter. 
Bisher: Suchfilter genutzt --> Wertpapier ändern, sodass es nun nicht mehr angezeigt werden sollte --> ist immer noch in der Liste, nur Labels sind aktualisiert
Neu: Suchfilter genutzt --> Wertpapier ändern, sodass es nun nicht mehr angezeigt werden sollte --> komplette Liste wird aktualisiert und es ist verschwunden