### PR TITLE
Feature add portfolio filter to security performance list view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -591,6 +591,7 @@ public class Messages extends NLS
     public static String PrefTitlePresentation;
     public static String PrefTitleProxy;
     public static String SecurityFilter;
+    public static String SecurityFilterPortfolioFilter;
     public static String SecurityFilterSharesHeldEqualZero;
     public static String SecurityFilterSharesHeldGreaterZero;
     public static String SecurityListFilter;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1175,7 +1175,9 @@ PrefTitleProxy = Proxy
 
 PrefUpdateSite = &Update URL:
 
-SecurityFilter = Filter securities based on the shares held
+SecurityFilter = Filter securities
+
+SecurityFilterPortfolioFilter = Portfolios
 
 SecurityFilterSharesHeldEqualZero = Shares held = 0
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1175,7 +1175,9 @@ PrefTitleProxy = Proxy-Server
 
 PrefUpdateSite = &Update URL:
 
-SecurityFilter = Wertpapiere anhand des Bestandes ausfiltern
+SecurityFilter = Wertpapiere filtern
+
+SecurityFilterPortfolioFilter = Depots
 
 SecurityFilterSharesHeldEqualZero = Bestand = 0
 


### PR DESCRIPTION
Ich habe für die "Performance -> Wertpapiere"-Ansicht einen Filter für vorhandene, nicht deaktivierte, Portfolios implementiert. Das ganze als Untermenü im bisherigen Filtermenü (Wertpapiere > 0 Stück, ...)
In #621 wird ein globaler Filter diskutiert, dieser hier ist nur für die Unteransicht, aber ein Schritt in die diskutierte Richtung.
Der pull request besteht bisher aus zwei Commits: 
- In [098454e](https://github.com/buchen/portfolio/commit/098454e642e3ac2f0e426ac351edcfcb0d249713) habe ich das Menü implementiert und einen ViewerFilter zum TableView records hinzugefügt. Wenn in einem Depot eine Wertpapier-Transaktion vorhanden ist, wird das Wertpapier (mit allen auch depotfremden Stücken) angezeigt. Da es bei mir zwischen Depot keine Aktienüberschneidungen gibt, war diese simple Filterung ausreichend.
- In [2985f9d](https://github.com/buchen/portfolio/commit/2985f9d8e616dac8265e97e526e29e54e20eb11e) wurde der ViewerFilter wieder entfernt und stattdessen wird für den TableView records ein neuer SecurityPerformanceSnapshot nur mit den ausgewählten Depots berechnet. Somit spiegeln die angezeigten Daten auch die tatsächliche Depotsituation wieder.

Folgende zwei Probleme sind mir aufgefallen:
- Haben zwei Depots mit überschneidenden Aktien und Dividendenzahlungen das selbe Verrechnungskonto, werden Dividenden falsch berechnet, da sie vom Depot unabhängig erfasst werden. Siehe [Kommentar](https://github.com/buchen/portfolio/commit/2985f9d8e616dac8265e97e526e29e54e20eb11e#commitcomment-19299390)
- Habe ich in zwei Depots die selbe Aktie (unterschiedliche Stückzahlen, unterschiedliche Kaufzeitpunkte, etc.), ändert sich der TTWROR nicht wenn ich einen neuen SecurityPerformanceSnapshot mit nur einem der Depots erstelle. Wird dort etwas depotübergreifend berechnet?