### PR TITLE
Add regions according to market classification by MSCI.

### DIFF
--- a/name.abuchen.portfolio/META-INF/taxonomy/regions-msci.properties
+++ b/name.abuchen.portfolio/META-INF/taxonomy/regions-msci.properties
@@ -1,0 +1,140 @@
+name = Regions (MSCI)
+
+labels = Market,Region,Country
+
+colors = 93.69063,0.7783507,0.83966147
+
+regions-msci.children = RW,REM,RFM
+
+RW.label = World
+RW.children = RW1,RW2,RW3
+
+RW1.label = Americas
+RW1.children = RW11,RW12
+
+RW11.label = Canada
+RW12.label = United States
+
+RW2.label = Europe & Middle East
+RW2.children = RW21,RW22,RW23,RW24,RW25,RW26,RW27,RW28,RW29,RW210,RW211,RW212,RW213,RW214,RW215,RW216,RW217
+
+RW21.label = Austria
+RW22.label = Belgium
+RW23.label = Denmark
+RW24.label = Finland
+RW25.label = France
+RW26.label = Germany
+RW27.label = Ireland
+RW29.label = Israel
+RW210.label = Italy
+RW211.label = Netherlands
+RW212.label = Norway
+RW213.label = Portugal
+RW214.label = Spain
+RW215.label = Sweden
+RW216.label = Switzerland
+RW217.label = United Kingdom
+
+RW3.label = Pacific
+RW3.children = RW31,RW32,RW33,RW34,RW35
+
+RW31.label = Australia
+RW32.label = Hong Kong
+RW33.label = Japan
+RW34.label = New Zealand
+RW35.label = Singapore
+
+REM.label = Emerging Markets
+REM.children = REM1,REM2,REM3
+
+REM1.label = Americas
+REM1.children = REM11,REM12,REM13,REM14,REM15
+
+REM11.label = Brazil
+REM12.label = Chile
+REM13.label = Colombia
+REM14.label = Mexico
+REM15.label = Peru
+
+REM2.label = Europe, Middle East & Africa
+REM2.children = REM21,REM22,REM23,REM24,REM25,REM26,REM27,REM28,REM29,REM210,REM211
+
+REM21.label = Czech Republic
+REM22.label = Egypt
+REM23.label = Greece
+REM24.label = Hungary
+REM25.label = Poland
+REM26.label = Qatar
+REM27.label = Russia
+REM28.label = South Africa
+REM29.label = Turkey
+REM210.label = United Arab Emirates
+REM211.label = Saudi Arabia
+
+REM3.label = Asia
+REM3.children = REM31,REM32,REM33,REM34,REM35,REM36,REM37,REM38,REM39
+
+REM31.label = China
+REM32.label = India
+REM33.label = Indonesia
+REM34.label = Korea
+REM35.label = Malaysia
+REM36.label = Pakistan
+REM37.label = Philippines
+REM38.label = Taiwan
+REM39.label = Thailand
+
+RFM.label = Frontier Markets
+RFM.children = RFM1,RFM2,RFM3,RFM4,RFM5
+
+RFM1.label = Americas
+RFM1.children = RFM11,RFM12,RFM13,RFM14
+
+RFM11.label = Argentina
+RFM12.label = Jamaica
+RFM13.label = Panama
+RFM14.label = Trinidad & Tobago
+
+RFM2.label = Europe & CIS
+RFM2.children = RFM21,RFM22,RFM23,RFM24,RFM25,RFM26,RFM27,RFM28,RFM29,RFM210
+
+RFM21.label = Croatia
+RFM22.label = Estonia
+RFM23.label = Lithuania
+RFM24.label = Kazakhstan
+RFM25.label = Romania
+RFM26.label = Serbia
+RFM27.label = Slovenia
+RFM28.label = Bosnia Herzegovina
+RFM29.label = Bulgaria
+RFM210.label = Ukraine
+
+RFM3.label = Africa
+RFM3.children = RFM31,RFM32,RFM33,RFM34,RFM35,RFM36,RFM37,RFM38,RFM39
+
+RFM31.label = Kenya
+RFM32.label = Mauritius
+RFM33.label = Morocco
+RFM34.label = Nigeria
+RFM35.label = Tunisia
+RFM36.label = WAEMU
+RFM37.label = Botswana
+RFM38.label = Ghana
+RFM39.label = Zimbabwe
+
+RFM4.label = Middle East
+RFM4.children = RFM41,RFM42,RFM43,RFM44,RFM45,RFM46
+
+RFM41.label = Bahrain
+RFM42.label = Jordan
+RFM43.label = Kuwait
+RFM44.label = Lebanon
+RFM45.label = Oman
+RFM46.label = Palestine
+
+RFM5.label = Asia
+RFM5.children = RFM51,RFM52,RFM53
+
+RFM51.label = Bangladesh
+RFM52.label = Sri Lanka
+RFM53.label = Vietnam

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TaxonomyTemplate.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TaxonomyTemplate.java
@@ -19,7 +19,8 @@ public final class TaxonomyTemplate
                     new TaxonomyTemplate(INDUSTRY_GICS), //
                     new TaxonomyTemplate(INDUSTRY_SIMPLE2LEVEL), //
                     new TaxonomyTemplate("kommer"), //$NON-NLS-1$
-                    new TaxonomyTemplate("regions")); //$NON-NLS-1$
+                    new TaxonomyTemplate("regions"), //$NON-NLS-1$
+                    new TaxonomyTemplate("regions-msci")); //$NON-NLS-1$
 
     private String id;
     private String name;


### PR DESCRIPTION
This makes it easier to classify securities as it does include meta classification like "Emerging Markets".
Furthermore the user is assisted by allowing him to choose a country, which then gets mapped to such a region.

Source: https://www.msci.com/market-classification respective https://www.justetf.com/uk/news/etf/msci-index-classification-and-how-they-divide-up-the-world.html

Note: I just included the English version as I do not see too much sense in translating specific terms like "Frontier Markets".