### PR TITLE
Parsing a part of a PDF requires a start and an end line

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaMultipartKaufVerkauf.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaMultipartKaufVerkauf.txt
@@ -1,0 +1,124 @@
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=Max Mustermann
+Verkauf ADRESSZEILE3=Musterstraße 1
+Kommissionsgeschäft ADRESSZEILE4=12345 Musterstadt
+Herr ADRESSZEILE5=
+Max Mustermann ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+Musterstraße 1 BELEGNUMMER=12345
+12345 Musterstadt 123456789 12345678 / 02.09.2016 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+Max Mustermann
+Frankfurt am Main, 02.09.2016
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+adesso AG Inhaber-Aktien o.N. DE000A0Z23Q5
+Nominal Kurs
+STK 20,000 EUR 31,5000
+Handelstag 02.09.2016 Kurswert EUR 630,00 
+Handelszeit 09:10 Orderprovision EUR 5,00-
+Börse Xetra/EDE Kapitalertragsteuer EUR 1,43-
+Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 0,08-
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+06.09.2016 243921041 EUR 623,49
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Aktien EUR 5,70
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 5,70
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 10,94
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,60
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Köln-Porz, Steuernummer 216/5881/1238.
+Jahressteuerbescheinigung folgt
+Wir werden in Ihrem Depot wie angegeben buchen.
+Es folgt Seite 2
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Herr
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=Max Mustermann
+123456789 435345 2 ADRESSZEILE3=Musterstraße 1
+ADRESSZEILE4=12345 Musterstadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=44556677
+Ausfuehrung zu XETRA Order Nummer: 654363534534 SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=Max Mustermann
+Verkauf ADRESSZEILE3=Musterstraße 1
+Kommissionsgeschäft ADRESSZEILE4=12345 Musterstadt
+Herr ADRESSZEILE5=
+Max Mustermann ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+Musterstraße 1 BELEGNUMMER=123455
+12345 Musterstadt 12345678 1234567 / 02.09.2016 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+Max Mustermann
+Frankfurt am Main, 02.09.2016
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+adesso AG Inhaber-Aktien o.N. DE000A0Z23Q5
+Nominal Kurs
+STK 80,000 EUR 31,5000
+Handelstag 02.09.2016 Kurswert EUR 2.520,00 
+Handelszeit 09:10 Handelsplatzgebühr EUR 1,50-
+Börse Xetra/EDE Kapitalertragsteuer EUR 9,51-
+Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 0,52-
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+06.09.2016 243921041 EUR 2.508,47
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Aktien EUR 41,30
+Aktienverlusttopf EUR 3,25 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 38,05
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 9,51
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,52
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Köln-Porz, Steuernummer 216/5881/1238.
+Jahressteuerbescheinigung folgt
+Wir werden in Ihrem Depot wie angegeben buchen.
+Es folgt Seite 2
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Herr
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=Max Mustermann
+123456789 43543534 2 ADRESSZEILE3=Musterstraße 1
+ADRESSZEILE4=12345 Musterstadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=4455667756
+Ausfuehrung zu XETRA Order Nummer: 346456346 SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractorTest.java
@@ -126,7 +126,7 @@ public class SBrokerPDFExtractorTest
         List<Item> results = extractor.extract(Arrays.asList(new File("sBroker_Ertragsgutschrift1.txt")), errors);
         
         assertThat(errors, empty());
