### PR TITLE
Various UI changes to reduce inconsistency

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -65,7 +65,18 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
     @Override
     public String getHeading()
     {
-        return type.toString();
+        switch (type)
+        {
+            case BUY:
+                return Messages.SecurityMenuBuy;
+            case SELL:
+                return Messages.SecurityMenuSell;
+            case TRANSFER_IN:
+            case TRANSFER_OUT:
+                return type.toString();
+            default:
+                throw new UnsupportedOperationException();
+        }
     }
 
     public abstract boolean accepts(Type type);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -65,18 +65,7 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
     @Override
     public String getHeading()
     {
-        switch (type)
-        {
-            case BUY:
-                return Messages.SecurityMenuBuy;
-            case SELL:
-                return Messages.SecurityMenuSell;
-            case TRANSFER_IN:
-            case TRANSFER_OUT:
-                return type.toString();
-            default:
-                throw new UnsupportedOperationException();
-        }
+        return type.toString();
     }
 
     public abstract boolean accepts(Type type);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1213,7 +1213,7 @@ SecurityMenuAddNewSecurityDescription = Search Yahoo Finance by ticker symbol, I
 
 SecurityMenuAddPrice = Add
 
-SecurityMenuBuy = Buy...
+SecurityMenuBuy = Buy
 
 SecurityMenuConfigureOnlineUpdate = Configure online update...
 
@@ -1225,7 +1225,7 @@ SecurityMenuDeletePrice = Delete
 
 SecurityMenuDeleteSecurity = Delete Security
 
-SecurityMenuDividends = Dividends...
+SecurityMenuDividends = Dividend
 
 SecurityMenuEditSecurity = Edit...
 
@@ -1243,7 +1243,7 @@ SecurityMenuRemoveFromWatchlist = Remove from ''{0}''
 
 SecurityMenuSearchYahoo = Search Yahoo Finance...
 
-SecurityMenuSell = Sell...
+SecurityMenuSell = Sell
 
 SecurityMenuStockSplit = Stock split...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1213,7 +1213,7 @@ SecurityMenuAddNewSecurityDescription = Auf Yahoo Finance anhand Ticker Symbol, 
 
 SecurityMenuAddPrice = Neu
 
-SecurityMenuBuy = Kaufen
+SecurityMenuBuy = Kauf
 
 SecurityMenuConfigureOnlineUpdate = Online-Aktualisierung konfigurieren...
 
@@ -1243,7 +1243,7 @@ SecurityMenuRemoveFromWatchlist = Aus ''{0}'' entfernen
 
 SecurityMenuSearchYahoo = Auf Yahoo Finance suchen...
 
-SecurityMenuSell = Verkaufen
+SecurityMenuSell = Verkauf
 
 SecurityMenuStockSplit = Aktiensplit...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1213,7 +1213,7 @@ SecurityMenuAddNewSecurityDescription = Auf Yahoo Finance anhand Ticker Symbol, 
 
 SecurityMenuAddPrice = Neu
 
-SecurityMenuBuy = Kaufen...
+SecurityMenuBuy = Kaufen
 
 SecurityMenuConfigureOnlineUpdate = Online-Aktualisierung konfigurieren...
 
@@ -1225,7 +1225,7 @@ SecurityMenuDeletePrice = L\u00F6schen
 
 SecurityMenuDeleteSecurity = Wertpapier l\u00F6schen
 
-SecurityMenuDividends = Dividenden...
+SecurityMenuDividends = Dividende
 
 SecurityMenuEditSecurity = Editieren...
 
@@ -1243,7 +1243,7 @@ SecurityMenuRemoveFromWatchlist = Aus ''{0}'' entfernen
 
 SecurityMenuSearchYahoo = Auf Yahoo Finance suchen...
 
-SecurityMenuSell = Verkaufen...
+SecurityMenuSell = Verkaufen
 
 SecurityMenuStockSplit = Aktiensplit...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -49,6 +49,13 @@ public class AccountContextMenu
 
         manager.add(new Separator());
 
+        new OpenDialogAction(owner, Messages.AccountMenuTransfer) //
+                                .type(AccountTransferDialog.class) //
+                                .with(account) //
+                                .addTo(manager);
+
+        manager.add(new Separator());
+
         // show security related actions only if
         // (a) a portfolio exists and (b) securities exist
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -50,9 +50,9 @@ public class AccountContextMenu
         manager.add(new Separator());
 
         new OpenDialogAction(owner, Messages.AccountMenuTransfer) //
