### PR TITLE
Changed volatility calculation using log returns

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
@@ -56,20 +56,20 @@ public class RiskTest
     @Test
     public void testVolatility()
     {
-        double[] delta = new double[] { 0.5, -1 / 3d, -0.5, 1, 1, -0.5 };
+        double[] delta = new double[] { 0.005, -1 / 300d, -0.005, 0.01, 0.01, -0.005 };
         Volatility volatility = new Volatility(delta, index -> true);
         // calculated reference values with excel
-        assertThat(volatility.getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
-        assertThat(volatility.getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
+        assertThat(volatility.getStandardDeviation(), closeTo(0.017736692475, 0.1e-10));
+        assertThat(volatility.getSemiDeviation(), closeTo(0.012188677034, 0.1e-10));
     }
 
     @Test
     public void testVolatilityWithSkip()
     {
-        double[] delta = new double[] { 0, 0.5, -1 / 3d, -0.5, 1, 1, -0.5 };
+        double[] delta = new double[] { 0, 0.005, -1 / 300d, -0.005, 0.01, 0.01, -0.005 };
         Volatility volatility = new Volatility(delta, index -> index > 0);
-        assertThat(volatility.getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
-        assertThat(volatility.getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
+        assertThat(volatility.getStandardDeviation(), closeTo(0.017736692475, 0.1e-10));
+        assertThat(volatility.getSemiDeviation(), closeTo(0.012188677034, 0.1e-10));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
@@ -58,17 +58,9 @@ public class RiskTest
     {
         double[] delta = new double[] { 0.5, -1 / 3d, -0.5, 1, 1, -0.5 };
         Volatility volatility = new Volatility(delta, index -> true);
-        // returns are 0.5, -1/3, -0.5, 1, 1, -0.5 with an average of 7/36
-        // the deviation from the average is 11/36 for 0.5, 19/36 for -1/3 and
-        // so on each of these deviations is squared and the sum divided by the
-        // number of returns (6) the resulting division is
-        // root((121+1250+1682+361)/(1296*6)) or 3414/7776
-        assertThat(volatility.getStandardDeviation(), closeTo(Math.sqrt(3414d / 7776), 0.1e-10));
-
-        // for semi deviation, only the returns lower than the average are
-        // counted so only the -1/3 and the two times -0.5
-        // root((361+1250)/(1296*3)) or 1611/7776
-        assertThat(volatility.getSemiDeviation(), closeTo(Math.sqrt(1611d / 7776), 0.1e-10));
+        // calculated reference values with excel
+        assertThat(volatility.getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
+        assertThat(volatility.getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
     }
 
     @Test
@@ -76,8 +68,8 @@ public class RiskTest
     {
         double[] delta = new double[] { 0, 0.5, -1 / 3d, -0.5, 1, 1, -0.5 };
         Volatility volatility = new Volatility(delta, index -> index > 0);
-        assertThat(volatility.getStandardDeviation(), closeTo(Math.sqrt(3414d / 7776), 0.1e-10));
-        assertThat(volatility.getSemiDeviation(), closeTo(Math.sqrt(1611d / 7776), 0.1e-10));
+        assertThat(volatility.getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
+        assertThat(volatility.getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
@@ -37,12 +37,12 @@ public class PerformanceIndexTest
                         LocalDate.parse("2015-02-07") /* weekend */, LocalDate.parse("2015-02-08") /* weekend */,
                         LocalDate.parse("2015-02-09"), LocalDate.parse("2015-02-10") };
         long[] totals = new long[] { 1000, 1500, 1000, 500, 1000, 1000, 1000, 2000, 1000 };
-        double[] delta = new double[] { 0, 0.5, -1 / 3d, -0.5, 1, 0, 0, 1, -0.5 };
+        double[] delta = new double[] { 0, 0.005, -1 / 300d, -0.005, 0.01, 0, 0, 0.01, -0.005 };
 
         PerformanceIndex index = new PerformanceIndexStub(dates, totals, delta);
 
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
-        assertThat(index.getVolatility().getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.017736692475, 0.1e-10));
+        assertThat(index.getVolatility().getSemiDeviation(), closeTo(0.012188677034, 0.1e-10));
     }
 
     @Test
@@ -54,11 +54,11 @@ public class PerformanceIndexTest
                         LocalDate.parse("2015-02-09"), LocalDate.parse("2015-02-10"), LocalDate.parse("2015-02-11"),
                         LocalDate.parse("2015-02-12") };
         long[] totals = new long[] { 0, 0, 1000, 1500, 1000, 1000, 1000, 500, 1000, 2000, 1000 };
-        double[] delta = new double[] { 0, 0, 0, 0.5, -1 / 3d, 0, 0, -0.5, 1, 1, -0.5 };
+        double[] delta = new double[] { 0, 0, 0, 0.005, -1 / 300d, 0, 0, -0.005, 0.01, 0.01, -0.005 };
 
         PerformanceIndex index = new PerformanceIndexStub(dates, totals, delta);
 
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
-        assertThat(index.getVolatility().getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.017736692475, 0.1e-10));
+        assertThat(index.getVolatility().getSemiDeviation(), closeTo(0.012188677034, 0.1e-10));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
@@ -41,8 +41,8 @@ public class PerformanceIndexTest
 
         PerformanceIndex index = new PerformanceIndexStub(dates, totals, delta);
 
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(Math.sqrt(3414d / 7776), 0.1e-10));
-        assertThat(index.getVolatility().getSemiDeviation(), closeTo(Math.sqrt(1611d / 7776), 0.1e-10));
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
+        assertThat(index.getVolatility().getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class PerformanceIndexTest
 
         PerformanceIndex index = new PerformanceIndexStub(dates, totals, delta);
 
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(Math.sqrt(3414d / 7776), 0.1e-10));
-        assertThat(index.getVolatility().getSemiDeviation(), closeTo(Math.sqrt(1611d / 7776), 0.1e-10));
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(1.632310053678, 0.1e-10));
+        assertThat(index.getVolatility().getSemiDeviation(), closeTo(1.118882075970, 0.1e-10));
     }
 }

--- a/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
@@ -52,16 +52,13 @@ public class VolatilityTestCase
 
         Security basf = client.getSecurities().stream().filter(s -> "Basf SE".equals(s.getName())).findAny().get();
         PerformanceIndex index = PerformanceIndex.forInvestment(client, converter, basf, report, warnings);
+        PerformanceIndex clientIndex = PerformanceIndex.forClient(client, converter, report, warnings);
 
         assertThat(warnings, empty());
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.01371839502, 0.00001)); // excel
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.200573810778, 0.1e-10)); // excel
+        assertThat(clientIndex.getVolatility().getStandardDeviation(), closeTo(0.200599730118, 0.1e-10)); // excel
         assertThat(index.getDates()[index.getDates().length - 1], is(LocalDate.parse("2015-01-31")));
