### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ set MAVEN_OPTS="-Xmx1g"
 
 ### Build
 
-Run Maven 3.0.x in the 'portfolio-app' directory:
+Run Maven 3.x.x in the 'portfolio-app' directory:
 
 ```
 mvn clean install
@@ -38,7 +38,7 @@ mvn clean install
 
 ### Setup
 
-To develop, use [Eclipse Luna](http://eclipse.org/downloads/) plus the Plug-in Development Tools (PDT).
+To develop, use [Eclipse Neon](http://eclipse.org/downloads/) plus the Plug-in Development Environment (PDE).
 
 Clone the git repository.
 


### PR DESCRIPTION
changed maven requirement to 3.x.x as it also runs with 3.2.x

updated to latest Eclipse release (tested, works)

PDT is commonly used as an abbreviation for Eclipse PHP Development Tools, PDE is the Plug-in Development Environment required for this project. Changed to avoid confusion.