### PR TITLE
Balancebug

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
@@ -653,6 +653,8 @@ public class AccountListView extends AbstractListView implements ModificationLis
                         account.deleteTransaction((AccountTransaction) transaction, getClient());
 
                     markDirty();
+                    transaction2balance.clear();
+                    updateBalance(account);
                     accounts.refresh();
                     transactions.setInput(account.getTransactions());
                 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
@@ -42,7 +42,7 @@ public class AccountTransaction extends Transaction
     }
 
     /**
-     * Comparator to stort by date, amount, and type in order to have a stable
+     * Comparator to sort by date, amount, and type in order to have a stable
      * enough sort order to calculate the balance per transaction.
      */
     public static final class ByDateAmountAndType implements Comparator<AccountTransaction>, Serializable


### PR DESCRIPTION
Beim Löschen einer Zeile in der Account-Tabelle wird zwar die Gesamtsumme richtig berechnet,
aber die Zeilensummen wurden nicht aktualisiert. Ich habe dazu die Hashmap mit den
berechneten Werten gelöscht und danach wieder neu berechnet. 