### PR TITLE
Change of securites chart - appearance of investment and dividend

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.HashMap;
 import org.apache.commons.lang3.ArrayUtils;
+import java.util.ArrayList;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
@@ -419,8 +420,10 @@ public class SecuritiesChart
 
     private void addInvestmentMarkerLines()
     {
-        Map<LocalDate, Double> mapBuy = new HashMap<LocalDate, Double>(); 
-        Map<LocalDate, Double> mapSell = new HashMap<LocalDate, Double>(); 
+        List<LocalDate> mapDatesBuyTemp = new ArrayList<> ();
+        List<LocalDate> mapDatesSellTemp = new ArrayList<> ();
+        List<Double> mapPriceBuyTemp = new ArrayList<> ();
+        List<Double> mapPriceSellTemp = new ArrayList<> ();
         for (Portfolio portfolio : client.getPortfolios())
         {
             for (PortfolioTransaction t : portfolio.getTransactions())
@@ -428,27 +431,29 @@ public class SecuritiesChart
                 if (t.getSecurity() == security && (chartPeriod == null || chartPeriod.isBefore(t.getDate())))
                 {
                     if (t.getType().isPurchase()) {
-                        mapBuy.put(t.getDate(), t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
+                        mapDatesBuyTemp.add(t.getDate());
+                        mapPriceBuyTemp.add(t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
                                         .getAmount() / Values.Quote.divider());
                         }
                     else {
-                        mapSell.put(t.getDate(), t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
+                        mapDatesSellTemp.add(t.getDate());
+                        mapPriceSellTemp.add(t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
                                         .getAmount() / Values.Quote.divider());
                     }
                 }
             }
         }
-        if (!mapBuy.isEmpty()) {
-            Map<LocalDate, Double> mapBuyTemp = new TreeMap(mapBuy);
-            LocalDate[] datesBuy = mapBuyTemp.keySet().toArray(new LocalDate[mapBuyTemp.size()]);
-            Double[] priceBuyTemp = mapBuyTemp.values().toArray(new Double[mapBuyTemp.size()]);
-            double[] priceBuy = ArrayUtils.toPrimitive(priceBuyTemp);
-
+        if (!mapDatesBuyTemp.isEmpty()) {
+            LocalDate[] mapDatesBuy;
+            mapDatesBuy = new LocalDate[mapDatesBuyTemp.size()];
+            mapDatesBuy = mapDatesBuyTemp.toArray(mapDatesBuy);
+            double[] mapPriceBuy = ArrayUtils.toPrimitive(mapPriceBuyTemp.toArray(new Double[mapPriceBuyTemp.size()]));
+            
             ILineSeries lineSeriesBuyBorder= (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuBuy + "2"); //$NON-NLS-1$
             lineSeriesBuyBorder.setLineStyle(LineStyle.NONE);
-            lineSeriesBuyBorder.setXDateSeries(TimelineChart.toJavaUtilDate(datesBuy));
-            lineSeriesBuyBorder.setYSeries(priceBuy);
+            lineSeriesBuyBorder.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesBuy));
+            lineSeriesBuyBorder.setYSeries(mapPriceBuy);
             lineSeriesBuyBorder.setYAxisId(0);
             lineSeriesBuyBorder.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesBuyBorder.setSymbolSize(7);
@@ -458,8 +463,8 @@ public class SecuritiesChart
             ILineSeries lineSeriesBuyBackground = (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuBuy + "1"); //$NON-NLS-1$
             lineSeriesBuyBackground.setLineStyle(LineStyle.NONE);
-            lineSeriesBuyBackground.setXDateSeries(TimelineChart.toJavaUtilDate(datesBuy));
-            lineSeriesBuyBackground.setYSeries(priceBuy);
+            lineSeriesBuyBackground.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesBuy));
+            lineSeriesBuyBackground.setYSeries(mapPriceBuy);
             lineSeriesBuyBackground.setYAxisId(0);
             lineSeriesBuyBackground.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesBuyBackground.setSymbolSize(6);
