### PR TITLE
Bollinger Bands @ Securities Chart & PopUp menu seperator

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -340,6 +340,9 @@ public class Messages extends NLS
     public static String LabelChartDetailEvents;
     public static String LabelChartDetailInvestments;
     public static String LabelChartDetailClosingIndicator;
+    public static String LabelChartDetailBollingerBands;
+    public static String LabelChartDetailBollingerBandsLower;
+    public static String LabelChartDetailBollingerBandsUpper;
     public static String LabelClientClearCustomItems;
     public static String LabelClientFilterDialogMessage;
     public static String LabelClientFilterDialogTitle;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -665,9 +665,15 @@ LabelChartDetailEvents = Stock Splits
 
 LabelChartDetailInvestments = Investments
 
-LabelChartDetailSMA200 = SMA 200
+LabelChartDetailSMA200 = Simple Moving Average (200 days)
 
-LabelChartDetailSMA50 = SMA 50
+LabelChartDetailSMA50 = Simple Moving Average (50 days)
+
+LabelChartDetailBollingerBands = Bollinger Bands
+
+LabelChartDetailBollingerBandsLower = Upper Bollinger Bands
+
+LabelChartDetailBollingerBandsUpper = Lower Bollinger Bands
 
 LabelChartDetailClosingIndicator = Closing Indicator
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -671,7 +671,7 @@ LabelChartDetailSMA50 = Einfacher gleitender Durchschnitt (50 Tage)
 
 LabelChartDetailClosingIndicator = Schlusskurs Indikator
 
-LabelChartDetailBollingerBands = Bollinger Band
+LabelChartDetailBollingerBands = Bollinger B\u00E4nder
 
 LabelChartDetailBollingerBandsLower = Unteres Bollinger Band
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -665,7 +665,17 @@ LabelChartDetailEvents = Stock Splits
 
 LabelChartDetailInvestments = Investitionen
 
+LabelChartDetailSMA200 = Einfacher gleitender Durchschnitt (200 Tage)
+
+LabelChartDetailSMA50 = Einfacher gleitender Durchschnitt (50 Tage)
+
 LabelChartDetailClosingIndicator = Schlusskurs Indikator
+
+LabelChartDetailBollingerBands = Bollinger Band
+
+LabelChartDetailBollingerBandsLower = Unteres Bollinger Band
+
+LabelChartDetailBollingerBandsUpper = Oberes Bollinger Band
 
 LabelClientClearCustomItems = Eintr\u00E4ge l\u00F6schen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
