### PR TITLE
update pdf import to merge transaction from different files (Comdirect dividend + tax)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -703,8 +703,10 @@ System.out.println(results);
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "comdirectDividende3.txt", "comdirectDividende3_Steuer.txt"), errors);
 
+        
         assertThat(errors, empty());
-        assertThat(results.size(), is(3));
+//        assertThat(results.size(), is(3));
+        assertThat(results.size(), is(2));
 
         // security
         Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
@@ -718,7 +720,8 @@ System.out.println(results);
                         .filter(i -> i instanceof TransactionItem && i.getSubject() instanceof AccountTransaction)
                         .map(i -> (AccountTransaction) i.getSubject())
                         .collect(Collectors.toList());
-        assertThat(items.size(), is(2));
+//        assertThat(items.size(), is(2));
+        assertThat(items.size(), is(1));
         
         // dividend
         Optional<AccountTransaction> oTransaction = items.stream()
@@ -728,21 +731,32 @@ System.out.println(results);
 
         assertThat(transaction.getDate(), is(LocalDate.parse("2017-11-07")));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(11.65)));
+//        assertThat(transaction.getAmount(), is(Values.Amount.factorize(11.65)));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(11.65 - 1.37 - 0.07)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
         assertThat(transaction.getId(), is("1BICAY8QGZE0000U"));
-        
-        
-        // tax
-        oTransaction = items.stream()
-                        .filter(t -> AccountTransaction.Type.TAXES.equals(t.getType())).findFirst();
-        assertThat(oTransaction.isPresent(), is(true));
-        transaction = oTransaction.get();
-        
-        assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
-        assertThat(transaction.getDate(), is(LocalDate.parse("2017-11-07")));
+//        assertThat(transaction.getUnitSum(Type.TAX), is(Money.of("EUR", 0)));   // ignores foreign taxes
         assertThat(transaction.getUnitSum(Type.TAX), is(Money.of("EUR", 1_37 + 7)));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.44)));
-        assertThat(transaction.getId(), is("1BICAY8QGZE0000U"));
+        
+        
+//        // tax
+//        oTransaction = items.stream()
+//                        .filter(t -> AccountTransaction.Type.TAXES.equals(t.getType())).findFirst();
+//        assertThat(oTransaction.isPresent(), is(true));
+//        transaction = oTransaction.get();
+//        
+//        assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
+//        assertThat(transaction.getDate(), is(LocalDate.parse("2017-11-07")));
+//        assertThat(transaction.getUnitSum(Type.TAX), is(Money.of("EUR", 1_37 + 7)));
+//        assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.44)));
+//        assertThat(transaction.getId(), is("1BICAY8QGZE0000U"));
     }
+    
+    // TODO: more tests
+    // - ignore tax file without div-file?
+    // - no confusion-test:
+    //  - div with empty tax file
+    //  - div without tax file (div1)
+    //  - 2 x div with matching tax-file
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -730,6 +730,7 @@ System.out.println(results);
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getAmount(), is(Values.Amount.factorize(11.65)));
         assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
+        assertThat(transaction.getId(), is("1BICAY8QGZE0000U"));
         
         
         // tax
@@ -742,5 +743,6 @@ System.out.println(results);
         assertThat(transaction.getDate(), is(LocalDate.parse("2017-11-07")));
         assertThat(transaction.getUnitSum(Type.TAX), is(Money.of("EUR", 1_37 + 7)));
         assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.44)));
