### PR TITLE
SecurityChart - StepChart FIFO price - interrupted time series

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -811,6 +811,8 @@ public class SecuritiesChart
                 }
                 else
                 {
+                    datesChart.add(dates.get(index));
+                    values.add(values.get(index - 1));
                     if (!datesChart.isEmpty())
                     {
                         seriesCounter++;


### PR DESCRIPTION
Hallo Andrea,

die bei der Darstellung der FIFO Preisanzeige mittels dem Treppendiagram, so werden unterbrochene Zeitreihen (ohne Bestand) im Wert mit 0 in der Datenreihe ausgewiesen. Dies hat zur Folge das die Skalierung des Charts sich deutlich verzehren kann, da der Bestand ja auf 0 ging und später wieder gekauft wurde.

Nachstehend die derzeitige Darstellung des "Einstandspreis (FIFO)":
![current](https://user-images.githubusercontent.com/29358155/33234979-db7b6ed6-d22f-11e7-85c1-368f5eadc3a8.JPG)

Diese Änderung erstellt jetzt für jeden in sich geschlossenen Zeitraum eine eigene Datenreihe als Treppendiagram. Nachstehend die neue Darstellung:
![new](https://user-images.githubusercontent.com/29358155/33235142-83de7ae4-d232-11e7-98b1-e258ce7e278b.JPG)

Gruß
Marco