### PR TITLE
SecurityChart - Option to toggle between old/new style; FIFO price indicator; latest purchase price horizon

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -341,6 +341,7 @@ public class Messages extends NLS
     public static String LabelAllSecurities;
     public static String LabelAssetChart;
     public static String LabelAvailableAttributes;
+    public static String LabelChartDetailCompactView;
     public static String LabelChartDetailDividends;
     public static String LabelChartDetailSMA50;
     public static String LabelChartDetailSMA200;
@@ -350,6 +351,8 @@ public class Messages extends NLS
     public static String LabelChartDetailBollingerBands;
     public static String LabelChartDetailBollingerBandsLower;
     public static String LabelChartDetailBollingerBandsUpper;
+    public static String LabelChartDetailFIFOpurchase;
+    public static String LabelChartDetailPurchaseIndicator;
     public static String LabelClientClearCustomItems;
     public static String LabelClientFilterDialogMessage;
     public static String LabelClientFilterDialogTitle;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -687,9 +687,9 @@ LabelChartDetailBollingerBandsUpper = Lower Bollinger Bands
 
 LabelChartDetailFIFOpurchase = Purchase Value (FIFO)
 
-LabelChartDetailPurchaseIndicator = Purchase Value Indicator
+LabelChartDetailPurchaseIndicator = Chart-Development vs. Purchase Value
 
-LabelChartDetailClosingIndicator =  Opening Price Indicator
+LabelChartDetailClosingIndicator =  Chart-Development
 
 LabelChartDetailDividends = Dividends
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -677,11 +677,17 @@ LabelAssetChart = Asset Chart
 
 LabelAvailableAttributes = Add new attribute
 
+LabelChartDetailCompactView = Compact View
+
 LabelChartDetailBollingerBands = Bollinger Bands
 
 LabelChartDetailBollingerBandsLower = Upper Bollinger Bands
 
 LabelChartDetailBollingerBandsUpper = Lower Bollinger Bands
+
+LabelChartDetailFIFOpurchase = Purchase Value (FIFO)
+
+LabelChartDetailPurchaseIndicator = Purchase Value Indicator
 
 LabelChartDetailClosingIndicator = Closing Indicator
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -689,7 +689,7 @@ LabelChartDetailFIFOpurchase = Purchase Value (FIFO)
 
 LabelChartDetailPurchaseIndicator = Purchase Value Indicator
 
-LabelChartDetailClosingIndicator = Closing Indicator
+LabelChartDetailClosingIndicator =  Opening Price Indicator
 
 LabelChartDetailDividends = Dividends
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -689,7 +689,7 @@ LabelChartDetailFIFOpurchase = Einstandspreis (FIFO)
 
 LabelChartDetailPurchaseIndicator = Einstandspreis Indikator
 
-LabelChartDetailClosingIndicator = Schlusskurs Indikator
+LabelChartDetailClosingIndicator = Er\u00F6ffnungskurs Indikator
 
 LabelChartDetailDividends = Dividenden
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -687,9 +687,9 @@ LabelChartDetailBollingerBandsUpper = Oberes Bollinger Band
 
 LabelChartDetailFIFOpurchase = Einstandspreis (FIFO)
 
-LabelChartDetailPurchaseIndicator = Einstandspreis Indikator
+LabelChartDetailPurchaseIndicator = Kursentwicklung zum Einstandspreis
 
-LabelChartDetailClosingIndicator = Er\u00F6ffnungskurs Indikator
+LabelChartDetailClosingIndicator = Kursentwicklung
 
 LabelChartDetailDividends = Dividenden
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -677,11 +677,17 @@ LabelAssetChart = Verm\u00F6gensaufstellung: Diagramm
 
 LabelAvailableAttributes = Neues Attribut hinzuf\u00FCgen
 
+LabelChartDetailCompactView = Kompakte Darstellung
+
 LabelChartDetailBollingerBands = Bollinger B\u00E4nder
 
 LabelChartDetailBollingerBandsLower = Unteres Bollinger Band
 
 LabelChartDetailBollingerBandsUpper = Oberes Bollinger Band
