### PR TITLE
Enhancement pdf import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbErtragsgutschriftDividende_2017_12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbErtragsgutschriftDividende_2017_12.txt
@@ -1,0 +1,50 @@
+PDF Author: '' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+10919 Berlin Seite 1
+Depotnummer 123456789
+Kundennummer 1234123412
+Max Mustermann
+Abrechnungsnr. 84033925310
+Herrn Datum 06.12.2017
+Max Mustermann
+Gutschrift von Investmenterträgen
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 216 DIM.FDS-GLOBAL SMALL COMPANIES IE00B3XNN521 (A1JJAG)
+REGISTERED SHARES EUR DIS.O.N.
+Zahlbarkeitstag 07.12.2017 Ertrag pro St. 0,211140000 EUR
+Bestandsstichtag 29.11.2017 Zinsanteil pro St. 0,211140000 EUR
+Ex-Tag 30.11.2017 Herkunftsland Irland
+Geschäftsjahr 01.12.2016 - 30.11.2017
+Ausschüttung 45,61+ EUR
+Kapitalertragsteuerpflichtiger Zinsanteil gesamt 45,61 EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 45,61 EUR
+Kapitalertragsteuer 24,51 % auf 45,61 EUR 11,18- EUR
+Solidaritätszuschlag 5,5 % auf 11,18 EUR 0,61- EUR
+Kirchensteuer 8 % auf 11,18 EUR 0,89- EUR
+Ausmachender Betrag 32,93+ EUR
+Lagerstelle Clearstream Banking Lux (849133 / 64003)
+Den Betrag buchen wir mit Wertstellung 07.12.2017 zu Gunsten des Kontos 123456789 (IBAN xxxx), BLZ 120 300 00 (BIC BYLADEM1001).
+Keine Steuerbescheinigung.
+Bis zum Zahlbarkeitstag wurden noch nicht alle steuerlich relevanten Daten vom Emittenten geliefert. Daher wird
+voraussichtlich zu einem späteren Zeitpunkt eine Korrektur dieser Ertragszahlung durch eine Storno- und eine
+Neuabrechnung erfolgen.
+Bitte ggf. Rückseite beachten.
+0883.12070100.0005675ER03
+
+Seite 2
+Depotnummer 123456789
+Kundennummer 1234123412
+Abrechnungsnr. 84033925310
+Datum 06.12.2017
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2017 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 524,00
+Ertrag 0,00 0,00 0,00 0,00 45,61
+Nachher 0,00 0,00 0,00 0,00 569,61
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0883.12070100.0005675ER03
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorPDFTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorPDFTest.java
@@ -53,7 +53,7 @@ public class DkbPDFExtractorPDFTest
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getWkn(), is("A0DJ58"));
         assertThat(security.getIsin(), is("GB00B02J6398"));
-        assertThat(security.getName(), is("ADMIRAL GROUP PLC"));
+        assertThat(security.getName(), is("ADMIRAL GROUP PLC REGISTERED SHARES LS -,001"));
 
         // check transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -112,7 +112,7 @@ public class DkbPDFExtractorTest
         Security security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("DE0007100000"));
         assertThat(security.getWkn(), is("710000"));
-        assertThat(security.getName(), is("DAIMLER AG"));
+        assertThat(security.getName(), is("DAIMLER AG NAMENS-AKTIEN O.N."));
 
         return security;
     }
@@ -124,7 +124,7 @@ public class DkbPDFExtractorTest
         Security security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("US0378331005"));
         assertThat(security.getWkn(), is("865985"));
-        assertThat(security.getName(), is("APPLE INC."));
+        assertThat(security.getName(), is("APPLE INC. REGISTERED SHARES O.N."));
 
         return security;
     }
