### PR TITLE
introduce additional dataseries normalizing performance to ppa

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -444,6 +444,7 @@ public class Messages extends NLS
     public static String LabelKeyIndicators;
     public static String LabelMaxDrawdown;
     public static String LabelMaxDrawdownDuration;
+    public static String LabelPerformanceNormalizedPerYear;
     public static String LabelStatementOfAssets;
     public static String LabelStatementOfAssetsHistory;
     public static String LabelStatementOfAssetsHoldings;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -821,6 +821,8 @@ LabelPerformanceCalculation = Performance Calculation
 
 LabelPerformanceChart = Performance Chart
 
+LabelPerformanceNormalizedPerYear = normalized ppa.
+
 LabelPortfolioPerformance = Portfolio Performance
 
 LabelPortfolioPerformanceFile = Portfolio Performance File

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -821,6 +821,8 @@ LabelPerformanceCalculation = Performance-Berechnung
 
 LabelPerformanceChart = Performance-Diagramm
 
+LabelPerformanceNormalizedPerYear = Performance pro Jahr
+
 LabelPortfolioPerformance = Portfolio Performance
 
 LabelPortfolioPerformanceFile = Porfolio Performance Datei

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -75,6 +75,8 @@ public final class DataSeries
 
     private RGB color;
 
+    private boolean isNormalized = false;
+
     private boolean showArea;
     private LineStyle lineStyle = LineStyle.SOLID;
 
@@ -84,6 +86,17 @@ public final class DataSeries
         this.instance = instance;
         this.label = label;
         this.color = color;
+    }
+
+    /* package */ DataSeries(Type type, Object instance, String label, RGB color, boolean isNormalized)
+    {
+        this.type = type;
+        this.instance = instance;
+        this.label = label;
+        this.color = color;
+        this.isNormalized = isNormalized;
+        if (isNormalized)
+            this.lineStyle = LineStyle.DOT;
     }
 
     public Type getType()
@@ -132,6 +145,11 @@ public final class DataSeries
     public RGB getColor()
     {
         return color;
+    }
+
+    public boolean isNormalized()
+    {
+        return isNormalized;
     }
 
     public boolean isLineChart()
@@ -197,7 +215,10 @@ public final class DataSeries
 
     public String getUUID()
     {
-        return this.type.buildUUID(instance);
+        String prefix = "";
+        if (isNormalized)
+            prefix = "[n]";
+        return prefix + this.type.buildUUID(instance);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
@@ -109,42 +109,42 @@ public class DataSeriesCache
             switch (series.getType())
             {
                 case CLIENT:
-                    return PerformanceIndex.forClient(client, converter, reportingPeriod, warnings);
+                    return PerformanceIndex.forClient(client, converter, reportingPeriod, warnings, series.isNormalized());
 
                 case SECURITY:
                     return PerformanceIndex.forInvestment(client, converter, (Security) series.getInstance(),
-                                    reportingPeriod, warnings);
+                                    reportingPeriod, warnings, series.isNormalized());
 
                 case SECURITY_BENCHMARK:
                     return PerformanceIndex.forSecurity(
                                     lookup(new DataSeries(DataSeries.Type.CLIENT, null, null, null), reportingPeriod),
-                                    (Security) series.getInstance());
+                                    (Security) series.getInstance(), series.isNormalized());
 
                 case PORTFOLIO:
                     return PerformanceIndex.forPortfolio(client, converter, (Portfolio) series.getInstance(),
-                                    reportingPeriod, warnings);
+                                    reportingPeriod, warnings, series.isNormalized());
 
                 case PORTFOLIO_PLUS_ACCOUNT:
                     return PerformanceIndex.forPortfolioPlusAccount(client, converter, (Portfolio) series.getInstance(),
-                                    reportingPeriod, warnings);
+                                    reportingPeriod, warnings, series.isNormalized());
 
                 case ACCOUNT:
                     Account account = (Account) series.getInstance();
-                    return PerformanceIndex.forAccount(client, converter, account, reportingPeriod, warnings);
+                    return PerformanceIndex.forAccount(client, converter, account, reportingPeriod, warnings, series.isNormalized());
 
                 case CLASSIFICATION:
                     Classification classification = (Classification) series.getInstance();
                     return PerformanceIndex.forClassification(client, converter, classification, reportingPeriod,
-                                    warnings);
+                                    warnings, series.isNormalized());
 
                 case CONSUMER_PRICE_INDEX:
                     return PerformanceIndex.forConsumerPriceIndex(
-                                    lookup(new DataSeries(DataSeries.Type.CLIENT, null, null, null), reportingPeriod));
+                                    lookup(new DataSeries(DataSeries.Type.CLIENT, null, null, null), reportingPeriod), series.isNormalized());
 
                 case CLIENT_FILTER:
                     ClientFilterMenu.Item item = (ClientFilterMenu.Item) series.getInstance();
                     return PerformanceIndex.forClient(item.getFilter().filter(client), converter, reportingPeriod,
-                                    warnings);
+                                    warnings, series.isNormalized());
 
                 default:
                     throw new IllegalArgumentException(series.getType().name());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