+
+LabelChartDetailFIFOpurchase = Einstandspreis (FIFO)
+
+LabelChartDetailPurchaseIndicator = Einstandspreis Indikator
 
 LabelChartDetailClosingIndicator = Schlusskurs Indikator
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -417,20 +417,20 @@ public class SecuritiesChart
                                 Messages.LabelChartDetailClosingIndicator+"Positive");
                 lineSeries2ndPositive.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndPositive.setYAxisId(1);
-                lineSeries2ndPositive = chartSeriesPainter(lineSeries2ndPositive, dates, valuesRelativePositive, 10, 0.6f, 2, LineStyle.SOLID, true, false);
+                lineSeries2ndPositive = chartSeriesPainter(lineSeries2ndPositive, dates, valuesRelativePositive, 10, 0.6f, 1, LineStyle.SOLID, true, false);
                 
                 ILineSeries lineSeries2ndNegative = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Negative");
                 lineSeries2ndNegative.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndNegative.setYAxisId(1);
-                lineSeries2ndNegative = chartSeriesPainter(lineSeries2ndNegative, dates, valuesRelativePositive, 3, 0.6f, 2, LineStyle.SOLID, true, false);
+                lineSeries2ndNegative = chartSeriesPainter(lineSeries2ndNegative, dates, valuesRelativePositive, 3, 0.6f, 1, LineStyle.SOLID, true, false);
 
                 ILineSeries lineSeries2ndZero = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Zero");
                 lineSeries2ndZero.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
                 lineSeries2ndZero.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndZero.setYAxisId(1);
-                lineSeries2ndZero = chartSeriesPainter(lineSeries2ndZero, dates, valuesRelativeNegative, 10, 0.464f, 2, LineStyle.SOLID, true, false);
+                lineSeries2ndZero = chartSeriesPainter(lineSeries2ndZero, dates, valuesRelativeNegative, 10, 0.464f, 1, LineStyle.SOLID, true, false);
             }
 
             ILineSeries lineSeries = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
@@ -709,6 +709,8 @@ public class SecuritiesChart
         ILineSeries lineSeriesBollingerBandsLowerBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                         Messages.LabelChartDetailBollingerBandsLower);
         lineSeriesBollingerBandsLowerBand.setXDateSeries(bollingerBandsLowerBand.getDates());
+        lineSeriesBollingerBandsLowerBand.setLineStyle(LineStyle.SOLID);
+        lineSeriesBollingerBandsLowerBand.setLineWidth(2);
         lineSeriesBollingerBandsLowerBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsLowerBand.setYSeries(bollingerBandsLowerBand.getValues());
         lineSeriesBollingerBandsLowerBand.setAntialias(SWT.ON);
@@ -723,7 +725,6 @@ public class SecuritiesChart
         lineSeriesBollingerBandsMiddleBand.setXDateSeries(bollingerBandsMiddleBand.getDates());
         lineSeriesBollingerBandsMiddleBand.setLineWidth(2);
         lineSeriesBollingerBandsMiddleBand.setLineStyle(LineStyle.DOT);
-        lineSeriesBollingerBandsMiddleBand.enableArea(false);
         lineSeriesBollingerBandsMiddleBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsMiddleBand.setYSeries(bollingerBandsMiddleBand.getValues());
         lineSeriesBollingerBandsMiddleBand.setAntialias(SWT.ON);
@@ -738,7 +739,6 @@ public class SecuritiesChart
         lineSeriesBollingerBandsUpperBand.setXDateSeries(bollingerBandsUpperBand.getDates());
         lineSeriesBollingerBandsUpperBand.setLineWidth(2);
         lineSeriesBollingerBandsUpperBand.setLineStyle(LineStyle.SOLID);
-        lineSeriesBollingerBandsUpperBand.enableArea(false);
         lineSeriesBollingerBandsUpperBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsUpperBand.setYSeries(bollingerBandsUpperBand.getValues());
         lineSeriesBollingerBandsUpperBand.setAntialias(SWT.ON);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -370,6 +370,7 @@ public class SecuritiesChart
                 if (Double.isInfinite(firstQuote) || firstQuote == 0) showAreaRelativeToFirstQuote = false;
             }
 
