### PR TITLE
PDF Import DKB und DAB

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -551,8 +551,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.47))));
         assertThat(transaction.getDate(), is(LocalDate.parse("2017-01-27")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(3.4256)));
-    }
-    
+    }    
 
     @Test
     public void testProceeds2() throws IOException
@@ -583,5 +582,6 @@ public class DABPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.06))));
         assertThat(transaction.getDate(), is(LocalDate.parse("2017-02-07")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(14.3755)));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.13))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABProceeds2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABProceeds2.txt
@@ -38,9 +38,9 @@ zu versteuern EUR 7,68
 einbehaltene Kapitalertragsteuer EUR 1,88
 einbehaltener Solidaritätszuschlag EUR 0,10
 einbehaltene Kirchensteuer EUR 0,15
-im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 5,21
-im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,28
-im laufenden Jahr einbehaltene Kirchensteuer EUR 0,41
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 55,55
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 55,55
+im laufenden Jahr einbehaltene Kirchensteuer EUR 5,55
 Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
 Finanzamt Frankfurt/M. V-Höchst, Steuernummer xxxxx.
 Steuerlicher Stichtag 07.02.2017

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbKaufFonds2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbKaufFonds2.txt
@@ -1,0 +1,32 @@
+10919 Berlin
+Depotnummer 123456789
+Kundennummer 123456789
+Max Mustermann
+Auftragsnummer 123456789/123456789
+Herrn Datum 06.10.2017
+Max Mustermann Rechnungsnummer 123456789
+Muster Straße Umsatzsteuer-ID 123456789
+Muster Ort
+Wertpapier Abrechnung Ausgabe Investmentfonds
+Auftrag vom 05.10.2017 00:05:54 Uhr
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 2,521 COMSTAGE-MSCI WORLD TRN U.ETF LU0392494562 (ETF110)
+INHABER-ANTEILE I O.N.
+Börse Außerbörslich (gemäß Weisung)
+Schlusstag 05.10.2017 Auftraggeber Max Mustermann
+Ausführungskurs 47,601 EUR Auftragserteilung sonstige
+Girosammelverw. mehrere Sammelurkunden - kein Stückeausdruck -
+Kurswert 120,00- EUR
+Provision 1,50- EUR
+Transaktionsentgelt Börse 0,71- EUR
+Übertragungs-/Liefergebühr 0,20- EUR
+Ausmachender Betrag 130,41- EUR
+Den Gegenwert buchen wir mit Valuta 09.10.2017 zu Lasten des Kontos 123456789
+(IBAN DE10 123456789123456789123456789), BLZ 123456789 (BIC 123456789).
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+Gegenpartei bei diesem Geschäft war BÖRSE QUOTRIX
+ABR. OHNE AUSGABEAUFSCHLAG
+IHR ETF-SPARPLAN NR. 2
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+123456789.123456789.123456789

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -428,6 +428,40 @@ public class DkbPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKaufFonds2() throws IOException // Fonds, only 3 decimal places for amount of shares
+    {       
+        DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DkbKaufFonds2.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        assertSecurityBuyFonds(results);
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(130.41))));
+        assertThat(entry.getPortfolioTransaction().getDate(), is(LocalDate.parse("2017-10-05")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2.521)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.41))));
+    }
+
+    @Test
     public void testWertpapierVerkauf() throws IOException
     {
         DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -195,6 +195,7 @@ public class Messages extends NLS
     public static String ColumnSymbol;
     public static String ColumnTargetValue;
     public static String ColumnTaxes;
+    public static String ColumnTaxes_Description;
     public static String ColumnTaxonomy;
     public static String ColumnTermCurrency;
     public static String ColumnTicker;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -423,6 +423,8 @@ ColumnTargetValue = TARGET Value
 
 ColumnTaxes = Taxes
 
+ColumnTaxes_Description = Retained Taxes
+
 ColumnTaxonomy = Taxonomy
 
 ColumnTermCurrency = Term Currency

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -423,6 +423,8 @@ ColumnTargetValue = SOLL Wert
 
 ColumnTaxes = Steuern
 
+ColumnTaxes_Description = Einbehaltende Steuern
+
 ColumnTaxonomy = Klassifizierung
 
 ColumnTermCurrency = Zielw\u00E4hrung

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -51,6 +51,7 @@ import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.model.Watchlist;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.money.Quote;
@@ -760,6 +761,33 @@ public class SecurityListView extends AbstractListView implements ModificationLi
             }
         });
         support.addColumn(column);
+        
+        
+        column = new Column(Messages.ColumnFees, SWT.RIGHT, 40);
+        column.setDescription(Messages.ColumnFees_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Transaction t = ((TransactionPair<?>) element).getTransaction();
+                return Values.Money.format(t.getUnitSum(Unit.Type.FEE), getClient().getBaseCurrency());
+            }
+        });
+        support.addColumn(column);        
+
+        column = new Column(Messages.ColumnTaxes, SWT.RIGHT, 40);
+        column.setDescription(Messages.ColumnTaxes_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Transaction t = ((TransactionPair<?>) element).getTransaction();
+                return Values.Money.format(t.getUnitSum(Unit.Type.TAX), getClient().getBaseCurrency());
+            }
+        });
+        support.addColumn(column);        
 
         column = new Column(Messages.ColumnPortfolio, SWT.NONE, 120);
         column.setLabelProvider(new ColumnLabelProvider()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -59,7 +59,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
         pdfTransaction.section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))
@@ -103,7 +103,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
         pdfTransaction.section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{4})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))
@@ -147,7 +147,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
         pdfTransaction.section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))
@@ -192,7 +192,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
         pdfTransaction.section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))
@@ -245,7 +245,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "amount")
-                        .match("(^Ausmachender Betrag) (?<amount>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)(.*) (?<currency>\\w{3}+)")
+                        .match("(^Ausmachender Betrag) (?<amount>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?)(.*) (?<currency>\\w{3}+)")
                         .match("(^Lagerstelle) (.*)")
                         .match("(^Den Betrag buchen wir mit Wertstellung) (?<date>\\d+.\\d+.\\d{4}+) zu Gunsten des Kontos (.*)")
                         .assign((t, v) -> {
@@ -328,7 +328,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
         pdfTransaction.section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))
@@ -384,7 +384,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .section("notation", "shares", "name", "isin", "wkn")
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<notation>^St\\Dck|^\\w{3}+) (?<shares>\\d{1,3}(\\.\\d{3})*(,\\d{2,})?) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
                         .assign((t, v) -> {
                             String notation = v.get("notation");
                             if (notation != null && !(notation.startsWith("St") && notation.endsWith("ck")))


### PR DESCRIPTION
wie versprochen die Aktualisierung meines letzten commits. Ohne firlefanz.

Änderungen:
1. Erkennung der einbehaltenden Steuern bei der DAB auf Dividenden
2. DKB Fondssparplan mit nur 3 Nachkommastellen wird nun erkannt
3. Anzeige der einbehaltenden Steuern und Gebühren in der Umsatzanzeige der Wertpapierübersicht (Einfachere Überprüfung der Importe)