### PR TITLE
Improvements of cortalconsors parser

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankKauf2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankKauf2.txt
@@ -1,0 +1,39 @@
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+0123456789/00
+Max Mustermann
+Musterstr. 1
+12345 Musterstadt Vermerk der Bank 1000
+02
+WERTPAPIERABRECHNUNG
+KAUF AM 21.09.2015  UM 12:45:38 FRANKFURT NR. 92612045.001
+Wertpapier WKN ISIN
+HELIAD EQ.PARTN.KGAA A0L1NN DE000A0L1NN5
+Einheit Umsatz
+ST 250,00000
+Kurs 5,480000 EUR P.ST.  
+Kurswert EUR 1.370,00
+Börsenplatzgebühr EUR 2,95
+Handelsentgelt EUR 3,00
+Provision EUR 5,00
+Grundgebühr EUR 4,95
+Eig. Spesen EUR 1,95
+Wert 23.09.2015 EUR 1.387,85
+zulasten Konto-Nr. 111222333
+Wertpapiere zugunsten Girosammelverwahrung 
+Clearstream Bk Ffm 2126
+Eigene Spesen enthalten 1,95 EUR Umschreibegebühr inkl. 19 % MWST
+Limitkurs  5,500000 EUR
+Hinweis für Kontoauszüge, Wertpapierabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankKaufSparplan.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankKaufSparplan.txt
@@ -1,0 +1,53 @@
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+0123456789/00
+Max Mustermann
+Musterstr. 1
+12345 Musterstadt Vermerk der Bank 1000
+02
+ORDERABRECHNUNG
+KAUF AM 15.06.2016  UM 11:07:25 AUSL.INVESTM.GESCH. NR. 100012345.001
+Bezeichnung WKN ISIN
+Sparplanname SP110Y PO6527623674
+Einheit Umsatz
+ST 6,43915
+Preis pro Anteil 15,530000 EUR  
+Nettoinventarwert EUR 100,00
+Wert 20.06.2016 EUR 100,00
+Consorsbank Ausgabegebühr 0,00%
+zulasten Konto-Nr. 111222333
+Bestand zugunsten Wertpapierrechnung Luxemburg
+Clearstream Bk Lux 62126
+Ausgabeaufschlag regulär 5,25%
+Sparplanname: Sparplan1         
+Hinweis für Kontoauszüge, Orderabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Seite 2 zu Orderabrechnung Nr. 100012345.001 vom 15.06.2016 Depotnummer 1234567890
+Infos zu Investmentpreisen
+Bereinigte akkum. ausschüttungsgleiche Erträge EUR 0,94
+Akkum. Substanzausschüttungen EUR 1,92
+ 
+Hinweis für Kontoauszüge, Orderabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankVerkauf1.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankVerkauf1.txt
@@ -1,0 +1,69 @@
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+0123456789/00
+Max Mustermann
+Musterstr. 1
+12345 Musterstadt Vermerk der Bank 1000
+02
+ORDERABRECHNUNG
+VERKAUF AM 18.02.2015  UM 12:10:30 FRANKFURT NR. 12345678.001
+Wertpapier WKN ISIN
+VOLKSWAGEN AG VZ ADR1/5 A0DPR2 US9286624021
+Einheit Umsatz
+ST 140,00000
+Kurs 43,200000 EUR P.ST.  
+Kurswert EUR 6.048,00
+Börsenplatzgebühr EUR 2,95
+Handelsentgelt EUR 3,63
+Provision EUR 15,12
+Grundgebühr EUR 4,95
+KAPST 24,45% EUR 198,08
+KIST 9,00% EUR 17,82
+SOLZ 5,50% EUR 10,89
+Wert 20.02.2015 EUR 5.794,56
+zugunsten Konto-Nr. 111222333
+Wertpapiere zulasten Wertpapierrechnung USA/Kanada
+Clearstream Bk Lux 62126
+JAHRESSTEUERBESCHEINIGUNG FOLGT
+Limitkurs  42,850000 EUR
+Hinweis für Kontoauszüge, Wertpapierabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Seite 2 zu Wertpapierabrechnung Nr. 86494940.001 vom 18.02.2015 Depotnummer 1234567980
+Infos bei Gewinn Aktien/ Wertpapiere ungleich Aktien
+Veräusserungsgewinn nach Differenzmethode EUR 810,13
+Summe ergibt
+KAPST-pflichtige Kapitalerträge EUR 810,13
+Mit Sparerpauschbetrag verrechnet EUR 0,00
+Bemessungsgrundlage für KAPST vor QUST EUR 810,13
+An Kapitalertrag anrechenbare. ausl. QUST 0,00*4 EUR 0,00
+Bemessungsgrundlage für KAPST EUR 810,13
+Bemessungsgrundlage für KAPST anteilig 100,00% EUR 810,13
+Salden nach dem Geschäft
+Verrechnungstopf Aktien nach dem Geschäft EUR 0,00
+Verrechnungstopf Allg. nach dem Geschäft EUR 0,00
+Verrechnungstopf QUST nach dem Geschäft EUR 0,00
+Sparerpauschbetrag nach dem Geschäft EUR 0,00
+Hinweis für Kontoauszüge, Wertpapierabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé


### PR DESCRIPTION
Added parsing of sell transactions
Improved parsing of buy transactions
Added parsing of fees
Added parsing of taxes

Ich habe vielleicht noch nicht alle Fälle abgedeckt und würde die Tage noch schauen, ob ich weitere Transaktionen bei mir entdecke, die ich mit dem Stand noch nicht abgedeckt bekomme.
Zudem sind noch nicht alle meine Dividendentransaktionen korrekt importierbar. Siehe dazu #633 