+            addChartMarkerBackground();
 
             for (int ii = 0; index < prices.size(); index++, ii++)
             {
@@ -446,7 +447,7 @@ public class SecuritiesChart
 
             chart.adjustRange();
 
-            addChartMarker();
+            addChartMarkerForeground();
 
             chart.adjustRange();
 
@@ -463,11 +464,20 @@ public class SecuritiesChart
         }
     }
 
-    private void addChartMarker()
+    private void addChartMarkerBackground()
     {
         if (chartConfig.contains(ChartDetails.BOLLINGERBANDS))
             addBollingerBandsMarkerLines(20, 2);
 
+        if (chartConfig.contains(ChartDetails.SMA50))
+            addSMAMarkerLines(50);
+
+        if (chartConfig.contains(ChartDetails.SMA200))
+            addSMAMarkerLines(200);
+    }
+
+    private void addChartMarkerForeground()
+    {
         if (chartConfig.contains(ChartDetails.FIFOPURCHASE))
             addFIFOPurchasePrice();
 
@@ -479,14 +489,7 @@ public class SecuritiesChart
 
         if (chartConfig.contains(ChartDetails.EVENTS))
             addEventMarkerLines();
-
-        if (chartConfig.contains(ChartDetails.SMA50))
-            addSMAMarkerLines(50);
-
-        if (chartConfig.contains(ChartDetails.SMA200))
-            addSMAMarkerLines(200);
-}
-
+    }
     private void addSMAMarkerLines(int SMADays)
     {
         JSColors colors = new JSColors();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -413,24 +413,17 @@ public class SecuritiesChart
             }
             if (showAreaRelativeToFirstQuote)
             {
+                ILineSeries lineSeries2ndNegative = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
+                                Messages.LabelChartDetailClosingIndicator+"Negative");
+                lineSeries2ndNegative.setSymbolType(PlotSymbolType.NONE);
+                lineSeries2ndNegative.setYAxisId(1);
+                lineSeries2ndNegative = chartSeriesPainter(lineSeries2ndNegative, dates, valuesRelativeNegative, 3, 0.6f, 1, LineStyle.SOLID, true, false);
+
                 ILineSeries lineSeries2ndPositive = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Positive");
                 lineSeries2ndPositive.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndPositive.setYAxisId(1);
                 lineSeries2ndPositive = chartSeriesPainter(lineSeries2ndPositive, dates, valuesRelativePositive, 10, 0.6f, 1, LineStyle.SOLID, true, false);
-                
-                ILineSeries lineSeries2ndNegative = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
-                                Messages.LabelChartDetailClosingIndicator+"Negative");
-                lineSeries2ndNegative.setSymbolType(PlotSymbolType.NONE);
-                lineSeries2ndNegative.setYAxisId(1);
-                lineSeries2ndNegative = chartSeriesPainter(lineSeries2ndNegative, dates, valuesRelativePositive, 3, 0.6f, 1, LineStyle.SOLID, true, false);
-
-                ILineSeries lineSeries2ndZero = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
-                                Messages.LabelChartDetailClosingIndicator+"Zero");
-                lineSeries2ndZero.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                lineSeries2ndZero.setSymbolType(PlotSymbolType.NONE);
-                lineSeries2ndZero.setYAxisId(1);
-                lineSeries2ndZero = chartSeriesPainter(lineSeries2ndZero, dates, valuesRelativeNegative, 10, 0.464f, 1, LineStyle.SOLID, true, false);
             }
 
             ILineSeries lineSeries = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -399,8 +399,7 @@ public class SecuritiesChart
                 ILineSeries lineSeries2ndPositive = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Positive");
                 lineSeries2ndPositive.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS))
-                    lineSeries2ndPositive.enableArea(true);
+                lineSeries2ndPositive.enableArea(true);
                 lineSeries2ndPositive.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndPositive.setYSeries(valuesRelativePositive);
                 lineSeries2ndPositive.setAntialias(SWT.ON);
