### PR TITLE
SecurityPrice methods getTime renamed to getDate

### DIFF
--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
@@ -40,7 +40,7 @@ public class SecurityTestCase
         PortfolioTransaction delivery = client.getPortfolios().get(0).getTransactions().get(0);
 
         assertThat("delivery transaction must be before earliest historical quote", delivery.getDate(),
-                        lessThan(security.getPrices().get(0).getTime()));
+                        lessThan(security.getPrices().get(0).getDate()));
 
         ReportingPeriod period = new ReportingPeriod.FromXtoY(LocalDate.parse("2013-12-04"), LocalDate.parse("2014-12-04"));
         TestCurrencyConverter converter = new TestCurrencyConverter();

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
@@ -34,7 +34,7 @@ public class SimpleMovingAverageTest
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd.MM.yyyy");
         formatter = formatter.withLocale(Locale.GERMANY);
         LocalDate date = LocalDate.parse("01.01.2017", formatter);
-        price.setTime(date);
+        price.setDate(date);
         price.setValue(0);
         securityOnePrice.addPrice(price);
 
@@ -47,7 +47,7 @@ public class SimpleMovingAverageTest
                 date = LocalDate.parse(i + ".01.2017", formatter);
 
             price = new SecurityPrice();
-            price.setTime(date);
+            price.setDate(date);
             price.setValue(i);
             securityTenPrices.addPrice(price);
             i++;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/QuotesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/QuotesTableViewer.java
@@ -111,7 +111,7 @@ public class QuotesTableViewer
                 switch (columnIndex)
                 {
                     case 0:
-                        return Values.Date.format(p.getTime());
+                        return Values.Date.format(p.getDate());
                     case 1:
                         return p.getHigh() == LatestSecurityPrice.NOT_AVAILABLE ? null : Values.Quote.format(p.getHigh());
                     case 2:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/BollingerBands.java
@@ -116,9 +116,9 @@ public class BollingerBands
         for (; index < prices.size(); index++)
         {
             if (index < BollingerBandsDays) continue; 
-            LocalDate nextDate = prices.get(index).getTime();
+            LocalDate nextDate = prices.get(index).getDate();
             LocalDate isBefore = nextDate.plusDays(1);
-            LocalDate isAfter = prices.get(index - BollingerBandsDays + 2).getTime();
+            LocalDate isAfter = prices.get(index - BollingerBandsDays + 2).getDate();
             List<SecurityPrice> filteredPrices = this.getFilteredList(isBefore, isAfter);
 
             if (filteredPrices.size() < calculatedMinimumDays)
@@ -141,7 +141,7 @@ public class BollingerBands
             valuesBollingerBandsLowerBands.add(valueBollingerBandsLowerBands);
             valuesBollingerBandsMiddleBands.add(QuotePriceAverage);
             valuesBollingerBandsUpperBands.add(valueBollingerBandsUpperBands);
-            datesBollingerBands.add(prices.get(index).getTime());
+            datesBollingerBands.add(prices.get(index).getDate());
         }
         LocalDate[] tmpDates = datesBollingerBands.toArray(new LocalDate[0]);
         Double[] tmpPricesLower = valuesBollingerBandsLowerBands.toArray(new Double[0]);
@@ -177,7 +177,7 @@ public class BollingerBands
     public SecurityPrice getStartPrice()
     {
         // get Date of first possible bollinger bands calculation
-        LocalDate BollingerBandsPeriodEnd = prices.get(0).getTime().plusDays(BollingerBandsDays - 1L);
+        LocalDate BollingerBandsPeriodEnd = prices.get(0).getDate().plusDays(BollingerBandsDays - 1L);
         int index = Math.abs(Collections.binarySearch(prices, new SecurityPrice(BollingerBandsPeriodEnd, 0),
                         new SecurityPrice.ByDate()));
         if (index >= prices.size())
@@ -192,7 +192,7 @@ public class BollingerBands
         List<SecurityPrice> filteredPrices = null;
         LocalDate isBefore = BollingerBandsPeriodEnd.plusDays(1);
         LocalDate isAfter = BollingerBandsPeriodEnd.minusDays(BollingerBandsDays);
-        LocalDate lastDate = prices.get(prices.size() - 1).getTime();
+        LocalDate lastDate = prices.get(prices.size() - 1).getDate();
         filteredPrices = this.getFilteredList(isBefore, isAfter);
 
         int i = 1;
@@ -215,7 +215,7 @@ public class BollingerBands
 
     private List<SecurityPrice> getFilteredList(LocalDate isBefore, LocalDate isAfter)
     {
-        return prices.stream().filter(p -> p.getTime().isAfter(isAfter) && p.getTime().isBefore(isBefore))
+        return prices.stream().filter(p -> p.getDate().isAfter(isAfter) && p.getDate().isBefore(isBefore))
                         .collect(Collectors.toList());
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -309,7 +309,7 @@ public class SecuritiesChart
             for (int ii = 0; index < prices.size(); index++, ii++)
             {
                 SecurityPrice p = prices.get(index);
-                dates[ii] = p.getTime();
+                dates[ii] = p.getDate();
                 values[ii] = p.getValue() / Values.Quote.divider();
                 values2nd[ii] = (p.getValue() / Values.Quote.divider()) - firstQuote;
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -403,7 +403,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
                 SecurityPerformanceRecord record = (SecurityPerformanceRecord) element;
 
                 return MessageFormat.format(Messages.TooltipQuoteAtDate, getText(element),
-                                Values.Date.format(record.getLatestSecurityPrice().getTime()));
+                                Values.Date.format(record.getLatestSecurityPrice().getDate()));
             }
         });
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "fifoCostPerSharesHeld")); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -301,7 +301,7 @@ public final class SecuritiesTable implements ModificationListener
             public String getText(Object element)
             {
                 SecurityPrice latest = ((Security) element).getSecurityPrice(LocalDate.now());
-                return latest != null ? Values.Date.format(latest.getTime()) : null;
+                return latest != null ? Values.Date.format(latest.getDate()) : null;
             }
 
             @Override
