### PR TITLE
Fixed data series for security chart to not skip the first entry

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -440,8 +440,13 @@ public class SecuritiesChart
             }
             else
             {
-                index = Math.abs(Collections.binarySearch(prices, new SecurityPrice(chartPeriod, 0),
-                                new SecurityPrice.ByDate()));
+                index = Collections.binarySearch(prices, new SecurityPrice(chartPeriod, 0), new SecurityPrice.ByDate());
+                if (index == -1)
+                {
+                    index = 0;
+                } else {
+                    index = Math.abs(index);
+                }
 
                 if (index >= prices.size())
                 {


### PR DESCRIPTION
-1 muss separat behandelt werden, sonst fehlt immer der erste Kurswert. Fällt üblicherweise nicht auf, außer man hat mal ein Wertpapier mit bspw. nur drei Kurswerten von denen nur zwei angezeigt weredn.