### PR TITLE
CreateTextFromPDFHandler CRLF bug

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
@@ -43,7 +43,7 @@ public class CreateTextFromPDFHandler
             String text = MessageFormat.format(Messages.PDFImportDebugAuthor, inputFile.getAuthor());
             text += "\nPDFBox Version: " + inputFile.getPDFBoxVersion().toString(); //$NON-NLS-1$
             text += "\n-----------------------------------------\n"; //$NON-NLS-1$
-            text += inputFile.getText();
+            text += inputFile.getText().replace("\r","");   // CRLF to spac;
 
             new DisplayTextDialog(shell, text).open();
         }


### PR DESCRIPTION
pdfbox getText at CreateTextFromPDFHandler adding the char \r at word wrap. If the generated text by PP is copy and pasted into a text file for integration into the PP Java environment, the according new test cases failed (CR LF bug). Unfortunately this behaviour is only visible at a file hex editor or at the GitHub Desktop (see screen dump).

![unbenannt](https://user-images.githubusercontent.com/29358155/32520607-e328f28e-c410-11e7-9cc9-bf2ec929a80d.JPG)