### PR TITLE
Remove bank identifier "BNP Paribas" at DAB PDFextractor

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
@@ -20,8 +20,7 @@ public class DABPDFExctractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("DAB"); //$NON-NLS-1$
-        addBankIdentifier("BNP Paribas"); //$NON-NLS-1$
+        addBankIdentifier("DAB Bank"); //$NON-NLS-1
 
         addBuyTransaction();
         addSellTransaction();


### PR DESCRIPTION
According to https://forum.portfolio-performance.info/t/pdf-import-hellobank/1653/5
Remove bank identifier "BNP Paribas" at DAB PDFextractor to avoid confusion with Helobank determination.