### PR TITLE
PDFimporter exDate Commerzbank, Consorsbank, DKB und Flatex

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractorPDFTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractorPDFTest.java
@@ -59,7 +59,7 @@ public class ConsorsbankPDFExtractorPDFTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2015-11-02")));
+        assertThat(t.getDate(), is(LocalDate.parse("2015-09-28")));
         assertThat(t.getShares(), is(Values.Share.factorize(300)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 121_36)));
         assertThat(t.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("USD", 180_00)));
@@ -89,7 +89,7 @@ public class ConsorsbankPDFExtractorPDFTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2016-01-11")));
+        assertThat(t.getDate(), is(LocalDate.parse("2015-12-22")));
         assertThat(t.getShares(), is(Values.Share.factorize(650)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 285_60)));
         assertThat(t.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("USD", 367_25)));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractorTest.java
@@ -154,7 +154,7 @@ public class ConsorsbankPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findAny().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2015-11-02")));
+        assertThat(t.getDate(), is(LocalDate.parse("2015-09-28")));
         assertThat(t.getShares(), is(Values.Share.factorize(300)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 121_36)));
         assertThat(t.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("USD", 180_00)));
@@ -192,7 +192,7 @@ public class ConsorsbankPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2015-07-02")));
+        assertThat(t.getDate(), is(LocalDate.parse("2015-05-13")));
         assertThat(t.getShares(), is(Values.Share.factorize(1.0002)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 46)));
         assertThat(t.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("AUD", 93)));
@@ -228,7 +228,7 @@ public class ConsorsbankPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2015-06-29")));
+        assertThat(t.getDate(), is(LocalDate.parse("2015-06-12")));
         assertThat(t.getShares(), is(Values.Share.factorize(0.27072)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 8)));
         assertThat(t.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("USD", 12)));
@@ -264,7 +264,7 @@ public class ConsorsbankPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2014-04-22")));
+        assertThat(t.getDate(), is(LocalDate.parse("2014-03-06")));
         assertThat(t.getShares(), is(Values.Share.factorize(80)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 33_51)));
         assertThat(t.getGrossValue(), is(Money.of("EUR", 64_08)));
@@ -302,7 +302,7 @@ public class ConsorsbankPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).filter(
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
-        assertThat(t.getDate(), is(LocalDate.parse("2016-05-20")));
+        assertThat(t.getDate(), is(LocalDate.parse("2016-05-06")));
         assertThat(t.getShares(), is(Values.Share.factorize(50)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 32_51)));
         assertThat(t.getGrossValue(), is(Money.of("EUR", 38_25)));
@@ -342,7 +342,7 @@ public class ConsorsbankPDFExtractorTest
                         i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.DIVIDENDS)
                         .findFirst().get().getSubject();
         assertThat(t.getSecurity(), is(existingSecurity));
-        assertThat(t.getDate(), is(LocalDate.parse("2014-04-22")));
+        assertThat(t.getDate(), is(LocalDate.parse("2014-03-06")));
         assertThat(t.getShares(), is(Values.Share.factorize(80)));
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", 33_51)));
         assertThat(t.getGrossValue(), is(Money.of("EUR", 64_08)));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractorPDFTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractorPDFTest.java
@@ -57,7 +57,7 @@ public class DkbPDFExtractorPDFTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-10-13")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-09-10")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", 227_63L)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(450)));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractorTest.java
@@ -320,7 +320,7 @@ public class DkbPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2017-02-20")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2017-02-09")));
         assertThat(transaction.getAmount(), is(2995L));
         assertThat(transaction.getShares(), is(Values.Share.factorize(66)));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.29))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
@@ -69,7 +69,7 @@ public class CommerzbankPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-06-22")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-05-27")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 223_45L)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(123)));
     }
@@ -107,7 +107,7 @@ public class CommerzbankPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-07-20")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-06-24")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1045_67L)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(1234)));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExctractor.java
@@ -81,22 +81,22 @@ public class CommerzbankPDFExctractor extends AbstractPDFExtractor
                             return transaction;
                         })
 
-                        .section("date", "amount", "currency") //
+                        .section("amount", "currency") //
                         .match(".*Zu I h r e n Gunsten.*")