-                                .type(AccountTransferDialog.class) //
-                                .with(account) //
-                                .addTo(manager);
+                            .type(AccountTransferDialog.class) //
+                            .with(account) //
+                            .addTo(manager);
 
         manager.add(new Separator());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -49,13 +49,6 @@ public class AccountContextMenu
 
         manager.add(new Separator());
 
-        new OpenDialogAction(owner, Messages.AccountMenuTransfer) //
-                        .type(AccountTransferDialog.class) //
-                        .with(account) //
-                        .addTo(manager);
-
-        manager.add(new Separator());
-
         // show security related actions only if
         // (a) a portfolio exists and (b) securities exist
 
@@ -73,21 +66,21 @@ public class AccountContextMenu
                 }
             }
 
-            new OpenDialogAction(owner, Messages.SecurityMenuBuy) //
+            new OpenDialogAction(owner, Messages.SecurityMenuBuy + "...") //
                             .type(SecurityTransactionDialog.class) //
                             .parameters(PortfolioTransaction.Type.BUY) //
                             .with(portfolio[0]) //
                             .with(security) //
                             .addTo(manager);
 
-            new OpenDialogAction(owner, Messages.SecurityMenuSell) //
+            new OpenDialogAction(owner, Messages.SecurityMenuSell + "...") //
                             .type(SecurityTransactionDialog.class) //
                             .parameters(PortfolioTransaction.Type.SELL) //
                             .with(portfolio[0]) //
                             .with(security) //
                             .addTo(manager);
 
-            new OpenDialogAction(owner, Messages.SecurityMenuDividends) //
+            new OpenDialogAction(owner, Messages.SecurityMenuDividends + "...") //
                             .type(AccountTransactionDialog.class) //
                             .parameters(AccountTransaction.Type.DIVIDENDS) //
                             .with(account) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountContextMenu.java
@@ -50,9 +50,9 @@ public class AccountContextMenu
         manager.add(new Separator());
 
         new OpenDialogAction(owner, Messages.AccountMenuTransfer) //
-                            .type(AccountTransferDialog.class) //
-                            .with(account) //
-                            .addTo(manager);
+                        .type(AccountTransferDialog.class) //
+                        .with(account) //
+                        .addTo(manager);
 
         manager.add(new Separator());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -568,7 +568,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "lastDividendPayment")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
-        // Periodizit��t der Dividendenzahlungen
+        // Periodizität der Dividendenzahlungen
         column = new Column("dperiod", Messages.ColumnDividendPeriodicity, SWT.None, 100); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendPeriodicity_Description);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -568,7 +568,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "lastDividendPayment")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
-        // Periodizität der Dividendenzahlungen
+        // Periodizit��t der Dividendenzahlungen
         column = new Column("dperiod", Messages.ColumnDividendPeriodicity, SWT.None, 100); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendPeriodicity_Description);
@@ -728,7 +728,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
                 else if (t instanceof AccountTransaction)
                     return ((AccountTransaction) t).getType().toString();
                 else if (t instanceof DividendTransaction)
-                    return Messages.LabelDividends;
+                    return Messages.SecurityMenuDividends;
                 else
                     return Messages.LabelQuote;
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -725,10 +725,10 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             {
                 if (t instanceof PortfolioTransaction)
                     return ((PortfolioTransaction) t).getType().toString();
+                else if (t instanceof DividendTransaction)
+                    return ((DividendTransaction) t).getType().toString();
                 else if (t instanceof AccountTransaction)
                     return ((AccountTransaction) t).getType().toString();
-                else if (t instanceof DividendTransaction)
-                    return Messages.SecurityMenuDividends;
                 else
                     return Messages.LabelQuote;
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -53,6 +53,7 @@ import name.abuchen.portfolio.ui.UpdateQuotesJob;
 import name.abuchen.portfolio.ui.dialogs.transactions.AccountTransactionDialog;
 import name.abuchen.portfolio.ui.dialogs.transactions.OpenDialogAction;
 import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransactionDialog;
+import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransferDialog;
 import name.abuchen.portfolio.ui.dnd.SecurityDragListener;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.util.BookmarkMenu;
@@ -607,37 +608,23 @@ public final class SecuritiesTable implements ModificationListener
 
     private void fillTransactionContextMenu(IMenuManager manager, Security security)
     {
-        new OpenDialogAction(view, Messages.SecurityMenuBuy) //
+        new OpenDialogAction(view, Messages.SecurityMenuBuy + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.BUY) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
 
-        new OpenDialogAction(view, Messages.SecurityMenuSell) //
+        new OpenDialogAction(view, Messages.SecurityMenuSell + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.SELL) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
 
-        new OpenDialogAction(view, Messages.SecurityMenuDividends) //
+        new OpenDialogAction(view, Messages.SecurityMenuDividends + "...") //
                         .type(AccountTransactionDialog.class) //
                         .parameters(AccountTransaction.Type.DIVIDENDS) //
-                        .with(security) //
-                        .onSuccess(d -> performFinish(security)) //
-                        .addTo(manager);
-
-        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_INBOUND.toString() + "...") //$NON-NLS-1$
-                        .type(SecurityTransactionDialog.class) //
-                        .parameters(PortfolioTransaction.Type.DELIVERY_INBOUND) //
-                        .with(security) //
-                        .onSuccess(d -> performFinish(security)) //
-                        .addTo(manager);
-
-        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_OUTBOUND.toString() + "...") //$NON-NLS-1$
-                        .type(SecurityTransactionDialog.class) //
-                        .parameters(PortfolioTransaction.Type.DELIVERY_OUTBOUND) //
                         .with(security) //
                         .onSuccess(d -> performFinish(security)) //
                         .addTo(manager);