@@ -196,12 +196,18 @@ public class DataSeriesSet
                 continue;
 
             availableSeries.add(new DataSeries(DataSeries.Type.SECURITY, security, security.getName(), //
-                            wheel.getRGB(index++)));
+                            wheel.getRGB(index++), false));
+            availableSeries.add(new DataSeries(DataSeries.Type.SECURITY, security, security.getName() + " ("+ Messages.LabelPerformanceNormalizedPerYear + ")", //
+                            wheel.getRGB(index++), true));
         }
 
         for (Portfolio portfolio : client.getPortfolios())
+        {
             availableSeries.add(new DataSeries(DataSeries.Type.PORTFOLIO, portfolio, portfolio.getName(), //
-                            wheel.getRGB(index++)));
+                            wheel.getRGB(index++), false));
+            availableSeries.add(new DataSeries(DataSeries.Type.PORTFOLIO, portfolio, portfolio.getName() + " ("+ Messages.LabelPerformanceNormalizedPerYear + ")", //
+                        wheel.getRGB(index++), true));
+        }
 
         // portfolio + reference account
         for (Portfolio portfolio : client.getPortfolios())
@@ -229,8 +235,12 @@ public class DataSeriesSet
         }
 
         for (Account account : client.getAccounts())
+        {
             availableSeries.add(
-                            new DataSeries(DataSeries.Type.ACCOUNT, account, account.getName(), wheel.getRGB(index++)));
+                            new DataSeries(DataSeries.Type.ACCOUNT, account, account.getName(), wheel.getRGB(index++), false));
+            availableSeries.add(
+                            new DataSeries(DataSeries.Type.ACCOUNT, account, account.getName() + " ("+ Messages.LabelPerformanceNormalizedPerYear + ")", wheel.getRGB(index++), true));
+        }
 
         for (Taxonomy taxonomy : client.getTaxonomies())
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/CPIIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/CPIIndex.java
@@ -18,7 +18,7 @@ import name.abuchen.portfolio.util.Interval;
         super(client, converter, reportInterval);
     }
 
-    /* package */void calculate(PerformanceIndex clientIndex)
+    /* package */void calculate(PerformanceIndex clientIndex, boolean isNormalized)
     {
         Interval actualInterval = clientIndex.getActualInterval();
         LocalDate firstDataPoint = clientIndex.getFirstDataPoint().orElse(actualInterval.getStart());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -51,6 +51,7 @@ public class PerformanceIndex
     protected long[] interest;
     protected long[] interestCharge;
     protected double[] accumulated;
+    protected double[] accumulatedNormalized;
     protected double[] delta;
 
     private Drawdown drawdown;
@@ -64,62 +65,116 @@ public class PerformanceIndex
         this.reportInterval = reportInterval;
     }
 
+    @Deprecated
     public static PerformanceIndex forClient(Client client, CurrencyConverter converter, ReportingPeriod reportInterval,
                     List<Exception> warnings)
     {
-        ClientIndex index = new ClientIndex(client, converter, reportInterval);
+        return forClient(client, converter, reportInterval, warnings, false);
+    }
+
+    public static PerformanceIndex forClient(Client client, CurrencyConverter converter, ReportingPeriod reportInterval,
+                    List<Exception> warnings, boolean isNormalized)
+    {
+        ClientIndex index = new ClientIndex(client, converter, reportInterval, isNormalized);
         index.calculate(warnings);
         return index;
     }
 
+    @Deprecated
     public static PerformanceIndex forAccount(Client client, CurrencyConverter converter, Account account,
                     ReportingPeriod reportInterval, List<Exception> warnings)
     {
-        Client pseudoClient = new PortfolioClientFilter(Collections.emptyList(), Arrays.asList(account)).filter(client);
-        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
+        return forAccount(client, converter, account, reportInterval, warnings, false);
     }
 
