### PR TITLE
Clean up of some small bits and pieces in the PDF importing files

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -215,7 +215,6 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Vergütung des Vermögensverwalters");
         this.addDocumentTyp(type);
         
-        System.out.println("Hier sind wir im Block Vergütung des Vermögensverwalters"); //SD
         Block block = new Block("Rechnung für .*");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>().subject(() -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExctractor.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Optional;
 
+//import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -14,6 +15,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.Transaction.Unit.Type;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 public class ConsorsbankPDFExctractor extends AbstractPDFExtractor
@@ -30,6 +32,7 @@ public class ConsorsbankPDFExctractor extends AbstractPDFExtractor
         addSellTransaction();
         addDividendTransaction();
         addIncomeTransaction();
+        addTaxAdjustmentTransaction();
     }
 
     @SuppressWarnings("nls")
@@ -386,6 +389,43 @@ public class ConsorsbankPDFExctractor extends AbstractPDFExtractor
                         .match("(^.*)(Eig. Spesen) (?<currency>\\w{3}+) (?<expenses>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)")
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE,
                                         Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("expenses"))))));
+    }
+    
+    @SuppressWarnings("nls")
+    private void addTaxAdjustmentTransaction()
+    {
+        
+        DocumentType type = new DocumentType("Nachträgliche Verlustverrechnung");
+        this.addDocumentTyp(type);
+        
+        Block block = new Block(" Erstattung/Belastung \\(-\\) von Steuern");
+        type.addBlock(block);
+        block.set(new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction t = new AccountTransaction();
+            t.setType(AccountTransaction.Type.TAX_REFUND);
+            t.setCurrencyCode(CurrencyUnit.EUR); // nirgends im Dokument ist die Währung aufgeführt.
+            return t;
+        })
+                        
+                        // Den Steuerausgleich buchen wir mit Wertstellung 10.07.2017
+                        .section("date")
+                        .match(" *Den Steuerausgleich buchen wir mit Wertstellung (?<date>\\d+.\\d+.\\d{4}) .*")
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                        // Erstattung/Belastung (-) von Steuern
+                        // Anteil                             100,00%
+                        // KapSt Person 1                                 :                79,89
+                        // SolZ  Person 1                                 :                 4,36
+                        // KiSt  Person 1                                 :                 6,36
+                        // ======================================================================
+                        //                                                                 90,61
+                        .section("amount")
+                        .find(" *Erstattung/Belastung \\(-\\) von Steuern *")
+                        .find(" *=* *")
+                        .match(" *(?<amount>[\\d.]+,\\d{2}) *")
+                        .assign((t, v) -> t.setAmount(asAmount(v.get("amount"))))
+                        
+                        .wrap(t -> new TransactionItem(t)));
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -53,7 +53,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         })
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.[0-9A-Za-z]*/(\\d*)  Kauf *(?<name>[^(]*) \\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
+                        .match("Nr.[0-9A-Za-z]*/(\\d*)  Kauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -99,7 +99,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         })
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>[^(]*) \\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
+                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -168,7 +168,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.[0-9A-Za-z]*/(\\d*)  Kauf *(?<name>[^(]*) \\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)") //
+                        .match("Nr.[0-9A-Za-z]*/(\\d*)  Kauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -309,7 +309,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("wkn", "isin", "name")
-                        .match("Nr\\.(\\d*) * (?<name>[^(]*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)").assign((t, v) -> {
+                        .match("Nr\\.(\\d*) * (?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)").assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
@@ -354,7 +354,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>[^(]*) \\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)") //
+                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -419,7 +419,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("isin", "name")
-                        .match("Depoteingang *(?<name>[^(]*) \\((?<isin>[^/]*)\\)") //
+                        .match("Depoteingang *(?<name>.*) *\\((?<isin>[^/]*)\\)") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -484,7 +484,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("isin", "name")
-                        .match("Depotausgang *(?<name>[^(]*) \\((?<isin>[^/]*)\\)") //
+                        .match("Depotausgang *(?<name>.*) *\\((?<isin>[^/]*)\\)") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -554,7 +554,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("isin", "name")
-                        .match("Bestandsausbuchung *(?<name>[^(]*) \\((?<isin>[^/]*)\\)") //
+                        .match("Bestandsausbuchung *(?<name>.*) *\\((?<isin>[^/]*)\\)") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -820,7 +820,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("wkn", "isin", "name")
-                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>[^(]*) \\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
+                        .match("Nr.(\\d*)/(\\d*)  Verkauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })


### PR DESCRIPTION
- removed a message that was printed to system.out while importing PDF
documents with fees from BaaderBank
- FinTechGroupBankPDFExtractor wasn't allowing parentheses in names of
shares
- ConsorsbankPDFExtractor now recognizes documents with regard to
"Nachträgliche Verlustverrechnung" resulting in a tax refund