-
-        // compare with client -> must be lower because cash has volatility of 0
-        PerformanceIndex clientIndex = PerformanceIndex.forClient(client, converter, report, warnings);
-        assertThat(clientIndex.getVolatility().getStandardDeviation(), lessThan(index.getVolatility()
-                        .getStandardDeviation()));
-    }
+    }  
 
     @Test
     public void testVolatilityIfSecurityIsSoldAndLaterBoughtDuringReportingPeriod() throws IOException
@@ -73,7 +70,7 @@ public class VolatilityTestCase
         PerformanceIndex index = PerformanceIndex.forInvestment(client, converter, basf, report, warnings);
 
         assertThat(warnings, empty());
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.0134468200485513, 0.00001)); // excel
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.202942041440, 0.1e-10)); // excel
         assertThat(index.getDates()[index.getDates().length - 1], is(LocalDate.parse("2015-02-20")));
     }
 
@@ -91,7 +88,7 @@ public class VolatilityTestCase
         assertThat(warnings, empty());
         // quotes only until December 31st
         assertThat(sapIndex.getDates()[sapIndex.getDates().length - 1], is(LocalDate.parse("2014-12-31")));
-        assertThat(sapIndex.getVolatility().getStandardDeviation(), closeTo(0.0126152529671108, 0.00001)); // excel
+        assertThat(sapIndex.getVolatility().getStandardDeviation(), closeTo(0.193062749491, 0.1e-10)); // excel
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
@@ -41,7 +41,7 @@ public class VolatilityTestCase
         PerformanceIndex index = PerformanceIndex.forClient(client, converter, report, warnings);
 
         assertThat(warnings, empty());
-        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.01251323582, 0.000001)); // excel
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.141568791460, 0.1e-10)); // excel
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -111,6 +111,7 @@ public final class Risk
 
             double tempStandard = 0;
             double tempSemi = 0;