@@ -469,8 +474,8 @@ public class SecuritiesChart
             ILineSeries lineSeriesBuy = (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuBuy);
             lineSeriesBuy.setLineStyle(LineStyle.NONE);
-            lineSeriesBuy.setXDateSeries(TimelineChart.toJavaUtilDate(datesBuy));
-            lineSeriesBuy.setYSeries(priceBuy);
+            lineSeriesBuy.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesBuy));
+            lineSeriesBuy.setYSeries(mapPriceBuy);
             lineSeriesBuy.setYAxisId(0);
             lineSeriesBuy.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesBuy.setSymbolSize(4);
@@ -479,17 +484,18 @@ public class SecuritiesChart
             lineSeriesBuy.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN));
         }
 
-        if (!mapSell.isEmpty()) {
-            Map<LocalDate, Double> mapSellTemp = new TreeMap(mapSell);
-            LocalDate[] datesSell = mapSellTemp.keySet().toArray(new LocalDate[mapSellTemp.size()]);
-            Double[] priceSellTemp = mapSellTemp.values().toArray(new Double[mapSellTemp.size()]);
-            double[] priceSell = ArrayUtils.toPrimitive(priceSellTemp);
+        if (!mapDatesSellTemp.isEmpty()) {
+            LocalDate[] mapDatesSell;
+            mapDatesSell = new LocalDate[mapDatesSellTemp.size()];
+            mapDatesSell = mapDatesSellTemp.toArray(mapDatesSell);
+            double[] mapPriceSell = ArrayUtils.toPrimitive(mapPriceSellTemp.toArray(new Double[mapPriceSellTemp.size()]));
+            
 
             ILineSeries lineSeriesSellBorder = (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuSell + "2"); //$NON-NLS-1$
             lineSeriesSellBorder.setLineStyle(LineStyle.NONE);
-            lineSeriesSellBorder.setXDateSeries(TimelineChart.toJavaUtilDate(datesSell));
-            lineSeriesSellBorder.setYSeries(priceSell);
+            lineSeriesSellBorder.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesSell));
+            lineSeriesSellBorder.setYSeries(mapPriceSell);
             lineSeriesSellBorder.setYAxisId(0);
             lineSeriesSellBorder.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesSellBorder.setSymbolSize(7);
@@ -499,8 +505,8 @@ public class SecuritiesChart
             ILineSeries lineSeriesSellBackground = (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuSell + "1"); //$NON-NLS-1$
             lineSeriesSellBackground.setLineStyle(LineStyle.NONE);
-            lineSeriesSellBackground.setXDateSeries(TimelineChart.toJavaUtilDate(datesSell));
-            lineSeriesSellBackground.setYSeries(priceSell);
+            lineSeriesSellBackground.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesSell));
+            lineSeriesSellBackground.setYSeries(mapPriceSell);
             lineSeriesSellBackground.setYAxisId(0);
             lineSeriesSellBackground.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesSellBackground.setSymbolSize(6);
@@ -510,8 +516,8 @@ public class SecuritiesChart
             ILineSeries lineSeriesSell = (ILineSeries) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, Messages.SecurityMenuSell);
             lineSeriesSell.setLineStyle(LineStyle.NONE);
-            lineSeriesSell.setXDateSeries(TimelineChart.toJavaUtilDate(datesSell));
-            lineSeriesSell.setYSeries(priceSell);
+            lineSeriesSell.setXDateSeries(TimelineChart.toJavaUtilDate(mapDatesSell));
+            lineSeriesSell.setYSeries(mapPriceSell);
             lineSeriesSell.setYAxisId(0);
             lineSeriesSell.setSymbolType(PlotSymbolType.DIAMOND);
             lineSeriesSell.setSymbolSize(4);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -104,13 +104,13 @@ public class SecuritiesChart
         chart.getTitle().setText("..."); //$NON-NLS-1$
         chart.getToolTip().setValueFormat(new DecimalFormat(Values.Quote.pattern()));
         chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailClosingIndicator);
