### PR TITLE
Fix für #720 & #521

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -279,7 +279,7 @@ import name.abuchen.portfolio.ui.views.columns.NoteColumn;
     }
 
     @Inject
-    public void setUseIndirectQuotation(
+    private void setUseIndirectQuotation(
                     @Preference(value = UIConstants.Preferences.USE_INDIRECT_QUOTATION) boolean useIndirectQuotation)
     {
         this.useIndirectQuotation = useIndirectQuotation;


### PR DESCRIPTION
Vermutlich der Fix für #720 & #521. 
Da mir der Fehler auch regelmäßig untergekommen ist, habe ich mir das mal genauer angeschaut. 

Intern werden für das Injecten von Werten die Klassen analysiert. Dabei wird auch die Klassenhierarchie nach oben gegangen und geschaut, ob die Subklassen Methoden überschreiben. Hier taucht dann das Problem auf. Für die Klasse ReBalancingViewer stellt er fest, dass setUseIndirectQuotation in ReBalancingViewer überschrieben wird. Das macht später beim Injecten Probleme, weil die Methode ja eigentlich nicht überschrieben ist. Die Ursache liegt wohl an http://bugs.java.com/view_bug.do?bug_id=6342411 (kurze Erklärung dazu auf https://stackoverflow.com/questions/43607522/class-getdeclaredmethods-of-reflection-unwanted-behavior). Gäbe mehrere Möglichkeiten das zu lösen. Entweder man ändert die visibility von AbstractNodeTreeViewer auf public, die visibility von ReBalancingViewer auch auf package oder macht die Methode private. Ich hab mich für Weg 3 entschieden, weil es das Problem am punktuellsten gelöst hat. Wenn du einen der anderen besser findest, kannst du natürlich auch das machen.