+            int count = 0;
 
             double averageLogReturn = logAverage(returns, filter);
             
@@ -119,20 +120,18 @@ public final class Risk
                 if (!filter.test(ii))
                     continue;
 
-                double logReturn = Math.log(1 + 0.01 * returns[ii]);
+                double logReturn = Math.log(1 + returns[ii]);
                 double add = Math.pow(logReturn - averageLogReturn, 2);
 
                 tempStandard = tempStandard + add;
+                count++;
 
                 if (logReturn < averageLogReturn)
                     tempSemi = tempSemi + add;
             }
             
-            double logStdDeviation = Math.sqrt(tempStandard);
-            double logSemiDeviation = Math.sqrt(tempSemi);
-            
-            stdDeviation = (Math.exp(logStdDeviation) - 1) * 100;
-            semiDeviation = (Math.exp(logSemiDeviation) - 1) * 100;            
+            stdDeviation = Math.sqrt(tempStandard / (count - 1) * count);
+            semiDeviation = Math.sqrt(tempSemi / (count - 1) * count);            
         }
 
         private double logAverage(double[] returns, Predicate<Integer> filter)
@@ -145,9 +144,7 @@ public final class Risk
                 if (!filter.test(ii))
                     continue;
 
-                double logReturn = Math.log(1 + 0.01 * returns[ii]);
-                
-                sum += logReturn;
+                sum += Math.log(1 + returns[ii]);
                 count++;
             }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -109,30 +109,33 @@ public final class Risk
         {
             Objects.requireNonNull(returns);
 
-            double averageReturn = average(returns, filter);
             double tempStandard = 0;
             double tempSemi = 0;
-            int count = 0;
 
+            double averageLogReturn = logAverage(returns, filter);
+            
             for (int ii = 0; ii < returns.length; ii++)
             {
                 if (!filter.test(ii))
                     continue;
 
-                double add = Math.pow(returns[ii] - averageReturn, 2);
+                double logReturn = Math.log(1 + 0.01 * returns[ii]);
+                double add = Math.pow(logReturn - averageLogReturn, 2);
 
                 tempStandard = tempStandard + add;
-                count++;
 
-                if (returns[ii] < averageReturn)
+                if (logReturn < averageLogReturn)
                     tempSemi = tempSemi + add;
             }
-
-            stdDeviation = Math.sqrt(tempStandard / count);
-            semiDeviation = Math.sqrt(tempSemi / count);
+            
+            double logStdDeviation = Math.sqrt(tempStandard);
+            double logSemiDeviation = Math.sqrt(tempSemi);
+            
+            stdDeviation = (Math.exp(logStdDeviation) - 1) * 100;
+            semiDeviation = (Math.exp(logSemiDeviation) - 1) * 100;            
         }
 
-        private double average(double[] returns, Predicate<Integer> filter)
+        private double logAverage(double[] returns, Predicate<Integer> filter)
         {
             double sum = 0;
             int count = 0;
@@ -142,7 +145,9 @@ public final class Risk
                 if (!filter.test(ii))
                     continue;
 
-                sum += returns[ii];
+                double logReturn = Math.log(1 + 0.01 * returns[ii]);
+                
+                sum += logReturn;
                 count++;
             }
 


### PR DESCRIPTION
Ich habe die Volatilitätsberechnung entsprechend meines Kommentars in Issue #631 angepasst. Die Berechnung basiert nun auf logarithmierten Renditen. Dies führt zu genaueren Ergebnissen und passt besser ins Konzept, da bei dieser Berechnungsmethode die TTWROR der erwarteten Rendite (Erwartungswert) entspricht.

Die mit den hier vorgeschlagenen Änderungen berechneten Volatilitäten habe ich für den ARERO ETF und die TESLA Aktie mit den auf comdirect angegebenen Volatilitäten für verschiedene Zeiträume verglichen und die Werte stimmen sehr gut überein.

Neben der Berechnung in "Risk.java" wurden auch die dazugehörigen Tests in "RiskTest.java" und "PerformanceIndexTest.java" angepasst. Die Tests in "VolatilityTestCase.java" müssen noch auf die neue Berechnung adaptiert werden. Dies konnte ich leider nicht selbst durchführen, da ich das dort referenzierte Excelsheet nicht habe. Das kann ich aber gerne nachholen, wenn mir jemand die Datei zur Verfügung stellen kann.