### PR TITLE
Bugfix ING Diba PDF Importer - Datum bei Verkauf via Fondsgesellschaft nicht gefunden

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -126,7 +126,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date") //
-                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+) .*") //
+                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -197,7 +197,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date") //
-                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -248,7 +248,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .section("date") //
-                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //


### PR DESCRIPTION
PDF Import bei ING-Diba erkennt bei Verkäufen das Datum nicht -> Regex Fehler.
Siehe auch das neue Beispiel für Verkauf Fondsgesellschaft