### PR TITLE
Minor change regarding context menus to be more consistent

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -65,7 +65,18 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
     @Override
     public String getHeading()
     {
-        return type.toString();
+        switch (type)
+        {
+            case BUY:
+                return Messages.SecurityMenuBuy;
+            case SELL:
+                return Messages.SecurityMenuSell;
+            case TRANSFER_IN:
+            case TRANSFER_OUT:
+                return type.toString();
+            default:
+                throw new UnsupportedOperationException();
+        }
     }
 
     public abstract boolean accepts(Type type);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1213,7 +1213,7 @@ SecurityMenuAddNewSecurityDescription = Search Yahoo Finance by ticker symbol, I
 
 SecurityMenuAddPrice = Add
 
-SecurityMenuBuy = Buy...
+SecurityMenuBuy = Buy
 
 SecurityMenuConfigureOnlineUpdate = Configure online update...
 
@@ -1225,7 +1225,7 @@ SecurityMenuDeletePrice = Delete
 
 SecurityMenuDeleteSecurity = Delete Security
 
-SecurityMenuDividends = Dividends...
+SecurityMenuDividends = Dividend
 
 SecurityMenuEditSecurity = Edit...
 
@@ -1243,7 +1243,7 @@ SecurityMenuRemoveFromWatchlist = Remove from ''{0}''
 
 SecurityMenuSearchYahoo = Search Yahoo Finance...
 
-SecurityMenuSell = Sell...
+SecurityMenuSell = Sell
 
 SecurityMenuStockSplit = Stock split...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1213,7 +1213,7 @@ SecurityMenuAddNewSecurityDescription = Auf Yahoo Finance anhand Ticker Symbol, 
 
 SecurityMenuAddPrice = Neu
 
-SecurityMenuBuy = Kaufen...
+SecurityMenuBuy = Kaufen
 
 SecurityMenuConfigureOnlineUpdate = Online-Aktualisierung konfigurieren...
 
@@ -1225,7 +1225,7 @@ SecurityMenuDeletePrice = L\u00F6schen
 
 SecurityMenuDeleteSecurity = Wertpapier l\u00F6schen
 
-SecurityMenuDividends = Dividenden...
+SecurityMenuDividends = Dividende
 
 SecurityMenuEditSecurity = Editieren...
 
@@ -1243,7 +1243,7 @@ SecurityMenuRemoveFromWatchlist = Aus ''{0}'' entfernen
 
 SecurityMenuSearchYahoo = Auf Yahoo Finance suchen...
 
-SecurityMenuSell = Verkaufen...
+SecurityMenuSell = Verkaufen
 
 SecurityMenuStockSplit = Aktiensplit...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -49,13 +49,6 @@ public class AccountContextMenu
 
         manager.add(new Separator());
 
-        new OpenDialogAction(owner, Messages.AccountMenuTransfer) //
-                        .type(AccountTransferDialog.class) //
-                        .with(account) //
-                        .addTo(manager);
-
-        manager.add(new Separator());
-
         // show security related actions only if
         // (a) a portfolio exists and (b) securities exist
 
@@ -73,21 +66,21 @@ public class AccountContextMenu
                 }
             }
 
-            new OpenDialogAction(owner, Messages.SecurityMenuBuy) //
+            new OpenDialogAction(owner, Messages.SecurityMenuBuy + "...") //
                             .type(SecurityTransactionDialog.class) //
                             .parameters(PortfolioTransaction.Type.BUY) //
                             .with(portfolio[0]) //
                             .with(security) //
                             .addTo(manager);
 
-            new OpenDialogAction(owner, Messages.SecurityMenuSell) //
+            new OpenDialogAction(owner, Messages.SecurityMenuSell + "...") //
                             .type(SecurityTransactionDialog.class) //
                             .parameters(PortfolioTransaction.Type.SELL) //
                             .with(portfolio[0]) //
                             .with(security) //
                             .addTo(manager);
 
-            new OpenDialogAction(owner, Messages.SecurityMenuDividends) //
+            new OpenDialogAction(owner, Messages.SecurityMenuDividends + "...") //
                             .type(AccountTransactionDialog.class) //
                             .parameters(AccountTransaction.Type.DIVIDENDS) //
                             .with(account) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -53,6 +53,7 @@ import name.abuchen.portfolio.ui.UpdateQuotesJob;
 import name.abuchen.portfolio.ui.dialogs.transactions.AccountTransactionDialog;
 import name.abuchen.portfolio.ui.dialogs.transactions.OpenDialogAction;
 import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransactionDialog;
