### PR TITLE
PDFimporter exDate für SLM, DAB und Deutsche Bank

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractorTest.java
@@ -307,7 +307,7 @@ public class BankSLMPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2016-07-05")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2016-06-17")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", 3302_00L)));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", 1415_14L)));
         assertThat(transaction.getGrossValue(), is(Money.of("CHF", 4717_14L)));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractorTest.java
@@ -164,7 +164,7 @@ public class DeutscheBankPDFExtractorTest
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2014-12-15")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2014-12-04")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 64_88L)));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, 8_71 + 47 + 13_07)));
         assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, 87_13)));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -432,7 +432,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, 56_91)));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-05-16")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-04-14")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
     }
 
@@ -472,7 +472,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, 56_91)));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-05-16")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-04-14")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
     }
 
@@ -548,7 +548,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(80.92))));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2016-07-29")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2016-07-13")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(500)));
     }
 
@@ -586,7 +586,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(586.80))));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2015-03-30")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2015-03-23")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(1300)));
     }
 
@@ -624,7 +624,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(198.79))));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2013-05-31")));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2013-05-30")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExctractor.java
@@ -184,16 +184,21 @@ public class BankSLMPDFExctractor extends AbstractPDFExtractor
                             return transaction;
                         })
 
-                        .section("date", "shares", "name", "wkn", "currency")
-                        .match("Am (?<date>\\d+.\\d+.\\d{4}+) wurde folgende Dividende gutgeschrieben:") //
+                        .section("shares", "name", "wkn", "currency")
+                        .match("Am \\d+.\\d+.\\d{4}+ wurde folgende Dividende gutgeschrieben:") //
                         .match("^.*$") //
                         .match("^(?<name>.*)$") //
                         .match("^Valor: (?<wkn>[^ ]*)$") //
                         .match("Brutto \\((?<shares>[\\d.']+) \\* ... ([\\d.']+)\\) (?<currency>\\w{3}+) ([\\d.']+)") //
                         .assign((t, v) -> {
-                            t.setDate(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
                             t.setSecurity(getOrCreateSecurity(v));
+                        })
+
+                        .section("date") //
+                        .match(".*Ex Datum: (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .assign((t, v) -> {
+                            t.setDate(asDate(v.get("date")));
                         })
 
                         .section("amount", "currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
@@ -226,27 +226,28 @@ public class DABPDFExctractor extends AbstractPDFExtractor
                         .match("STK ([\\d.]+(,\\d+)?) (\\d+.\\d+.\\d{4}+) (\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (\\d+,\\d+)")
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
-                        .section("shares") //
+                        .section("date", "shares") //
                         .find("^Nominal Ex-Tag Zahltag .*") //
-                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) .*$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) (?<date>\\d+.\\d+.\\d{4}+).*$")
+                        .assign((t, v) -> {
+                            t.setShares(asShares(v.get("shares")));
+                            t.setDate(asDate(v.get("date")));
+                        })
 
-                        .section("date", "amount", "currency") //
+                        .section("amount", "currency") //
                         .optional() //
                         .find("Wert *Konto-Nr. *Betrag *zu *Ihren *Gunsten")