@@ -412,8 +411,7 @@ public class SecuritiesChart
                 ILineSeries lineSeries2ndNegative = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Negative");
                 lineSeries2ndNegative.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS))
-                    lineSeries2ndNegative.enableArea(true);
+                lineSeries2ndNegative.enableArea(true);
                 lineSeries2ndNegative.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndNegative.setYSeries(valuesRelativeNegative);
                 lineSeries2ndNegative.setAntialias(SWT.ON);
@@ -425,8 +423,7 @@ public class SecuritiesChart
                 ILineSeries lineSeries2ndZero = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                                 Messages.LabelChartDetailClosingIndicator+"Zero");
                 lineSeries2ndZero.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
-                if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS))
-                    lineSeries2ndZero.enableArea(true);
+                lineSeries2ndZero.enableArea(true);
                 lineSeries2ndZero.setSymbolType(PlotSymbolType.NONE);
                 lineSeries2ndZero.setYSeries(valuesZeroLine);
                 lineSeries2ndZero.setAntialias(SWT.ON);
@@ -439,8 +436,7 @@ public class SecuritiesChart
                             Messages.ColumnQuote);
             lineSeries.setXDateSeries(TimelineChart.toJavaUtilDate(dates));
             lineSeries.setLineWidth(2);
-            if (!chartConfig.contains(ChartDetails.BOLLINGERBANDS))
-                lineSeries.enableArea(!showAreaRelativeToFirstQuote);
+            lineSeries.enableArea(!showAreaRelativeToFirstQuote);
             lineSeries.setSymbolType(PlotSymbolType.NONE);
             lineSeries.setYSeries(values);
             lineSeries.setAntialias(SWT.ON);
@@ -469,15 +465,6 @@ public class SecuritiesChart
 
     private void addChartMarker()
     {
-        if (chartConfig.contains(ChartDetails.EVENTS))
-            addEventMarkerLines();
-
-        if (chartConfig.contains(ChartDetails.SMA50))
-            addSMAMarkerLines(50);
-
-        if (chartConfig.contains(ChartDetails.SMA200))
-            addSMAMarkerLines(200);
-
         if (chartConfig.contains(ChartDetails.BOLLINGERBANDS))
             addBollingerBandsMarkerLines(20, 2);
 
@@ -489,6 +476,15 @@ public class SecuritiesChart
 
         if (chartConfig.contains(ChartDetails.DIVIDENDS))
             addDividendMarkerLines();
+
+        if (chartConfig.contains(ChartDetails.EVENTS))
+            addEventMarkerLines();
+
+        if (chartConfig.contains(ChartDetails.SMA50))
+            addSMAMarkerLines(50);
+
+        if (chartConfig.contains(ChartDetails.SMA200))
+            addSMAMarkerLines(200);
 }
 
     private void addSMAMarkerLines(int SMADays)
@@ -508,7 +504,7 @@ public class SecuritiesChart
         lineSeriesSMA.setSymbolType(PlotSymbolType.NONE);
         lineSeriesSMA.setYSeries(SMALines.getValues());
         lineSeriesSMA.setAntialias(SWT.ON);
-        rgbColor = colors.byIndex(SMADays == 200 ? 7:2, 0.464f);
+        rgbColor = colors.byIndex(SMADays == 200 ? 7:0, 0.464f);
         lineSeriesSMA.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
         lineSeriesSMA.setYAxisId(0);
         lineSeriesSMA.setVisibleInLegend(true);
@@ -648,7 +644,6 @@ public class SecuritiesChart
 
         Color color = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA); 
         List<LocalDate> dividendDate = new ArrayList<> ();
-        List<Double> dividendValue = new ArrayList<> ();
         List<Double> dividendAxisValue = new ArrayList<> ();
         for (Account account : this.client.getAccounts())
         {
@@ -739,6 +734,10 @@ public class SecuritiesChart
                         || bollingerBandsLowerBand.getDates() == null)
             return;
 