-        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuBuy + "1");
-        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuBuy + "2");
-        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuSell + "1");
-        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuSell + "2");
-        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends);
-        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends + "1");
-        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends + "2");
+        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuBuy + "1"); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuBuy + "2"); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuSell + "1"); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.SecurityMenuSell + "2"); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends + "1"); //$NON-NLS-1$
+        chart.getToolTip().addSeriesExclude(Messages.LabelChartDetailDividends + "2"); //$NON-NLS-1$
         GridDataFactory.fillDefaults().grab(true, true).applyTo(chart);
 
         ILegend legend = chart.getLegend();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -423,15 +423,11 @@ public class SecuritiesChart
             {
                 if (t.getSecurity() == security && (chartPeriod == null || chartPeriod.isBefore(t.getDate())))
                 {
-                    if((t.getType() != name.abuchen.portfolio.model.PortfolioTransaction.Type.TRANSFER_IN) &&
-                       (t.getType() != name.abuchen.portfolio.model.PortfolioTransaction.Type.TRANSFER_OUT))
-                    {
-                        if (t.getType().isPurchase()) {
-                            CounterBuy++;
-                        }
-                        else {
-                            CounterSell++;
-                        }
+                    if (t.getType().isPurchase()) {
+                        CounterBuy++;
+                    }
+                    else {
+                        CounterSell++;
                     }
                 }
             }
@@ -452,21 +448,17 @@ public class SecuritiesChart
             {
                 if (t.getSecurity() == security && (chartPeriod == null || chartPeriod.isBefore(t.getDate())))
                 {
-                    if((t.getType() != name.abuchen.portfolio.model.PortfolioTransaction.Type.TRANSFER_IN) &&
-                                    (t.getType() != name.abuchen.portfolio.model.PortfolioTransaction.Type.TRANSFER_OUT))
-                    {
-                        if (t.getType().isPurchase()) {
-                            DatesBuy[CounterBuy] = t.getDate();
-                            PriceBuy[CounterBuy] = t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
-                                                    .getAmount() / Values.Quote.divider();
-                            CounterBuy++;
+                    if (t.getType().isPurchase()) {
+                        DatesBuy[CounterBuy] = t.getDate();
+                        PriceBuy[CounterBuy] = t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
+                                        .getAmount() / Values.Quote.divider();
+                        CounterBuy++;
                         }
-                        else {
-                            DatesSell[CounterSell] = t.getDate();
-                            PriceSell[CounterSell] = t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
+                    else {
+                        DatesSell[CounterSell] = t.getDate();
+                        PriceSell[CounterSell] = t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode()))
                                                     .getAmount() / Values.Quote.divider();
-                            CounterSell++;
-                        }
+                        CounterSell++;
                     }
                 }
             }


### PR DESCRIPTION
Belonging to issue #862

This pull changing how the investments and dividend will be displayed by removing the MarkerLine and add them as scatter chart with diamonds / square as plot symbol. This upgrade the presentation of investments especially at monthly saving plans. Investments indicated by diamond plot symbol, dividend as square.

The information of each buy / selling price is now added to the mouse tooltip. For dividend payments only the date is indicated by an square at the chart bottom line.

Further improvement is to exclude the portfolio transfer in/out transactions as I guess this is just a transfer from one portfolio to each other and therefore should not be displayed as an investment at the chart.

Newly I've added a legend at the chart bottom to get a quick overview of the added information.

Last but not least please find below the replaced investments / dividend appearance with a 2 vs. 10 years scaling.
![unbenannt](https://user-images.githubusercontent.com/29358155/32702192-513f31d6-c7e3-11e7-83fa-447eda515079.JPG)

