### PR TITLE
ING DiBa date extration bug at buy/sell transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -302,6 +302,43 @@ public class INGDiBaPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf8() throws IOException
+    {
+        INGDiBaExtractor extractor = new INGDiBaExtractor(new Client())
+        {
+            @Override
+            protected String strip(File file) throws IOException
+            {
+                return from(file.getName());
+            }
+        };
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(Arrays.asList(new File("INGDiBa_Kauf8.txt")), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("GB0030934490"));
+        assertThat(security.getWkn(), is("797739"));
+        assertThat(security.getName(), is("M&G Inv.(1)-M&G Global Leaders"));
+
+        // check buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst()
+                        .get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(75.00)));
+        assertThat(entry.getPortfolioTransaction().getDate(), is(LocalDate.parse("2012-02-01")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(6.41234)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of("EUR", 0L)));
+    }
+
+    @Test
     public void testWertpapierVerkauf1() throws IOException
     {
         INGDiBaExtractor extractor = new INGDiBaExtractor(new Client())

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_Kauf8.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_Kauf8.txt
@@ -1,0 +1,48 @@
+ING-DiBa AG 60628 Frankfurt am Main
+Depotinhaber: XXXX XXXXX
+Herrn Direkt-Depot Nr.: 0000000000
+XXXX XXXXXX Datum: 02.02.2012
+XXXXXXstr. XX Seite: 1 von 2
+00000 XXXXXX
+Wertpapierabrechnung Kauf aus Sparplan
+Ordernummer 00000000.000
+ISIN (WKN) GB0030934490 (797739)
+Wertpapierbezeichnung M&G Inv.(1)-M&G Global Leaders
+Reg. Shares Euro-Class A o.N.
+Nominale 6,41234 Stück
+Kurs 12,31025
+Handelsplatz Fondsgesellsch.Ausl.
+Schlusstag 01.02.2012
+Kurswert EUR 78,94
+Rabatt EUR - 3,94
+Zwischensumme EUR 75,00
+Endbetrag zu Ihren Lasten EUR 75,00
+Abrechnungskonto 0000000000
+Valuta 06.02.2012
+Wertpapiere zugunsten Wertpapierrechnung Luxemburg.
+Der reguläre Ausgabeaufschlag von 5,250% ist im Kurs enthalten.
+Der ING-DiBa Ausgabeaufschlag beträgt 0,000%.
+Akk. ausschüttungsgl. Ertr. p. Ant. EUR 0,680073
+Weitere steuerliche Informationen entnehmen Sie bitte der Rückseite.
+Einfach überall handeln - mit dem neuen Mobile Brokerage. Mehr unter xxxxxx .
+ING-DiBa AG Vorsitzender des Aufsichtsrates: Ben Tellings Sitz: Frankfurt am Main Internet xxxxx
+Theodor-Heuss-Allee 106 Vorstand: Roland Boekhout (Vorsitzender), AG Frankfurt am Main HRB 7727 E-Mail info@ing-diba.de
+60486 Frankfurt am Main Bas Brouwers, Bernd Geilen, Katharina Herrmann, Steuernummer 047 220 2800 4 Bankleitzahl 500 105 17
+Martin Krebs, Herbert Willius USt-IdNr. DE 114 103 475
+34WAAD4444004513_T
+Depotinhaber: XXXX XXXXXX
+Direkt-Depot Nr.: 0000000000
+Datum: 02.02.2012
+Seite: 2 von 2
+Ordernummer 00000000.000
+ISIN (WKN) GB0030934490 (797739)
+Akkumulierte ausschüttungsgleiche Erträge 4,36 EUR
+Bereinigte akkumulierte ausschüttungsgleiche Erträge 1,00 EUR
+Verrechnungstopf Aktien vor Geschäft 0,00 EUR
+Verrechnungstopf Aktien nach Geschäft 0,00 EUR
+Verrechnungstopf Allgemein vor Geschäft 0,00 EUR
+Verrechnungstopf Allgemein nach Geschäft 0,00 EUR
+Verrechnungstopf ausländ. Quellensteuer vor Geschäft 0,00 EUR
+Verrechnungstopf ausländ. Quellensteuer nach Geschäft 0,00 EUR
+Für Fragen stehen wir Ihnen gerne telefonisch 7 Tage die Woche von 7.30 bis 22 Uhr unter 069 / 50 60 30 50
+zur Verfügung.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -84,12 +84,8 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .match("^Nominale( St.ck)? (?<shares>[\\d.]+(,\\d+)?).*")
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date").optional() //
-                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
-
-                        .section("date").optional() //
-                        .match("(Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .section("date") //
+                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag|Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -149,12 +145,8 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .match("^Nominale St.ck (?<shares>[\\d.]+(,\\d+)?)")
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date").optional() //
-                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
-
-                        .section("date").optional() //
-                        .match("(Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .section("date") //
+                        .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag|Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -89,7 +89,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("date").optional() //
-                        .match("Schlusstag / -zeit (?<date>\\d+.\\d+.\\d{4}+) .*") //
+                        .match("(Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //
@@ -151,6 +151,10 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
 
                         .section("date") //
                         .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                        .section("date").optional() //
+                        .match("(Schlusstag . -zeit|Schlusstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         .section("amount", "currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -149,7 +149,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .match("^Nominale St.ck (?<shares>[\\d.]+(,\\d+)?)")
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date") //
+                        .section("date").optional() //
                         .match("(Ausf.hrungstag . -zeit|Ausf.hrungstag) (?<date>\\d+.\\d+.\\d{4}+).*") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 


### PR DESCRIPTION
Refering to https://forum.portfolio-performance.info/t/missing-date-bei-ing-diba-pdf-import/1430

A buy/sell via investment companies the date is defined as "Schlusstag" instead of "Ausführungstag / -zeit"

Regards
Marco