+        JSColors colors = new JSColors();
+        int[] rgbColor;
+        rgbColor = colors.byIndex(4, 0.464f);
+
         ILineSeries lineSeriesBollingerBandsLowerBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                         Messages.LabelChartDetailBollingerBandsLower);
         lineSeriesBollingerBandsLowerBand.setXDateSeries(bollingerBandsLowerBand.getDates());
@@ -748,7 +747,7 @@ public class SecuritiesChart
         lineSeriesBollingerBandsLowerBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsLowerBand.setYSeries(bollingerBandsLowerBand.getValues());
         lineSeriesBollingerBandsLowerBand.setAntialias(SWT.ON);
-        lineSeriesBollingerBandsLowerBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+        lineSeriesBollingerBandsLowerBand.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
         lineSeriesBollingerBandsLowerBand.setYAxisId(0);
         lineSeriesBollingerBandsLowerBand.setVisibleInLegend(false);
 
@@ -757,13 +756,13 @@ public class SecuritiesChart
         ILineSeries lineSeriesBollingerBandsMiddleBand = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,
                         Messages.LabelChartDetailBollingerBands);
         lineSeriesBollingerBandsMiddleBand.setXDateSeries(bollingerBandsMiddleBand.getDates());
-        lineSeriesBollingerBandsMiddleBand.setLineWidth(1);
+        lineSeriesBollingerBandsMiddleBand.setLineWidth(2);
         lineSeriesBollingerBandsMiddleBand.setLineStyle(LineStyle.DOT);
         lineSeriesBollingerBandsMiddleBand.enableArea(false);
         lineSeriesBollingerBandsMiddleBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsMiddleBand.setYSeries(bollingerBandsMiddleBand.getValues());
         lineSeriesBollingerBandsMiddleBand.setAntialias(SWT.ON);
-        lineSeriesBollingerBandsMiddleBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+        lineSeriesBollingerBandsMiddleBand.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
         lineSeriesBollingerBandsMiddleBand.setYAxisId(0);
         lineSeriesBollingerBandsMiddleBand.setVisibleInLegend(true);
 
@@ -778,7 +777,7 @@ public class SecuritiesChart
         lineSeriesBollingerBandsUpperBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsUpperBand.setYSeries(bollingerBandsUpperBand.getValues());
         lineSeriesBollingerBandsUpperBand.setAntialias(SWT.ON);
-        lineSeriesBollingerBandsUpperBand.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+        lineSeriesBollingerBandsUpperBand.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
         lineSeriesBollingerBandsUpperBand.setYAxisId(0);
         lineSeriesBollingerBandsUpperBand.setVisibleInLegend(false);
     }
@@ -827,9 +826,11 @@ public class SecuritiesChart
             int lineSeriesCounter = 0;
             double fifoValue = 0;
             double fifoShare = 0;
