### PR TITLE
Improvement of Comdirect parser

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirectWertpapierabrechnung_Kauf3.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirectWertpapierabrechnung_Kauf3.txt
@@ -1,0 +1,181 @@
+Ihren Auftrag haben wir gemäß unseren produktbezogenen
+Geschäftsbedingungen "Trading" wie nachstehend ausgeführt.
+Die Wertpapiere haben wir der Abrechnung entsprechend gebucht.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und
+Vollständigkeit zu überprüfen und etwaige Einwendungen
+25449 Quickborn unverzüglich zu erheben.
+                                       
+Telefon   :   04106-708 25 00           
+                                                                              
+                             
+                                       
+                             
+    12345 010
+Depotnr.:        0000000 00 
+            BLZ:             200 411 55
+Vorname Nachname                  
+                             
+                             
+Weg 7                                          
+12345 Stadt                                          
+                             
+                             
+                             
+                                                  
+                                                  
+GESCHÄFTSABRECHNUNG VOM 27.06.2016                                                   
+                                                                                                                                    
+*
+Wertpapierkauf                                                                                                                      
+Geschäftsnummer   : 92 018390                                                                                                       
+Ordernummer       : 123456789123-001  Rechnungsnummer   : 123456789987DE35                                                          
+Geschäftstag      : 27.06.2016        Abwicklung        : Live Trading                                                              
+Handelszeit       : 17:00 Uhr (MEZ/MESZ)                                                                                            
+                                                                                                                                    
+Wertpapier-Bezeichnung                                               WPKNR/ISIN                                                     
+NXP Semiconductors NV                                                    A1C5WJ                                                     
+Aandelen aan toonder EO -,20                                       NL0009538784                                                     
+                                                                                                                                    
+                                                                                                                                    
+Nennwert                  Zum Preis von                                                                                             
+St.  12                   EUR  67,73            franco Courtage                                                                     
+                          Kurswert                    : EUR              812,76                                                     
+                                                                                                                                    
+--------------------------------------------------------------------------------                                                    
+Eigene Entgelte                                                                                                                     
+                          Provision                   : EUR                9,90                                                     
+--------------------------------------------------------------------------------                                                    
+                                                                                                                                    
+                                                                                                                                    
+IBAN                                  Valuta         Zu Ihren Lasten vor Steuern                                                    
+DE12 3456 7891 2345 6789 01   EUR     29.06.2016        EUR              822,66                                                     
+                                                                                                                                    
+Verwahrungs-Art: GIROSAMMELDEPOT                                                                                                    
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    
+Informationen zur steuerlichen Behandlung dieses Geschäftsvorgangs und den auf                                                      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung.                                                      
+                                                                                                                                    
+                                                                                                                                    
+Bei Fragen geben Sie bitte die Ordernummer an.                                                                                      
+                                                                                                                                    
+comdirect bank AG                                                                                                                   
+                                                                                                                                    
+Diese Abrechnung wird von der Bank nicht unterschrieben                                                                             
+Die Leistung ist gemäß §4 Nr.8 UStG umsatzsteuerfrei. USt-Id-Nr.: DE 812 279 461                                                    
+A113
+DO15DD/16/04/2010
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+Vorname  Nachname                                      
+ 1234567  
+                                                  
+            
+200 411 55 Weg 7                                  12345 Stadt                                  
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+c  o  m   d  i r e  c  t   b  a  n  k    A  G               
+               
+ 2  5  4  5  1   Q  u  i c  k  b  o  r n                   
+ 0 1   0  9  7872
+                                                  
+T   e  le  f o  n  :             0   4  1  0  6   -  7  0 8 25 00
+                              
+Herrn                          D  a  t u  m   :                        2  7  . 0  6  .2016         
+ M a x   M u s t e r m a n n                                D   e  p  o  t  n  u  m   m  er:         1  2  3  4  5  6 7 89  
+M u s t e r s t r a s s e   6                     
+12345 Stadt              R   e  f e  r e  n  z  - N   u mmer:     1 2  A B  C  D  E  F    A1B000CD                               
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Wertpapierkauf  Nr. 92018390  vom 27.06.2016                                                              
+Stk.              12 NXP SEMICONDUCTORS EO-,20 , WKN / ISIN: A1C5WJ  / NL0009538784                                               
+Z u  Ih r e n L a s te n  v o r  S te u e r n:                                                                                                       E U R            -822,6 6   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  0 , 0 0                          
+                                                                                                                                
+                                                                                                                                
+K  ap i ta le r tr a gs t e ue r                                                                        E  U   R                                  0 , 0 0                          
+S  ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0                          
+K  irc h e n s te u e r                                                                              _E  U_   _R  _  _  _   _  _  _   _  _  _  _   _  _  _   _  _0 _, _0 _0                          
+a b g e f ü h rt e S t e u er n                                                                                                                    _E U_ _R _ _ _ _ _ _ _  __ _ _  _ _ __0,_0_ 0_   
+                                                                                                                                
+Z u  Ih r e n L a s te n  n a ch  S te u e r n :                                                                                                    E U R            -822,6 6   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Belastung erfolgt mit Valuta 29.06.2016 auf Konto EUR mit der IBAN DE12 3456 7891 2345 6789 01                                                    
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2016 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+                0,00                 0,00
+                0,00                 0,00
+nach Ermittlung
+                0,00 0,00                 0,00                 0,00                
+Verrechnungssalden in EUR (4)
+in 2016 Gewinne / Verluste sonstige anrechenbare verfügbareraus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+                0,00               000,00                 0,00               000,00
+nach Ermittlung
+                0,00               000,00
+                0,00               000,00
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+comdirect bank AG                                                                                                                                     
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG


### PR DESCRIPTION
Fee is added correctly, when there is no seperate sum in the invoice
(e.g. LiveTrading and saving plan)