@@ -115,9 +115,10 @@ public class BollingerBands
 
         for (; index < prices.size(); index++)
         {
+            if (index < BollingerBandsDays) continue; 
             LocalDate nextDate = prices.get(index).getTime();
             LocalDate isBefore = nextDate.plusDays(1);
-            LocalDate isAfter = isBefore.minusDays(BollingerBandsDays + 1L);
+            LocalDate isAfter = prices.get(index - BollingerBandsDays + 2).getTime();
             List<SecurityPrice> filteredPrices = this.getFilteredList(isBefore, isAfter);
 
             if (filteredPrices.size() < calculatedMinimumDays)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
@@ -1,0 +1,221 @@
+// Source based on SimpleMovingAverage.java by alex0711 
+
+package name.abuchen.portfolio.ui.views;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.ArrayUtils;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+
+public class BollingerBands
+
+{
+    public static final int MIN_AVERAGE_PRICES_PER_WEEK = 2;
+    private int BollingerBandsDays;
+    private double BollingerBandsFactor;
+    private Security security;
+    private LocalDate startDate;
+    private ChartLineSeriesAxes BollingerBandsLowerBand;
+    private ChartLineSeriesAxes BollingerBandsMiddleBand;
+    private ChartLineSeriesAxes BollingerBandsUpperBand;
+    private int calculatedMinimumDays;
+    private List<SecurityPrice> prices;
+    private List<LocalDate> datesBollingerBands;
+    private List<Double> valuesBollingerBandsLowerBands;
+    private List<Double> valuesBollingerBandsMiddleBands;
+    private List<Double> valuesBollingerBandsUpperBands;
+
+    public BollingerBands(int BollingerBandsDays, double BollingerBandsFactor, Security security, LocalDate startDate)
+    {
+        this.BollingerBandsDays = BollingerBandsDays;
+        this.BollingerBandsFactor = BollingerBandsFactor;
+        this.security = security;
+        this.startDate = startDate;
+        this.BollingerBandsLowerBand = new ChartLineSeriesAxes();
+        this.BollingerBandsMiddleBand = new ChartLineSeriesAxes();
+        this.BollingerBandsUpperBand = new ChartLineSeriesAxes();
+        this.datesBollingerBands = new ArrayList<>();
+        this.valuesBollingerBandsLowerBands = new ArrayList<>();
+        this.valuesBollingerBandsMiddleBands = new ArrayList<>();
+        this.valuesBollingerBandsUpperBands = new ArrayList<>();
+        this.calculatedMinimumDays = getMinimumDaysForBollingerBands();
+        this.calculateBollingerBands();
+    }
+
+    /**
+     * Returns the calculated Simple Moving Average
+     * 
+     * @return The ChartLineSeriesAxes contains the X and Y Axes of the
+     *         generated Bollinger Bands
+     */
+    public ChartLineSeriesAxes getLowerBands()
+    {
+        return this.BollingerBandsLowerBand;
+    }
+
+    public ChartLineSeriesAxes getMiddleBands()
+    {
+        return this.BollingerBandsMiddleBand;
+    }
+
+    public ChartLineSeriesAxes getUpperBands()
+    {
+        return this.BollingerBandsUpperBand;
+    }
+
+    public BollingerBands calculateBollingerBands(int BollingerBandsDays, double BollingerBandsFactor, Security security, LocalDate startDate)
+    {
+        return new BollingerBands(BollingerBandsDays, BollingerBandsFactor, security, startDate);
+    }
+
+    /**
+     * Calculates the Simple Moving Average for the given range of days from the
+     * given startDate on The method returns an object containing the X and Y
+     * Axes of the generated bollinger bands
+     */
+    private void calculateBollingerBands()
+    {
+        if (security == null)
+            return;
+
+        this.prices = security.getPricesIncludingLatest();
+        int index;
+
+        SecurityPrice startPrice = null;
+
+        if (prices == null || prices.size() < calculatedMinimumDays)
+            return;
+
+        if (startDate == null)
+        {
+            startPrice = this.getStartPrice();
+            // in case no valid start date could be determined, return null
+            if (startPrice == null)
+                return;
+            index = prices.indexOf(startPrice);
+            if (index >= prices.size())
+                return;
+        }
+        else
+        {
+            startPrice = this.getStartPriceFromStartDate();
+            // in case no valid start date could be determined, return null
+            if (startPrice == null)
+                return;
+            index = prices.indexOf(startPrice);
+            if (index >= prices.size())
+                return;
+        }
+
+        for (; index < prices.size(); index++)
+        {
+            LocalDate nextDate = prices.get(index).getTime();
+            LocalDate isBefore = nextDate.plusDays(1);
+            LocalDate isAfter = isBefore.minusDays(BollingerBandsDays + 1L);
+            List<SecurityPrice> filteredPrices = this.getFilteredList(isBefore, isAfter);
+
+            if (filteredPrices.size() < calculatedMinimumDays)
+                continue; // skip this date and try to calculate bollinger bands for next
+                          // entry
+
+            double sum = filteredPrices.stream().mapToLong(SecurityPrice::getValue).sum();
+            double QuotePriceAverage = sum / Values.Quote.divider() / filteredPrices.size();
+            double tempQuotePriceVariance = 0;
+            for (int i = 0; i < filteredPrices.size(); i++) {
+                tempQuotePriceVariance += ((filteredPrices.get(i).getValue() / Values.Quote.divider()) - QuotePriceAverage) * ((filteredPrices.get(i).getValue() / Values.Quote.divider()) - QuotePriceAverage);
+            }
+
+            Double StandardDeviationBollingerBands = Math.sqrt(tempQuotePriceVariance / (filteredPrices.size() - 1)) * BollingerBandsFactor;
+            Double valueBollingerBandsLowerBands = QuotePriceAverage;
+            Double valueBollingerBandsUpperBands = QuotePriceAverage;
+            valueBollingerBandsLowerBands -= StandardDeviationBollingerBands;
+            valueBollingerBandsUpperBands += StandardDeviationBollingerBands;
+            
+            valuesBollingerBandsLowerBands.add(valueBollingerBandsLowerBands);
+            valuesBollingerBandsMiddleBands.add(QuotePriceAverage);
+            valuesBollingerBandsUpperBands.add(valueBollingerBandsUpperBands);
+            datesBollingerBands.add(prices.get(index).getTime());
+        }
+        LocalDate[] tmpDates = datesBollingerBands.toArray(new LocalDate[0]);
+        Double[] tmpPricesLower = valuesBollingerBandsLowerBands.toArray(new Double[0]);
+        Double[] tmpPricesMiddle = valuesBollingerBandsMiddleBands.toArray(new Double[0]);
+        Double[] tmpPricesUpper = valuesBollingerBandsUpperBands.toArray(new Double[0]);
+
+        this.BollingerBandsLowerBand.setDates(TimelineChart.toJavaUtilDate(tmpDates));
+        this.BollingerBandsLowerBand.setValues(ArrayUtils.toPrimitive(tmpPricesLower));
+        this.BollingerBandsMiddleBand.setDates(TimelineChart.toJavaUtilDate(tmpDates));
+        this.BollingerBandsMiddleBand.setValues(ArrayUtils.toPrimitive(tmpPricesMiddle));
+        this.BollingerBandsUpperBand.setDates(TimelineChart.toJavaUtilDate(tmpDates));
+        this.BollingerBandsUpperBand.setValues(ArrayUtils.toPrimitive(tmpPricesUpper));
+    }
+
+    public int getMinimumDaysForBollingerBands()
+    {
+        int weeks = BollingerBandsDays / 7;
+        int minDays = weeks * MIN_AVERAGE_PRICES_PER_WEEK;
+        return minDays > 0 ? minDays : 1;
+    }
+
+    public SecurityPrice getStartPriceFromStartDate()
+    {
+        // get Date of first possible bollinger bands calculation beginning from startDate
+        int index = Math.abs(
+                        Collections.binarySearch(prices, new SecurityPrice(startDate, 0), new SecurityPrice.ByDate()));
+
+        if (index >= prices.size())
+            return null;
+        return determineStartPrice(startDate);
+    }
+
+    public SecurityPrice getStartPrice()
+    {
+        // get Date of first possible bollinger bands calculation
+        LocalDate BollingerBandsPeriodEnd = prices.get(0).getTime().plusDays(BollingerBandsDays - 1L);
+        int index = Math.abs(Collections.binarySearch(prices, new SecurityPrice(BollingerBandsPeriodEnd, 0),
+                        new SecurityPrice.ByDate()));
+        if (index >= prices.size())
+            return null;
+
+        return determineStartPrice(BollingerBandsPeriodEnd);
+    }
+
+    private SecurityPrice determineStartPrice(LocalDate BollingerBandsPeriodEnd)
+    {
+        // check if an bollinger bands can be calculated for this Date
+        List<SecurityPrice> filteredPrices = null;
+        LocalDate isBefore = BollingerBandsPeriodEnd.plusDays(1);
+        LocalDate isAfter = BollingerBandsPeriodEnd.minusDays(BollingerBandsDays);
+        LocalDate lastDate = prices.get(prices.size() - 1).getTime();
+        filteredPrices = this.getFilteredList(isBefore, isAfter);
+
+        int i = 1;
+        while (!this.checkListIsValidForBollingerBands(filteredPrices))
+        {
+            if (isBefore.plusDays(i).isAfter(lastDate) || isAfter.plusDays(i).isAfter(lastDate))
+                return null;
+
+            filteredPrices = this.getFilteredList(isBefore.plusDays(i), isAfter.plusDays(i));
+            i++;
+        }
+
+        return filteredPrices.get(filteredPrices.size() - 1);
+    }
+
+    private boolean checkListIsValidForBollingerBands(List<SecurityPrice> filteredPrices)
+    {
+        return filteredPrices.size() < calculatedMinimumDays ? false : true;
+    }
+
+    private List<SecurityPrice> getFilteredList(LocalDate isBefore, LocalDate isAfter)
+    {
+        return prices.stream().filter(p -> p.getTime().isAfter(isAfter) && p.getTime().isBefore(isBefore))
+                        .collect(Collectors.toList());
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.RowLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -28,6 +29,9 @@ import org.swtchart.ILineSeries;
 import org.swtchart.ILineSeries.PlotSymbolType;
 import org.swtchart.ISeries;
 import org.swtchart.ISeries.SeriesType;
+import org.swtchart.LineStyle;
+import org.swtchart.IAxis;
+import org.swtchart.Range;
 
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
@@ -41,7 +45,6 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
-import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 
@@ -52,12 +55,13 @@ public class SecuritiesChart
 {
     private enum ChartDetails
     {
-        CLOSING(Messages.LabelChartDetailClosingIndicator), //
-        INVESTMENT(Messages.LabelChartDetailInvestments), //
-        EVENTS(Messages.LabelChartDetailEvents), //
-        SMA50(Messages.LabelChartDetailSMA50), //
-        SMA200(Messages.LabelChartDetailSMA200), //
-        DIVIDENDS(Messages.LabelChartDetailDividends);
+        typeCLOSING(Messages.LabelChartDetailClosingIndicator + "\\-----\\"), //
+        markerINVESTMENT(Messages.LabelChartDetailInvestments), //
+        markerDIVIDENDS(Messages.LabelChartDetailDividends), //
+        markerEVENTS(Messages.LabelChartDetailEvents + "\\-----\\"), //
+        indicatorSMA50(Messages.LabelChartDetailSMA50), //
+        indicatorSMA200(Messages.LabelChartDetailSMA200), //
+        indicatorBOLLINGERBANDS(Messages.LabelChartDetailBollingerBands);
 
         private final String label;
 
@@ -83,7 +87,7 @@ public class SecuritiesChart
 
     private TimelineChart chart;
     private LocalDate chartPeriod = LocalDate.now().minusYears(2);
-    private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.INVESTMENT, ChartDetails.EVENTS);
+    private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.markerINVESTMENT, ChartDetails.markerEVENTS);
 
     public SecuritiesChart(Composite parent, Client client, CurrencyConverter converter)
     {
@@ -177,7 +181,8 @@ public class SecuritiesChart
     {
         for (ChartDetails detail : ChartDetails.values())
         {
-            Action action = new SimpleAction(detail.toString(), a -> {
+            String ButtonDescription = detail.toString().replaceAll("\\\\-----\\\\", ""); 
+            Action action = new SimpleAction(ButtonDescription, a -> {
                 boolean isActive = chartConfig.contains(detail);
 
                 if (isActive)
@@ -193,6 +198,7 @@ public class SecuritiesChart
 
             action.setChecked(chartConfig.contains(detail));
             manager.add(action);
+            if (detail.toString().matches(".*\\\\-----\\\\.*")) manager.add(new Separator());
         }
     }
 
@@ -260,7 +266,7 @@ public class SecuritiesChart
 
             chart.getTitle().setText(security.getName());
             
-            boolean showAreaRelativeToFirstQuote = chartConfig.contains(ChartDetails.CLOSING);
+            boolean showAreaRelativeToFirstQuote = chartConfig.contains(ChartDetails.typeCLOSING);
 
             List<SecurityPrice> prices = security.getPricesIncludingLatest();
 
@@ -309,7 +315,7 @@ public class SecuritiesChart
                             Messages.ColumnQuote);
             lineSeries.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
             lineSeries.setLineWidth(2);
-            lineSeries.enableArea(!showAreaRelativeToFirstQuote);
+            if (!chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS)) lineSeries.enableArea(!showAreaRelativeToFirstQuote);
             lineSeries.setSymbolType(PlotSymbolType.NONE);
             lineSeries.setYSeries(values);
             lineSeries.setAntialias(SWT.ON);
@@ -320,16 +326,20 @@ public class SecuritiesChart
                                 Messages.LabelChartDetailClosingIndicator);
                 lineSeries2nd.setLineWidth(2);
                 lineSeries2nd.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                lineSeries2nd.enableArea(true);
+                if (!chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS)) lineSeries2nd.enableArea(true);
                 lineSeries2nd.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2nd.setYSeries(values2nd);
                 lineSeries2nd.setAntialias(SWT.ON);
                 lineSeries2nd.setYAxisId(1);
             }
 
+            addChartMarker();
+
             chart.adjustRange();
             
-            addChartMarker();
+            IAxis yAxis1st = chart.getAxisSet().getYAxis(0);
+            IAxis yAxis2nd = chart.getAxisSet().getYAxis(1);
+            yAxis2nd.setRange(new Range(yAxis1st.getRange().lower - firstQuote, yAxis1st.getRange().upper - firstQuote));
 
         }
         finally
@@ -341,21 +351,24 @@ public class SecuritiesChart
 
     private void addChartMarker()
     {
-        if (chartConfig.contains(ChartDetails.INVESTMENT))
+        if (chartConfig.contains(ChartDetails.markerINVESTMENT))
             addInvestmentMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.DIVIDENDS))
+        if (chartConfig.contains(ChartDetails.markerDIVIDENDS))
             addDividendMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.EVENTS))