+            JSColors colors = new JSColors();
+            int[] rgbColor;
+            rgbColor = colors.byIndex(3, 0.464f);
             for (Map.Entry<LocalDate, Double> e : purchaseDeltaValueMap.entrySet()) {
                 Map.Entry<LocalDate, Double> next = purchaseDeltaValueMap.higherEntry(e.getKey()); // next
-                Map.Entry<LocalDate, Double> prev = purchaseDeltaValueMap.lowerEntry(e.getKey());  // previous
 
                 LocalDate startDate = e.getKey();
                 fifoValue = fifoValue + e.getValue(); 
@@ -844,8 +845,8 @@ public class SecuritiesChart
                 if (daysBetween==0) continue;
                 List<LocalDate> datesChartTemp = new ArrayList<> ();
                 List<Double> valuesChartTemp = new ArrayList<> ();
-                for (int relevantDays=0; relevantDays <= daysBetween; relevantDays++) {
-                    if (startDate.isAfter(chartPeriod) || startDate.isEqual(chartPeriod))
+                for (int relevantDays=0; relevantDays < daysBetween; relevantDays++) {
+                    if ((chartPeriod == null) || (startDate.isAfter(chartPeriod) || startDate.isEqual(chartPeriod)))
                     {
                         datesChartTemp.add(startDate);
                         valuesChartTemp.add(fifoValuePerShare);
@@ -865,7 +866,7 @@ public class SecuritiesChart
                     FIFOlineSeries.setYSeries(valuesChart);
                     FIFOlineSeries.setLineWidth(2);
                     FIFOlineSeries.setSymbolType(PlotSymbolType.NONE);
-                    FIFOlineSeries.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_DARK_YELLOW));
+                    FIFOlineSeries.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
                     FIFOlineSeries.setYAxisId(0);
                     FIFOlineSeries.setVisibleInLegend(lineSeriesCounter == 1 ? true : false);
                 }
@@ -917,10 +918,6 @@ public class SecuritiesChart
             NavigableMap<LocalDate, Double> purchaseShareMap = new TreeMap(purchaseShareMapTemp);
 
             for (Map.Entry<LocalDate, Double> e : purchaseDeltaValueMap.entrySet()) {
-                Map.Entry<LocalDate, Double> next = purchaseDeltaValueMap.higherEntry(e.getKey()); // next
-                Map.Entry<LocalDate, Double> prev = purchaseDeltaValueMap.lowerEntry(e.getKey());  // previous
-
-                LocalDate startDate = e.getKey();
                 fifoValue = fifoValue + e.getValue(); 
                 fifoShare = fifoShare + purchaseShareMap.get(e.getKey());
                 fifoValuePerShare = Double.isInfinite(fifoValue / fifoShare) ? 0 : fifoValue / fifoShare;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -430,7 +430,8 @@ public class SecuritiesChart
                 lineSeries2ndZero.setAntialias(SWT.ON);
                 lineSeries2ndZero.setYAxisId(1);
                 lineSeries2ndZero.setVisibleInLegend(false);
-                lineSeries2ndZero.setLineColor(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+                rgbColor = colors.byIndex(10, 0.464f);
+                lineSeries2ndZero.setLineColor(new Color(Display.getDefault(), new RGB(rgbColor[0], rgbColor[1], rgbColor[2])));
             }
 
             ILineSeries lineSeries = (ILineSeries) chart.getSeriesSet().createSeries(SeriesType.LINE,


### PR DESCRIPTION
Basierend auf den Vorschlägen aus Pull #885
----
Dieser Pull auf die Darstellung des SecurityChart enthält folgende Neuerungen:
- Wahlmöglichkeit zwischen alter Darstellung (MarkerLine) oder der geänderten Darstellung (Diamanten/Rauten)
- Indikator / Horizontlinie zum "aktuellen Einstandspreis"
- Die Flächenfüllung für den "Schlusskurs Indikator" und den "aktuellen Einstandspreis" unterscheidet jetzt farblich zwischen positiven und negativen Entwicklungen

Manko, die zu verwendenden Farben fördern den Augenkrebs, da pastellhaltig gleichwohl die Routine von den Beständen verwendet wurde.

@buchen 
@sebasbaumh  
@cmaoling 
Ich habe einmal eure Hinweise aus der vorherigen Diskussion mit eingearbeitet.
Vielen Dank dafür, dass hat mir sehr geholfen. 

Lediglich der Punkt zum Thema Farbe bedarf dringend einer Nachbearbeitung,
da der verwendete Farbraum A) zu grell ist, wenn keine Flächenfüllung aktiv ist (siehe Bollinger Bänder)
und B) SWTchart bei der Flächenfüllung zusätzlich die Helligkeit korrigiert.
Habt ihr evtl. Ideen bzw. Vorschläge?

Nachstehend ein paar Beispiele je Indikator (Mountain, Schlusskurs oder Einstandskurs im Horizont).
Zusätzlich wird der Einstandspreis nach FIFO als waagrechte Linie dargestellt.
 
![0](https://user-images.githubusercontent.com/29358155/33152285-333cd228-cfdc-11e7-9730-8d830612e1bb.JPG)

![1](https://user-images.githubusercontent.com/29358155/33152289-3af5227c-cfdc-11e7-8e90-9381c72821e5.JPG)

![2](https://user-images.githubusercontent.com/29358155/33152300-4376c202-cfdc-11e7-916b-f8f9bb43ed1a.JPG)

