### PR TITLE
Create historical quotes from transactions (#473)

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -633,6 +633,7 @@ public class Messages extends NLS
     public static String SecurityMenuBuy;
     public static String SecurityMenuConfigureOnlineUpdate;
     public static String SecurityMenuCreateManually;
+    public static String SecurityMenuCreateQuotesFromTransactions;
     public static String SecurityMenuDeleteAllPrices;
     public static String SecurityMenuDeletePrice;
     public static String SecurityMenuDeleteSecurity;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1261,6 +1261,8 @@ SecurityMenuConfigureOnlineUpdate = Configure online update...
 
 SecurityMenuCreateManually = Create manually...
 
+SecurityMenuCreateQuotesFromTransactions = Create historical quotes from transactions
+
 SecurityMenuDeleteAllPrices = Delete All
 
 SecurityMenuDeletePrice = Delete

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1257,6 +1257,8 @@ SecurityMenuConfigureOnlineUpdate = Online-Aktualisierung konfigurieren...
 
 SecurityMenuCreateManually = Manuell erfassen...
 
+SecurityMenuCreateQuotesFromTransactions = Historische Kurse aus Buchungen erzeugen
+
 SecurityMenuDeleteAllPrices = Alle l\u00F6schen
 
 SecurityMenuDeletePrice = L\u00F6schen

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/QuotesContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/QuotesContextMenu.java
@@ -25,6 +25,7 @@ import name.abuchen.portfolio.ui.dialogs.SecurityPriceDialog;
 import name.abuchen.portfolio.ui.wizards.datatransfer.CSVImportWizard;
 import name.abuchen.portfolio.ui.wizards.datatransfer.ImportQuotesWizard;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityDialog;
+import name.abuchen.portfolio.util.QuoteFromTransactionExtractor;
 
 public class QuotesContextMenu
 {
@@ -130,6 +131,21 @@ public class QuotesContextMenu
                 owner.notifyModelUpdated();
             }
         });
+        
+        manager.add(new Action(Messages.SecurityMenuCreateQuotesFromTransactions)
+        {
+            @Override
+            public void run()
+            {
+                QuoteFromTransactionExtractor qte = new QuoteFromTransactionExtractor(owner.getClient());
+                if (qte.extractQuotes(security))
+                {
+                    owner.markDirty();
+                    owner.notifyModelUpdated();
+                }
+            }
+        });
+        
 
         manager.add(new Separator());
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/QuoteFromTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/QuoteFromTransactionExtractor.java
@@ -1,0 +1,76 @@
+package name.abuchen.portfolio.util;
+
+import java.time.LocalDate;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.model.TransactionPair;
+import name.abuchen.portfolio.money.Quote;
+
+/**
+ * A helper for extracting historic quotes from the transactions of a security.
+ * Aims to provide at least quotes from buying or selling to allow calculating
+ * the correct performance.
+ *
+ * @author SB
+ */
+public class QuoteFromTransactionExtractor
+{
+
+    private final Client client;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param client
+     *            {@link Client}
+     */
+    public QuoteFromTransactionExtractor(Client client)
+    {
+        this.client = client;
+    }
+
+    /**
+     * Extracts the quotes for the given {@link Security}.
+     *
+     * @param security
+     *            {@link Security}
+     * @return true if quotes were found, else false
+     */
+    public boolean extractQuotes(Security security)
+    {
+        boolean bChanges = false;
+        SecurityPrice pLatest = null;
+        // walk through all all transactions for securiy
+        for (TransactionPair<?> p : security.getTransactions(client))
+        {
+            Transaction t = p.getTransaction();
+            // check the type of the transaction
+            if (t instanceof PortfolioTransaction)
+            {
+                PortfolioTransaction pt = (PortfolioTransaction) t;
+                // get date and quote and build a price from it
+                Quote q = pt.getGrossPricePerShare();
+                LocalDate d = pt.getDate();
+                SecurityPrice price = new SecurityPrice(d, q.getAmount());
+                bChanges |= security.addPrice(price);
+                // remember the lates price
+                if ((pLatest == null) || d.isAfter(pLatest.getTime()))
+                {
+                    pLatest = price;
+                }
+            }
+        }
+        // set the latest price (if at leas one price was found)
+        if (pLatest != null)
+        {
+            LatestSecurityPrice lsp = new LatestSecurityPrice(pLatest.getTime(), pLatest.getValue());
+            bChanges |= security.setLatest(lsp);
+        }
+        return bChanges;
+    }
+}


### PR DESCRIPTION
This functionality provides quotes for securities, which are bought or sold in the account, but do not have any quotes available.
That allows to calculate the correct performance (fixes #473).

Can be started from the security sub-menu "quotes"/"Kurse".