+        if (chartConfig.contains(ChartDetails.markerEVENTS))
             addEventMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.SMA200))
+        if (chartConfig.contains(ChartDetails.indicatorSMA200))
             addSMAMarkerLines(200);
 
-        if (chartConfig.contains(ChartDetails.SMA50))
+        if (chartConfig.contains(ChartDetails.indicatorSMA50))
             addSMAMarkerLines(50);
-    }
+
+        if (chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS))
+            addBollingerBandsMarkerLines(20, 2);
+}
 
     private void addSMAMarkerLines(int SMADays)
     {
@@ -367,12 +380,13 @@ public class SecuritiesChart
 
         ILineSeries lineSeriesSMA = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE, lineID);
         lineSeriesSMA.setXDateSeries(SMALines.getDates());
-        lineSeriesSMA.setLineWidth(2);
+        lineSeriesSMA.setLineWidth(1);
         lineSeriesSMA.enableArea(false);
         lineSeriesSMA.setSymbolType(PlotSymbolType.NONE);
         lineSeriesSMA.setYSeries(SMALines.getValues());
         lineSeriesSMA.setAntialias(SWT.ON);
-        lineSeriesSMA.setLineColor(Colors.getColor(SMADays, 22, 22));
+        lineSeriesSMA.setLineColor(Display.getDefault().getSystemColor(
+                        SMADays == 200 ? SWT.COLOR_RED : SWT.COLOR_GREEN));
         lineSeriesSMA.setYAxisId(0);
     }
 
