### PR TITLE
Code-Refactoring: Abstract Finance View Titel handling

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/AbstractFinanceView.java
@@ -38,11 +38,11 @@ public abstract class AbstractFinanceView
     private LocalResourceManager resourceManager = new LocalResourceManager(JFaceResources.getResources());
     private List<Menu> contextMenus = new ArrayList<>();
 
-    protected abstract String getTitle();
-
-    protected final void updateTitle()
+    protected abstract String getDefaultTitle();
+    
+    protected String getTitle()
     {
-        this.title.setText(getTitle());
+        return title.getText();
     }
 
     protected final void updateTitle(String title)
@@ -122,7 +122,7 @@ public abstract class AbstractFinanceView
                         .createFrom(JFaceResources.getFont(JFaceResources.HEADER_FONT)).setStyle(SWT.BOLD));
 
         title = new Label(header, SWT.NONE);
-        title.setText(getTitle());
+        title.setText(getDefaultTitle());
         title.setFont(boldFont);
         title.setForeground(resourceManager.createColor(Colors.HEADINGS.swt()));
         title.setBackground(header.getBackground());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
@@ -102,7 +102,7 @@ public class AccountListView extends AbstractListView implements ModificationLis
     private ExchangeRateProviderFactory factory;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelAccounts;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BrowserTestView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BrowserTestView.java
