### PR TITLE
fix for Yahoo returning "null" for dates without data or before start date of query

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -335,6 +335,25 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
                 if (values.length != 7)
                     throw new IOException(MessageFormat.format(Messages.MsgUnexpectedValue, line));
 
+                // first check if all values except the date are not "null"
+                if (!"null".equals(values[0]))
+                {
+                    boolean hasValue = false;
+                    for (int i = 1; i < values.length; i++)
+                    {
+                        if (!"null".equals(values[i]))
+                        {
+                            hasValue = true;
+                            break;
+                        }
+                    }
+                    // skip this line if there are no values
+                    if (!hasValue)
+                    {
+                        continue;
+                    }
+                }
+
                 try
                 {
                     T price = klass.newInstance();


### PR DESCRIPTION
Ich habe das Problem im [Forum](https://forum.portfolio-performance.info/t/meldung-fehler-beim-umwandeln-der-werte-von-yahoo-finance/1681/3) mal genauer angeschaut.

Als Beispiel hier für die Abfrage von AXA (ISIN FR0000120628) im Zeitraum ab 09.11.2017 bis heute.
Für ein Startdatum von `2007-11-09` werden 3 lines zurückgegeben:
* Header
* Vortag mit null-Werten
* startDate mit Werten

```
"Date,Open,High,Low,Close,Adj Close,Volume"	
"2017-11-08,null,null,null,null,null,null"	
"2017-11-09,25.288000,25.691999,25.195000,25.195000,25.195000,300"	
```

Ich habe mit diesem Pull Request eine Prüfung eingebaut, die leere Zeilen (nur mit Datum) ignoriert.