-                        .match("^.* (?<date>\\d \\d . \\d \\d . \\d \\d \\d \\d) (?<currency>\\w{3}+)(?<amount>( \\d)*( \\.)?( \\d)* ,( \\d)*)$")
+                        .match("^.* \\d \\d . \\d \\d . \\d \\d \\d \\d (?<currency>\\w{3}+)(?<amount>( \\d)*( \\.)?( \\d)* ,( \\d)*)$")
                         .assign((t, v) -> {
-                            t.setDate(asDate(stripBlanks(v.get("date"))));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                         })
 
-                        .section("wkn", "name", "shares", "isin")
+                        .section("date", "wkn", "name", "shares", "isin")
                         //
                         .match(".*W e r t p a p i e r - B e z e i c h n u n g.*")
-                        .match("p e r \\d \\d . \\d \\d . \\d \\d \\d \\d (?<name>.*) (?<wkn>\\S*)")
+                        .match("p e r (?<date>\\d \\d . \\d \\d . \\d \\d \\d \\d) (?<name>.*) (?<wkn>\\S*)")
                         .match("^STK (?<shares>(\\d )*(\\. )?(\\d )*, (\\d )*).* (?<isin>\\S*)$").assign((t, v) -> {
                             // if necessary, create the security with the
                             // currency of the transaction
+                            t.setDate(asDate(stripBlanks(v.get("date"))));
                             v.put("currency", t.getCurrencyCode());
                             t.setSecurity(getOrCreateSecurity(v));
                             t.setShares(asShares(stripBlanks(v.get("shares"))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
@@ -269,7 +269,7 @@ public class ConsorsbankPDFExctractor extends AbstractPDFExtractor
                         })
 
                         .section("date") //
-                        .match("WERT (?<date>\\d+.\\d+.\\d{4}+).*").assign((t, v) -> t.setDate(asDate(v.get("date"))))
+                        .match(".*EX-TAG  (?<date>\\d+.\\d+.\\d{4}+).*").assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("currency", "amount").optional() //
                         .match("WERT \\d+.\\d+.\\d{4}+ *(?<currency>\\w{3}+) *(?<amount>[\\d.]+,\\d+) *")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -248,6 +248,10 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
+                        .section("date") //
+                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
                         .wrap(TransactionItem::new);
         addTaxesSectionsTransaction(pdfTransaction);
         addFeesSectionsTransaction(pdfTransaction);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -237,13 +237,11 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                             t.setShares(asShares(v.get("shares")));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
-
-                        .section("date", "amount")
+                        
+                        .section("amount")
                         .match("(^Ausmachender Betrag) (?<amount>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)(.*) (?<currency>\\w{3}+)")
                         .match("(^Lagerstelle) (.*)")
-                        .match("(^Den Betrag buchen wir mit Wertstellung) (?<date>\\d+.\\d+.\\d{4}+) zu Gunsten des Kontos (.*)")
                         .assign((t, v) -> {
-                            t.setDate(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
@@ -252,6 +250,16 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
+                        .section("date") //
+                        .match("(^Den Betrag buchen wir mit Wertstellung) (?<date>\\d+.\\d+.\\d{4}+) zu Gunsten des Kontos (.*)")
+                        .assign((t, v) -> {
+
+                        if (t.getDate() == null)
+                        {
+                            t.setDate(asDate(v.get("date")));
+                        }})
+
+                        
                         .wrap(TransactionItem::new);
         addTaxesSectionsTransaction(pdfTransaction);
         addFeesSectionsTransaction(pdfTransaction);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FlatexPDFExtractor.java
@@ -322,7 +322,7 @@ public class FlatexPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date") //
-                        .match("Valuta * : *(?<date>\\d+.\\d+.\\d{4}+).*")
+                        .match("Extag * : *(?<date>\\d+.\\d+.\\d{4}+).*")
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .wrap(t -> new TransactionItem(t)));


### PR DESCRIPTION
Umstellung auf ex-date für Commerzbank, Consorsbank, DKB und Flatex.

Querverweis auf https://forum.portfolio-performance.info/t/buchungsdatum-vs-valutadatum/292

------
Und ich bitte 1000 mal um Entschuldigung für die von mir verursachten Verwirrungen.
Github Desktop und Maven wollte zunächst nicht am PC funktionieren so das ich meine Vorschläge im Browser versemmelt habe. Aber jetzt JAAAAA