### PR TITLE
Attributes with percentage formatting

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/dax.xml
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/dax.xml
@@ -36786,7 +36786,7 @@
         <columnLabel>TER</columnLabel>
         <target>name.abuchen.portfolio.model.Security</target>
         <type>java.lang.Double</type>
-        <converterClass>name.abuchen.portfolio.model.AttributeType$PercentPlainConverter</converterClass>
+        <converterClass>name.abuchen.portfolio.model.AttributeType$PercentConverter</converterClass>
       </attribute-type>
       <attribute-type>
         <id>aum</id>

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/kommer.xml
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/kommer.xml
@@ -37717,7 +37717,7 @@
         <columnLabel>TER</columnLabel>
         <target>name.abuchen.portfolio.model.Security</target>
         <type>java.lang.Double</type>
-        <converterClass>name.abuchen.portfolio.model.AttributeType$PercentPlainConverter</converterClass>
+        <converterClass>name.abuchen.portfolio.model.AttributeType$PercentConverter</converterClass>
       </attribute-type>
       <attribute-type>
         <id>aum</id>

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
@@ -8,6 +8,7 @@ import name.abuchen.portfolio.model.AttributeType.AmountConverter;
 import name.abuchen.portfolio.model.AttributeType.AmountPlainConverter;
 import name.abuchen.portfolio.model.AttributeType.Converter;
 import name.abuchen.portfolio.model.AttributeType.DateConverter;
+import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.AttributeType.PercentPlainConverter;
 import name.abuchen.portfolio.model.AttributeType.QuoteConverter;
 import name.abuchen.portfolio.model.AttributeType.ShareConverter;
@@ -18,6 +19,7 @@ public enum AttributeFieldType
     STRING(String.class, StringConverter.class), //
     AMOUNT(Long.class, AmountConverter.class), //
     AMOUNTPLAIN(Long.class, AmountPlainConverter.class), //
+    PERCENT(Double.class, PercentConverter.class), //
     PERCENTPLAIN(Double.class, PercentPlainConverter.class), //
     QUOTE(Long.class, QuoteConverter.class), //
     SHARE(Long.class, ShareConverter.class), //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels.properties
@@ -5,7 +5,9 @@ AMOUNTPLAIN.name = Amount (simple)
 
 DATE.name = Date
 
-PERCENTPLAIN.name = Precent
+PERCENT.name = Percent
+
+PERCENTPLAIN.name = Percent (simple)
 
 QUOTE.name = Quote
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels_de.properties
@@ -5,7 +5,9 @@ AMOUNTPLAIN.name = Betrag (einfach)
 
 DATE.name = Datum
 
-PERCENTPLAIN.name = Prozentzahl
+PERCENT.name = Prozentzahl
+
+PERCENTPLAIN.name = Prozentzahl (einfach)
 
 QUOTE.name = Kurs
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -9,6 +9,8 @@ public class Messages extends NLS
     public static String AttributesAcquisitionFeeName;
     public static String AttributesAUMColumn;
     public static String AttributesAUMName;
+    public static String AttributesManagementFeeColumn;
+    public static String AttributesManagementFeeName;
     public static String AttributesTERColumn;
     public static String AttributesTERName;
     public static String AttributesVendorColumn;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -7,6 +7,10 @@ AttributesAcquisitionFeeColumn = Acquisition Fee
 
 AttributesAcquisitionFeeName = Acquisition Fee (percentaged)
 
+AttributesManagementFeeColumn = Management Fee
+
+AttributesManagementFeeName = Management Fee (percentaged)
+
 AttributesTERColumn = TER
 
 AttributesTERName = Total Expense Ratio (TER)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
@@ -7,6 +7,10 @@ AttributesAcquisitionFeeColumn = Kaufgeb\u00FChr
 
 AttributesAcquisitionFeeName = Kaufgeb\u00FChr (prozentual)
 
+AttributesManagementFeeColumn = Verwaltungsgeb\u00FChr
+
+AttributesManagementFeeName = Verwaltungsgeb\u00FChr (prozentual)
+
 AttributesTERColumn = TER
 
 AttributesTERName = Gesamtkostenquote (TER)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -188,9 +188,14 @@ public class AttributeType
         {
             try
             {
-                if (value.trim().length() == 0)
+                value = value.trim();
+                if (value.length() == 0)
                     return null;
-
+                // ensure there is a percent sign at the end
+                if (!value.endsWith("%"))
+                {
+                    value += "%";
+                }
                 return format.parse(value).doubleValue();
             }
             catch (ParseException e)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -168,6 +168,38 @@ public class AttributeType
         }
     }
 
+    public static class PercentConverter implements Converter
+    {
+        private final NumberFormat format = NumberFormat.getPercentInstance(); //$NON-NLS-1$
+
+        public PercentConverter()
+        {
+            format.setMinimumFractionDigits(2);
+        }
+
+        @Override
+        public String toString(Object object)
+        {
+            return object != null ? format.format((double) object) : ""; //$NON-NLS-1$
+        }
+
+        @Override
+        public Object fromString(String value)
+        {
+            try
+            {
+                if (value.trim().length() == 0)
+                    return null;
+
+                return format.parse(value).doubleValue();
+            }
+            catch (ParseException e)
+            {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+
     public static class PercentPlainConverter extends DoubleConverter
     {
         public PercentPlainConverter()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
@@ -95,6 +95,14 @@ public class ClientSettings
         fee.setType(Double.class);
         fee.setConverter(PercentConverter.class);
         attributeTypes.add(fee);
+
+        AttributeType managementFee = new AttributeType("managementFee"); //$NON-NLS-1$
+        managementFee.setName(Messages.AttributesManagementFeeName);
+        managementFee.setColumnLabel(Messages.AttributesManagementFeeColumn);
+        managementFee.setTarget(Security.class);
+        managementFee.setType(Double.class);
+        managementFee.setConverter(PercentConverter.class);
+        attributeTypes.add(managementFee);
     }
 
     public List<Bookmark> getBookmarks()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.model.AttributeType.AmountPlainConverter;
-import name.abuchen.portfolio.model.AttributeType.PercentPlainConverter;
+import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.AttributeType.StringConverter;
 
 public class ClientSettings
@@ -69,7 +69,7 @@ public class ClientSettings
         ter.setColumnLabel(Messages.AttributesTERColumn);
         ter.setTarget(Security.class);
         ter.setType(Double.class);
-        ter.setConverter(PercentPlainConverter.class);
+        ter.setConverter(PercentConverter.class);
         attributeTypes.add(ter);
 
         AttributeType aum = new AttributeType("aum"); //$NON-NLS-1$
@@ -93,7 +93,7 @@ public class ClientSettings
         fee.setColumnLabel(Messages.AttributesAcquisitionFeeColumn);
         fee.setTarget(Security.class);
         fee.setType(Double.class);
-        fee.setConverter(PercentPlainConverter.class);
+        fee.setConverter(PercentConverter.class);
         attributeTypes.add(fee);
     }
 


### PR DESCRIPTION
I added a type for percentage attributes beside the existing plain percentage type.
It shows the value formatted with a percent sign - just like the standard percentage columns in the performance view etc.
The existing plain percentage type just shows the value, but does not indicate that it actually resembles a percentage value.

Additionally I changed the existing percentage attributes to use this new type by default.
The user is able to enter a percentage value of 1.25% either as "1.25%" or "1.25" (respecting the locale).

Furthermore I extended the default set of attributes with the management fee ("Verwaltungsgebühr").
It is pretty common for funds and ETFs like the existing TER.
I just put it into this pull request as it depends on the new attribute type.