+import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransferDialog;
 import name.abuchen.portfolio.ui.dnd.SecurityDragListener;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.util.BookmarkMenu;
@@ -607,37 +608,23 @@ public final class SecuritiesTable implements ModificationListener
 
     private void fillTransactionContextMenu(IMenuManager manager, Security security)
     {
-        new OpenDialogAction(view, Messages.SecurityMenuBuy) //
+        new OpenDialogAction(view, Messages.SecurityMenuBuy + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.BUY) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
 
-        new OpenDialogAction(view, Messages.SecurityMenuSell) //
+        new OpenDialogAction(view, Messages.SecurityMenuSell + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.SELL) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
 
-        new OpenDialogAction(view, Messages.SecurityMenuDividends) //
+        new OpenDialogAction(view, Messages.SecurityMenuDividends + "...") //
                         .type(AccountTransactionDialog.class) //
                         .parameters(AccountTransaction.Type.DIVIDENDS) //
-                        .with(security) //
-                        .onSuccess(d -> performFinish(security)) //
-                        .addTo(manager);
-
-        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_INBOUND.toString() + "...") //$NON-NLS-1$
-                        .type(SecurityTransactionDialog.class) //
-                        .parameters(PortfolioTransaction.Type.DELIVERY_INBOUND) //
-                        .with(security) //
-                        .onSuccess(d -> performFinish(security)) //
-                        .addTo(manager);
-
-        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_OUTBOUND.toString() + "...") //$NON-NLS-1$
-                        .type(SecurityTransactionDialog.class) //
-                        .parameters(PortfolioTransaction.Type.DELIVERY_OUTBOUND) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
@@ -658,6 +645,31 @@ public final class SecuritiesTable implements ModificationListener
                 return new WizardDialog(getShell(), wizard);
             }
         });
+
+        if (view.getClient().getActivePortfolios().size() > 1)
+        {
+            manager.add(new Separator());
+            new OpenDialogAction(view, Messages.SecurityMenuTransfer) //
+                            .type(SecurityTransferDialog.class) //
+                            .with(security) //
+                            .addTo(manager);
+        }
+
+        manager.add(new Separator());
+
+        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_INBOUND.toString() + "...") //$NON-NLS-1$
+            .type(SecurityTransactionDialog.class) //
+            .parameters(PortfolioTransaction.Type.DELIVERY_INBOUND) //
+            .with(security) //
+            .onSuccess(d -> performFinish(security)) //
+            .addTo(manager);
+
+        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_OUTBOUND.toString() + "...") //$NON-NLS-1$
+            .type(SecurityTransactionDialog.class) //
+            .parameters(PortfolioTransaction.Type.DELIVERY_OUTBOUND) //
+            .with(security) //
+            .onSuccess(d -> performFinish(security)) //
+            .addTo(manager);
 
         manager.add(new Separator());
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
@@ -46,21 +46,21 @@ public class SecurityContextMenu
             return;
         }
 
-        new OpenDialogAction(owner, Messages.SecurityMenuBuy) //
+        new OpenDialogAction(owner, Messages.SecurityMenuBuy + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.BUY) //
                         .with(portfolio) //
                         .with(security) //
                         .addTo(manager);
 
-        new OpenDialogAction(owner, Messages.SecurityMenuSell) //
+        new OpenDialogAction(owner, Messages.SecurityMenuSell + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.SELL) //
                         .with(portfolio) //
                         .with(security) //
                         .addTo(manager);
 
-        new OpenDialogAction(owner, Messages.SecurityMenuDividends) //
+        new OpenDialogAction(owner, Messages.SecurityMenuDividends + "...") //
                         .type(AccountTransactionDialog.class) //
                         .parameters(AccountTransaction.Type.DIVIDENDS) //
                         .with(portfolio != null ? portfolio.getReferenceAccount() : null) //


### PR DESCRIPTION
Add Transfer to SecuritiesTable for consistency and convenience
"Referencing #658: Get SecurityTransaction Heading based on message text
rather than type of SecurityTransactionDialog.class