### PR TITLE
introduce delayedDividend parameter for dividend payment of a security

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -101,6 +101,7 @@ public class Messages extends NLS
     public static String ColumnAbsolutePerformance_Description;
     public static String ColumnAbsolutePerformance;
     public static String ColumnAbsolutePerformance_Option;
+    public static String ColumnDelayedDividend;
     public static String ColumnDeltaPercent;
     public static String ColumnDeltaShares;
     public static String ColumnDeltaValue;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
@@ -329,7 +329,7 @@ public class AccountTransactionDialog extends AbstractTransactionDialog // NOSON
 
         CurrencyConverter converter = new CurrencyConverterImpl(model.getExchangeRateProviderFactory(),
                         client.getBaseCurrency());
-        ClientSnapshot snapshot = ClientSnapshot.create(client, converter, model().getDate());
+        ClientSnapshot snapshot = ClientSnapshot.create(client, converter, model().getDate().minusDays((long) model().getSecurity().getDelayedDividend()));
 
         if (snapshot != null && model().getSecurity() != null)
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -223,6 +223,8 @@ ColumnDaysLow = Day's Low
 
 ColumnDebitNote = Debit Note
 
+ColumnDelayedDividend = Delayed Dividend Payment (days)
+
 ColumnDeltaPercent = Delta %
 
 ColumnDeltaShares = Delta Shares

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -223,6 +223,8 @@ ColumnDaysLow = Tief (Tag)
 
 ColumnDebitNote = Belastung
 
+ColumnDelayedDividend = Verzögerte Auszahlung (Tage)
+
 ColumnDeltaPercent = Delta %
 
 ColumnDeltaShares = Delta St\u00FCcke

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityModel.java
@@ -175,6 +175,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
     private String isin;
     private String tickerSymbol;
     private String wkn;
+    private int    delayedDividend;
     private String feed;
     private String feedURL;
     private String latestFeed;
@@ -203,6 +204,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
         this.isin = security.getIsin();
         this.tickerSymbol = security.getTickerSymbol();
         this.wkn = security.getWkn();
+        this.delayedDividend = security.getDelayedDividend();
         this.feed = security.getFeed();
         this.feedURL = security.getFeedURL();
         this.latestFeed = security.getLatestFeed();
@@ -281,6 +283,16 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
     public void setWkn(String wkn)
     {
         firePropertyChange("wkn", this.wkn, this.wkn = wkn); //$NON-NLS-1$
+    }
+
+    public int getDelayedDividend()
+    {
+        return delayedDividend;
+    }
+
+    public void setDelayedDividend(int delayedDividend)
+    {
+        firePropertyChange("delayedDividend", this.delayedDividend, this.delayedDividend = delayedDividend); //$NON-NLS-1$
     }
 
     public String getFeed()
@@ -394,6 +406,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
         security.setIsin(isin);
         security.setTickerSymbol(tickerSymbol);
         security.setWkn(wkn);
+        security.setDelayedDividend(delayedDividend);
         security.setFeed(feed);
         security.setFeedURL(feedURL);
         security.setLatestFeed(latestFeed);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -57,6 +57,7 @@ public class SecurityMasterDataPage extends AbstractPage
         bindings.bindISINInput(container, Messages.ColumnISIN, "isin"); //$NON-NLS-1$
         bindings.bindStringInput(container, Messages.ColumnTicker, "tickerSymbol", SWT.NONE, 12); //$NON-NLS-1$
         bindings.bindStringInput(container, Messages.ColumnWKN, "wkn", SWT.NONE, 12); //$NON-NLS-1$
+        bindings.bindSpinner(container, Messages.ColumnDelayedDividend, "delayedDividend", 0, 90, SWT.NONE, 2);
 
         Control control = bindings.bindBooleanInput(container, Messages.ColumnRetired, "retired"); //$NON-NLS-1$
         Image image = FieldDecorationRegistry.getDefault().getFieldDecoration(FieldDecorationRegistry.DEC_INFORMATION)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -37,6 +37,7 @@ public final class Security implements Attributable, InvestmentVehicle
     private String isin;
     private String tickerSymbol;
     private String wkn;
+    private int    delayedDividend;
 
     // feed and feedURL are used to update historical prices
     private String feed;
@@ -169,6 +170,16 @@ public final class Security implements Attributable, InvestmentVehicle
     public void setWkn(String wkn)
     {
         this.wkn = wkn;
+    }
+
+    public int getDelayedDividend()
+    {
+        return delayedDividend;
+    }
+
+    public void setDelayedDividend(int delayedDividend)
+    {
+        this.delayedDividend = delayedDividend;
     }
 
     /**
@@ -483,6 +494,7 @@ public final class Security implements Attributable, InvestmentVehicle
         answer.isin = isin;
         answer.tickerSymbol = tickerSymbol;
         answer.wkn = wkn;
+        answer.delayedDividend = delayedDividend;
 
         answer.feed = feed;
         answer.feedURL = feedURL;


### PR DESCRIPTION
Abend Andreas,
mein pull request des Tages. :)
Ich habe Aktien deren Dividend Payment mit dem Valuta/Buchungstag nicht übereinstimmt, aber parallel ein Aktienkaufplan besteht.
Deshalb schlage ich folgende Codeänderung vor, damit man Verzögerung der Dividendenzahlung einmalig für eine Security definiert und dann im Dividendendialog die korrekte Zahl der zu diesem früheren Zeitpunkt gehaltenen Aktien aus den Daten entnommen wird.
Würde mich freue, wenn diese Änderung Deine Zustimmung findet.
Grüße,
cmaoling