@@ -284,6 +284,43 @@ public class DkbPDFExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(66)));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.29))));
+    }
+    
+    @Test
+    public void testErtragsgutschriftDividende_2017_12() throws IOException
+    {
+        DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "DkbErtragsgutschriftDividende_2017_12.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security        
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("IE00B3XNN521"));
+        assertThat(security.getWkn(), is("A1JJAG"));
+        assertThat(security.getName(), is("DIM.FDS-GLOBAL SMALL COMPANIES REGISTERED SHARES EUR DIS.O.N."));
+
+        // check transaction
+        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getSecurity(), is(security));
+        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(transaction.getDate(), is(LocalDate.parse("2017-12-07")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(32.93)));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(216)));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.68))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -162,6 +162,11 @@ public abstract class AbstractPDFExtractor implements Extractor
         if (name != null)
             name = name.trim();
 
+        String nameRowTwo = values.get("nameContinued"); //$NON-NLS-1$
+        if (nameRowTwo != null)
+            name = name + " " + nameRowTwo.trim();
+        
+
         Security security = securityCache.lookup(isin, tickerSymbol, wkn, name, () -> {
             Security s = new Security();
             s.setCurrencyCode(asCurrencyCode(values.get("currency"))); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -236,9 +236,10 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
             return transaction;
         });
         block.set(pdfTransaction);
-        pdfTransaction.section("shares", "name", "isin", "wkn") //
+        pdfTransaction.section("shares", "name", "nameContinued", "isin", "wkn") //
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
                         .match("(^St\\Dck) (?<shares>[\\d,.]*) (?<name>.*) (?<isin>[^ ]*) (\\((?<wkn>.*)\\).*)$")
+                        .match("(?<nameContinued>.*)")
                         .assign((t, v) -> {
                             t.setShares(asShares(v.get("shares")));
                             t.setSecurity(getOrCreateSecurity(v));
@@ -286,10 +287,22 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
 
         pdfTransaction.section("shares", "name", "isin", "wkn", "currency")
+                        .exclusiveOrGroup(1)
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
-                        .match("(^St\\Dck) (?<shares>[\\d,.]*) (?<name>.*)$").match(".*") //
+                        .match("(^St\\Dck) (?<shares>[\\d,.]*) (?<name>.*)$")
+                        .match(".*")
                         .match("(?<isin>[^ ]*) \\((?<wkn>.*)\\)$") //
                         .match("^Ertrag pro St. [\\d,.]* (?<currency>\\w{3}+)").assign((t, v) -> {
+                            t.setShares(asShares(v.get("shares")));
+                            t.setSecurity(getOrCreateSecurity(v));
+                        })
+                        
+                        .section("shares", "name", "nameContinued", "isin", "wkn")
+                        .exclusiveOrGroup(1)
+                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
+                        .match("(^St\\Dck) (?<shares>[\\d,.]*) (?<name>.*) (?<isin>[^ ]*) \\((?<wkn>.*)\\)$")
+                        .match("(?<nameContinued>.*)")
+                        .assign((t, v) -> {
                             t.setShares(asShares(v.get("shares")));
                             t.setSecurity(getOrCreateSecurity(v));
                         })


### PR DESCRIPTION
Auf ein neues! Die Banken änderen ihre PDFs wie ich meine Unterhosen...

Update umfasst die Ertragsgutschriften bei der DKB. Da sich die Reihenfolge grundsätzlich zum vorhandenen Parser geändert hat, hätte ich nochmal ein neuen Dokumenttype erstellen müssen. Da dies schon bei der DAB ähnlich aufgetreten ist und wahrscheinlich auch in Zukunft wieder auftreten wird, wollte ich ein bisschen Ordnung in all die unterschiedlichen dokumentenTypen bringen.

Hierfür habe ich versucht die Sections zu bündeln um so unterschiedliche Stände eines Dokumenttypes zu addressieren. 

D.h. ich kann jetzt ganze Reihenfolgen von match Ausdrücken (die ja nur ab der zeile des letzten matches suchen) clustern und damit in einer weiteren section die gleiche aufgabe in einer anderen Reihenfolge ausführen. Logischer weise darf nur eine einzige Gruppe alle Anforderungen erfüllen.

Zudem wird jetzt der Name des Wertpapiers, welcher meist über zwei Zeilen bei der DKB geht, zusammen gesetzt. Alte Testfälle haben dies nicht berücksichtigt und wurden daher korregiert.


Um feedback wäre ich dankbar.

Beste grüße