@@ -317,7 +317,7 @@ public final class SecuritiesTable implements ModificationListener
                     return null;
 
                 LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
-                return latest.getTime().isBefore(sevenDaysAgo) ? Colors.WARNING : null;
+                return latest.getDate().isBefore(sevenDaysAgo) ? Colors.WARNING : null;
             }
         });
         column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
@@ -329,7 +329,7 @@ public final class SecuritiesTable implements ModificationListener
             if (p2 == null)
                 return 1;
 
-            return p1.getTime().compareTo(p2.getTime());
+            return p1.getDate().compareTo(p2.getDate());
         }));
         support.addColumn(column);
     }
@@ -348,7 +348,7 @@ public final class SecuritiesTable implements ModificationListener
                     return null;
 
                 SecurityPrice latest = prices.get(prices.size() - 1);
-                return latest != null ? Values.Date.format(latest.getTime()) : null;
+                return latest != null ? Values.Date.format(latest.getDate()) : null;
             }
 
             @Override
@@ -363,7 +363,7 @@ public final class SecuritiesTable implements ModificationListener
                     return null;
 
                 SecurityPrice latest = prices.get(prices.size() - 1);
-                if (!((Security) element).isRetired() && latest.getTime().isBefore(LocalDate.now().minusDays(7)))
+                if (!((Security) element).isRetired() && latest.getDate().isBefore(LocalDate.now().minusDays(7)))
                     return Colors.WARNING;
                 else
                     return null;
@@ -380,7 +380,7 @@ public final class SecuritiesTable implements ModificationListener
             if (p2 == null)
                 return 1;
 
