### PR TITLE
Improve DAB bank identifier to avoid conflicts with HelloBank

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend6.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend6.txt
@@ -1,4 +1,4 @@
-DAB
+﻿DAB Bank
 
 Dividendengutschrift München, 31.05.2013
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABKauf4.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABKauf4.txt
@@ -1,4 +1,4 @@
-DAB
+﻿DAB Bank
 Kauf ADRESSZEILE2=XXX
 
 Wir haben für Sie gekauft

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf3.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf3.txt
@@ -1,4 +1,4 @@
-DAB
+﻿DAB Bank
 Verkauf  ADRESSZEILE2=Vorname Nachname
 
 Wir haben für Sie verkauft

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExctractor.java
@@ -20,8 +20,8 @@ public class DABPDFExctractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("DAB"); //$NON-NLS-1$
-        addBankIdentifier("BNP Paribas"); //$NON-NLS-1$
+        addBankIdentifier("DAB Bank"); //$NON-NLS-1$
+        addBankIdentifier("BNP Paribas S.A. Niederlassung Deutschland"); //$NON-NLS-1$
 
         addBuyTransaction();
         addSellTransaction();


### PR DESCRIPTION
According to forum discussion https://forum.portfolio-performance.info/t/pdf-import-hellobank/1653/7 , minor adjustments of DAB bank identifier. This allows that the PDF Import Assistent detect the HelloBank instead of DAB due to "BNP Paribas" at both banks.