### PR TITLE
Fix invisible cells in 'Shares' column on linux

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
@@ -135,7 +135,7 @@ public abstract class SharesLabelProvider extends OwnerDrawLabelProvider
 
         Rectangle layoutBounds = textLayout.getBounds();
         int x = event.x + tableItem.width - Math.min(size.width, tableItem.width);
-        int y = tableItem.y + Math.max(0, (tableItem.height - layoutBounds.height) / 2);
+        int y = event.y + Math.max(0, (tableItem.height - layoutBounds.height) / 2);
 
         textLayout.draw(event.gc, x, y);
 


### PR DESCRIPTION
Dies behebt mein Problem mit der unsichtbaren Spalte "Shares" u.a. auf der "Statement of Assets" Seite. Kannst du vielleicht testen, ob das so auch unter Windows korrekt funktioniert?

https://forum.portfolio-performance.info/t/inhalt-der-spalte-shares-auf-der-seite-statement-of-assets-unsichtbar/1289