### PR TITLE
Prevent NullPointerException while checking duplicates if account null

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesAction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesAction.java
@@ -27,7 +27,11 @@ public class DetectDuplicatesAction implements ImportAction
     @Override
     public Status process(AccountTransaction transaction, Account account)
     {
-        return check(transaction, account.getTransactions());
+        if (account != null) 
+        {
+            return check(transaction, account.getTransactions()); 
+        }
+        return Status.OK_STATUS;
     }
 
     @Override


### PR DESCRIPTION
This allows to import a bunch of PDF files without breaking down the import on an invalid file. If there are no accounts, there are no duplicates so the check is not harmed with this workaround.

Prevents
````
Internal Error

org.eclipse.swt.SWTException: Failed to execute runnable (java.lang.NullPointerException)
	at org.eclipse.swt.SWT.error(SWT.java:4533)
	at org.eclipse.swt.SWT.error(SWT.java:4448)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:185)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4211)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3827)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1121)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1022)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:150)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Application.start(E4Application.java:161)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:673)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:610)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1519)
Caused by: java.lang.NullPointerException
	at name.abuchen.portfolio.datatransfer.actions.DetectDuplicatesAction.process(DetectDuplicatesAction.java:30)
	at name.abuchen.portfolio.datatransfer.Extractor$TransactionItem.apply(Extractor.java:117)
	at name.abuchen.portfolio.ui.wizards.datatransfer.ReviewExtractedItemsPage.checkEntries(ReviewExtractedItemsPage.java:568)
	at name.abuchen.portfolio.ui.wizards.datatransfer.ReviewExtractedItemsPage.setResults(ReviewExtractedItemsPage.java:530)
	at name.abuchen.portfolio.ui.wizards.datatransfer.ReviewExtractedItemsPage.access$3(ReviewExtractedItemsPage.java:528)
	at name.abuchen.portfolio.ui.wizards.datatransfer.ReviewExtractedItemsPage$10.lambda$1(ReviewExtractedItemsPage.java:509)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	... 19 more
````