+    public static PerformanceIndex forAccount(Client client, CurrencyConverter converter, Account account,
+                    ReportingPeriod reportInterval, List<Exception> warnings, boolean isNormalized)
+    {
+        Client pseudoClient = new PortfolioClientFilter(Collections.emptyList(), Arrays.asList(account)).filter(client);
+        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings, isNormalized);
+    }
+
+    @Deprecated
     public static PerformanceIndex forPortfolio(Client client, CurrencyConverter converter, Portfolio portfolio,
                     ReportingPeriod reportInterval, List<Exception> warnings)
     {
+        return forPortfolio(client, converter, portfolio, reportInterval, warnings, false);
+    }
+
+    public static PerformanceIndex forPortfolio(Client client, CurrencyConverter converter, Portfolio portfolio,
+                    ReportingPeriod reportInterval, List<Exception> warnings, boolean isNormalized)
+    {
         Client pseudoClient = new PortfolioClientFilter(portfolio).filter(client);
-        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
+        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings, isNormalized);
+    }
+
+    @Deprecated
+    public static PerformanceIndex forPortfolioPlusAccount(Client client, CurrencyConverter converter, Portfolio portfolio,
+                    ReportingPeriod reportInterval, List<Exception> warnings)
+    {
+        return forPortfolioPlusAccount(client, converter, portfolio, reportInterval, warnings, false);
     }
 
     public static PerformanceIndex forPortfolioPlusAccount(Client client, CurrencyConverter converter,
-                    Portfolio portfolio, ReportingPeriod reportInterval, List<Exception> warnings)
+                    Portfolio portfolio, ReportingPeriod reportInterval, List<Exception> warnings, boolean isNormalized)
     {
         Client pseudoClient = new PortfolioClientFilter(portfolio, portfolio.getReferenceAccount()).filter(client);
-        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
+        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings, isNormalized);
+    }
+
+    @Deprecated
+    public static PerformanceIndex forClassification(Client client, CurrencyConverter converter, 
+                    Classification classification, ReportingPeriod reportInterval, List<Exception> warnings)
+    {
+        return forClassification(client, converter, classification, reportInterval, warnings, false);
     }
 
     public static PerformanceIndex forClassification(Client client, CurrencyConverter converter,
-                    Classification classification, ReportingPeriod reportInterval, List<Exception> warnings)
+                    Classification classification, ReportingPeriod reportInterval, List<Exception> warnings, boolean isNormalized)
     {
         Client filteredClient = new ClientClassificationFilter(classification).filter(client);
-        return PerformanceIndex.forClient(filteredClient, converter, reportInterval, warnings);
+        return PerformanceIndex.forClient(filteredClient, converter, reportInterval, warnings, isNormalized);
     }
 
+    @Deprecated
     public static PerformanceIndex forInvestment(Client client, CurrencyConverter converter, Security security,
                     ReportingPeriod reportInterval, List<Exception> warnings)
     {
-        Client filteredClient = new ClientSecurityFilter(security).filter(client);
-        return forClient(filteredClient, converter, reportInterval, warnings);
+        return forInvestment(client, converter, security, reportInterval, warnings, false);
     }
 
+    public static PerformanceIndex forInvestment(Client client, CurrencyConverter converter, Security security,
+                    ReportingPeriod reportInterval, List<Exception> warnings, boolean isNormalized)
+    {
+        Client filteredClient = new ClientSecurityFilter(security).filter(client);
+        return forClient(filteredClient, converter, reportInterval, warnings, isNormalized);
+    }
+
+    @Deprecated
     public static PerformanceIndex forSecurity(PerformanceIndex clientIndex, Security security)
+    {
+        return forSecurity(clientIndex, security, false);
+    }
+
+    public static PerformanceIndex forSecurity(PerformanceIndex clientIndex, Security security, boolean isNormalized)
     {
         SecurityIndex index = new SecurityIndex(clientIndex.getClient(), clientIndex.getCurrencyConverter(),
                         clientIndex.getReportInterval());
-        index.calculate(clientIndex, security);
+        index.calculate(clientIndex, security, isNormalized);
         return index;
     }
 
+    @Deprecated
     public static PerformanceIndex forConsumerPriceIndex(PerformanceIndex clientIndex)
+    {
+        return forConsumerPriceIndex(clientIndex, false);
+    }
+
+    public static PerformanceIndex forConsumerPriceIndex(PerformanceIndex clientIndex, boolean isNormalized)
     {
         CPIIndex index = new CPIIndex(clientIndex.getClient(), clientIndex.getCurrencyConverter(),
                         clientIndex.getReportInterval());
-        index.calculate(clientIndex);
+        index.calculate(clientIndex, isNormalized);
         return index;
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityIndex.java
@@ -19,7 +19,7 @@ import name.abuchen.portfolio.util.Interval;
         super(client, converter, reportInterval);
     }
 
-    /* package */void calculate(PerformanceIndex clientIndex, Security security)
+    /* package */void calculate(PerformanceIndex clientIndex, Security security, boolean isNormalized)
     {
         List<SecurityPrice> prices = security.getPrices();
         if (prices.isEmpty())


### PR DESCRIPTION
Moin Andreas,
mir war die Tage aufgefallen, daß die Performance positiv berechnet wurden, wenn der Kontostand negativ ist (ClientIndex.java L92).
Wo ich schonmal dabei war, habe ich eine Änderung erarbeitet, bei der zusätzliche Dataseries angezeigt werden können, bei der die Performance auf 365 Tage bzw. ein Jahr Anlagezeitraum normalisiert wird.

Grüße,
cmaoling