### PR TITLE
Use List instead of fixed size Arrays in SMA

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
@@ -91,11 +91,13 @@ public class SimpleMovingAverageTest
         }
 
         security.addPrice(new SecurityPrice(LocalDate.parse("2017-01-01"), Values.Quote.factorize(12)));
+        LocalDate tmp = LocalDate.parse("2016-01-01");
+        tmp = tmp.plusDays(99);
+        Date lastSMADate = java.sql.Date.valueOf(tmp);
 
         ChartLineSeriesAxes SMALines = new SimpleMovingAverage(10, security, null).getSMA();
-        assertThat(SMALines.getDates(), is(IsNull.nullValue())); // null because not enough
-                                                      // prices for sma in last
-                                                      // sma period
+        assertThat(SMALines.getDates(), is(IsNull.notNullValue()));
+        assertThat(SMALines.getDates()[SMALines.getDates().length - 1], is(lastSMADate));
     }
 
     @Test


### PR DESCRIPTION
Hallo buchen,

dies setzt deinen Vorschlag um:
Mit der List erfolgt nun kein Abbruch der SMA-Berechnung mehr, falls für ein LocalDate kein SMA berechnet werden kann (aufgrund zu weniger vorhandener Daten), stattdessen wird für jedes LocalDate im  Prices Array ein SMA berechnet, für den dies möglich ist - alle anderen werden ignoriert.

Anpassung der Tests folgt die Tage.