@@ -429,5 +443,48 @@ public class SecuritiesChart
                         .filter(e -> chartPeriod == null || chartPeriod.isBefore(e.getDate())) //
                         .forEach(e -> chart.addMarkerLine(e.getDate(),
                                         Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY), e.getDetails()));
+    }
+
+    private void addBollingerBandsMarkerLines(int BollingerBandsDays, double BollingerBandsFactor)
+    {
+        ChartLineSeriesAxes BollingerBandsLowerBand = new BollingerBands(BollingerBandsDays, BollingerBandsFactor, this.security, chartPeriod).getLowerBands();
+        if (BollingerBandsLowerBand == null || BollingerBandsLowerBand.getValues() == null || BollingerBandsLowerBand.getDates() == null)
+            return;
+
+
+//      ILineSeries lineSeriesBollingerBandsMiddleBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE, Messages.LabelChartDetailBollingerBands);
+//      lineSeriesBollingerBandsMiddleBand.setXDateSeries(BollingerBandsMiddleBand.getDates());
+//      lineSeriesBollingerBandsMiddleBand.setLineWidth(1);
+//      lineSeriesBollingerBandsMiddleBand.setLineStyle(LineStyle.DOT);
+//      lineSeriesBollingerBandsMiddleBand.enableArea(false);
+//      lineSeriesBollingerBandsMiddleBand.setSymbolType(PlotSymbolType.NONE);
+//      lineSeriesBollingerBandsMiddleBand.setYSeries(BollingerBandsMiddleBand.getValues());
+//      lineSeriesBollingerBandsMiddleBand.setAntialias(SWT.ON);
+//      lineSeriesBollingerBandsMiddleBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+//      lineSeriesBollingerBandsMiddleBand.setYAxisId(0);
+
+        ILineSeries lineSeriesBollingerBandsLowerBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE, Messages.LabelChartDetailBollingerBandsLower);
+        lineSeriesBollingerBandsLowerBand.setXDateSeries(BollingerBandsLowerBand.getDates());
+        lineSeriesBollingerBandsLowerBand.setLineWidth(1);
+        lineSeriesBollingerBandsLowerBand.setLineStyle(LineStyle.SOLID);
+        lineSeriesBollingerBandsLowerBand.enableArea(false);
+        lineSeriesBollingerBandsLowerBand.setSymbolType(PlotSymbolType.NONE);
+        lineSeriesBollingerBandsLowerBand.setYSeries(BollingerBandsLowerBand.getValues());
+        lineSeriesBollingerBandsLowerBand.setAntialias(SWT.ON);
+        lineSeriesBollingerBandsLowerBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+        lineSeriesBollingerBandsLowerBand.setYAxisId(0);
+
+        ChartLineSeriesAxes BollingerBandsUpperBand = new BollingerBands(BollingerBandsDays, BollingerBandsFactor, this.security, chartPeriod).getUpperBands();
+        ILineSeries lineSeriesBollingerBandsUpperBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE, Messages.LabelChartDetailBollingerBandsUpper);
+        lineSeriesBollingerBandsUpperBand.setXDateSeries(BollingerBandsUpperBand.getDates());
+        lineSeriesBollingerBandsUpperBand.setLineWidth(1);
+        lineSeriesBollingerBandsUpperBand.setLineStyle(LineStyle.SOLID);
+        lineSeriesBollingerBandsUpperBand.enableArea(false);
+        lineSeriesBollingerBandsUpperBand.setSymbolType(PlotSymbolType.NONE);
+        lineSeriesBollingerBandsUpperBand.setYSeries(BollingerBandsUpperBand.getValues());
+        lineSeriesBollingerBandsUpperBand.setAntialias(SWT.ON);
+        lineSeriesBollingerBandsUpperBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+        lineSeriesBollingerBandsUpperBand.setYAxisId(0);
+
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -55,13 +55,13 @@ public class SecuritiesChart
 {
     private enum ChartDetails
     {
-        typeCLOSING(Messages.LabelChartDetailClosingIndicator + "\\-----\\"), //
-        markerINVESTMENT(Messages.LabelChartDetailInvestments), //
-        markerDIVIDENDS(Messages.LabelChartDetailDividends), //
-        markerEVENTS(Messages.LabelChartDetailEvents + "\\-----\\"), //
-        indicatorSMA50(Messages.LabelChartDetailSMA50), //
-        indicatorSMA200(Messages.LabelChartDetailSMA200), //
-        indicatorBOLLINGERBANDS(Messages.LabelChartDetailBollingerBands);
+        CLOSING(Messages.LabelChartDetailClosingIndicator + "---"), //
+        INVESTMENT(Messages.LabelChartDetailInvestments), //
+        DIVIDENDS(Messages.LabelChartDetailDividends), //
+        EVENTS(Messages.LabelChartDetailEvents + "---"), //
+        SMA50(Messages.LabelChartDetailSMA50), //
+        SMA200(Messages.LabelChartDetailSMA200), //
+        BOLLINGERBANDS(Messages.LabelChartDetailBollingerBands);
 
         private final String label;
 
@@ -87,7 +87,7 @@ public class SecuritiesChart
 
     private TimelineChart chart;
     private LocalDate chartPeriod = LocalDate.now().minusYears(2);
-    private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.markerINVESTMENT, ChartDetails.markerEVENTS);
+    private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.INVESTMENT, ChartDetails.EVENTS);
 
     public SecuritiesChart(Composite parent, Client client, CurrencyConverter converter)
     {
@@ -181,7 +181,7 @@ public class SecuritiesChart
     {
         for (ChartDetails detail : ChartDetails.values())
         {
-            String ButtonDescription = detail.toString().replaceAll("\\\\-----\\\\", ""); 
+            String ButtonDescription = detail.toString().replaceAll("---", ""); 
             Action action = new SimpleAction(ButtonDescription, a -> {
                 boolean isActive = chartConfig.contains(detail);
 
@@ -198,7 +198,7 @@ public class SecuritiesChart
 
             action.setChecked(chartConfig.contains(detail));
             manager.add(action);
-            if (detail.toString().matches(".*\\\\-----\\\\.*")) manager.add(new Separator());
+            if (detail.toString().matches(".*---")) manager.add(new Separator());
         }
     }
 
@@ -266,7 +266,7 @@ public class SecuritiesChart
 
             chart.getTitle().setText(security.getName());
             
-            boolean showAreaRelativeToFirstQuote = chartConfig.contains(ChartDetails.typeCLOSING);
+            boolean showAreaRelativeToFirstQuote = chartConfig.contains(ChartDetails.CLOSING);
 
             List<SecurityPrice> prices = security.getPricesIncludingLatest();
 
@@ -315,7 +315,7 @@ public class SecuritiesChart
                             Messages.ColumnQuote);
             lineSeries.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
             lineSeries.setLineWidth(2);
-            if (!chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS)) lineSeries.enableArea(!showAreaRelativeToFirstQuote);
+            if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS)) lineSeries.enableArea(!showAreaRelativeToFirstQuote);
             lineSeries.setSymbolType(PlotSymbolType.NONE);
             lineSeries.setYSeries(values);
             lineSeries.setAntialias(SWT.ON);