@@ -658,6 +645,31 @@ public final class SecuritiesTable implements ModificationListener
                 return new WizardDialog(getShell(), wizard);
             }
         });
+
+        if (view.getClient().getActivePortfolios().size() > 1)
+        {
+            manager.add(new Separator());
+            new OpenDialogAction(view, Messages.SecurityMenuTransfer) //
+                            .type(SecurityTransferDialog.class) //
+                            .with(security) //
+                            .addTo(manager);
+        }
+
+        manager.add(new Separator());
+
+        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_INBOUND.toString() + "...") //$NON-NLS-1$
+            .type(SecurityTransactionDialog.class) //
+            .parameters(PortfolioTransaction.Type.DELIVERY_INBOUND) //
+            .with(security) //
+            .onSuccess(d -> performFinish(security)) //
+            .addTo(manager);
+
+        new OpenDialogAction(view, PortfolioTransaction.Type.DELIVERY_OUTBOUND.toString() + "...") //$NON-NLS-1$
+            .type(SecurityTransactionDialog.class) //
+            .parameters(PortfolioTransaction.Type.DELIVERY_OUTBOUND) //
+            .with(security) //
+            .onSuccess(d -> performFinish(security)) //
+            .addTo(manager);
 
         manager.add(new Separator());
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
@@ -46,21 +46,21 @@ public class SecurityContextMenu
             return;
         }
 
-        new OpenDialogAction(owner, Messages.SecurityMenuBuy) //
+        new OpenDialogAction(owner, Messages.SecurityMenuBuy + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.BUY) //
                         .with(portfolio) //
                         .with(security) //
                         .addTo(manager);
 
-        new OpenDialogAction(owner, Messages.SecurityMenuSell) //
+        new OpenDialogAction(owner, Messages.SecurityMenuSell + "...") //
                         .type(SecurityTransactionDialog.class) //
                         .parameters(PortfolioTransaction.Type.SELL) //
                         .with(portfolio) //
                         .with(security) //
                         .addTo(manager);
 
-        new OpenDialogAction(owner, Messages.SecurityMenuDividends) //
+        new OpenDialogAction(owner, Messages.SecurityMenuDividends + "...") //
                         .type(AccountTransactionDialog.class) //
                         .parameters(AccountTransaction.Type.DIVIDENDS) //
                         .with(portfolio != null ? portfolio.getReferenceAccount() : null) //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
@@ -1,7 +1,7 @@
 
 account.BUY             = Buy
 account.DEPOSIT         = Deposit
-account.DIVIDENDS       = Dividends
+account.DIVIDENDS       = Dividend
 account.FEES            = Fees
 account.INTEREST        = Interest
 account.INTEREST_CHARGE = Interest Charge

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendTransaction.java
@@ -1,12 +1,12 @@
 package name.abuchen.portfolio.snapshot.security;
 
 import name.abuchen.portfolio.model.Account;
-import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.model.AccountTransaction;
 
-public class DividendTransaction extends Transaction
+public class DividendTransaction extends AccountTransaction
 {
     private Account account;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshot.java
@@ -88,6 +88,7 @@ public class SecurityPerformanceSnapshot
                             || t.getType() == AccountTransaction.Type.INTEREST)
             {
                 DividendTransaction dt = new DividendTransaction();
+                dt.setType(t.getType());
                 dt.setDate(t.getDate());
                 dt.setSecurity(t.getSecurity());
                 dt.setAccount(account);


### PR DESCRIPTION
Second (First one: #687) attempt to address the concerns highlighted in #658.
Based on comments the items are now nouns and minor alignment of English and German wording.
**Modification to be mentioned is, that DividendTransaction now extents AccountTransaction to enable the common types to be reused and used as basis in the SecurityPerformanceSnapshot view.**