### PR TITLE
Adapt portfolio client filter to handle "virtual" depots

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/AccountBuilder.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/AccountBuilder.java
@@ -12,7 +12,9 @@ import name.abuchen.portfolio.model.Classification.Assignment;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
 
 public class AccountBuilder
 {
@@ -56,19 +58,44 @@ public class AccountBuilder
         return transaction(Type.INTEREST, date, amount);
     }
     
+    public AccountBuilder interest(String date, long amount, Security security)
+    {
+        return transaction(Type.INTEREST, date, amount, security);
+    }
+    
+    public AccountBuilder interest(String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(Type.INTEREST, date, amount, affectedShares, security);
+    }
+    
     public AccountBuilder interest_charge(String date, long amount)
     {
         return transaction(Type.INTEREST_CHARGE, date, amount);
     }
 
-    public AccountBuilder interest_charge(LocalDateTime date, long amount)
+    public AccountBuilder interest_charge(String date, long amount, Security security)
     {
-        return transaction(Type.INTEREST_CHARGE, date, amount);
+        return transaction(Type.INTEREST_CHARGE, date, amount, security);
+    }
+    
+    public AccountBuilder interest_charge(String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(Type.INTEREST_CHARGE, date, amount, affectedShares, security);
     }
 
     public AccountBuilder fees____(String date, long amount)
     {
         return transaction(Type.FEES, date, amount);
+    }
+    
+    public AccountBuilder fees____(String date, long amount, Security security)
+    {
+        return transaction(Type.FEES, date, amount, security);
+    }
+    
+    public AccountBuilder fees____(String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(Type.FEES, date, amount, affectedShares, security);
     }
 
     public AccountBuilder fees____(LocalDateTime date, long amount)
@@ -79,6 +106,16 @@ public class AccountBuilder
     public AccountBuilder fees_refund(String date, long amount)
     {
         return transaction(Type.FEES_REFUND, date, amount);
+    }
+    
+    public AccountBuilder fees_refund(String date, long amount, Security security)
+    {
+        return transaction(Type.FEES_REFUND, date, amount, security);
+    }
+    
+    public AccountBuilder fees_refund(String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(Type.FEES_REFUND, date, amount, affectedShares, security);
     }
 
     public AccountBuilder withdraw(String date, long amount)
@@ -93,20 +130,55 @@ public class AccountBuilder
 
     public AccountBuilder dividend(String date, long amount, Security security)
     {
-        AccountTransaction t = new AccountTransaction(asDateTime(date), account.getCurrencyCode(), amount,
-                        security, Type.DIVIDENDS);
-        account.addTransaction(t);
-        return this;
+        return transaction(Type.DIVIDENDS, date, amount, security);
+    }
+    
+    public AccountBuilder dividend(String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(Type.DIVIDENDS, date, amount, affectedShares, security);
+    }
+    
+    public AccountBuilder dividend(String date, long amount, long fees, long taxes, Security security)
+    {
+        return transaction(Type.DIVIDENDS, date, amount, 0, fees, taxes, security);
+    }
+    
+    public AccountBuilder dividend(String date, long amount, long affectedShares, long fees, long taxes, Security security)
+    {
+        return transaction(Type.DIVIDENDS, date, amount, affectedShares, fees, taxes, security);
     }
 
     private AccountBuilder transaction(Type type, String date, long amount)
     {
         return transaction(type, asDateTime(date), amount);
     }