-            return p1.getTime().compareTo(p2.getTime());
+            return p1.getDate().compareTo(p2.getDate());
         }));
         support.addColumn(column);
     }
@@ -403,7 +403,7 @@ public final class SecuritiesTable implements ModificationListener
             if (previous.getValue() == 0)
                 return null;
 
-            if (previous.getTime().isAfter(option.getStartDate()))
+            if (previous.getDate().isAfter(option.getStartDate()))
                 return null;
 
             return new Double((latest.getValue() - previous.getValue()) / (double) previous.getValue());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
@@ -282,7 +282,7 @@ public class SecurityDetailsViewer
                 LatestSecurityPrice p = security.getLatest();
 
                 valueLatestPrices.setText(Values.Quote.format(p.getValue()));
-                valueLatestTrade.setText(Values.Date.format(p.getTime()));
+                valueLatestTrade.setText(Values.Date.format(p.getDate()));
                 long daysHigh = p.getHigh();
                 valueDaysHigh.setText(daysHigh == LatestSecurityPrice.NOT_AVAILABLE ? Messages.LabelNotAvailable
                                 : Values.Quote.format(daysHigh));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -502,7 +502,7 @@ public class SecurityListView extends AbstractListView implements ModificationLi
             @Override
             public String getText(Object element)
             {
-                return Values.Date.format(((SecurityPrice) element).getTime());
+                return Values.Date.format(((SecurityPrice) element).getDate());
             }
 
             @Override
@@ -516,12 +516,12 @@ public class SecurityListView extends AbstractListView implements ModificationLi
                     return null;
 
                 SecurityPrice previous = (SecurityPrice) all.get(index - 1);
-                int days = Dates.daysBetween(previous.getTime(), current.getTime());
+                int days = Dates.daysBetween(previous.getDate(), current.getDate());
                 return days > 3 ? Colors.WARNING : null;
             }
         });
-        ColumnViewerSorter.create(SecurityPrice.class, "time").attachTo(column, SWT.UP); //$NON-NLS-1$
-        new DateEditingSupport(SecurityPrice.class, "time").addListener(this).attachTo(column); //$NON-NLS-1$
+        ColumnViewerSorter.create(SecurityPrice.class, "date").attachTo(column, SWT.UP); //$NON-NLS-1$
+        new DateEditingSupport(SecurityPrice.class, "date").addListener(this).attachTo(column); //$NON-NLS-1$
         support.addColumn(column);
 
         column = new Column(Messages.ColumnQuote, SWT.RIGHT, 80);
@@ -566,7 +566,7 @@ public class SecurityListView extends AbstractListView implements ModificationLi
                         return;
 
                     SecurityPrice price = new SecurityPrice();
-                    price.setTime(LocalDate.now());
+                    price.setDate(LocalDate.now());
 
                     security.addPrice(price);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SimpleMovingAverage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SimpleMovingAverage.java
@@ -93,7 +93,7 @@ public class SimpleMovingAverage
 
         for (; index < prices.size(); index++)
         {
-            LocalDate nextDate = prices.get(index).getTime();
+            LocalDate nextDate = prices.get(index).getDate();
             LocalDate isBefore = nextDate.plusDays(1);
             LocalDate isAfter = isBefore.minusDays(rangeSMA + 1L);
             List<SecurityPrice> filteredPrices = this.getFilteredList(isBefore, isAfter);
@@ -105,7 +105,7 @@ public class SimpleMovingAverage
             double sum = filteredPrices.stream().mapToLong(SecurityPrice::getValue).sum();
 
             valuesSMA.add(sum / Values.Quote.divider() / filteredPrices.size());
-            datesSMA.add(prices.get(index).getTime());
+            datesSMA.add(prices.get(index).getDate());
         }
         LocalDate[] tmpDates = datesSMA.toArray(new LocalDate[0]);
         Double[] tmpPrices = valuesSMA.toArray(new Double[0]);
