### PR TITLE
made small changes so that HTMLTableQuoteFeed also works for ARD and FT

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -134,7 +134,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
         @SuppressWarnings("nls")
         public DateColumn()
         {
-            super(new String[] { "Datum", "Date" });
+            super(new String[] { "Datum.*", "Date.*" });
 
             formatters = new DateTimeFormatter[] { DateTimeFormatter.ofPattern("y-M-d"),
                             DateTimeFormatter.ofPattern("d.M.yy"), //$NON-NLS-1$
@@ -143,7 +143,8 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                             DateTimeFormatter.ofPattern("d. MMMM y"), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("d. MMM. y"), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("MMM d, y", Locale.ENGLISH), //$NON-NLS-1$
-                            DateTimeFormatter.ofPattern("MMM dd, y", Locale.ENGLISH) //$NON-NLS-1$
+                            DateTimeFormatter.ofPattern("MMM dd, y", Locale.ENGLISH), //$NON-NLS-1$
+                            DateTimeFormatter.ofPattern("EEEE, MMMM dd, yEEE, MMM dd, y", Locale.ENGLISH) //$NON-NLS-1$
             };
         }
 


### PR DESCRIPTION
These changes address issue #771 .

The problem with ARD was that included the character `&nbsp;` in the date table head  `<th id="datum" scope="col" title="Datum" class="tright rightborder"><strong>Datum</strong>&nbsp;&nbsp;&nbsp;&nbsp;</th>` and thus the column header was not recognized.

The problem with FT was that the date rows included the date in two differerent formats which were separated by span tags, the short date was shown on mobile phones and the long date on web pages but the extraction did not work: `"<td class="mod-ui-table__cell--text"><span
class="mod-ui-hide-small-below">Friday, July 28, 2017</span><span
class="mod-ui-hide-medium-above">Fri, Jul 28, 2017</span></td>"`