### PR TITLE
Polished parser for Cortalconsors

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankBezug1.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankBezug1.txt
@@ -1,0 +1,35 @@
+Cortal Consors • 90318 Nürnberg
+Depotnummer 0123456789
+1234567890/00
+Max Mustermann
+Musterstraße 1
+12345 Musterstadt Vermerk der Bank 1000
+02
+ORDERABRECHNUNG
+BEZUG AM 06.06.2016 AUSSERBOERSLICH CA NR. 12345678.001
+Bezeichnung WKN ISIN
+EYEMAXX R.EST.AG A0V9L9 DE000A0V9L94
+Einheit Umsatz
+ST 66,00000
+Kurs 6,000000 EUR P.ST. FRANCO COURTAGE  
+Kurswert EUR 396,00
+Provision EUR 3,96
+Wert 10.05.2016 EUR 399,96
+zulasten Konto-Nr. 123456789
+Bestand zugunsten Girosammelverwahrung 
+Clearstream Bk Ffm 2126
+DIE FUER DEN BEZUG ERFORDERLICHEN BEZUGSRECHTE HABEN WIR AUSGEBUCHT
+ABRECHNUNG BEZUG GEM. IHREM AUFTRAG
+Hinweis für Kontoauszüge, Orderabrechnungen und Depotbuchungsanzeigen:
+Kapitalerträge und Spekulationsgewinne sind einkommensteuerpflichtig.
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung oder die Nichtgenehmigung einer im Wege der Einzugsermächtigung erfolgten
+Lastschriftabbuchung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken) sowie
+unter B. VII. Ziffer 2.4 der Lastschriftbedingungen. Umsätze und Kontobuchungen, die nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des
+abgelaufenen Abrechnungszeitraumes auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankErtragsgutschrift8.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankErtragsgutschrift8.txt
@@ -1,0 +1,69 @@
+Cortal Consors • 90318 Nürnberg
+Depotnummer 0123456789
+1234567890/00
+Max Mustermann
+Musterstraße 1 Vermerk der Bank 1000
+12345 Musterstadt 02
+NUERNBERG, 22.04.2014
+DIVIDENDENGUTSCHRIFT                                                    
+ST                       80,00000          WKN:  891106                 
+           ROCHE HOLDING AG                                             
+           Inh.-Genuß.(Sp.ADRs) 1/8/SF100                               
+ZINS-/DIVIDENDENSATZ            1,108981  USD SCHLUSSTAG PER 05.03.2014 
+                                                     EX-TAG  06.03.2014 
+BRUTTO                                        USD                 88,72 
+QUST 35,00000  %   EUR                 22,43  USD                 31,05 
+FREMDE SPESEN                                 USD                  1,91 
+                                              USD                 55,76 
+UMGER.ZUM DEV.-KURS                 1,384600  EUR                 40,27 
+KAPST                                 25,00 % EUR                  6,41 
+SOLZ                                   5,50 % EUR                  0,35 
+WERT 22.04.2014                               EUR                 33,51 
+ZU GUNSTEN KONTO-NR. 1235 543 123 / IBAN DE6765876876567776539
+(BIC CSDBDE71XXX)
+FREMDE SPESEN ENTHALTEN 19,00 %  MWST EUR                 0,22          
+UMSATZSTEUER-IDNR. DE123456678                                          
+ANRECHENBARE AUSLAEND. QUELLENSTEUER          EUR                 9,61  
+KAPST-PFLICHTIGER KAPITALERTRAG               EUR                64,08  
+BEMESSUNGSGRUNDLAGE FUER KAPST VOR QUST       EUR                64,08  
+A.KAPITALERTRAG ANR.AUSL.QUST         9,61 *4 EUR                38,44  
+BEMESSUNGSGRUNDLAGE FUER KAPST                EUR                25,64  
+VERRECHNUNGSTOPF ALLGEMEIN NACH ERTRAG        EUR                 0,00  
+SPARERPAUSCHBETRAG NACH ERTRAG                EUR                 0,00  
+VERRECHNUNGSTOPF AUSL. QUST NACH ERTRAG       EUR                 0,00  
+VOLLER QUST-ABZUG, FUER GEBIETSANSAESSIGE RUECKERSTATTUNG AUF ANTRAG    
+ES WURDE KEINE KIRCHENSTEUER EINBEHALTEN                                
+JAHRESSTEUERBESCHEINIGUNG FOLGT                                         
+          KAPITALERTRAEGE SIND EINKOMMENSTEUERPFLICHTIG                 
+           DIESE MITTEILUNG WIRD NICHT UNTERSCHRIEBEN                   
+Cortal Consors S.A. Zweigniederlassung Deutschland
+Bahnhofstraße 55, 90402 Nürnberg, HR Nürnberg B20075, USt-IdNr. DE225900761, info@cortalconsors.de, www.cortalconsors.de
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00
+Sitz der Cortal Consors S.A.: 1, boulevard Haussmann, 75318 Paris CEDEX 09, Frankreich, Registergericht: R.C.S. Paris 327 787 909
+Président du Conseil d’Administration (Verwaltungsratsvorsitzender) und Directeur Général (Generaldirektor) der Cortal Consors S.A.: Olivier Le Grand
+Leitung der Zweigniederlassung Deutschland: Kai Friedrich (CEO), Richard Döppmann, Stefan Gröning, Dr. Gérard Derszteler
+Hinweis für Zins- und Dividendengutschriften:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl.
+Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken). Umsätze und Kontobuchungen, die
+nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des abgelaufenen Abrechnungszeitraumes
+auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an
+Cortal Consors Deutschland (Revision) oder per Fax oder Mail an die unten angegebenen Adressen. Das Unterlassen
+rechtzeitiger Einwendungen gilt als Genehmigung.
+Die mit „Steuerbescheinigung“ gekennzeichneten Abrechnungen sind sorgfältig aufzubewahren, da nur gegen Vorlage
+dieser Belege die Abrechnung im Rahmen der steuerlichen Veranlagung möglich ist. Bei Stornierung ist die Bank verpflichtet,
+die falsche Steuerbescheinigung zurückzufordern. Andernfalls ist sie verpflichtet, nach Ablauf eines Monats dem
+Wohnsitzfinanzamt des Depotinhabers Meldung zu machen. Gebietsansässige machen wir auf die ggf. bestehende
+Meldepflicht an die Landeszentralbank gemäß Außenwirtschaftsverordnung aufmerksam. Für weitere Auskünfte stehen wir
+Ihnen gerne zur Verfügung. Meldevordrucke sind bei uns erhältlich.
+Erträge unterliegen der Einkommen- bzw Körperschaftssteuer. Falls Doppelbesteuerungsabkommen bestehen, ist die
+einbehaltene ausländische Quellensteuer, soweit diese nicht erstattungspflichtig ist, auf die zu zahlende Einkommen- bzw.
+Körperschaftssteuer anrechenbar. Besteht mit dem Staat, aus dem die Erträge zufließen, kein
+Doppelbesteuerungsabkommen und werden ausländische Steuern auf diese Erträge einbehalten, so ist die Steuer gemäß
+§34 c EStG auf die deutsche Einkommen- bzw. Körperschaftssteuer anrechenbar.
+Cortal Consors S.A. Zweigniederlassung Deutschland
+Bahnhofstraße 55, 90402 Nürnberg, HR Nürnberg B20075, USt-IdNr. DE225900761, info@cortalconsors.de, www.cortalconsors.de
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00
+Sitz der Cortal Consors S.A.: 1, boulevard Haussmann, 75318 Paris CEDEX 09, Frankreich, Registergericht: R.C.S. Paris 327 787 909
+Président du Conseil d’Administration (Verwaltungsratsvorsitzender) und Directeur Général (Generaldirektor) der Cortal Consors S.A.: Olivier Le Grand
+Leitung der Zweigniederlassung Deutschland: Kai Friedrich (CEO), Richard Döppmann, Stefan Gröning, Dr. Gérard Derszteler

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankErtragsgutschrift9.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankErtragsgutschrift9.txt
@@ -1,0 +1,63 @@
+Cortal Consors • 90318 Nürnberg
+Depotnummer 0123456789
+1234567890/00
+Max Mustermann
+Musterstraße 1 Vermerk der Bank 1000
+12345 Musterstadt 02
+NUERNBERG, 20.05.2016
+ERTRAGSGUTSCHRIFT                                                       
+ST                       50,00000          WKN:  A1409D                 
+           Welltower Inc.                                               
+           Registered Shares DL 1                                       
+ERTRAGSAUSSCHUETTUNG P. ST.     0,860000  USD SCHLUSSTAG PER 05.05.2016 
+                                                     EX-TAG  06.05.2016 
+BRUTTO                                        USD                 43,00 
+QUST 15,00000  %   EUR                  5,74  USD                  6,45 
+                                              USD                 36,55 
+UMGER.ZUM DEV.-KURS                 1,124400  EUR                 32,51 
+WERT 20.05.2016                                                         
+ZU GUNSTEN KONTO-NR. 1235 543 123 / IBAN DE6765876876567776539
+(BIC CSDBDE71XXX)
+ANRECHENBARE AUSLAEND. QUELLENSTEUER          EUR                 5,74  
+KAPST-PFLICHTIGER KAPITALERTRAG               EUR                38,24  
+MIT VERRECHNUNGSTOPF ALLG. VERRECHNET         EUR                38,00- 
+BEMESSUNGSGRUNDLAGE FUER KAPST VOR QUST       EUR                 0,24  
+A.KAPITALERTRAG ANR.AUSL.QUST         0,06 *4 EUR                 0,24  
+BEMESSUNGSGRUNDLAGE FUER KAPST                EUR                 0,00  
+VERRECHNUNGSTOPF ALLGEMEIN NACH ERTRAG        EUR                 0,00  
+SPARERPAUSCHBETRAG NACH ERTRAG                EUR                 0,00  
+IN DEN VERRECHNUNGSTOPF QUST EINGESTELLT      EUR                 5,68  
+VERRECHNUNGSTOPF AUSL. QUST NACH ERTRAG       EUR                 5,68  
+AUSLAENDISCHER IMMOBILIENFONDS                                          
+JAHRESSTEUERBESCHEINIGUNG FOLGT                                         
+          KAPITALERTRAEGE SIND EINKOMMENSTEUERPFLICHTIG                 
+           DIESE MITTEILUNG WIRD NICHT UNTERSCHRIEBEN                   
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Hinweis für Zins- und Dividendengutschriften:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl.
+Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken). Umsätze und Kontobuchungen, die
+nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des abgelaufenen Abrechnungszeitraumes
+auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an
+die Consorsbank (Revision) oder per Fax oder Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger
+Einwendungen gilt als Genehmigung.
+Die mit „Steuerbescheinigung“ gekennzeichneten Abrechnungen sind sorgfältig aufzubewahren, da nur gegen Vorlage
+dieser Belege die Abrechnung im Rahmen der steuerlichen Veranlagung möglich ist. Bei Stornierung ist die Bank verpflichtet,
+die falsche Steuerbescheinigung zurückzufordern. Andernfalls ist sie verpflichtet, nach Ablauf eines Monats dem
+Wohnsitzfinanzamt des Depotinhabers Meldung zu machen. Gebietsansässige machen wir auf die ggf. bestehende
+Meldepflicht an die Landeszentralbank gemäß Außenwirtschaftsverordnung aufmerksam. Für weitere Auskünfte stehen wir
+Ihnen gerne zur Verfügung. Meldevordrucke sind bei uns erhältlich.
+Erträge unterliegen der Einkommen- bzw Körperschaftssteuer. Falls Doppelbesteuerungsabkommen bestehen, ist die
+einbehaltene ausländische Quellensteuer, soweit diese nicht erstattungspflichtig ist, auf die zu zahlende Einkommen- bzw.
+Körperschaftssteuer anrechenbar. Besteht mit dem Staat, aus dem die Erträge zufließen, kein
+Doppelbesteuerungsabkommen und werden ausländische Steuern auf diese Erträge einbehalten, so ist die Steuer gemäß
+§34 c EStG auf die deutsche Einkommen- bzw. Körperschaftssteuer anrechenbar.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé


### PR DESCRIPTION
Betrifft auch #633

Mit diesem Stand kann ich alle meine Dokumente wie gewünscht einlesen. Durch die Einarbeitung der Steuern in die Dividendenbuchung haben sich natürlich alle existierenden Tests auch geändert.

Added fees
Added taxes
Added sell transactions
Added preemptive buy transaction
Extended buy transactions
Extended dividends