@@ -135,7 +135,7 @@ public class SimpleMovingAverage
     public SecurityPrice getStartPrice()
     {
         // get Date of first possible SMA calculation
-        LocalDate smaPeriodEnd = prices.get(0).getTime().plusDays(rangeSMA - 1L);
+        LocalDate smaPeriodEnd = prices.get(0).getDate().plusDays(rangeSMA - 1L);
         int index = Math.abs(Collections.binarySearch(prices, new SecurityPrice(smaPeriodEnd, 0),
                         new SecurityPrice.ByDate()));
         if (index >= prices.size())
@@ -150,7 +150,7 @@ public class SimpleMovingAverage
         List<SecurityPrice> filteredPrices = null;
         LocalDate isBefore = smaPeriodEnd.plusDays(1);
         LocalDate isAfter = smaPeriodEnd.minusDays(rangeSMA);
-        LocalDate lastDate = prices.get(prices.size() - 1).getTime();
+        LocalDate lastDate = prices.get(prices.size() - 1).getDate();
         filteredPrices = this.getFilteredList(isBefore, isAfter);
 
         int i = 1;
@@ -173,7 +173,7 @@ public class SimpleMovingAverage
 
     private List<SecurityPrice> getFilteredList(LocalDate isBefore, LocalDate isAfter)
     {
-        return prices.stream().filter(p -> p.getTime().isAfter(isAfter) && p.getTime().isBefore(isBefore))
+        return prices.stream().filter(p -> p.getDate().isAfter(isAfter) && p.getDate().isBefore(isBefore))
                         .collect(Collectors.toList());
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -297,12 +297,12 @@ public class StatementOfAssetsViewer
             public String getText(Object e)
             {
                 Element element = (Element) e;
-                return element.isSecurity() ? Values.Date.format(element.getSecurityPosition().getPrice().getTime())
+                return element.isSecurity() ? Values.Date.format(element.getSecurityPosition().getPrice().getDate())
                                 : null;
             }
         });
         column.setComparator(new ElementComparator(new AttributeComparator(e -> ((Element) e).isSecurity()
-                        ? ((Element) e).getSecurityPosition().getPrice().getTime() : null)));
+                        ? ((Element) e).getSecurityPosition().getPrice().getDate() : null)));
         column.setVisible(false);
         support.addColumn(column);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ImportQuotesWizard.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ImportQuotesWizard.java