@@ -10,7 +10,7 @@ public class BrowserTestView extends AbstractFinanceView
 {
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return "Browser Test"; //$NON-NLS-1$
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ConsumerPriceIndexListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ConsumerPriceIndexListView.java
@@ -45,7 +45,7 @@ public class ConsumerPriceIndexListView extends AbstractListView implements Modi
     private TimelineChart chart;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelConsumerPriceIndex;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ExceptionView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ExceptionView.java
@@ -19,7 +19,7 @@ public class ExceptionView extends AbstractFinanceView
     private Exception exception;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelError;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ExchangeRatesListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ExchangeRatesListView.java
@@ -34,7 +34,7 @@ public class ExchangeRatesListView extends AbstractListView
     private TimelineChart chart;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelCurrencies;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
@@ -28,7 +28,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
     private ExchangeRateProviderFactory factory;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelStatementOfAssetsHoldings;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/InvestmentPlanListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/InvestmentPlanListView.java
@@ -61,7 +61,7 @@ public class InvestmentPlanListView extends AbstractListView implements Modifica
     private ExchangeRateProviderFactory factory;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelInvestmentPlans;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -55,7 +55,7 @@ public class PerformanceChartView extends AbstractHistoricView
     private PerformanceChartSeriesBuilder seriesBuilder;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelPerformanceChart;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -137,6 +137,7 @@ public class PerformanceChartView extends AbstractHistoricView
         DataSeriesChartLegend legend = new DataSeriesChartLegend(composite, picker);
 
         updateTitle(Messages.LabelPerformanceChart + " (" + picker.getConfigurationName() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        chart.getTitle().setText(getTitle());
 
         GridLayoutFactory.fillDefaults().numColumns(1).margins(0, 0).spacing(0, 0).applyTo(composite);
         GridDataFactory.fillDefaults().grab(true, true).applyTo(chart);
@@ -175,6 +176,7 @@ public class PerformanceChartView extends AbstractHistoricView
             updateTitle(Messages.LabelPerformanceChart + " (" + picker.getConfigurationName() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 
             chart.suspendUpdate(true);
+            chart.getTitle().setText(getTitle());
             for (ISeries s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -59,7 +59,7 @@ public class PerformanceView extends AbstractHistoricView
     private TableViewer earningsByAccount;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelPerformanceCalculation;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
@@ -62,7 +62,7 @@ public class PortfolioListView extends AbstractListView implements ModificationL
     private boolean isFiltered = false;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelPortfolios;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -86,7 +86,6 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
         resources = new LocalResourceManager(JFaceResources.getResources(), composite);
 
         chart = new ScatterChart(composite);
-        chart.getTitle().setText(getTitle());
         chart.getTitle().setVisible(false);
 
         IAxis xAxis = chart.getAxisSet().getXAxis(0);
@@ -122,6 +121,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
         DataSeriesChartLegend legend = new DataSeriesChartLegend(composite, configurator);
 
         updateTitle(Messages.LabelHistoricalReturnsAndVolatiltity + " (" + configurator.getConfigurationName() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        chart.getTitle().setText(getTitle());
 
         GridLayoutFactory.fillDefaults().numColumns(1).margins(0, 0).spacing(0, 0).applyTo(composite);
         GridDataFactory.fillDefaults().grab(true, true).applyTo(chart);
@@ -161,6 +161,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
                             + ")"); //$NON-NLS-1$
 
             chart.suspendUpdate(true);
+            chart.getTitle().setText(getTitle());
             for (ISeries s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -49,7 +49,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
     private DataSeriesCache cache;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelHistoricalReturnsAndVolatiltity;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -147,7 +147,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
     private SecurityDetailsViewer latest;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return recordColumns == null ? Messages.LabelSecurityPerformance
                         : Messages.LabelSecurityPerformance + " (" + recordColumns.getConfigurationName() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -221,8 +221,8 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         recordColumns = new ShowHideColumnHelper(SecuritiesPerformanceView.class.getName(), getClient(),
                         getPreferenceStore(), records, layout);
 
-        updateTitle();
-        recordColumns.addListener(() -> updateTitle());
+        updateTitle(getDefaultTitle());
+        recordColumns.addListener(() -> updateTitle(getDefaultTitle()));
 
         ColumnViewerToolTipSupport.enableFor(records, ToolTip.NO_RECREATE);
         ColumnEditingSupport.prepare(records);
@@ -871,8 +871,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
     public void notifyModelUpdated()
     {
         reportingPeriodUpdated();
-        updateTitle();
-
+        updateTitle(getDefaultTitle());
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -206,7 +206,7 @@ public class SecurityListView extends AbstractListView implements ModificationLi
     private Pattern filterPattern;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         StringBuilder title = new StringBuilder();
         if (watchlist == null)
@@ -231,7 +231,7 @@ public class SecurityListView extends AbstractListView implements ModificationLi
     {
         if (securities != null && !securities.getTableViewer().getTable().isDisposed())
         {
-            updateTitle();
+            updateTitle(getDefaultTitle());
             securities.getTableViewer().refresh(true);
             securities.getTableViewer().setSelection(securities.getTableViewer().getSelection());
         }
@@ -378,8 +378,8 @@ public class SecurityListView extends AbstractListView implements ModificationLi
     protected void createTopTable(Composite parent)
     {
         securities = new SecuritiesTable(parent, this);
-        updateTitle();
-        securities.getColumnHelper().addListener(() -> updateTitle());
+        updateTitle(getDefaultTitle());
+        securities.getColumnHelper().addListener(() -> updateTitle(getDefaultTitle()));
 
         securities.addSelectionChangedListener(event -> onSecurityChanged(
                         (Security) ((IStructuredSelection) event.getSelection()).getFirstElement()));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -115,7 +115,6 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
         composite.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 
         chart = new TimelineChart(composite);
-        chart.getTitle().setText(getTitle());
         chart.getTitle().setVisible(false);
 
         DataSeriesCache cache = make(DataSeriesCache.class);
@@ -127,6 +126,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
         DataSeriesChartLegend legend = new DataSeriesChartLegend(composite, configurator);
 
         updateTitle(Messages.LabelStatementOfAssetsHistory + " (" + configurator.getConfigurationName() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        chart.getTitle().setText(getTitle());
 
         GridLayoutFactory.fillDefaults().numColumns(1).margins(0, 0).spacing(0, 0).applyTo(composite);
         GridDataFactory.fillDefaults().grab(true, true).applyTo(chart);
@@ -174,7 +174,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
             updateTitle(Messages.LabelStatementOfAssetsHistory + " (" + configurator.getConfigurationName() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 
             chart.suspendUpdate(true);
-
+            chart.getTitle().setText(getTitle());
             for (ISeries s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -30,7 +30,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
     private StatementOfAssetsSeriesBuilder seriesBuilder;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelStatementOfAssetsHistory;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -35,7 +35,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
     private ExchangeRateProviderFactory factory;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return assetViewer == null ? Messages.LabelStatementOfAssets : Messages.LabelStatementOfAssets + //
                         " (" + assetViewer.getColumnHelper().getConfigurationName() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
@@ -48,7 +48,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
         ClientSnapshot snapshot = ClientSnapshot.create(getClient(), converter, LocalDate.now());
 
         assetViewer.setInput(snapshot);
-        updateTitle();
+        updateTitle(getDefaultTitle());
     }
 
     @Override
@@ -124,8 +124,8 @@ public class StatementOfAssetsView extends AbstractFinanceView
         assetViewer = make(StatementOfAssetsViewer.class);
         Control control = assetViewer.createControl(parent);
 
-        updateTitle();
-        assetViewer.getColumnHelper().addListener(() -> updateTitle());
+        updateTitle(getDefaultTitle());
+        assetViewer.getColumnHelper().addListener(() -> updateTitle(getDefaultTitle()));
 
         hookContextMenu(assetViewer.getTableViewer().getControl(), new IMenuListener()
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
@@ -186,7 +186,7 @@ public class DashboardView extends AbstractHistoricView
     private DashboardData dashboardData;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelDashboard;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dividends/DividendsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dividends/DividendsView.java
@@ -62,7 +62,7 @@ public class DividendsView extends AbstractFinanceView
     }
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelDividends;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/SettingsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/SettingsView.java
@@ -28,7 +28,7 @@ public class SettingsView extends AbstractFinanceView
     private int initiallySelectedTab = 0;
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return Messages.LabelSettings;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
@@ -42,7 +42,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     private List<Action> viewActions = new ArrayList<>();
 
     @Override
-    protected String getTitle()
+    protected String getDefaultTitle()
     {
         return taxonomy.getName();
     }
@@ -73,7 +73,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     @Override
     public void propertyChange(PropertyChangeEvent event)
     {
-        updateTitle();
+        updateTitle(taxonomy.getName());
     }
 
     @Override


### PR DESCRIPTION
Da ich mit den aktuellen Methoden zum setzen und abrufen des Titels eines FinanceViews nicht zurecht kam, habe ich die Methoden etwas angepasst.
Konkret störte mich, dass es eine Methode updateTitle(String title) gab, die den Titel verändert hat, jedoch hat die abstract getTitle()-Methode diese Änderung nicht beachtet (und auch nicht beachten können, da das Label titel private in der super-Klasse is.) Ich finde der Methodenname getDefaultTitle() passt hier besser. Falls ein FinanceView den Titel ändern will, soll er den neuen gewünschten Titel übergeben und nicht dies der super-Klasse überlassen (deshalb wurde updateTitle() gelöscht).
Die Änderungen haben auch zur Folge, dass der Titel eines Charts beim Speichern nun auch den kompletten Titel eines Views (z. B. "Performance-Diagramm (Standard)", ....) repräsentiert.

Die Änderungen aus den beiden Commits;
- rename abstract getTitle() to getDefaultTitle()
- add new getTitle() returning the text of title label
- remove updateTitle()
- update all classes using the methods mentioned above
- Keep hidden chart title in sync with view title

