### PR TITLE
added exchange rate extraction to FinTechGroupBankPDFExtractor

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankDividendeAusland1.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankDividendeAusland1.txt
@@ -1,0 +1,31 @@
+FinTech Group Bank AG
+Hausbroicher Str. 222
+47877 Willich
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+FinTech Group Bank AG -  Rotfeder-Ring 7 - 60327 Frankfurt am Main
+XXXXXXXXXXXXXXXXXXX
+Dividendengutschrift für ausländische Wertpapiere
+Ihre Depotnummer: XXXXXXXXXX
+Depotinhaber    : XXXXX, XXXXX
+Nr.111111111                  STARBUCKS CORP.           (US8552441094/884437)
+St.             :         105          Bruttodividende
+                                       pro Stück       :       0,2500 USD
+Extag           :  08.08.2017          Bruttodividende :        26,25 USD
+Zahlungstag     :  25.08.2017          Bemessungs-
+Valuta          :  25.08.2017          grundlage       :         X,XX EUR
+Devisenkurs     :    1,180800         *Einbeh. Steuer  :         1,11 EUR
+Quellenst.-satz :       30,00 %        Gez. Quellenst. :         7,88 USD
+                                       Endbetrag       :        14,45 EUR
+* Enthalten sind folgende Steuern (negative Werte bedeuten Steuererstattung)
+                                  Kapitalertragsteuer  :         X,XX EUR
+                                  Solidaritätszuschlag :         X,XX EUR
+                                  Kirchensteuer        :         X,XX EUR
+  Details dazu inkl. evtl. angerechneter ausländischer Quellensteuer
+  finden Sie im Steuerreport unter der Transaktion-Nr.: XXXXXXXX
+Die Verrechnung des Endbetrages erfolgt über Ihr Konto Nr.:  XXXXXXXXXX
+Anrechenbare Quellensteuer**           15,00 % =                 3,94 USD
+Rückforderbare Quellensteuer**         15,00 % =                 3,94 USD
+** nur relevant für Steuerinländer

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -354,19 +354,19 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 if (m.matches())
                 {
                     context.put("currency", m.group(1));
-                    System.out.println("context currency found: " + context.get("currency"));
+                    //System.out.println("context currency found: " + context.get("currency"));
                 }
                 m = pCurrencyFx.matcher(line);
                 if (m.matches())
                 {
                     context.put("currencyFx", m.group(1));
-                    System.out.println("context currencyFx found: " + context.get("currencyFx"));
+                    //System.out.println("context currencyFx found: " + context.get("currencyFx"));
                 }
                 m = pExchangeRate.matcher(line);
                 if (m.matches())
                 {
                     context.put("exchangeRate", m.group(1));
-                    System.out.println("context exchangeRate found: " + context.get("exchangeRate"));
+                    //System.out.println("context exchangeRate found: " + context.get("exchangeRate"));
                 }
             }
         });
@@ -390,9 +390,9 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                             
                                 Map<String, String> context = type.getCurrentContext();
                                 v.put("currency", context.get("currencyFx")); // the security must be in Fx units, otherwise, dividends and taxes cannot be in Fx units
-                                System.out.println("Security Currency: " + context.get("currency"));
+                                //System.out.println("Security Currency: " + context.get("currency"));
                                 t.setSecurity(getOrCreateSecurity(v));
-                                System.out.println("Security Info: " + t.getSecurity().toInfoString());
+                                //System.out.println("Security Info: " + t.getSecurity().toInfoString());
                         })
 
                         // St.             :         105          Bruttodividende


### PR DESCRIPTION
This addresses the issue described in https://forum.portfolio-performance.info/t/dividenden-import-wechselkurs-des-nettowertes-fehlt-flatex/1366


