### PR TITLE
Update YahooFinanceQuoteFeed.java - neue URL

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -37,7 +37,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
 {
     public static final String ID = "YAHOO"; //$NON-NLS-1$
 
-    private static final String LATEST_URL = "http://finance.yahoo.com/d/quotes.csv?s={0}&f=sl1d1hgpv"; //$NON-NLS-1$
+    private static final String LATEST_URL = "http://download.finance.yahoo.com/d/quotes.csv?s={0}&f=sl1d1hgpv"; //$NON-NLS-1$
     // s = symbol
     // l1 = last trade (price only)
     // d1 = last trade date


### PR DESCRIPTION
Yahoo hat nun einen redirect drin und teilt mit, dass die Quotes nun unter einer anderen Adresse zu beziehen sind.

Nachzuvollziehen mit curl "http://finance.yahoo.com/d/quotes.csv?s=AAPL&f=sl1d1hgpv"

<HTML>
<HEAD>
<TITLE>Document Has Moved</TITLE>
</HEAD>

<BODY BGCOLOR="white" FGCOLOR="black">
<H1>Document Has Moved</H1>
<HR>

<FONT FACE="Helvetica,Arial"><B>
Description: The document you requested has moved to a new location.  The new location is "http://download.finance.yahoo.com/d/quotes.csv?s=AAPL&f=sl1d1hgpv".
</B></FONT>
<HR>
</BODY>