### PR TITLE
PR Neuer Buchungstyp "Zinsbelastung" (interest charge)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/AccountBuilder.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/AccountBuilder.java
@@ -54,6 +54,16 @@ public class AccountBuilder
     {
         return transaction(Type.INTEREST, date, amount);
     }
+    
+    public AccountBuilder interest_charge(String date, long amount)
+    {
+        return transaction(Type.INTEREST_CHARGE, date, amount);
+    }
+
+    public AccountBuilder interest_charge(LocalDate date, long amount)
+    {
+        return transaction(Type.INTEREST_CHARGE, date, amount);
+    }
 
     public AccountBuilder fees____(String date, long amount)
     {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/CheckValidTypesActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/CheckValidTypesActionTest.java
@@ -44,6 +44,8 @@ public class CheckValidTypesActionTest
         assertThat(action.process(t, account).getCode(), is(Status.Code.OK));
         t.setType(AccountTransaction.Type.INTEREST);
         assertThat(action.process(t, account).getCode(), is(Status.Code.OK));
+        t.setType(AccountTransaction.Type.INTEREST_CHARGE);
+        assertThat(action.process(t, account).getCode(), is(Status.Code.OK));
         t.setType(AccountTransaction.Type.REMOVAL);
         assertThat(action.process(t, account).getCode(), is(Status.Code.OK));
         t.setType(AccountTransaction.Type.TAX_REFUND);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractorTest.java
@@ -16,8 +16,6 @@ import java.util.Optional;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
@@ -34,6 +32,8 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Quote;
 import name.abuchen.portfolio.money.Values;
 
+import org.junit.Test;
+
 @SuppressWarnings("nls")
 public class FlatexPDFExtractorTest
 {
@@ -41,7 +41,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierKauf() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -146,7 +146,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierKauf2() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -189,7 +189,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testKontoauszug() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -219,7 +219,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testKontoauszug2() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -248,7 +248,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testErtragsgutschrift() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -288,7 +288,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testErtragsgutschrift2() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -326,7 +326,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testZinsgutschriftInland() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -364,7 +364,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierVerkauf() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -407,7 +407,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierÜbertrag() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -446,7 +446,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierAusgang() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -487,7 +487,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierAusgang2() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -527,7 +527,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierBestandsausbuchung() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -631,7 +631,7 @@ public class FlatexPDFExtractorTest
     @Test
     public void testWertpapierBestandsausbuchungNeuesFormat() throws IOException
     {
-        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
         {
             @Override
             String strip(File file) throws IOException
@@ -669,35 +669,34 @@ public class FlatexPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(83)));
     }
     
-//TODO: activate after feature interest charge...    
-//    @Test
-//    public void testZinsBelastung() throws IOException
-//    {
-//        FlatexPDFExctractor extractor = new FlatexPDFExctractor(new Client())
-//        {
-//            @Override
-//            String strip(File file) throws IOException
-//            {
-//                return from("FlatexZinsBelastung.txt");
-//            }
-//        };
-//        List<Exception> errors = new ArrayList<Exception>();
-//
-//        List<Item> results = extractor.extract(Arrays.asList(new File("t")), errors);
-//
-//        assertThat(errors, empty());
-//        assertThat(results.size(), is(1));
-//
-//        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-//        assertThat(item.isPresent(), is(true));
-//        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
-//        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
-//
-//        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-//        assertThat(transaction.getDate(), is(LocalDate.parse("2010-12-31")));
-//        assertThat(transaction.getAmount(), is(Values.Amount.factorize(-0.20)));
-//        assertThat(transaction.getCurrencyCode(), is("EUR"));
-//    }
+    @Test
+    public void testZinsBelastung() throws IOException
+    {
+        FlatexPDFExtractor extractor = new FlatexPDFExtractor(new Client())
+        {
+            @Override
+            String strip(File file) throws IOException
+            {
+                return from("FlatexZinsBelastung.txt");
+            }
+        };
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(Arrays.asList(new File("t")), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2010-12-31")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.20)));
+        assertThat(transaction.getCurrencyCode(), is("EUR"));
+    }
     
 
    private String from(String resource)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
@@ -13,9 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import org.hamcrest.number.IsCloseTo;
-import org.junit.Test;
-
 import name.abuchen.portfolio.AccountBuilder;
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioBuilder;
@@ -28,6 +25,9 @@ import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.util.Dates;
+
+import org.hamcrest.number.IsCloseTo;
+import org.junit.Test;
 
 @SuppressWarnings("nls")
 public class ClientIndexTest
@@ -52,6 +52,7 @@ public class ClientIndexTest
                         .withdraw("2012-01-07", 369704) //
                         .fees____("2012-01-07", 88252) //
                         .fees____("2012-01-08", 100385) //
+                        // .interest_charge("2012-01-08", 1) //TODO
                         .addTo(client);
 
         return client;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
@@ -364,6 +364,7 @@ public class AccountTransactionDialog extends AbstractTransactionDialog // NOSON
         {
             case TAXES:
             case FEES:
+            case INTEREST_CHARGE:
             case REMOVAL:
                 return Messages.ColumnDebitNote;
             case INTEREST:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -81,6 +81,7 @@ public class AccountTransactionModel extends AbstractModel
             case TAXES:
             case TAX_REFUND:
             case INTEREST:
+            case INTEREST_CHARGE:
             case DIVIDENDS:
                 return;
             case BUY:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -29,7 +29,7 @@ import name.abuchen.portfolio.datatransfer.pdf.ConsorsbankPDFExctractor;
 import name.abuchen.portfolio.datatransfer.pdf.DABPDFExctractor;
 import name.abuchen.portfolio.datatransfer.pdf.DeutscheBankPDFExctractor;
 import name.abuchen.portfolio.datatransfer.pdf.DkbPDFExtractor;
-import name.abuchen.portfolio.datatransfer.pdf.FlatexPDFExctractor;
+import name.abuchen.portfolio.datatransfer.pdf.FlatexPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.INGDiBaExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.OnvistaPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.SBrokerPDFExtractor;
@@ -111,7 +111,7 @@ public class ImportPDFHandler
             case "dkb": //$NON-NLS-1$
                 return new DkbPDFExtractor(client);
             case "flatex": //$NON-NLS-1$
-                return new FlatexPDFExctractor(client);
+                return new FlatexPDFExtractor(client);
             case "ingdiba": //$NON-NLS-1$
                 return new INGDiBaExtractor(client);
             case "onvista": //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -36,7 +36,8 @@ public class AccountContextMenu
                         AccountTransaction.Type.DEPOSIT, //
                         AccountTransaction.Type.REMOVAL, //
                         AccountTransaction.Type.TAXES, //
-                        AccountTransaction.Type.FEES))
+                        AccountTransaction.Type.FEES, //
+                        AccountTransaction.Type.INTEREST_CHARGE))
         {
             new OpenDialogAction(owner, type.toString() + "...") //$NON-NLS-1$
                             .type(AccountTransactionDialog.class) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
@@ -722,6 +722,7 @@ public class AccountListView extends AbstractListView implements ModificationLis
                     break;
                 case REMOVAL:
                 case FEES:
+                case INTEREST_CHARGE:
                 case TAXES:
                 case BUY:
                 case TRANSFER_OUT:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/CheckValidTypesAction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/CheckValidTypesAction.java
@@ -37,6 +37,7 @@ public class CheckValidTypesAction implements ImportAction
             case DEPOSIT:
             case DIVIDENDS:
             case INTEREST:
+            case INTEREST_CHARGE:
             case TAX_REFUND:
             case TAXES:
             case REMOVAL:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
@@ -107,6 +107,7 @@ import name.abuchen.portfolio.money.Money;
             case TAX_REFUND:
             case FEES:
             case INTEREST:
+            case INTEREST_CHARGE:
             case REMOVAL:
                 AccountTransaction t = new AccountTransaction();
                 t.setType(type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Account.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Account.java
@@ -116,6 +116,7 @@ public class Account implements TransactionOwner<AccountTransaction>, Investment
                 case TAX_REFUND:
                     return t.getAmount();
                 case FEES:
+                case INTEREST_CHARGE:
                 case TAXES:
                 case REMOVAL:
                 case BUY:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
@@ -12,7 +12,7 @@ public class AccountTransaction extends Transaction
 {
     public enum Type
     {
-        DEPOSIT(false), REMOVAL(true), INTEREST(false), DIVIDENDS(false), FEES(true), TAXES(true), TAX_REFUND(
+        DEPOSIT(false), REMOVAL(true), INTEREST(false), INTEREST_CHARGE(true), DIVIDENDS(false), FEES(true), TAXES(true), TAX_REFUND(
                         false), BUY(true), SELL(false), TRANSFER_IN(false), TRANSFER_OUT(true);
 
         private static final ResourceBundle RESOURCES = ResourceBundle.getBundle("name.abuchen.portfolio.model.labels"); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
@@ -1,15 +1,16 @@
 
-account.BUY          = Buy
-account.DEPOSIT      = Deposit
-account.DIVIDENDS    = Dividends
-account.FEES         = Fees
-account.INTEREST     = Interest
-account.REMOVAL      = Removal
-account.SELL         = Sell
-account.TAXES        = Taxes
-account.TAX_REFUND   = Tax Refund
-account.TRANSFER_IN  = Transfer (Inbound)
-account.TRANSFER_OUT = Transfer (Outbound)
+account.BUY          	= Buy
+account.DEPOSIT      	= Deposit
+account.DIVIDENDS    	= Dividends
+account.FEES         	= Fees
+account.INTEREST     	= Interest
+account.INTEREST_CHARGE	= Interest Charge
+account.REMOVAL      	= Removal
+account.SELL         	= Sell
+account.TAXES        	= Taxes
+account.TAX_REFUND   	= Tax Refund
+account.TRANSFER_IN  	= Transfer (Inbound)
+account.TRANSFER_OUT 	= Transfer (Outbound)
 
 event.STOCK_SPLIT = Stock Split
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels_de.properties
@@ -1,15 +1,16 @@
 
-account.BUY          = Kauf
-account.DEPOSIT      = Einlage
-account.DIVIDENDS    = Dividende
-account.FEES         = Geb\u00FChren
-account.INTEREST     = Zinsen
-account.REMOVAL      = Entnahme
-account.SELL         = Verkauf
-account.TAXES        = Steuern
-account.TAX_REFUND   = Steuerr\u00FCckerstattung
-account.TRANSFER_IN  = Umbuchung (Eingang)
-account.TRANSFER_OUT = Umbuchung (Ausgang)
+account.BUY          	= Kauf
+account.DEPOSIT      	= Einlage
+account.DIVIDENDS    	= Dividende
+account.FEES         	= Geb\u00FChren
+account.INTEREST     	= Zinsen
+account.INTEREST_CHARGE	= Zinsbelastung
+account.REMOVAL      	= Entnahme
+account.SELL         	= Verkauf
+account.TAXES        	= Steuern
+account.TAX_REFUND   	= Steuerr\u00FCckerstattung
+account.TRANSFER_IN  	= Umbuchung (Eingang)
+account.TRANSFER_OUT 	= Umbuchung (Ausgang)
 
 event.STOCK_SPLIT = Aktiensplit
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClassificationIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClassificationIndex.java
@@ -121,6 +121,7 @@ import name.abuchen.portfolio.money.Money;
                         case DEPOSIT:
                         case REMOVAL:
                         case INTEREST:
+                        case INTEREST_CHARGE:
                         case TAXES:
                         case FEES:
                             // do nothing
@@ -185,6 +186,7 @@ import name.abuchen.portfolio.money.Money;
                 case DEPOSIT:
                 case REMOVAL:
                 case INTEREST:
+                case INTEREST_CHARGE:
                 case TAXES:
                 case FEES:
                     if (weight != Classification.ONE_HUNDRED_PERCENT)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIRRYield.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIRRYield.java
@@ -95,6 +95,7 @@ public class ClientIRRYield
                                     case TAXES:
                                     case DIVIDENDS:
                                     case INTEREST:
+                                    case INTEREST_CHARGE:
                                     case TAX_REFUND:
                                         break;
                                     default:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
@@ -52,6 +52,7 @@ import name.abuchen.portfolio.util.Interval;
         taxes = new long[size];
         dividends = new long[size];
         interest = new long[size];
+        interestCharge = new long[size];
 
         collectTransferalsAndTaxes(interval);
 
@@ -145,6 +146,9 @@ import name.abuchen.portfolio.util.Interval;
                                         break;
                                     case INTEREST:
                                         addValue(interest, t.getCurrencyCode(), t.getAmount(), interval, t.getDate());
+                                        break;
+                                    case INTEREST_CHARGE:
+                                        addValue(interestCharge, t.getCurrencyCode(), t.getAmount(), interval, t.getDate());
                                         break;
                                     default:
                                         // do nothing

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
@@ -292,6 +292,8 @@ public class ClientPerformanceSnapshot
                     case INTEREST:
                         addEarningTransaction(t, earnings, otherEarnings, taxes, earningsBySecurity);
                         break;
+                    case INTEREST_CHARGE:
+                        earnings.subtract(t.getMonetaryAmount().with(converter.at(t.getDate())));
                     case DEPOSIT:
                         deposits.add(t.getMonetaryAmount().with(converter.at(t.getDate())));
                         break;
@@ -419,6 +421,7 @@ public class ClientPerformanceSnapshot
                         break;
                     case REMOVAL:
                     case FEES:
+                    case INTEREST_CHARGE:
                     case TAXES:
                     case BUY:
                         value.add(t.getMonetaryAmount().with(converter.at(t.getDate())));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/GroupEarningsByAccount.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/GroupEarningsByAccount.java
@@ -59,6 +59,7 @@ public class GroupEarningsByAccount
                         case DEPOSIT:
                         case REMOVAL:
                         case FEES:
+                        case INTEREST_CHARGE:
                         case TAXES:
                         case TAX_REFUND:
                         case BUY:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -11,9 +11,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.csv.CSVStrategy;
-
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.math.Risk.Drawdown;
 import name.abuchen.portfolio.math.Risk.Volatility;
@@ -28,6 +25,9 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.TradeCalendar;
 
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVStrategy;
+
 public class PerformanceIndex
 {
     private final Client client;
@@ -40,6 +40,7 @@ public class PerformanceIndex
     protected long[] taxes;
     protected long[] dividends;
     protected long[] interest;
+    protected long[] interestCharge;
     protected double[] accumulated;
     protected double[] delta;
 
@@ -227,6 +228,11 @@ public class PerformanceIndex
     public long[] getInterest()
     {
         return interest;
+    }
+    
+    public long[] getInterestCharge()
+    {
+        return interestCharge;
     }
 
     public long[] calculateInvestedCapital()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioIndex.java
@@ -112,6 +112,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
                 case DEPOSIT:
                 case REMOVAL:
                 case INTEREST:
+                case INTEREST_CHARGE:
                 case TAXES:
                 case FEES:
                     // do nothing

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioPlusIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioPlusIndex.java
@@ -151,6 +151,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
                 case DEPOSIT:
                 case REMOVAL:
                 case INTEREST:
+                case INTEREST_CHARGE:
                 case TAXES:
                 case FEES:
                     pseudoAccount.addTransaction(t);


### PR DESCRIPTION
Hier nun ein erster Versuch meiner Änderungen zur Einführung eines neuen Buchungstyps "Zinsbelastung"

Habe mir die commits aus dem Screenshot von https://github.com/buchen/portfolio/pull/558#issuecomment-230862410
angesehen (einige Klassen gibts in der Form inzwischen aber nicht mehr, da fand wohl das ein- oder andere Refactoring statt...)  und in
`name.abuchen.portfolio.model.AccountTransaction.Type `
einen neuen Typ `INTEREST_CHARGE` eingeführt und mir angeguckt, wo überall `name.abuchen.portfolio.model.AccountTransaction.Type` vorkommt und die diversen `switch` Statements erweitert.

In folgenden Klassen bin ich mir nicht sicher, ob das so passt, vielleicht könntest du da noch mal einen Blick drauf werfen:

`name.abuchen.portfolio.datatransfer.csv.CSVAccountTransactionExtractor`
`name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot`

Die Tests könnten wohl auch noch erweitert werden:

`name.abuchen.portfolio.snapshot.ClientIndexTest`

Da habe ich die Berechnungs-Logik jetzt auf die Schnelle nicht komplett durchdrungen.