### PR TITLE
changed value date to trade date for BaaderBankPDFExtractor

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
@@ -77,7 +77,7 @@ public class BaaderBankPDFExtractorTest
         assertThat(entry.getAccountTransaction()  .getType(),                 is(AccountTransaction.Type.BUY));
         assertThat(entry.getPortfolioTransaction().getType(),                 is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getPortfolioTransaction().getAmount(),               is(Values.Amount.factorize(208.95)));
-        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-03-22")));
+        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-03-20")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.21))));
         assertThat(entry.getPortfolioTransaction().getShares(),               is(Values.Share.factorize(2)));        
 
@@ -123,7 +123,7 @@ public class BaaderBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(),                 is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction()  .getType(),                 is(AccountTransaction.Type.BUY));
         assertThat(entry.getPortfolioTransaction().getAmount(),               is(Values.Amount.factorize(1551.00)));
-        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-03-22")));
+        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-03-20")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.55))));
         assertThat(entry.getPortfolioTransaction().getShares(),               is(Values.Share.factorize(70)));
     }
@@ -166,7 +166,7 @@ public class BaaderBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(),                 is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction()  .getType(),                 is(AccountTransaction.Type.SELL));
         assertThat(entry.getPortfolioTransaction().getAmount(),               is(Values.Amount.factorize(75.92)));
-        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-05-12")));
+        assertThat(entry.getPortfolioTransaction().getDate(),                 is(LocalDate.parse("2017-05-10")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.08))));
         assertThat(entry.getPortfolioTransaction().getShares(),               is(Values.Share.factorize(2)));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -60,9 +60,11 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                         
                         .section("date", "amount", "currency")
-                        .match("Zu Lasten Konto \\d+ Valuta: (?<date>\\d+\\.\\d+\\.\\d{4}) *(?<currency>\\w{3}) *(?<amount>[\\d.]+,\\d{2})")
+                        .match("Zu Lasten Konto \\d+ Valuta: \\d+\\.\\d+\\.\\d{4} *(?<currency>\\w{3}) *(?<amount>[\\d.]+,\\d{2})")
+                        .find("Handelsdatum Handelsuhrzeit")
+                        .match("^(?<date>\\d+\\.\\d+\\.\\d{4}) \\d{2}:\\d{2}:\\d{2}:\\d{2}$")
                         .assign((t, v) -> {
-                            t.setDate(asDate(v.get("date")));
+                            t.setDate(asDate(v.get("date")));                            
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
                         })
@@ -98,7 +100,9 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                         
                         .section("date", "amount", "currency")
-                        .match("Zu Gunsten Konto \\d+ Valuta: (?<date>\\d+.\\d+.\\d{4}) *(?<currency>\\w{3}) *(?<amount>[\\d.]+,\\d{2})")
+                        .match("Zu Gunsten Konto \\d+ Valuta: \\d+\\.\\d+\\.\\d{4} *(?<currency>\\w{3}) *(?<amount>[\\d.]+,\\d{2})")
+                        .find("Handelsdatum Handelsuhrzeit")
+                        .match("^(?<date>\\d+\\.\\d+\\.\\d{4}) \\d{2}:\\d{2}:\\d{2}:\\d{2}$")
                         .assign((t, v) -> {
                             t.setDate(asDate(v.get("date")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));


### PR DESCRIPTION
According to the discussion in https://forum.portfolio-performance.info/t/buchungsdatum-vs-valutadatum/292, the dates for importing security buy and sell transactions was changed from value date to trade date.