@@ -326,7 +326,7 @@ public class SecuritiesChart
                                 Messages.LabelChartDetailClosingIndicator);
                 lineSeries2nd.setLineWidth(2);
                 lineSeries2nd.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                if (!chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS)) lineSeries2nd.enableArea(true);
+                if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS)) lineSeries2nd.enableArea(true);
                 lineSeries2nd.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2nd.setYSeries(values2nd);
                 lineSeries2nd.setAntialias(SWT.ON);
@@ -351,22 +351,22 @@ public class SecuritiesChart
 
     private void addChartMarker()
     {
-        if (chartConfig.contains(ChartDetails.markerINVESTMENT))
+        if (chartConfig.contains(ChartDetails.INVESTMENT))
             addInvestmentMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.markerDIVIDENDS))
+        if (chartConfig.contains(ChartDetails.DIVIDENDS))
             addDividendMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.markerEVENTS))
+        if (chartConfig.contains(ChartDetails.EVENTS))
             addEventMarkerLines();
 
-        if (chartConfig.contains(ChartDetails.indicatorSMA200))
+        if (chartConfig.contains(ChartDetails.SMA200))
             addSMAMarkerLines(200);
 
-        if (chartConfig.contains(ChartDetails.indicatorSMA50))
+        if (chartConfig.contains(ChartDetails.SMA50))
             addSMAMarkerLines(50);
 
-        if (chartConfig.contains(ChartDetails.indicatorBOLLINGERBANDS))
+        if (chartConfig.contains(ChartDetails.BOLLINGERBANDS))
             addBollingerBandsMarkerLines(20, 2);
 }
 


### PR DESCRIPTION
Add Bollinger bands to securities chart, rearrange the popup menu, add separator lines between each category, redefine the SMA line colors, reduce the line size of the SMA indicator and enhance the SMA description.

If the Bollinger Bands as indicator is used, the area filling is disabled to improve the appearance of the BBs.

The Bollinger Bands based on the SimpleMovingAverage.java logic.

Last but not least, since my implementation of the closing indicator chart, the  chart.adjustRange() had an negative impact at a later reuse. This pull will fix this handicap.
![bollinger bands](https://user-images.githubusercontent.com/29358155/30249831-755f6764-9644-11e7-9193-7e43e7ac78ff.jpg)

Best regards
Marco