+        assertThat(transaction.getId(), is("1BICAY8QGZE0000U"));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende4.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende4.txt
@@ -1,0 +1,50 @@
+PDF Author: 'HAVI Solutions GmbH & Co. KG, phg' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    111111111
+33333 333 BLZ:        222 222 22      
+Herrn                              
+                             
+Max Mustermann             
+                             
+                             
+                                   
+Musterstr. 123                                                        
+                             
+66666 Musterstadt                                                    
+13.10.2017
+G  u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Dividendengutschrift                                                               
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+p e r   2 8.  09 .  20 1 7                         R  e al t y   In  co m e   Co r p .                     8 9 9  7 4 4
+S  TK               3  9 , 00 0                 R e g is  te r  ed  S  h ar e s  D L  1            U  S 7 56 1  09 1 0 4 9 
+                                      Emissionsland: VEREINIGTE STAATEN            
+USD 0,212      Dividende pro Stück für Geschäftsjahr        01.10.16 bis 30.09.17  
+zahlbar ab 13.10.2017                 monatl. Dividende                            
+                         Abrechnung Dividendengutschrift                           
+Bruttobetrag:                     USD               8,27                           
+15,000 % Quellensteuer            USD               1,24 -                         
+Ausmachender Betrag               USD               7,03                           
+    zum Devisenkurs: EUR/USD      1,185600                 EUR               5,93  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+DE33 3333 3333 3333 3333 33   EUR       17.10.2017         EUR               5,93  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 2NIC9K86U45000UE).                                                   
+comdirect bank                                                                     
+Aktiengesellschaft                                                                 
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende4_Steuer.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende4_Steuer.txt
@@ -1,0 +1,117 @@
+PDF Author: 'HAVI Solutions GmbH & Co. KG, phg' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+1111111  Max  Mustermann                                  
+                                                  
+            
+222 222 22 Gartenstr. 123                                    66666 Musterstadt                                 
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+c  o  m   d  i r e  c  t   b  a  n  k    A  G               
+               
+2   5  4  5  1   Q  u  i c  k  b  o  r n                   
+0  1   0  9  7828
+                                                  
+T   e  le  f o  n  :              0  4  1  0  6   -  7  0 8 25 00
+                              
+Herrn                          D  a  t u  m   :                       1   3  . 1  0  .2017         
+ M  a x  M  u  s t e  r m a  n  n
+ D  e  p  o  t  n  u  m   m  er:        1   1  1  1  1  1 1 00
+M   u  s t e  r  s  t r .  1  2  3
+66  R  e  f e  r e  n  z  - N   u mmer:    2 N   I C   9  K  8  6  U 45000UE       6  6  6   M  u  s  t  e  r s t a d t                   
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Ausländische Dividende  vom 13.10.2017                                                                    
+Stk.              39 REALTY INC. CORP.    DL 1 , WKN / ISIN: 899744  / US7561091049                                               
+ Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               5,9 3   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+ S te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  6 , 9 8                          
+                                                                                                                                
+                                                                                                                                
+ K ap i ta le r tr a gs t e ue r                                                                        E  U   R                                -  0 , 7 0                          
+(angerechnete ausländische Quellensteuer:       EUR               1,05  )                                                       
+S  ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                -  0 , 0 3                          
+ K irc h e n s te u e r                                                                              _E  _U   _R  _  _  _   _  _  _   _  _  _  _   _  _  _   _  0_ ,_ _0 0_                          
+a b g e f ü h rt e S t e u er n                                                                                                                    _E _U R_ _ _ _ _ _ _ _ _ _ _  _ __ -__0,_7_ _3   
+                                                                                                                                
+Z u  Ih r e n G u n s t e n n a c h S t e u er n :                                                                                                   E U R               5,2 0   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Gutschrift erfolgt mit Valuta 17.10.2017 auf Konto EUR mit der IBAN DE33 3333 3333 3333 3333 33
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2017 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+              XXX,XX               XXX,XX
+              XXX,XX               XXX,XX
+nach Ermittlung
+              XXX,XX X,XX                 X,XX               XXX,XX
+Verrechnungssalden in EUR (4)
+in 2017 Gewinne / Verluste sonstige anrechenbare verfügbareraus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+              XXX,XX             X.XXX,XX                 X,XX                 X,XX
+nach Ermittlung
+              XXX,XX             X.XXX,XX
+                X,XX                 X,XX
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+comdirect bank AG                                                                                                                                     
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende5.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende5.txt
@@ -1,0 +1,50 @@
+PDF Author: 'HAVI Solutions GmbH & Co. KG, phg' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    111111111 
+33333 333 BLZ:        222 222 22      
+Herrn                              
+                             
+Max Mustermann             
+                             
+                             
+                                   
+Musterstr. 123                                                        
+                             
+66666 Musterstadt                                               
+13.01.2017
+G  u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Dividendengutschrift                                                               
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+p e r   2 8.  12 .  20 1 6                         R  e al t y   In  co m e   Co r p .                     8 9 9  7 4 4
+S  TK               3  9 , 00 0                 R e g is  te r  ed  S  h ar e s  D L  1            U  S 7 56 1  09 1 0 4 9 
+                                      Emissionsland: VEREINIGTE STAATEN            
+USD 0,2025     Dividende pro Stück für Geschäftsjahr        01.10.16 bis 30.09.17  
+zahlbar ab 13.01.2017                 monatl. Dividende                            
+                         Abrechnung Dividendengutschrift                           
+Bruttobetrag:                     USD               7,90                           
+15,000 % Quellensteuer            USD               1,19 -                         
+Ausmachender Betrag               USD               6,71                           
+    zum Devisenkurs: EUR/USD      1,067600                 EUR               6,29  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+DE33 3333 3333 3333 3333 33   EUR       17.01.2017         EUR               6,29  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 2HIBRI2RS8H000PH).                                                   
+comdirect bank                                                                     
+Aktiengesellschaft                                                                 
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende5_Steuer.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectDividende5_Steuer.txt
@@ -1,0 +1,116 @@
+PDF Author: 'HAVI Solutions GmbH & Co. KG, phg' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+1111111  Max  Mustermann                                  
+                                                  
+            
+222 222 22 Musterstr. 123                                    66666 Musterstadt                                 
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+c  o  m   d  i r e  c  t   b  a  n  k    A  G               
+               
+2   5  4  5  1   Q  u  i c  k  b  o  r n                   
+0  1   0  9  7828
+                                                  
+T   e  le  f o  n  :             0   4  1  0  6   -  7  0 8 25 00
+                              
+ H  e  r r n                            D  a  t u  m   :                       1   3  . 0  1  .2017
+ M  a x  M  u  s t e  r m a  n  n               D   e  p  o  t  n  u  m   m  er:        1   1  1  1  1  1 1 11  
+ M  u  s t e  r  s  t r .  1  2  3                  
+66666 Musterstadt                  R   e  f e  r e  n  z  - N   u mmer:    2 H   I B  R   I 2  R   S 8H000PH                        
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Ausländische Dividende  vom 13.01.2017                                                                    
+Stk.              39 REALTY INC. CORP.    DL 1 , WKN / ISIN: 899744  / US7561091049                                               
+ Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               6,2 9   
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e v o r V e r lu s tv e r re c h n u n g                  E  U   R                                  7 , 4 0                          
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+ in A n s p ru c h  g e n o m m e n e r F r ei s te ll un g s a u ft ra g                                         E    U   R                                  7 , 4 0                          
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e n a c h V e r lu s t ve r r ec h n u n g               E   U  R                                  0 , 0 0                          
+                                                                                                                                
+                                                                                                                                
+ K ap i ta le r tr a gs t e ue r                                                                        E  U   R                                  0 , 0 0                          
+ S ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0                          
+ K irc h e n s te u e r                                                                              _E  _U   R_  _  _  _   _  _  _   _  _  _  _   _  _  _   _  _0 _, _0 _0                          
+a b g e f ü h rt e S t e u er n                                                                                                                    E_ U_ _R _ _ _ _ _ _ _  __ _  _ __ _ _0_,_0 0_   
+                                                                                                                                
+Z u  Ih r e n G u n s t e n n a c h S t e u er n :                                                                                                   E U R               6,2 9   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Gutschrift erfolgt mit Valuta 17.01.2017 auf Konto EUR mit der IBAN DE33 3333 3333 3333 3333 33
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2017 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+              XXX,XX               XXX,XX
+              XXX,XX               XXX,XX
+nach Ermittlung
+              XXX,XX X,XX                 X,XX               XXX,XX
+Verrechnungssalden in EUR (4)
+in 2017 Gewinne / Verluste sonstige anrechenbare verfügbareraus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+              XXX,XX             X.XXX,XX                 X,XX                 X,XX
+nach Ermittlung
+              XXX,XX             X.XXX,XX
+                X,XX                 X,XX
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+comdirect bank AG                                                                                                                                     
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG
+

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -82,11 +82,18 @@ public abstract class AbstractPDFExtractor implements Extractor
             results.addAll(extract(inputFile.getFile().getName(), text, errors));
         }
 
