### PR TITLE
PDFextractor Comdirect - Additional spacing fix at dividends section

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -627,4 +627,36 @@ public class ComdirectPDFExtractorTest
         assertThat(transaction.getAmount(), is(Values.Amount.factorize(7.52)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(175)));
     }
+    @Test
+    public void testGutschrift4() throws IOException
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "comdirectGutschrift4.txt"),
+                        errors);
+System.out.println(results);
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("IE00B9M6RS56"));
+        assertThat(security.getName(), is("i S hs  VI -  JP  M  D L  EM  B d   E OH  U .  ET F D"));
+        assertThat(security.getWkn(), is("A1W0MQ"));
+
+        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2017-10-31")));
+        assertThat(transaction.getSecurity(), is(security));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(8.54)));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(42)));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectGutschrift4.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectGutschrift4.txt
@@ -1,0 +1,45 @@
+﻿PDF author: 'HAVI Solutions GmbH & Co. KG, phg' 
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    xxxxxxxxx 
+     10xxx xxx BLZ:        xxx xxx xx 
+Herrn                              
+                             
+xxx xxxx                    
+                             
+                             
+                                   
+Musterstr. 1                                                           
+                             
+xxxxx Musterstadt                                                  
+31.10.2017
+G  u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Ertragsgutschrift                                                                  
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+p e r  1 7  . 01 . 2 0 1 1                          i S hs  VI -  JP  M  D L  EM  B d   E OH  U .  ET F D           A1  W0  MQ 
+ S TK                4 2 , 00  0                Re g i s t  er  ed   S ha  re s   o .N  .           I E 0 0  B9  M6  RS  5 6
+
+EUR 0,2034     Ausschüttung pro Stück für Geschäftsjahr     01.04.17 bis 31.12.17  
+zahlbar ab 01.11.2017                                                              
+                         Abrechnung Ertragsgutschrift                              
+Bruttobetrag:                                              EUR               8,54  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+DExx xxxx xxxx xxxx xxxx xx   EUR       31.10.2017         EUR               8,54  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 0SICAP53xxxxxxxx).                                                   
+comdirect bank                                                                     
+Aktiengesellschaft                                                                 
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -116,18 +116,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("wkn", "name", "isin", "shares").optional() //
-                        .match("p e r *\\d *\\d *\\. *\\d *\\d *\\. *\\d *\\d *\\d *\\d (?<name>.*)      (?<wkn>.*)") //
-                        .match("^S T K *(?<shares>(\\d )*(\\. )?(\\d )*, (\\d )*).*    .* {4}(?<isin>.*)$") //
-                        .assign((t, v) -> {
-                            v.put("isin", stripBlanks(v.get("isin")));
-                            v.put("wkn", stripBlanks(v.get("wkn")));
-                            t.setSecurity(getOrCreateSecurity(v));
-                            t.setShares(asShares(stripBlanks(v.get("shares"))));
-                        })
-
-                        .section("wkn", "name", "isin", "shares").optional() //
-                        .match("p e r *\\d *\\d *\\. *\\d *\\d *\\. *\\d *\\d *\\d *\\d (?<name>.*)      (?<wkn>.*)") //
-                        .match(" ST K *(?<shares>(\\d  )?(\\d )*(\\. )?(\\d )*,(\\d )*).*    .* {4}(?<isin>.*)$") //
+                        .match("^(p e r| p e r) *\\+?[\\d .]+  (?<name>.*)      (?<wkn>.*)") //
+                        .match("^(S T K| ST K| S TK) *(?<shares>\\+?[\\d .]+,\\+?[\\d ]+).*    .* {4}(?<isin>.*)$") //
                         .assign((t, v) -> {
                             v.put("isin", stripBlanks(v.get("isin")));
                             v.put("wkn", stripBlanks(v.get("wkn")));


### PR DESCRIPTION
Belonging to issue #864
---
Changed regex expression to improve the extraction of shares and date.
Existing logic require exact knowing of positioning of numbers and seperator.
New logic is collectiong the share by collecting just numbers and the seperator.

Best regards
Marco

P.S. Still unknown why the original source file at issue #864 and pull #854 has the folling word-wrap:
**Carriage Return + Carriage Return + Line Feed** instead of **Carriage Return + Line Feed**