### PR TITLE
Consorsbank Datum Fix

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
@@ -59,12 +59,14 @@ public class ConsorsbankPDFExctractor extends AbstractPDFExtractor
                         .match("^ST (?<shares>[\\d.]+(,\\d+)?).*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date", "amount", "currency")
-                        .match("Wert (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)") //
+                        .section("date") //
+                        .match("KAUF AM (?<date>\\d+\\.\\d+\\.\\d{4}+).*") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                        .section("amount", "currency").match("Kurswert (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setDate(asDate(v.get("date")));
                         })
 
                         .wrap(BuySellEntryItem::new);


### PR DESCRIPTION
Das Kaufdatum bei Belegen der Consorsbank wird falsch eingelesen