+        results = mergeItems(results);
+
         results.addAll(securityCache.createMissingSecurityItems(results));
 
         securityCache = null;
 
         return results;
+    }
+
+    protected List<Item> mergeItems(List<Item> results)
+    {
+        return results;   // default: ignore
     }
 
     private final List<Item> extract(String filename, String text, List<Exception> errors)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -116,6 +116,7 @@ public abstract class Transaction implements Annotated
     private CrossEntry crossEntry;
     private long shares;
     private String note;
+    private String id;  // id from pdf documents (used f.e. in tax document and dividend document)
 
     private List<Unit> units;
 
@@ -298,5 +299,15 @@ public abstract class Transaction implements Annotated
     {
         Collections.sort(transactions, new ByDate());
         return transactions;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(String id)
+    {
+        this.id = id;
     }
 }


### PR DESCRIPTION
Hallo @buchen,
Comdirect liefert die pdfs für Dividenden in 2 separaten Dokumenten pro Transaktion
- Dividende mit ausländischer Quellensteuer
- Steuerbescheinigung für deutsche Steuern
(siehe Issue #759)

Ich habe den AbstractPdfExtractor um eine merge-Methode erweitert, die aktuell nur vom Comdirect-Extractor überschrieben wird und im Transaction-Datenmodell die Id hinzugefügt um Dokumente für die selbe TransaktionId zu finden.
Für meinen Anwendungsfall funktioniert der Import jetzt, wenn beide Dokumente in einem Rutsch importiert werden.

Jetzt habe ich noch ein Problem mit dem zeitlich versetzten Import der beiden Dokumente:

Man könnte
a) die Steuerdokumente einzeln immer ignorieren
b) mit dem Steuerdokument das Dividendendokument updaten (ich weiß noch nicht ganz wo)
c) theoretisch auch nur mit dem Steuerdokument zufrieden sein, es enthält auch Amount, Shares und Datum - eine Dividenden-Transaktion aus einem Steuerdokument sollte dann aber eine vorhandene Dividenden-Transaktion aus einem Dividendendokument ersetzen

Welche Variante für den zeitlich getrennten Import hältst du für am saubersten und wo könnte ich die umsetzen?

Deine generischen Überprüfungen scheitern aktuell wegen den Datenmodell-Anpassungen - die Anpassungen überlasse ich lieber dir wenn das andere Problem gelöst ist.

Gruß
Frank