-        assertThat(results.size(), is(3));
+        assertThat(results.size(), is(2));
 
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -880,10 +880,16 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         // en o.St.o.N
                         .match("^(?<nameP4>^.*\\.*)$")
                         .assign((t, v) -> {
+                            type.getCurrentContext().put("nameP4", v.get("nameP4"));
+                        })
+
+                        .section("combine")
+                        .match("(?<combine>.*)")
+                        .assign((t, v) -> {
                             String name = type.getCurrentContext().get("nameP1") + 
                                           type.getCurrentContext().get("nameP2") +
                                           type.getCurrentContext().get("nameP3") + 
-                                          v.get("nameP4");
+                                          type.getCurrentContext().get("nameP4");
                             v.put("isin", type.getCurrentContext().get("isin"));
                             if (name.indexOf(v.get("isin")) > -1)
                             {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -1109,6 +1109,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                         .addUnit(new Unit(Unit.Type.FEE,
                                                         Money.of(asCurrencyCode(v.get("currency")),
                                                                         asAmount(v.get("stockfees"))))))
+                        .section("stockfees2").optional()
+                        .match("(^.*) (Handelsplatzgeb\\Dhr) (\\w{3}+) (?<stockfees2>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)(-)")
+                        .assign((t, v) -> t.getPortfolioTransaction()
+                                        .addUnit(new Unit(Unit.Type.FEE,
+                                                        Money.of(asCurrencyCode(v.get("currency")),
+                                                                        asAmount(v.get("stockfees2"))))))
                         .section("agent").optional()
                         .match("(^.*)(Maklercourtage)(\\s+)(\\w{3}+) (?<agent>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)(-)")
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE,

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -111,15 +111,23 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 
         public void parse(String filename, List<Item> items, String[] lines)
         {
-            int currentLastTransactionLine = lines.length-1;
-            for (int ii = lines.length-1; ii >= 0; ii--)
+            int currentLastTransactionLine = -1;
+            for (int ii = 0; ii < lines.length; ii++)
             {
                 Matcher matcher = marker.matcher(lines[ii]);
                 if (matcher.matches())
                 {
-                    transaction.parse(filename, items, lines, ii, currentLastTransactionLine);
-                    currentLastTransactionLine = ii-1;
+                    if(currentLastTransactionLine >= 0)
+                    {
+                        transaction.parse(filename, items, lines, currentLastTransactionLine, ii-1);
+                    }
+                    currentLastTransactionLine = ii;
                 }
+            }
+            
+            if (currentLastTransactionLine >= 0 && currentLastTransactionLine != lines.length-1)
+            {
+                transaction.parse(filename, items, lines, currentLastTransactionLine, lines.length-1);
             }
         }
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -111,11 +111,15 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 
         public void parse(String filename, List<Item> items, String[] lines)
         {
-            for (int ii = 0; ii < lines.length; ii++)
+            int currentLastTransactionLine = lines.length-1;
+            for (int ii = lines.length-1; ii >= 0; ii--)
             {
                 Matcher matcher = marker.matcher(lines[ii]);
                 if (matcher.matches())
-                    transaction.parse(filename, items, lines, ii);
+                {
+                    transaction.parse(filename, items, lines, ii, currentLastTransactionLine);
+                    currentLastTransactionLine = ii-1;
+                }
             }
         }
     }
@@ -145,12 +149,12 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
             return this;
         }
 
-        public void parse(String filename, List<Item> items, String[] lines, int lineNo)
+        public void parse(String filename, List<Item> items, String[] lines, int lineNoStart, int lineNoEnd)
         {
             T target = supplier.get();
 
             for (Section<T> section : sections)
-                section.parse(filename, items, lines, lineNo, target);
+                section.parse(filename, items, lines, lineNoStart, lineNoEnd, target);
 
             if (wrapper == null)
                 throw new IllegalArgumentException("Wrapping function missing"); //$NON-NLS-1$
@@ -199,12 +203,12 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
             return transaction;
         }
 
-        public void parse(String filename, List<Item> items, String[] lines, int lineNo, T target)
+        public void parse(String filename, List<Item> items, String[] lines, int lineNo, int lineNoEnd, T target)
         {
             Map<String, String> values = new HashMap<>();
 
             int patternNo = 0;
-            for (int ii = lineNo; ii < lines.length; ii++)
+            for (int ii = lineNo; ii <= lineNoEnd; ii++)
             {
                 Pattern p = pattern.get(patternNo);
                 Matcher m = p.matcher(lines[ii]);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -130,7 +130,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Erträgnisgutschrift");
         this.addDocumentTyp(type);
 
-        Block block = new Block("Erträgnisgutschrift.*");
+        Block block = new Block("Erträgnisgutschrift.*\\d+.\\d+.\\d{4}");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 


### PR DESCRIPTION
Otherwise the parser cannot handle PDF files containing more than one
transaction, e.g. OnVista