@@ -47,7 +47,7 @@ public class ImportQuotesWizard extends Wizard
 
         for (LatestSecurityPrice p : quotes)
         {
-            SecurityPrice quote = new SecurityPrice(p.getTime(), p.getValue());
+            SecurityPrice quote = new SecurityPrice(p.getDate(), p.getValue());
             security.addPrice(quote);
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/LatestQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/LatestQuoteProviderPage.java
@@ -120,7 +120,7 @@ public class LatestQuoteProviderPage extends AbstractQuoteProviderPage
                         LatestSecurityPrice p = s.getLatest();
 
                         valueLatestPrices.setText(Values.Quote.format(p.getValue()));
-                        valueLatestTrade.setText(Values.Date.format(p.getTime()));
+                        valueLatestTrade.setText(Values.Date.format(p.getDate()));
                         long daysHigh = p.getHigh();
                         valueDaysHigh.setText(
                                         daysHigh == -1 ? Messages.LabelNotAvailable : Values.Quote.format(daysHigh));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewQuotesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewQuotesPage.java
@@ -41,11 +41,11 @@ public class PreviewQuotesPage extends AbstractWizardPage
             switch (columnIndex)
             {
                 case 0:
-                    return Values.Date.format(p.getTime());
+                    return Values.Date.format(p.getDate());
                 case 1:
                     return Values.Quote.format(p.getValue());
                 case 2:
-                    if (model.isChangeHistoricalQuotes() && p.getTime().isBefore(model.getExDate()))
+                    if (model.isChangeHistoricalQuotes() && p.getDate().isBefore(model.getExDate()))
                     {
                         long shares = p.getValue() * model.getOldShares() / model.getNewShares();
                         return Values.Quote.format(shares);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -112,7 +112,7 @@ public class StockSplitModel extends BindingHelper.Model
             List<SecurityPrice> quotes = security.getPrices();
             for (SecurityPrice p : quotes)
             {
-                if (p.getTime().isBefore(exDate))
+                if (p.getDate().isBefore(exDate))
                     p.setValue(p.getValue() * oldShares / newShares);
             }
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
@@ -197,7 +197,7 @@ public class CSVExporter
 
             for (SecurityPrice p : security.getPrices())
             {
-                printer.print(p.getTime().toString());
+                printer.print(p.getDate().toString());
                 printer.print(Values.Quote.format(p.getValue()));
                 printer.println();
             }
@@ -223,7 +223,7 @@ public class CSVExporter
             {
                 export.add(s);
 
-                LocalDate quoteDate = prices.get(0).getTime();
+                LocalDate quoteDate = prices.get(0).getDate();
                 if (earliestDate == null)
                     earliestDate = quoteDate;
                 else

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -269,7 +269,8 @@ public class ClientFactory
                             // "Given final block not properly padded" is thrown
                             // if we do not read the stream - so ignore that
                             // kind of exception
-                            if (!(ex.getCause() instanceof BadPaddingException)) { throw ex; }
+                            if (!(ex.getCause() instanceof BadPaddingException)) 
+                                throw ex;
                         }
                     }
                 }
@@ -1065,8 +1066,8 @@ public class ClientFactory
                     xstream.alias("attribute-type", AttributeType.class);
 
                     xstream.alias("price", SecurityPrice.class);
-                    xstream.useAttributeFor(SecurityPrice.class, "time");
-                    xstream.aliasField("t", SecurityPrice.class, "time");
+                    xstream.useAttributeFor(SecurityPrice.class, "date");
+                    xstream.aliasField("t", SecurityPrice.class, "date");
                     xstream.useAttributeFor(SecurityPrice.class, "value");
                     xstream.aliasField("v", SecurityPrice.class, "value");
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LatestSecurityPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LatestSecurityPrice.java
@@ -15,14 +15,14 @@ public class LatestSecurityPrice extends SecurityPrice
     public LatestSecurityPrice()
     {}
 
-    public LatestSecurityPrice(LocalDate time, long price)
+    public LatestSecurityPrice(LocalDate date, long price)
     {
-        super(time, price);
+        super(date, price);
     }
 
-    public LatestSecurityPrice(LocalDate time, long price, long high, long low, long volume)
+    public LatestSecurityPrice(LocalDate date, long price, long high, long low, long volume)
     {
-        super(time, price);
+        super(date, price);
 
         this.high = high;
         this.low = low;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -244,7 +244,7 @@ public final class Security implements Attributable, InvestmentVehicle
         if (latest == null)
             return getPrices();
 
-        int index = Collections.binarySearch(prices, new SecurityPrice(latest.getTime(), latest.getValue()));
+        int index = Collections.binarySearch(prices, new SecurityPrice(latest.getDate(), latest.getValue()));
 
         if (index >= 0) // historic quote exists -> use it
             return getPrices();
@@ -297,7 +297,7 @@ public final class Security implements Attributable, InvestmentVehicle
         prices.clear();
     }
 
-    public SecurityPrice getSecurityPrice(LocalDate requestedTime)
+    public SecurityPrice getSecurityPrice(LocalDate requestedDate)
     {
         // assumption: prefer historic quote over latest if there are more
         // up-to-date historic quotes
@@ -313,19 +313,19 @@ public final class Security implements Attributable, InvestmentVehicle
 
         if (latest != null //
                         && (lastHistoric == null //
-                                        || (!requestedTime.isBefore(latest.getTime()) && //
-                                                        !latest.getTime().isBefore(lastHistoric.getTime()) //
+                                        || (!requestedDate.isBefore(latest.getDate()) && //
+                                                        !latest.getDate().isBefore(lastHistoric.getDate()) //
                                         )))
             return latest;
 
         if (lastHistoric == null)
-            return new SecurityPrice(requestedTime, 0);
+            return new SecurityPrice(requestedDate, 0);
 
         // avoid binary search if last historic quote <= requested date
-        if (!lastHistoric.getTime().isAfter(requestedTime))
+        if (!lastHistoric.getDate().isAfter(requestedDate))
             return lastHistoric;
 
-        SecurityPrice p = new SecurityPrice(requestedTime, 0);
+        SecurityPrice p = new SecurityPrice(requestedDate, 0);
         int index = Collections.binarySearch(prices, p);
 
         if (index >= 0)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPrice.java
@@ -15,30 +15,30 @@ public class SecurityPrice implements Comparable<SecurityPrice>
         @Override
         public int compare(SecurityPrice p1, SecurityPrice p2)
         {
-            return p1.time.compareTo(p2.time);
+            return p1.date.compareTo(p2.date);
         }
     }
 
-    private LocalDate time;
+    private LocalDate date;
     private long value;
 
     public SecurityPrice()
     {}
 
-    public SecurityPrice(LocalDate time, long price)
+    public SecurityPrice(LocalDate date, long price)
     {
         this.value = price;
-        this.time = time;
+        this.date = date;
     }
 
-    public LocalDate getTime()
+    public LocalDate getDate()
     {
-        return time;
+        return date;
     }
 
-    public void setTime(LocalDate time)
+    public void setDate(LocalDate date)
     {
-        this.time = time;
+        this.date = date;
     }
 
     public long getValue()
@@ -54,7 +54,7 @@ public class SecurityPrice implements Comparable<SecurityPrice>
     @Override
     public int compareTo(SecurityPrice o)
     {
-        return time.compareTo(o.time);
+        return this.date.compareTo(o.date);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class SecurityPrice implements Comparable<SecurityPrice>
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        result = prime * result + ((date == null) ? 0 : date.hashCode());
         result = prime * result + (int) (value ^ (value >>> 32));
         return result;
     }
@@ -77,12 +77,12 @@ public class SecurityPrice implements Comparable<SecurityPrice>
         if (getClass() != obj.getClass())
             return false;
         SecurityPrice other = (SecurityPrice) obj;
-        if (time == null)
+        if (date == null)
         {
-            if (other.time != null)
+            if (other.date != null)
                 return false;
         }
-        else if (!time.equals(other.time))
+        else if (!date.equals(other.date))
             return false;
         if (value != other.value)
             return false;
@@ -93,7 +93,7 @@ public class SecurityPrice implements Comparable<SecurityPrice>
     @SuppressWarnings("nls")
     public String toString()
     {
-        return String.format("%tF: %,10.2f", time, value / Values.Quote.divider());
+        return String.format("%tF: %,10.2f", date, value / Values.Quote.divider());
     }
 
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -157,7 +157,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                 try
                 {
                     LocalDate date = LocalDate.parse(text, formatters[ii]);
-                    price.setTime(date);
+                    price.setDate(date);
                     return;
                 }
                 catch (DateTimeParseException e) // NOSONAR
@@ -287,7 +287,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
         boolean isUpdated = false;
         for (LatestSecurityPrice quote : quotes)
         {
-            boolean isAdded = security.addPrice(new SecurityPrice(quote.getTime(), quote.getValue()));
+            boolean isAdded = security.addPrice(new SecurityPrice(quote.getDate(), quote.getValue()));
             isUpdated = isUpdated || isAdded;
         }
 
@@ -544,7 +544,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
 
         for (LatestSecurityPrice p : prices)
         {
-            writer.print(Values.Date.format(p.getTime()));
+            writer.print(Values.Date.format(p.getDate()));
             writer.print("\t");
             writer.print(Values.Quote.format(p.getValue()));
             writer.print("\t");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -116,7 +116,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
             if (time.isPresent())
             {
                 long epoch = Long.parseLong(time.get());
-                price.setTime(Instant.ofEpochSecond(epoch).atZone(ZoneId.systemDefault()).toLocalDate());
+                price.setDate(Instant.ofEpochSecond(epoch).atZone(ZoneId.systemDefault()).toLocalDate());
             }
 
             Optional<String> value = extract(body, startIndex, "\"regularMarketPrice\":{\"raw\":", ","); //$NON-NLS-1$ //$NON-NLS-2$
@@ -139,7 +139,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
             if (volume.isPresent())
                 price.setVolume(asNumber(volume.get()));
             
-            if (price.getTime() == null || price.getValue() <= 0)
+            if (price.getDate() == null || price.getValue() <= 0)
             {
                 errors.add(new IOException(body));
                 return false;
@@ -197,7 +197,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
         if (!security.getPrices().isEmpty())
         {
             SecurityPrice lastHistoricalQuote = security.getPrices().get(security.getPrices().size() - 1);
-            return lastHistoricalQuote.getTime();
+            return lastHistoricalQuote.getDate();
         }
         else
         {
@@ -363,7 +363,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
 
         long v = asPrice(values[CSVColumn.Close]);
 
-        price.setTime(date);
+        price.setDate(date);
         price.setValue(v);
 
         if (price instanceof LatestSecurityPrice)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityIndex.java
@@ -34,7 +34,7 @@ import name.abuchen.portfolio.util.Interval;
 
         Interval actualInterval = clientIndex.getActualInterval();
 
-        LocalDate firstPricePoint = prices.get(0).getTime();
+        LocalDate firstPricePoint = prices.get(0).getDate();
         if (firstPricePoint.isAfter(actualInterval.getEnd()))
         {
             initEmpty(clientIndex);
@@ -46,7 +46,7 @@ import name.abuchen.portfolio.util.Interval;
             startDate = firstPricePoint;
 
         LocalDate endDate = actualInterval.getEnd();
-        LocalDate lastPricePoint = prices.get(prices.size() - 1).getTime();
+        LocalDate lastPricePoint = prices.get(prices.size() - 1).getDate();
 
         if (lastPricePoint.isBefore(endDate))
             endDate = lastPricePoint;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/QuoteFromTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/QuoteFromTransactionExtractor.java
@@ -59,7 +59,7 @@ public class QuoteFromTransactionExtractor
                 SecurityPrice price = new SecurityPrice(d, q.getAmount());
                 bChanges |= security.addPrice(price);
                 // remember the lates price
-                if ((pLatest == null) || d.isAfter(pLatest.getTime()))
+                if ((pLatest == null) || d.isAfter(pLatest.getDate()))
                 {
                     pLatest = price;
                 }
@@ -68,7 +68,7 @@ public class QuoteFromTransactionExtractor
         // set the latest price (if at leas one price was found)
         if (pLatest != null)
         {
-            LatestSecurityPrice lsp = new LatestSecurityPrice(pLatest.getTime(), pLatest.getValue());
+            LatestSecurityPrice lsp = new LatestSecurityPrice(pLatest.getDate(), pLatest.getValue());
             bChanges |= security.setLatest(lsp);
         }
         return bChanges;


### PR DESCRIPTION
Hello Andreas,

dedicated pull request to cleanup an inconsistency in the SecurityPrice declaration IMHO.
The methods getTime and setTime of the class SecurityPrice (and LatestSecurityPrice accordingly) actually referred to a LocalDate variable.
This pull requests renames these methods to getDate and setDate and aligns all references in the remaining code base.
Looking forward to see this modification being pulled