+    
+    private AccountBuilder transaction(Type type, String date, long amount, Security security)
+    {
+        return transaction(type, date, amount, 0, security);
+    }
+
+    private AccountBuilder transaction(Type type, String date, long amount, long affectedShares, Security security)
+    {
+        return transaction(type, date, amount, affectedShares, 0, 0, security);
+    }
 
     private AccountBuilder transaction(Type type, LocalDateTime date, long amount)
     {
-        AccountTransaction t = new AccountTransaction(date, account.getCurrencyCode(), amount, null, type);
+        return transaction(type, date, amount, 0, 0, 0, null);
+    }
+    
+    private AccountBuilder transaction(Type type, String date, long amount, long affectedShares, long fees, long taxes, Security security)
+    {
+        return transaction(type, asDateTime(date), amount, affectedShares, fees, taxes, security);
+    }
+    
+    private AccountBuilder transaction(Type type, LocalDateTime date, long amount, long affectedShares, long fees, long taxes, Security security)
+    {
+        AccountTransaction t = new AccountTransaction(date, account.getCurrencyCode(), amount, security, type);
+        t.setShares(affectedShares);
+        t.addUnit(new Unit(Unit.Type.FEE, Money.of(account.getCurrencyCode(), fees)));
+        t.addUnit(new Unit(Unit.Type.TAX, Money.of(account.getCurrencyCode(), taxes)));
         account.addTransaction(t);
         return this;
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/PortfolioBuilder.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/PortfolioBuilder.java
@@ -53,36 +53,59 @@ public class PortfolioBuilder
 
     public PortfolioBuilder buy(Security security, String date, long shares, long amount)
     {
-        return buysell(Type.BUY, security, date, shares, amount, 0);
+        return buysell(Type.BUY, security, date, shares, amount, 0, 0);
+    }
+    
+    public PortfolioBuilder buy(Security security, String date, long shares, long amount, long fees, long taxes)
+    {
+        return buysell(Type.BUY, security, date, shares, amount, fees, taxes);
+    }
+    
+    public PortfolioBuilder buy(Security security, String date, long shares, long amount, long fees, long taxes, Account account)
+    {
+        return buysell(Type.BUY, security, date, shares, amount, fees, taxes, account);
     }
 
     public PortfolioBuilder sell(Security security, String date, long shares, long amount)
     {
-        return buysell(Type.SELL, security, date, shares, amount, 0);
+        return buysell(Type.SELL, security, date, shares, amount, 0, 0);
     }
 
-    public PortfolioBuilder sell(Security security, String date, long shares, long amount, int fees)
+    public PortfolioBuilder sell(Security security, String date, long shares, long amount, long fees)
     {
-        return buysell(Type.SELL, security, date, shares, amount, fees);
+        return buysell(Type.SELL, security, date, shares, amount, fees, 0);
     }
 
-    private PortfolioBuilder buysell(Type type, Security security, String date, long shares, long amount, int fees)
+    private PortfolioBuilder buysell(Type type, Security security, String date, long shares, long amount, long fees, long taxes)
     {
         if (portfolio.getReferenceAccount() == null)
         {
             account = new Account(UUID.randomUUID().toString());
             portfolio.setReferenceAccount(account);
         }
-
-        BuySellEntry entry = new BuySellEntry(portfolio, portfolio.getReferenceAccount());
+        return buysell(type, security, date, shares, amount, fees, taxes, account == null ? portfolio.getReferenceAccount() : account);
+    }
+    
+    private PortfolioBuilder buysell(Type type, Security security, String date, long shares, long amount, long fees, long taxes, Account account)
+    {
+        BuySellEntry entry = new BuySellEntry(portfolio, account);
         entry.setType(type);
         entry.setDate(AccountBuilder.asDateTime(date));
         entry.setSecurity(security);
         entry.setShares(shares);
         entry.setCurrencyCode(CurrencyUnit.EUR);
         entry.setAmount(amount);
-        entry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, Money.of(CurrencyUnit.EUR, fees)));
-
+        
+        if (fees != 0)
+        {
+            entry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, Money.of(CurrencyUnit.EUR, fees)));
+        }
+        
+        if (taxes != 0)
+        {
+            entry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.TAX, Money.of(CurrencyUnit.EUR, taxes)));
+        }
+        
         entry.insert();
 
         return this;

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterWithNtoMTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterWithNtoMTest.java
@@ -1,0 +1,131 @@
+package name.abuchen.portfolio.snapshot.filter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import name.abuchen.portfolio.AccountBuilder;
+import name.abuchen.portfolio.PortfolioBuilder;
+import name.abuchen.portfolio.SecurityBuilder;
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.util.SecurityUtil;
+
+@SuppressWarnings("nls")
+public class PortfolioClientFilterWithNtoMTest
+{
+    private Client client;
+
+    /**
+     * Creates three portfolios (A-C) with a reference account each.
+     */
+    @Before
+    public void setupClient()
+    {
+        client = new Client();
+
+        Security secA = new SecurityBuilder().addTo(client);
+        secA.setName("SecA");
+        
+        Security secB = new SecurityBuilder().addTo(client);
+        secB.setName("SecB");
+        
+        Security secC = new SecurityBuilder().addTo(client);
+        secC.setName("SecC");
+
+        SecurityUtil.addDividendEvent(secA, LocalDate.of(2016, 1, 3));
+        SecurityUtil.addDividendEvent(secB, LocalDate.of(2016, 1, 3));
+        SecurityUtil.addDividendEvent(secC, LocalDate.of(2016, 1, 3));
+        
+        // accounts
+        Account accountA1 = new AccountBuilder() //
+                        .deposit_("2016-01-01", Values.Amount.factorize(1000))
+                        .dividend("2016-01-03", Values.Amount.factorize(10), Values.Amount.factorize(4), Values.Amount.factorize(2), secA) // dividend without shares count
+                        .dividend("2016-01-03", Values.Amount.factorize(12), Values.Share.factorize(12), Values.Amount.factorize(4), Values.Amount.factorize(2), secB) // dividend with shares count
+                        .fees____("2016-01-05", Values.Amount.factorize(20), secA) // security fee without shares count
+                        .fees____("2016-01-05", Values.Amount.factorize(22), Values.Share.factorize(11), secB) // security fee with shares count
+                        .fees____("2016-01-05", Values.Amount.factorize(24)) // fee without a security
+                        .fees_refund("2016-01-07", Values.Amount.factorize(40), secA) // security fee refund without shares count
+                        .fees_refund("2016-01-07", Values.Amount.factorize(44), Values.Share.factorize(11), secB) // security fee refund with shares count
+                        .fees_refund("2016-01-07", Values.Amount.factorize(48)) // fee refund without a security
+                        .interest("2016-01-09", Values.Amount.factorize(50), secA) // security interest without shares count
+                        .interest("2016-01-09", Values.Amount.factorize(55), Values.Share.factorize(11), secB) // security interest with shares count
+                        .interest("2016-01-09", Values.Amount.factorize(58)) // interest without a security
+                        .interest_charge("2016-01-11", Values.Amount.factorize(50), secA) // security interest charge without shares count
+                        .interest_charge("2016-01-11", Values.Amount.factorize(55), Values.Share.factorize(11), secB) // security interest charge with shares count
+                        .interest_charge("2016-01-11", Values.Amount.factorize(58)) // interest charge without a security
+                        .addTo(client);
+        accountA1.setName("A1");
+        
+        Account accountA2 = new AccountBuilder() //
+                        .deposit_("2016-01-01", Values.Amount.factorize(500))
+                        .dividend("2016-01-13", Values.Amount.factorize(10), 15, secC) //
+                        .addTo(client);
+        accountA2.setName("A2");
+        
+        // portfolios
+        Portfolio portfolioP1 = new PortfolioBuilder(accountA1) //
+                        .buy(secA, "2016-01-02", Values.Share.factorize(6), Values.Amount.factorize(60), Values.Amount.factorize(12), Values.Amount.factorize(6))
+                        .buy(secA, "2016-01-03", Values.Share.factorize(10), Values.Amount.factorize(60), Values.Amount.factorize(12), Values.Amount.factorize(6))
+                        .buy(secB, "2016-01-02", Values.Share.factorize(8), Values.Amount.factorize(110), Values.Amount.factorize(15), Values.Amount.factorize(9))
+                        .buy(secB, "2016-01-03", Values.Share.factorize(8), Values.Amount.factorize(110), Values.Amount.factorize(15), Values.Amount.factorize(9))
+                        .buy(secC, "2016-01-02", Values.Share.factorize(15), Values.Amount.factorize(150), Values.Amount.factorize(9), Values.Amount.factorize(4), accountA2)
+                        .addTo(client);
+        portfolioP1.setName("P1");
+        
+        Portfolio portfolioP2 = new PortfolioBuilder(accountA1) //
+                        .buy(secA, "2016-01-02", Values.Share.factorize(4), Values.Amount.factorize(40), Values.Amount.factorize(8), Values.Amount.factorize(4))
+                        .buy(secB, "2016-01-02", Values.Share.factorize(4), Values.Amount.factorize(40), Values.Amount.factorize(8), Values.Amount.factorize(4))
+                        .addTo(client);
+        portfolioP2.setName("P2");
+    }
+
+    @Test
+    public void testCorrectAdjustmentsOfTransactionsWith2PortfoliosForOneAccount()
+    {
+        Portfolio portfolio = client.getPortfolios().get(0);
+
+        Client result = new PortfolioClientFilter(portfolio).filter(client);
+
+        assertThat(result.getPortfolios().size(), is(1));
+        assertThat(result.getAccounts().size(), is(2));
+
+        Account acc1 = result.getAccounts().get(0);
+        Account acc2 = result.getAccounts().get(1);
+        
+        // only dividends, fees & fee refunds are kept
+        assertThat(acc1.getTransactions().size(), is(12));
+        assertThat(acc2.getTransactions().size(), is(2));
+        
+        List<AccountTransaction> dividendTransactionsAcc1 = acc1.getTransactions().stream().filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS).collect(Collectors.toList());
+        assertThat(dividendTransactionsAcc1.size(), is(2));
+        AccountTransaction dividendSecA = dividendTransactionsAcc1.get(0);
+        assertThat(dividendSecA.getSecurity().getName(), is("SecA"));
+        assertThat(dividendSecA.getAmount(), is(Values.Amount.factorize(6)));
+        assertThat(dividendSecA.getUnitSum(Unit.Type.FEE), is(Money.of(dividendSecA.getCurrencyCode(), Values.Amount.factorize(2.40))));
+        assertThat(dividendSecA.getUnitSum(Unit.Type.TAX), is(Money.of(dividendSecA.getCurrencyCode(), Values.Amount.factorize(1.20))));
+        AccountTransaction dividendSecB = dividendTransactionsAcc1.get(1);
+        assertThat(dividendSecB.getSecurity().getName(), is("SecB"));
+        assertThat(dividendSecB.getAmount(), is(Values.Amount.factorize(8)));
+        assertThat(dividendSecB.getUnitSum(Unit.Type.FEE), is(Money.of(dividendSecA.getCurrencyCode(), Values.Amount.factorize(2.67))));
+        assertThat(dividendSecB.getUnitSum(Unit.Type.TAX), is(Money.of(dividendSecA.getCurrencyCode(), Values.Amount.factorize(1.33))));
+        
+        List<AccountTransaction> dividendTransactionsAcc2 = acc2.getTransactions().stream().filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS).collect(Collectors.toList());
+        assertThat(dividendTransactionsAcc2.size(), is(1));
+        AccountTransaction dividendSecC = dividendTransactionsAcc2.get(0);
+        assertThat(dividendSecC.getSecurity().getName(), is("SecC"));
+        assertThat(dividendSecC.getAmount(), is(Values.Amount.factorize(10)));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
@@ -7,7 +7,7 @@ public class SecurityEvent
 {
     public enum Type
     {
-        STOCK_SPLIT;
+        STOCK_SPLIT, STOCK_EX_DIVIDEND;
 
         private static final ResourceBundle RESOURCES = ResourceBundle.getBundle("name.abuchen.portfolio.model.labels"); //$NON-NLS-1$
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels.properties
@@ -14,6 +14,7 @@ account.TRANSFER_IN     = Transfer (Inbound)
 account.TRANSFER_OUT    = Transfer (Outbound)
 
 event.STOCK_SPLIT = Stock Split
+event.STOCK_EX_DIVIDEND = Ex-dividend date
 
 portfolio.BUY               = Buy
 portfolio.DELIVERY_INBOUND  = Delivery (Inbound)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/labels_de.properties
@@ -14,6 +14,7 @@ account.TRANSFER_IN     = Umbuchung (Eingang)
 account.TRANSFER_OUT    = Umbuchung (Ausgang)
 
 event.STOCK_SPLIT = Aktiensplit
+event.STOCK_EX_DIVIDEND = Ex-Tag
 
 portfolio.BUY               = Kauf
 portfolio.DELIVERY_INBOUND  = Einlieferung

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.InvestmentVehicle;
@@ -228,6 +229,23 @@ public class SecurityPosition
     public long getShares()
     {
         return shares;
+    }
+    
+    public long getFilteredShares(Predicate<PortfolioTransaction> filter)
+    {
+        return transactions.stream()
+        .filter(filter)
+        .mapToLong(pt -> {
+            switch (pt.getType())
+            {
+                case SELL:
+                case TRANSFER_OUT:
+                case DELIVERY_OUTBOUND:
+                    return -pt.getShares();
+                default:
+                    return pt.getShares();
+            }
+        }).sum();
     }
 
     public Money calculateValue()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -1,19 +1,37 @@
 package name.abuchen.portfolio.snapshot.filter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CrossEntry;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityEvent;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.model.TransactionOwner;
+import name.abuchen.portfolio.money.CurrencyConverterImpl;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.snapshot.SecurityPosition;
+import name.abuchen.portfolio.util.SecurityUtil;
 
 /**
  * Filters the Client to include only transactions related to the given
@@ -50,20 +68,22 @@ public class PortfolioClientFilter implements ClientFilter
 
         for (Portfolio portfolio : portfolios)
         {
-            ReadOnlyAccount pseudoAccount = account2pseudo.computeIfAbsent(portfolio.getReferenceAccount(), a -> {
-                ReadOnlyAccount pa = new ReadOnlyAccount(a);
-                pseudoClient.internalAddAccount(pa);
-                return pa;
-            });
+            // collect all accounts that are connected to the given portfolio
+            // via transactions
+            Set<ReadOnlyAccount> accountsWithPortfolioTransactions = collectAccountsWithTransactions(portfolio,
+                            pseudoClient, account2pseudo);
 
             ReadOnlyPortfolio pseudoPortfolio = new ReadOnlyPortfolio(portfolio);
-            pseudoPortfolio.setReferenceAccount(pseudoAccount);
+            pseudoPortfolio.setReferenceAccount(account2pseudo.get(portfolio.getReferenceAccount()));
             pseudoClient.internalAddPortfolio(pseudoPortfolio);
 
             adaptPortfolioTransactions(portfolio, pseudoPortfolio, usedSecurities);
 
-            if (!accounts.contains(portfolio.getReferenceAccount()))
-                collectSecurityRelevantTx(portfolio, pseudoAccount, usedSecurities);
+            // collect security relevant transactions for all connected accounts
+            accountsWithPortfolioTransactions.forEach(acc -> {
+                if (!accounts.contains(acc.getSource()))
+                    collectSecurityRelevantTx(pseudoClient, portfolio, acc, usedSecurities);
+            });
         }
 
         for (Account account : accounts)
@@ -81,6 +101,45 @@ public class PortfolioClientFilter implements ClientFilter
             pseudoClient.internalAddSecurity(security);
 
         return pseudoClient;
+    }
+
+    private Set<ReadOnlyAccount> collectAccountsWithTransactions(Portfolio portfolio, ReadOnlyClient pseudoClient,
+                    Map<Account, ReadOnlyAccount> account2pseudo)
+    {
+        return portfolio.getTransactions().stream().map(t -> {
+            CrossEntry crossEntry = t.getCrossEntry();
+            Account account = null;
+            if (crossEntry instanceof BuySellEntry)
+            {
+                // if it is a buy-sell entry use the affected account
+                account = ((BuySellEntry) crossEntry).getAccount();
+            }
+            else if (crossEntry instanceof PortfolioTransferEntry)
+            {
+                // if it is a portfolio transfer entry use the owning account or
+                // the reference account of the owning portfolio
+                TransactionOwner<? extends Transaction> transactionOwner = crossEntry
+                                .getCrossOwner(((PortfolioTransferEntry) crossEntry).getTargetTransaction());
+                if (transactionOwner instanceof Portfolio)
+                {
+                    account = ((Portfolio) transactionOwner).getReferenceAccount();
+                }
+                else if (transactionOwner instanceof Account)
+                {
+                    account = (Account) transactionOwner;
+                }
+            }
+            if (account != null)
+            {
+                // if an account was found, return a pseudo account
+                return account2pseudo.computeIfAbsent(account, a -> {
+                    ReadOnlyAccount pa = new ReadOnlyAccount(a);
+                    pseudoClient.internalAddAccount(pa);
+                    return pa;
+                });
+            }
+            return null;
+        }).filter(Objects::nonNull).collect(Collectors.toSet());
     }
 
     private void adaptPortfolioTransactions(Portfolio portfolio, ReadOnlyPortfolio pseudoPortfolio,
@@ -130,12 +189,126 @@ public class PortfolioClientFilter implements ClientFilter
         }
     }
 
-    private void collectSecurityRelevantTx(Portfolio portfolio, ReadOnlyAccount pseudoAccount, Set<Security> usedSecurities)
+    private double calculatePercentageOfDividendsOfSecurities(ReadOnlyClient pseudoClient,
+                    ReadOnlyAccount pseudoAccount, Transaction t)
+    {
+        Security security = t.getSecurity();
+        Optional<SecurityEvent> lastExDay = SecurityUtil.findLastDividendEvent(security, t.getDateTime().toLocalDate());
+        if (!lastExDay.isPresent())
+        {
+            // no ex day available, therefor it is not possible to know how many
+            // shares belong to this portfolio 
+            // -> fallback: divide transaction to all portfolios with the given account as reference account
+            return calculatePercentage(pseudoClient, pseudoAccount);
+        }
+        else if (lastExDay.get().getDate().isBefore(t.getDateTime().toLocalDate().minusMonths(3)))
+        {
+            // if the ex day is more than three months before the transaction they cannot belong together
+            // -> divide transaction to all portfolios with the given account as reference account
+            return calculatePercentage(pseudoClient, pseudoAccount);
+        }
+        LocalDate exDay = lastExDay.get().getDate();
+        // The stocks must be hold on the day BEFORE the ex day to be entitled
+        // to the dividend
+        return calculatePercentageOfSecurities(pseudoClient, pseudoAccount, t, exDay.atStartOfDay());
+    }
+
+    private double calculatePercentage(ReadOnlyClient pseudoClient, ReadOnlyAccount pseudoAccount)
+    {
+        Client client = pseudoClient.getSource();
+        return 1d * pseudoClient.getPortfolios().stream().filter(p -> p.getReferenceAccount() == pseudoAccount) .count() /
+                client.getPortfolios().stream().filter(p -> p.getReferenceAccount() == pseudoAccount.getSource()) .count();
+    }
+
+    private double calculatePercentageOfSecurities(ReadOnlyClient pseudoClient, ReadOnlyAccount pseudoAccount,
+                    Transaction t, LocalDateTime referenceDate)
+    {
+        Client client = pseudoClient.getSource();
+        // get the security position at the time of the given date
+        SecurityPosition securityPosition = calculateSecurityPosition(pseudoClient.getPortfolios().stream() //
+                                        .map(p -> ((ReadOnlyPortfolio) p).getSource()) //
+                                        .collect(Collectors.toList()) //
+                        , pseudoAccount, t.getSecurity(), referenceDate);
+        if (securityPosition.getShares() == 0)
+        {
+            // there is no security available for this transaction at this date
+            return 0;
+        }
+
+        long referenceShareCount;
+        if (t.getShares() == 0)
+        {
+            // there is no information available about the amount of shares the
+            // transaction is affecting. Use the number of shares for this
+            // security in all portfolios tracked in the given account instead.
+            SecurityPosition clientSecurityPosition = calculateSecurityPosition(client.getPortfolios(), pseudoAccount, t.getSecurity(), referenceDate);
+            referenceShareCount = clientSecurityPosition.getFilteredShares(pt -> pseudoAccount.getSource().equals(pt.getCrossEntry().getCrossOwner(pt)));
+        }
+        else
+        {
+            referenceShareCount = t.getShares();
+        }
+
+        // Count the number of shares of this security tracked in the given account
+        long accountShares = securityPosition.getFilteredShares(
+                        pt -> pseudoAccount.getSource().equals(pt.getCrossEntry().getCrossOwner(pt)));
+
+        return Math.min(1d, accountShares * 1d / referenceShareCount);
+    }
+
+    private SecurityPosition calculateSecurityPosition(Collection<Portfolio> portfolios, ReadOnlyAccount pseudoAccount, Security security, LocalDateTime exDay)
+    {
+        // we need to add the real portfolios here, because the transactions are
+        // probably changed
+        List<Portfolio> sourcePortfolios = portfolios.stream().map(p -> {
+            if (p instanceof ReadOnlyPortfolio)
+            {
+                return ((ReadOnlyPortfolio) p).getSource();
+            }
+            else
+            {
+                return p;
+            }
+        }).collect(Collectors.toList());
+        // only the account of the evaluated transaction is interesting here
+        Account referenceAccount = pseudoAccount.getSource();
+        
+        // for dividends we must use the ex-day to evaluate the stock count
+        // relevant for the calculation
+        return getSecurityPosition(sourcePortfolios, referenceAccount, security, exDay);
+    }
+    
+    private static SecurityPosition getSecurityPosition(Collection<Portfolio> portfolios, Account referenceAccount, Security security, LocalDateTime date)
+    {
+        List<PortfolioTransaction> transactions = new ArrayList<>();
+        portfolios.forEach(portfolio ->
+        {
+            transactions.addAll(
+                    portfolio.getTransactions() //
+                        .stream() //
+                        .filter(t -> t.getSecurity().equals(security)) //
+                        .filter(t -> t.getDateTime().isBefore(date)) //
+                        .filter(t -> {
+                            CrossEntry crossEntry = t.getCrossEntry();
+                            if (crossEntry instanceof BuySellEntry)
+                            {
+                                return referenceAccount.equals(((BuySellEntry) crossEntry).getAccount());
+                            }
+                            return true;
+                        }) //
+                        .collect(Collectors.toList())
+            );
+        });
+        return new SecurityPosition(security, new CurrencyConverterImpl(null, referenceAccount.getCurrencyCode()), security.getSecurityPrice(date.toLocalDate()), transactions);
+    }
+
+    private void collectSecurityRelevantTx(ReadOnlyClient pseudoClient, Portfolio portfolio, ReadOnlyAccount pseudoAccount, Set<Security> usedSecurities)
     {
         if (portfolio.getReferenceAccount() == null)
             return;
 
-        for (AccountTransaction t : portfolio.getReferenceAccount().getTransactions()) // NOSONAR
+        // Iterate through the transactions of the "real" account
+        for (AccountTransaction t : pseudoAccount.getSource().getTransactions()) // NOSONAR
         {
             if (t.getSecurity() == null)
                 continue;
@@ -149,17 +322,23 @@ public class PortfolioClientFilter implements ClientFilter
                 case FEES_REFUND:
                     // security must be non-null -> tax refund is relevant for
                     // performance of security
-                case DIVIDENDS:
-                    pseudoAccount.internalAddTransaction(t);
-                    pseudoAccount.internalAddTransaction(new AccountTransaction(t.getDateTime(), t.getCurrencyCode(),
-                                    t.getAmount(), null, AccountTransaction.Type.REMOVAL));
+                    // ATTENTION: the transaction cannot be matched to a portfolio transaction.
+                    // Therefore it is not possible to know if this transaction is really relevant for this portfolio.
+                    // As a compromise the transaction is spread between all portfolios, where the current account is also the reference account
+                    // Otherwise those transactions would be fully considered for each portfolio. 
+                    double taxRefundPart = calculatePercentage(pseudoClient, pseudoAccount);
+                    addAdjustedSecurityRelevantTransaction(pseudoAccount, t, taxRefundPart,
+                                    AccountTransaction.Type.REMOVAL);
                     break;
+                case DIVIDENDS:
+                    double dividendPart = calculatePercentageOfDividendsOfSecurities(pseudoClient, pseudoAccount, t);
+                    addAdjustedSecurityRelevantTransaction(pseudoAccount, t, dividendPart,
+                                    AccountTransaction.Type.REMOVAL);                    break;
                 case TAXES:
                 case FEES:
-                    pseudoAccount.internalAddTransaction(t);
-                    pseudoAccount.internalAddTransaction(new AccountTransaction(t.getDateTime(), t.getCurrencyCode(),
-                                    t.getAmount(), null, AccountTransaction.Type.DEPOSIT));
-                    break;
+                    double taxFeePart = calculatePercentage(pseudoClient, pseudoAccount);
+                    addAdjustedSecurityRelevantTransaction(pseudoAccount, t, taxFeePart,
+                                    AccountTransaction.Type.DEPOSIT);                    break;
                 case BUY:
                 case TRANSFER_IN:
                 case SELL:
@@ -172,6 +351,49 @@ public class PortfolioClientFilter implements ClientFilter
                     break;
                 default:
                     throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    private void addAdjustedSecurityRelevantTransaction(ReadOnlyAccount account, AccountTransaction t,
+                    double percentage, AccountTransaction.Type type)
+    {
+        // the percentage must be > 0 to create transactions
+        if (percentage > 0)
+        {
+            if (percentage == 1)
+            {
+                // if the full amount can be used, add the transaction directly
+                account.internalAddTransaction(t);
+                account.internalAddTransaction(convertTo(t, type));
+            }
+            else
+            {
+                // calculate the amount to use of this transaction
+                long amount = Math.round(t.getAmount() * percentage);
+                AccountTransaction adjustedTransaction = new AccountTransaction(t.getDateTime(), t.getCurrencyCode(),
+                                amount, t.getSecurity(), t.getType());
+                // adjust all units accordingly
+                adjustedTransaction.addUnits(t.getUnits().map(u -> {
+                    Money unitMoney = u.getAmount();
+                    Money adjustedUnitMoney = Money.of(unitMoney.getCurrencyCode(),
+                                    Math.round(unitMoney.getAmount() * percentage));
+                    if (u.getForex() == null)
+                    {
+                        return new Unit(u.getType(), adjustedUnitMoney);
+                    }
+                    else
+                    {
+                        Money unitForex = u.getForex();
+                        Money adjustedUnitForex = Money.of(unitForex.getCurrencyCode(),
+                                        Math.round(unitForex.getAmount() * percentage));
+                        return new Unit(u.getType(), adjustedUnitMoney, adjustedUnitForex, u.getExchangeRate());
+                    }
+                }));
+
+                account.internalAddTransaction(adjustedTransaction);
+                account.internalAddTransaction(
+                                new AccountTransaction(t.getDateTime(), t.getCurrencyCode(), amount, null, type));
             }
         }
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/SecurityUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/SecurityUtil.java
@@ -1,0 +1,39 @@
+package name.abuchen.portfolio.util;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityEvent;
+import name.abuchen.portfolio.model.SecurityEvent.Type;
+
+public class SecurityUtil
+{
+    private SecurityUtil()
+    {
+    }
+
+    public static void addDividendEvent(final Security security, final LocalDate exDay)
+    {
+        Optional<SecurityEvent> securityEvent = security.getEvents().stream()
+                        .filter(e -> e.getType() == SecurityEvent.Type.STOCK_EX_DIVIDEND && e.getDate().equals(exDay))
+                        .findAny();
+        if (!securityEvent.isPresent())
+        {
+            security.addEvent(new SecurityEvent(exDay, SecurityEvent.Type.STOCK_EX_DIVIDEND, ""));
+        }
+    }
+
+    public static Optional<SecurityEvent> findLastDividendEvent(final Security security, final LocalDate date)
+    {
+        return security.getEvents().stream() //
+                        .filter(e -> e.getType() == Type.STOCK_EX_DIVIDEND) // only the stock dividend events
+                        .filter(e -> !e.getDate().isAfter(date)) // only events before the date
+                        .sorted((o1, o2) -> {
+                            if (o1.getDate() == null)
+                                return 1;
+                            return -1 * o1.getDate().compareTo(o2.getDate());
+                        }) // sort descending
+                        .findFirst();
+    }
+}


### PR DESCRIPTION
Erste Anpassungen bezüglich https://forum.portfolio-performance.info/t/performanceberechnung-bei-mehreren-depots-gleichem-verrechnungskonto/

Offene Punkte:
- Aktiengenaue Zuordnung von Security-relevanten Account-Transaktionen für Steuerrückerstattungen etc. Das ist nicht möglich, da bisher nur der Buchungs- und nicht der Ausführungszeitpunkt erfasst wird, d.h. es kann nicht ermittelt werden, wie die Aktien zum Ausführungszeitpunkt verteilt waren. Eine mögliche Lösung hierfür wäre es TransactionEvents einzuführen - äquivalent zu den SecurityEvents.

- Der neue SecurityEvent für den Dividenden Ex-Tag wird noch nicht gesetzt. Das würde ich in einem separaten pull request beisteuern. Davon ab benötigt man ab dann auch langsam die Möglichkeit die events manuell zu editieren/löschen