-                        .match("^(?<date>\\d+.\\d+.\\d{4}+) ([0-9]*) (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)$")
+                        .match("^(\\d+.\\d+.\\d{4}+) ([0-9]*) (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)$")
                         .assign((t, v) -> {
-                            t.setDate(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
-                        .section("date", "amount", "currency", "forexCurrency", "exchangeRate") //
+                        .section("amount", "currency", "forexCurrency", "exchangeRate") //
                         .optional() //
                         .find("Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten")
-                        .match("^(?<date>\\d+.\\d+.\\d{4}+) ([0-9]*) \\w{3}+/(?<forexCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+) (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)$")
+                        .match("^(\\d+.\\d+.\\d{4}+) ([0-9]*) \\w{3}+/(?<forexCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+) (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)$")
                         .assign((t, v) -> {
-                            t.setDate(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExctractor.java
@@ -23,8 +23,8 @@ public class DeutscheBankPDFExctractor extends AbstractPDFExtractor
 
         addBuyTransaction();
         addSellTransaction();
-        addDividendTransaction("Ertragsgutschrift"); //$NON-NLS-1$
-        addDividendTransaction("Dividendengutschrift"); //$NON-NLS-1$
+        addDividendEarnings(); 
+        addDividendTransaction();
     }
 
     @SuppressWarnings("nls")
@@ -158,12 +158,12 @@ public class DeutscheBankPDFExctractor extends AbstractPDFExtractor
     }
 
     @SuppressWarnings("nls")
-    private void addDividendTransaction(String nameOfTransaction)
+    private void addDividendEarnings() 
     {
-        DocumentType type = new DocumentType(nameOfTransaction);
+        DocumentType type = new DocumentType("Ertragsgutschrift");
         this.addDocumentTyp(type);
 
-        Block block = new Block(nameOfTransaction);
+        Block block = new Block("Ertragsgutschrift");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -187,7 +187,88 @@ public class DeutscheBankPDFExctractor extends AbstractPDFExtractor
                         .section("date", "amount", "currency")
                         .match("Gutschrift mit Wert (?<date>\\d+.\\d+.\\d{4}+) (?<amount>[\\d.]+,\\d+) (?<currency>\\w{3}+)")
                         .assign((t, v) -> {
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setDate(asDate(v.get("date")));
+                            })
+
+                        .section("grossValue", "currency") //
+                        .optional() //
+                        .match("Bruttoertrag (?<grossValue>[\\d.]+,\\d+) (?<currency>\\w{3}+)").assign((t, v) -> {
+                            Money grossValue = Money.of(asCurrencyCode(v.get("currency")),
+                                            asAmount(v.get("grossValue")));
+
+                            // calculating taxes as the difference between gross
+                            // value and transaction amount
+                            Money taxes = MutableMoney.of(t.getCurrencyCode()).add(grossValue)
+                                            .subtract(t.getMonetaryAmount()).toMoney();
+                            if (!taxes.isZero())
+                                t.addUnit(new Unit(Unit.Type.TAX, taxes));
+                        })
+
+                        // will match gross value only if forex data exists
+                        .section("forexSum", "forexCurrency", "grossValue", "currency", "exchangeRate") //
+                        .optional() //
+                        .match("Bruttoertrag (?<forexSum>[\\d.]+,\\d+) (?<forexCurrency>\\w{3}+) (?<grossValue>[\\d.]+,\\d+) (?<currency>\\w{3}+)")
+                        .match("Umrechnungskurs (\\w{3}+) zu (\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)") //
+                        .assign((t, v) -> {
+                            Money grossValue = Money.of(asCurrencyCode(v.get("currency")),
+                                            asAmount(v.get("grossValue")));
+                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forexSum")));
+                            BigDecimal exchangeRate = BigDecimal.ONE.divide( //
+                                            asExchangeRate(v.get("exchangeRate")), 10, BigDecimal.ROUND_HALF_DOWN);
+                            Unit unit = new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate);
+
+                            // add gross value unit only if currency code of
+                            // security actually matches
+                            if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                                t.addUnit(unit);
+
+                            // calculating taxes as the difference between gross
+                            // value and transaction amount
+                            Money taxes = MutableMoney.of(t.getCurrencyCode()).add(grossValue)
+                                            .subtract(t.getMonetaryAmount()).toMoney();
+                            if (!taxes.isZero())
+                                t.addUnit(new Unit(Unit.Type.TAX, taxes));
+                        })
+
+                        .wrap(t -> new TransactionItem(t)));
+    }
+
+    @SuppressWarnings("nls")
+    private void addDividendTransaction()
+    {
+        DocumentType type = new DocumentType("Dividendengutschrift");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("Dividendengutschrift");
+        type.addBlock(block);
+        block.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> {
+                            AccountTransaction transaction = new AccountTransaction();
+                            transaction.setType(AccountTransaction.Type.DIVIDENDS);
+                            return transaction;
+                        })
+
+                        .section("wkn", "isin", "name", "currency") //
+                        .find("Stück WKN ISIN") //
+                        .match("(\\d+,\\d*) (?<wkn>\\S*) (?<isin>\\S*)") //
+                        .match("^(?<name>.*)$") //
+                        .match("Bruttoertrag ([\\d.]+,\\d+) (?<currency>\\w{3}+).*") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        .section("shares") //
+                        .match("(?<shares>\\d+,\\d*) (\\S*) (\\S*)")
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        .section("date") //
+                        .match(".*Ex-Tag (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                        .section("amount", "currency")
+                        .match("Gutschrift mit Wert (?<date>\\d+.\\d+.\\d{4}+) (?<amount>[\\d.]+,\\d+) (?<currency>\\w{3}+)")
+                        .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
@@ -234,7 +315,7 @@ public class DeutscheBankPDFExctractor extends AbstractPDFExtractor
 
                         .wrap(t -> new TransactionItem(t)));
     }
-
+    
     @Override
     public String getLabel()
     {


### PR DESCRIPTION
Umstellung auf ex-date für SLM, DAB und Deutsche Bank.

Bei der Deutschen Bank wurde die Funktion addDividendTransaction für Dividendengutschrift und Ertragsgutschrift auf zwei Funktionen aufgetrennt, da die Datumserkennung Probleme bereitet hat.

Querverweis auf https://forum.portfolio-performance.info/t/buchungsdatum-vs-valutadatum/292

Gruß
Ragas