### PR TITLE
PDF Importer Ing Diba - Zahltag vs Ex-Tag

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDibaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDibaPDFExtractorTest.java
@@ -550,7 +550,7 @@ public class INGDibaPDFExtractorTest
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(t.getAmount(), is(Values.Amount.factorize(44.01)));
-        assertThat(t.getDate(), is(LocalDate.parse("2016-12-15")));
+        assertThat(t.getDate(), is(LocalDate.parse("2016-11-29")));
         assertThat(t.getShares(), is(Values.Share.factorize(66)));
 
         assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.24))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -192,7 +192,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date") //
-                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -238,7 +238,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .section("date") //
-                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -289,7 +289,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date") //
-                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //


### PR DESCRIPTION
Leave a commentUmstellung der Datumserkennung von Zahltag auf Ex-Tag beim Ing Diba PDF Importer für Ertragsgutschriften, Zinsgutschriften und Dividendengutschriften.

Ex-Tag kann bei ausländischen Vorgängen vom Zahltag deutlich abweichen.
Beispielsweise der IE00B2NPKV68 mit unten stehendem Beispiel:

Gruß
Ragas

P.S. Sorry für erneuten Pull Request, ist meine erste Erfahrung mit Github^^
P.P.S. Danke für den Hinweis auf das anpassen des Testszenarios

```
ING-DiBa AG   60628 Frankfurt am Main
Depotinhaber: xxxxxxxxxxx
xxxxxxxxxxx Direkt-Depot Nr.: xxxxxxxxxxx
xxxxxxxxxxx Datum: 02.06.2017
xxxxxxxxxxx Seite: 1 von 2
xxxxxxxxxxx
Ertragsgutschrift
ISIN (WKN) IE00B2NPKV68 (A0NECU)
Wertpapierbezeichnung iShsII-J.P.M.$ EM Bond U.ETF
Registered Shares o.N.
Nominale 123,456 Stück
Ertragsausschüttung per Stück 0,4665 USD
Anteil Zinsen per Stück 0,4665 USD
Ex-Tag 11.05.2017
Zahltag 31.05.2017
Brutto USD 123,45
Zwischensumme USD 123,45
Umg. z. Dev.-Kurs (1,126409) EUR 123.45
Gesamtbetrag zu Ihren Gunsten EUR 123.45
Abrechnungs-IBAN XXXX XXXX XXXX XXXX XXXX XX
Valuta 31.05.2017
Ausländischer Investmentfonds - Barausschüttung
Jahressteuerbescheinigung folgt.
Weitere steuerliche Informationen entnehmen Sie bitte der Rückseite.
Rund 1.000 ETFs gebührenfrei kaufen - kein Cent Provision oder sonstige Kosten.
Mehr Infos gefällig? Dann besuchen Sie uns einfach auf www.ing-diba.de/handeln
ING-DiBa AG   Theodor-Heuss-Allee 2   60486 Frankfurt am Main   Vorsitzender des Aufsichtsrates: Ben Tellings   Vorstand: Nick Jue (Vorsitzender), Bernd Geilen,
Katharina Herrmann, Zeljko Kaurin, Remco Nieland, Dr. Joachim von Schorlemer   Sitz: Frankfurt am Main   AG Frankfurt am Main HRB 7727   Steuernummer: 047 220 2800 4
USt-IdNr.: DE 114 103 475   Internet: www.ing-diba.de   E-Mail: info@ing-diba.de   BIC: INGDDEFFXXX   Mitglied im Einlagensicherungsfonds
Depotinhaber: xxxxxxxxx
Direkt-Depot Nr.: xxxxxxxxx
Datum: 02.06.2017
Seite: 2 von 2
ISIN (WKN) IE00B2NPKV68 (A0NECU)
KapSt-pflichtiger Kapitalertrag 123,45 EUR
Mit Verrechnungstopf Allgemein verrechnet 0,00 EUR
Mit Sparer-Pauschbetrag verrechnet 0,00 EUR
Verrechnungstopf Allgemein vor Ertrag 0,00 EUR
Verrechnungstopf Allgemein nach Ertrag 0,00 EUR
Verrechnungstopf ausländ. Quellenst. vor Ertrag 0,00 EUR
Verrechnungstopf ausländ. Quellenst. nach Ertrag 0,00 EUR
Sparer-Pauschbetrag vor Ertrag 0,00 EUR
Sparer-Pauschbetrag nach Ertrag 0,00 EUR
Bei Fragen besuchen Sie uns einfach unter www.ing-diba.de/wertpapierwissen - da gibt es viele schnelle
Antworten. Oder senden Sie uns eine E-Mail an info@ing-diba.de .
```
