### PR TITLE
Feature gleitender Durchschnittspreis

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -86,6 +86,12 @@ public class Messages extends NLS
     public static String ColumnCapitalGainsPercent;
     public static String ColumnCapitalGainsPercent_Description;
     public static String ColumnCapitalGainsPercent_Option;
+    public static String ColumnCapitalGainsMovingAverage;
+    public static String ColumnCapitalGainsMovingAverage_Description;
+    public static String ColumnCapitalGainsMovingAverage_Option;
+    public static String ColumnCapitalGainsMovingAveragePercent;
+    public static String ColumnCapitalGainsMovingAveragePercent_Description;
+    public static String ColumnCapitalGainsMovingAveragePercent_Option;
     public static String ColumnChangeOnPrevious;
     public static String ColumnChangeOnPrevious_MenuLabel;
     public static String ColumnColor;
@@ -126,6 +132,8 @@ public class Messages extends NLS
     public static String ColumnDividendSum_MenuLabel;
     public static String ColumnDividendTotalRateOfReturn;
     public static String ColumnDividendTotalRateOfReturn_Description;
+    public static String ColumnDividendMovingAverageTotalRateOfReturn;
+    public static String ColumnDividendMovingAverageTotalRateOfReturn_Description;
     public static String ColumnEntity;
     public static String ColumnErrorMessages;
     public static String ColumnExchangeRate;
@@ -171,6 +179,8 @@ public class Messages extends NLS
     public static String ColumnPerShare_Description;
     public static String ColumnPersonalDividendYield;
     public static String ColumnPersonalDividendYield_Description;
+    public static String ColumnPersonalDividendYieldMovingAverage;
+    public static String ColumnPersonalDividendYieldMovingAverage_Description;
     public static String ColumnPortfolio;
     public static String ColumnPreviousClose;
     public static String ColumnProfitLoss;
@@ -180,6 +190,10 @@ public class Messages extends NLS
     public static String ColumnPurchaseValue;
     public static String ColumnPurchaseValue_Description;
     public static String ColumnPurchaseValueBaseCurrency;
+    public static String ColumnPurchasePriceMovingAverage;
+    public static String ColumnPurchasePriceMovingAverage_Description;
+    public static String ColumnPurchaseValueMovingAverage;
+    public static String ColumnPurchaseValueMovingAverage_Description;
     public static String ColumnQuote;
     public static String ColumnQuote_DescriptionEndOfReportingPeriod;
     public static String ColumnQuoteChange;
@@ -369,6 +383,8 @@ public class Messages extends NLS
     public static String LabelChartDetailBollingerBandsUpper;
     public static String LabelChartDetailFIFOpurchase;
     public static String LabelChartDetailFIFOpurchaseHoldingPeriod;
+    public static String LabelChartDetailMovingAveragePurchase;
+    public static String LabelChartDetailMovingAveragePurchaseHoldingPeriod;
     public static String LabelChartDetailPurchaseIndicator;
     public static String LabelClientClearCustomItems;
     public static String LabelClientFilterDialogMessage;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -209,6 +209,18 @@ ColumnCapitalGains_Description = Capital Gains (current holdings) = Purchase Val
 
 ColumnCapitalGains_Option = Capital Gains {0}
 
+ColumnCapitalGainsMovingAverage = Capital Gains (moving average, current holdings)
+
+ColumnCapitalGainsMovingAveragePercent = Capital Gains % (moving average, current holdings)
+
+ColumnCapitalGainsMovingAveragePercent_Description = Capital Gains % (moving average, current holdings) = Market Value / Purchase Value (moving average)\n\nThe capital gains figure is always limited to the reporting period, e.g. the purchase value is either a security purchase within the reporting period or the valuation of the security at the beginning of the period.\n\nThe figure considers only holdings at the end of the reporting period.\n\nThe purchase value is calculated according to the moving average principle (as opposed to FIFO).
+
+ColumnCapitalGainsMovingAveragePercent_Option = Capital Gains (moving average) % {0}
+
+ColumnCapitalGainsMovingAverage_Description = Capital Gains (moving average, current holdings) = Purchase Value (moving average) - Market Value\n\nThe capital gains figure is always limited to the reporting period, e.g. the purchase value is either a security purchase within the reporting period or the valuation of the security at the beginning of the period.\n\nThe figure considers only holdings at the end of the reporting period.\n\nThe purchase value is calculated according to the moving average principle (as opposed to FIFO).
+
+ColumnCapitalGainsMovingAverage_Option = Capital Gains (moving average) {0}
+
 ColumnChangeOnPrevious = \u0394
 
 ColumnChangeOnPrevious_MenuLabel = Change on Previous Day
@@ -272,6 +284,10 @@ ColumnDividendSum_MenuLabel = Sum of dividends
 ColumnDividendTotalRateOfReturn = Div%
 
 ColumnDividendTotalRateOfReturn_Description = dividend rate of return = sum of dividend payments / purchase value based on FIFO\n\nAttention: if shares are sold after a dividend payment then dividend payment is not reduced. Therefore the rate of return might be over estimated.
+
+ColumnDividendMovingAverageTotalRateOfReturn = Div% (moving average)
+
+ColumnDividendMovingAverageTotalRateOfReturn_Description = dividend rate of return (moving average) = sum of dividend payments / purchase value based on moving average\n\nAttention: if shares are sold after a dividend payment then dividend payment is not reduced. Therefore the rate of return might be over estimated.
 
 ColumnEntity = Entity
 
@@ -369,6 +385,10 @@ ColumnPersonalDividendYield = Dividend yield
 
 ColumnPersonalDividendYield_Description = Dividend yield = dividends / purchase price using FIFO method
 
+ColumnPersonalDividendYieldMovingAverage = Dividend yield (moving average)
+
+ColumnPersonalDividendYieldMovingAverage_Description = Dividend yield (moving average) = dividends / purchase price using moving average method
+
 ColumnPortfolio = Securities Account
 
 ColumnPreviousClose = Previous Close
@@ -386,6 +406,14 @@ ColumnPurchaseValue = Purchase Value
 ColumnPurchaseValueBaseCurrency = Purchase Value (Base Currency)
 
 ColumnPurchaseValue_Description = Purchase value of held shares calculated using the FIFO method.\nThe purchase value includes the transaction fees paid.
+
+ColumnPurchasePriceMovingAverage = Purchase Price (moving average)
+
+ColumnPurchasePriceMovingAverage_Description = Purchase price of held shares calculated using the moving average method.\nThe price does not include the transaction fees and taxes paid.
+
+ColumnPurchaseValueMovingAverage = Purchase Value (moving average)
+
+ColumnPurchaseValueMovingAverage_Description = Purchase value of held shares calculated using the moving average method.\nThe purchase value includes the transaction fees paid.
 
 ColumnQuote = Quote
 
@@ -722,6 +750,10 @@ LabelChartDetailEvents = Stock Splits
 LabelChartDetailFIFOpurchase = Purchase Value (FIFO)
 
 LabelChartDetailFIFOpurchaseHoldingPeriod = Purchase Value (FIFO) ({0}. holding period)
+
+LabelChartDetailMovingAveragePurchase = Purchase Value (moving average)
+
+LabelChartDetailMovingAveragePurchaseHoldingPeriod = Purchase Value (moving average) ({0}. holding period)
 
 LabelChartDetailInvestments = Investments
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -209,6 +209,18 @@ ColumnCapitalGains_Description = Kursgewinn (aktueller Bestand) = Einstandspreis
 
 ColumnCapitalGains_Option = Kursgewinn {0}
 
+ColumnCapitalGainsMovingAverage = Kursgewinn (gleitender Durchschnitt, aktueller Bestand)
+
+ColumnCapitalGainsMovingAveragePercent = Kursgewinn % (gleitender Durchschnitt, aktueller Bestand)
+
+ColumnCapitalGainsMovingAveragePercent_Description = Kursgewinn % (gleitender Durchschnitt, aktueller Bestand) = Marktwert / Einstandspreis (gleitender Durchschnitt)\n\nDie Berechnung der Kursgewinne bezieht sich immer auf den Berichtszeitraum, d.h. der Einstandspreis ist entweder eine Kaufbuchung innerhalb des Zeitraumes oder der Wert der Position am Anfang der Berichtsperiode.\n\nEs werden nur die Kursgewinne der aktuell noch im Bestand befindlichen Wertpapiere betrachtet.\n\nDer Einstandspreis wird nach dem Prinzip des gleitenden Durchschnitts (anstatt FIFO) berechnet.
+
+ColumnCapitalGainsMovingAveragePercent_Option = Kursgewinn (gleitender Durchschnitt) % {0}
+
+ColumnCapitalGainsMovingAverage_Description = Kursgewinn (gleitender Durchschnitt, aktueller Bestand) = Einstandspreis (gleitender Durchschnitt) - Marktwert\n\nDie Berechnung der Kursgewinne bezieht sich immer auf den Berichtszeitraum, d.h. der Einstandspreis ist entweder eine Kaufbuchung innerhalb des Zeitraumes oder der Wert der Position am Anfang der Berichtsperiode.\n\nEs werden nur die Kursgewinne der aktuell noch im Bestand befindlichen Wertpapiere betrachtet.\n\nDer Einstandspreis wird nach dem Prinzip des gleitenden Durchschnitts (anstatt FIFO) berechnet.
+
+ColumnCapitalGainsMovingAverage_Option = Kursgewinn (gleitender Durchschnitt) {0}
+
 ColumnChangeOnPrevious = \u0394
 
 ColumnChangeOnPrevious_MenuLabel = Kurs\u00E4nderung zum Vortag
@@ -272,6 +284,10 @@ ColumnDividendSum_MenuLabel = Summe Dividenden
 ColumnDividendTotalRateOfReturn = Div%
 
 ColumnDividendTotalRateOfReturn_Description = Dividendenrendite = Summe der Dividendenzahlungen / Einstand nach FIFO\n\nAchtung: wenn Verk\u00E4ufe nach einer Dividendenzahlung vorliegen, werden die momentan nicht abgezogen. D.h. die Rendite ist eventuell zu hoch.
+
+ColumnDividendMovingAverageTotalRateOfReturn = Div% (gleitender Durchschnitt)
+
+ColumnDividendMovingAverageTotalRateOfReturn_Description = Dividendenrendite (gleitender Durchschnitt) = Summe der Dividendenzahlungen / Einstand nach gleitendem Durchschnitt\n\nAchtung: wenn Verk\u00E4ufe nach einer Dividendenzahlung vorliegen, werden die momentan nicht abgezogen. D.h. die Rendite ist eventuell zu hoch.
 
 ColumnEntity = Objekt
 
@@ -369,6 +385,10 @@ ColumnPersonalDividendYield = Dividendenrendite
 
 ColumnPersonalDividendYield_Description = Dividendenrendite = Dividende / anteiligen Einstandspreis nach FIFO\n\nHinweis zur Berechnung: Wenn keine St\u00FCcke zu der Dividendenzahlung erfasst sind, dann wird die Rendite mit dem FIFO Einstandspreis errechnet. Wenn St\u00FCcke erfasst sind, dann wird der anteilige FIFO Einstandspreis verwendet, d.h. Einstandspreis * St\u00FCcke Dividende / St\u00FCcke Gesamtbestand. Es handelt sich also um einen durchschnittlichen Einstandspreis und nicht um den Einstandspreis genau jener St\u00FCcke, auf die sich die Dividende bezieht.
 
+ColumnPersonalDividendYieldMovingAverage = Dividendenrendite (gleitender Durchschnitt)
+
+ColumnPersonalDividendYieldMovingAverage_Description = Dividendenrendite (gleitender Durchschnitt) = Dividende / anteiligen Einstandspreis nach gleitendem Durchschnitt\n\nHinweis zur Berechnung: Wenn keine St\u00FCcke zu der Dividendenzahlung erfasst sind, dann wird die Rendite mit dem Einstandspreis (gleitender Durchschnitt) errechnet. Wenn St\u00FCcke erfasst sind, dann wird der anteilige Einstandspreis (gleitender Durchschnitt) verwendet, d.h. Einstandspreis * St\u00FCcke Dividende / St\u00FCcke Gesamtbestand. Es handelt sich also um einen durchschnittlichen Einstandspreis und nicht um den Einstandspreis genau jener St\u00FCcke, auf die sich die Dividende bezieht.
+
 ColumnPortfolio = Depot
 
 ColumnPreviousClose = Letzter Schlusskurs
@@ -386,6 +406,14 @@ ColumnPurchaseValue = Einstandspreis
 ColumnPurchaseValueBaseCurrency = Einstandspreis in Basisw\u00E4hrung
 
 ColumnPurchaseValue_Description = Einstandspreis der gehaltenen Papiere berechnet nach dem FIFO-Prinzip.\nDer Wert beinhaltet die angefallenen Transaktionsgeb\u00FChren.
+
+ColumnPurchasePriceMovingAverage = Einstandskurs (gleitender Durchschnitt)
+
+ColumnPurchasePriceMovingAverage_Description = Einstandskurs der gehaltenen Papiere berechnet nach dem Prinzip des gleitenden Durchschnitts.\nDer Kurs wird ohne die angefallenen Transaktionsgeb\u00FChren und Steuern errechnet.
+
+ColumnPurchaseValueMovingAverage = Einstandspreis (gleitender Durchschnitt)
+
+ColumnPurchaseValueMovingAverage_Description = Einstandspreis der gehaltenen Papiere berechnet nach dem Prinzip des gleitenden Durchschnitts.\nDer Wert beinhaltet die angefallenen Transaktionsgeb\u00FChren.
 
 ColumnQuote = Kurs
 
@@ -722,6 +750,10 @@ LabelChartDetailEvents = Stock Splits
 LabelChartDetailFIFOpurchase = Einstandspreis (FIFO)
 
 LabelChartDetailFIFOpurchaseHoldingPeriod = Einstandspreis (FIFO) ({0}. Halteperiode)
+
+LabelChartDetailMovingAveragePurchase = Einstandspreis (gleitender Durchschnitt)
+
+LabelChartDetailMovingAveragePurchaseHoldingPeriod = Einstandspreis (gleitender Durchschnitt) ({0}. Halteperiode)
 
 LabelChartDetailInvestments = Investitionen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -370,6 +370,21 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "fifoCost")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
+        // cost value - moving average
+        column = new Column("pvmvavg", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 75); //$NON-NLS-1$
+        column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object r)
+            {
+                return Values.Money.format(((SecurityPerformanceRecord) r).getMovingAverageCost(),
+                                getClient().getBaseCurrency());
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "movingAverageCost")); //$NON-NLS-1$
+        recordColumns.addColumn(column);
+
         // cost value per share - fifo
         column = new Column("pp", Messages.ColumnPurchasePrice, SWT.RIGHT, 75); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchasePrice_Description);
@@ -383,6 +398,21 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "fifoCostPerSharesHeld")); //$NON-NLS-1$
+        recordColumns.addColumn(column);
+
+        // cost value per share - moving average
+        column = new Column("pp", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 75); //$NON-NLS-1$
+        column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object r)
+            {
+                return Values.Quote.format(((SecurityPerformanceRecord) r).getMovingAverageCostPerSharesHeld(),
+                                getClient().getBaseCurrency());
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "movingAverageCostPerSharesHeld")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
         // latest / current quote
@@ -503,6 +533,25 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "capitalGainsOnHoldingsPercent")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
+        column = new Column("capitalgainsmvavg", Messages.ColumnCapitalGainsMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.GroupLabelPerformance);
+        column.setDescription(Messages.ColumnCapitalGainsMovingAverage_Description);
+        column.setLabelProvider(new MoneyColorLabelProvider(
+                        element -> ((SecurityPerformanceRecord) element).getCapitalGainsOnHoldingsMovingAverage(),
+                        getClient().getBaseCurrency()));
+        column.setVisible(false);
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "capitalGainsOnHoldingsMovingAverage")); //$NON-NLS-1$
+        recordColumns.addColumn(column);
+
+        column = new Column("capitalgainsmvavg%", Messages.ColumnCapitalGainsMovingAveragePercent, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.GroupLabelPerformance);
+        column.setDescription(Messages.ColumnCapitalGainsMovingAveragePercent_Description);
+        column.setLabelProvider(new NumberColorLabelProvider<>(Values.Percent2,
+                        r -> ((SecurityPerformanceRecord) r).getCapitalGainsOnHoldingsMovingAveragePercent()));
+        column.setVisible(false);
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "capitalGainsOnHoldingsMovingAveragePercent")); //$NON-NLS-1$
+        recordColumns.addColumn(column);
+
         // delta
         column = new Column("delta", Messages.ColumnAbsolutePerformance, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setDescription(Messages.ColumnAbsolutePerformance_Description);
@@ -557,6 +606,22 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "totalRateOfReturnDiv")); //$NON-NLS-1$
+        recordColumns.addColumn(column);
+
+        // Rendite insgesamt, nach gleitendem Durchschnitt
+        column = new Column("d%", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.GroupLabelDividends);
+        column.setDescription(Messages.ColumnDividendMovingAverageTotalRateOfReturn_Description);
+        column.setVisible(false);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object r)
+            {
+                return Values.Percent2.formatNonZero(((SecurityPerformanceRecord) r).getTotalRateOfReturnDivMovingAverage());
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "totalRateOfReturnDivMovingAverage")); //$NON-NLS-1$
         recordColumns.addColumn(column);
 
         // Anzahl der Dividendenereignisse
@@ -823,6 +888,22 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             {
                 if (t instanceof DividendTransaction)
                     return Values.Percent2.formatNonZero(((DividendTransaction) t).getPersonalDividendYield());
+                else
+                    return null;
+            }
+        });
+        support.addColumn(column);
+
+        // dividend per share (moving average)
+        column = new Column(Messages.ColumnPersonalDividendYieldMovingAverage, SWT.RIGHT, 80);
+        column.setDescription(Messages.ColumnPersonalDividendYieldMovingAverage_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object t)
+            {
+                if (t instanceof DividendTransaction)
+                    return Values.Percent2.formatNonZero(((DividendTransaction) t).getPersonalDividendYieldMovingAverage());
                 else
                     return null;
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -383,6 +383,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "movingAverageCost")); //$NON-NLS-1$
+        column.setVisible(false);
         recordColumns.addColumn(column);
 
         // cost value per share - fifo
@@ -413,6 +414,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
             }
         });
         column.setSorter(ColumnViewerSorter.create(SecurityPerformanceRecord.class, "movingAverageCostPerSharesHeld")); //$NON-NLS-1$
+        column.setVisible(false);
         recordColumns.addColumn(column);
 
         // latest / current quote

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -402,7 +402,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         recordColumns.addColumn(column);
 
         // cost value per share - moving average
-        column = new Column("pp", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 75); //$NON-NLS-1$
+        column = new Column("ppmvavg", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 75); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -611,7 +611,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
         recordColumns.addColumn(column);
 
         // Rendite insgesamt, nach gleitendem Durchschnitt
-        column = new Column("d%", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("d%mvavg", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendMovingAverageTotalRateOfReturn_Description);
         column.setVisible(false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -370,7 +370,28 @@ public class StatementOfAssetsViewer
         column.setVisible(false);
         support.addColumn(column);
 
-        column = new Column("8", Messages.ColumnPurchaseValue, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("8", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 60); //$NON-NLS-1$
+        column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                Element element = (Element) e;
+                if (element.isSecurity())
+                {
+                    Money purchasePrice = element.getSecurityPosition().getMovingAveragePurchasePrice();
+                    return Values.Money.formatNonZero(purchasePrice, client.getBaseCurrency());
+                }
+                return null;
+            }
+        });
+        column.setComparator(new ElementComparator(new AttributeComparator(e -> ((Element) e).isSecurity()
+                        ? ((Element) e).getSecurityPosition().getMovingAveragePurchasePrice() : null)));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        column = new Column("9", Messages.ColumnPurchaseValue, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchaseValue_Description);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -393,7 +414,30 @@ public class StatementOfAssetsViewer
                         .wrap(ElementComparator::new));
         support.addColumn(column);
 
-        column = new Column("9", Messages.ColumnProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("10", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                Element element = (Element) e;
+                Money purchaseValue = element.getMovingAveragePurchaseValue();
+                return Values.Money.formatNonZero(purchaseValue, client.getBaseCurrency());
+            }
+
+            @Override
+            public Font getFont(Object e)
+            {
+                return ((Element) e).isGroupByTaxonomy() || ((Element) e).isCategory() ? boldFont : null;
+            }
+        });
+        column.setVisible(false);
+        column.setSorter(ColumnViewerSorter.create(Element.class, "MovingAveragePurchaseValue") //$NON-NLS-1$
+                        .wrap(ElementComparator::new));
+        support.addColumn(column);
+
+        column = new Column("11", Messages.ColumnProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider() // NOSONAR
         {
             @Override
@@ -510,6 +554,27 @@ public class StatementOfAssetsViewer
         column.setVisible(false);
         support.addColumn(column);
 
+        column = new Column("capitalgainsmvavg", Messages.ColumnCapitalGainsMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
+        labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAverage, sum,
+                        true);
+        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAverage_Option, options));
+        column.setGroupLabel(Messages.GroupLabelPerformance);
+        column.setDescription(Messages.ColumnCapitalGainsMovingAverage_Description);
+        column.setLabelProvider(labelProvider);
+        column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        column = new Column("capitalgainsmvavg%", Messages.ColumnCapitalGainsMovingAveragePercent, SWT.RIGHT, 80); //$NON-NLS-1$
+        labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAveragePercent);
+        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAveragePercent_Option, options));
+        column.setGroupLabel(Messages.GroupLabelPerformance);
+        column.setDescription(Messages.ColumnCapitalGainsMovingAveragePercent_Description);
+        column.setLabelProvider(labelProvider);
+        column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
+        column.setVisible(false);
+        support.addColumn(column);
+
         column = new Column("delta", Messages.ColumnAbsolutePerformance_MenuLabel, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getDelta, sum, true);
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnAbsolutePerformance_Option, options));
@@ -556,6 +621,17 @@ public class StatementOfAssetsViewer
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendTotalRateOfReturn_Description);
+        column.setLabelProvider(labelProvider);
+        column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        column = new Column("d%", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
+        labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getTotalRateOfReturnDivMovingAverage, null,
+                        false);
+        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendMovingAverageTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
+        column.setGroupLabel(Messages.GroupLabelDividends);
+        column.setDescription(Messages.ColumnDividendMovingAverageTotalRateOfReturn_Description);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -977,6 +1053,16 @@ public class StatementOfAssetsViewer
                 return category.getFIFOPurchaseValue();
             else
                 return groupByTaxonomy.getFIFOPurchaseValue();
+        }
+
+        public Money getMovingAveragePurchaseValue()
+        {
+            if (position != null)
+                return position.getMovingAveragePurchaseValue();
+            else if (category != null)
+                return category.getMovingAveragePurchaseValue();
+            else
+                return groupByTaxonomy.getMovingAveragePurchaseValue();
         }
 
         public Money getProfitLoss()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -370,7 +370,7 @@ public class StatementOfAssetsViewer
         column.setVisible(false);
         support.addColumn(column);
 
-        column = new Column("8", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 60); //$NON-NLS-1$
+        column = new Column("ppmvavg", Messages.ColumnPurchasePriceMovingAverage, SWT.RIGHT, 60); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -391,7 +391,7 @@ public class StatementOfAssetsViewer
         column.setVisible(false);
         support.addColumn(column);
 
-        column = new Column("9", Messages.ColumnPurchaseValue, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("8", Messages.ColumnPurchaseValue, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchaseValue_Description);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -414,7 +414,7 @@ public class StatementOfAssetsViewer
                         .wrap(ElementComparator::new));
         support.addColumn(column);
 
-        column = new Column("10", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("pvmvavg", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -437,7 +437,7 @@ public class StatementOfAssetsViewer
                         .wrap(ElementComparator::new));
         support.addColumn(column);
 
-        column = new Column("11", Messages.ColumnProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("9", Messages.ColumnProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider() // NOSONAR
         {
             @Override
@@ -626,7 +626,7 @@ public class StatementOfAssetsViewer
         column.setVisible(false);
         support.addColumn(column);
 
-        column = new Column("d%", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
+        column = new Column("d%mvavg", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getTotalRateOfReturnDivMovingAverage, null,
                         false);
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendMovingAverageTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/AssetCategory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/AssetCategory.java
@@ -45,6 +45,12 @@ public class AssetCategory
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
     }
 
+    public Money getMovingAveragePurchaseValue()
+    {
+        return positions.stream().map(AssetPosition::getMovingAveragePurchaseValue)
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+    }
+
     public Money getProfitLoss()
     {
         return positions.stream().map(AssetPosition::getProfitLoss)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/AssetPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/AssetPosition.java
@@ -50,6 +50,11 @@ public class AssetPosition
         return position.getFIFOPurchaseValue(converter.getTermCurrency());
     }
 
+    public Money getMovingAveragePurchaseValue()
+    {
+        return position.getMovingAveragePurchaseValue(converter.getTermCurrency());
+    }
+
     public Money getProfitLoss()
     {
         // calculate profit/loss on the converted values to avoid rounding

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/GroupByTaxonomy.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/GroupByTaxonomy.java
@@ -208,6 +208,12 @@ public final class GroupByTaxonomy
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
     }
 
+    public Money getMovingAveragePurchaseValue()
+    {
+        return categories.stream().map(AssetCategory::getMovingAveragePurchaseValue)
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+    }
+
     public Money getProfitLoss()
     {
         return categories.stream().map(AssetCategory::getProfitLoss)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
@@ -24,8 +24,10 @@ public class SecurityPosition
 {
     private static class Record
     {
-        private Money purchasePrice;
-        private Money purchaseValue;
+        private Money purchasePrice; // by FIFO calculation
+        private Money purchaseValue; // by FIFO calculation
+	private Money movingAveragePurchasePrice; // by moving avg calculation
+	private Money movingAveragePurchaseValue; // by moving avg calculation
 
         public static Record calculate(CurrencyConverter converter, SecurityPosition position)
         {
@@ -37,6 +39,16 @@ public class SecurityPosition
         public Money getPurchasePrice()
         {
             return purchasePrice;
+        }
+
+        public Money getMovingAveragePurchasePrice()
+        {
+            return movingAveragePurchasePrice;
+        }
+
+        public Money getMovingAveragePurchaseValue()
+        {
+            return movingAveragePurchaseValue;
         }
 
         public Money getPurchaseValue()
@@ -91,6 +103,43 @@ public class SecurityPosition
         private void calculatePurchaseValuePrice(CurrencyConverter converter, List<PortfolioTransaction> input)
         {
             Collections.sort(input, new Transaction.ByDate());
+
+	    // first, calculate by moving average method:
+	    {
+		    long sharesHeld = 0;
+		    long grossInvestment = 0;
+		    long netInvestment = 0;
+		    for (PortfolioTransaction t : input)
+		    {
+			    long numShares = t.getShares();
+			    long grossAmount = t.getMonetaryAmount(converter).getAmount();
+			    long netAmount = t.getGrossValue(converter).getAmount();
+			    if (t.getType() == Type.TRANSFER_IN || t.getType() == Type.BUY || t.getType() == Type.DELIVERY_INBOUND) {
+				    // this is a buy
+				    sharesHeld += numShares;
+				    netInvestment += netAmount;
+				    grossInvestment += grossAmount;
+			    }
+			    if (t.getType() == Type.TRANSFER_OUT || t.getType() == Type.SELL
+					    || t.getType() == Type.DELIVERY_OUTBOUND) {
+				    // this is a sell
+				    long remainingShares = sharesHeld - numShares;
+				    if (remainingShares <= 0) {
+					    netInvestment = 0;
+					    grossInvestment = 0;
+					    sharesHeld = 0;
+				    } else {
+					    netInvestment *= remainingShares / (double) sharesHeld;
+					    grossInvestment *= remainingShares / (double) sharesHeld;
+					    sharesHeld = remainingShares;
+				    }
+			    }
+		    }
+		    this.movingAveragePurchasePrice = Money.of(converter.getTermCurrency(), sharesHeld > 0 ? Math.round((netInvestment * Values.Share.factor()) / (double) sharesHeld) : 0);
+		    this.movingAveragePurchaseValue = Money.of(converter.getTermCurrency(), grossInvestment);
+	    }
+	    
+	    // now, calculate by FIFO method:
 
             long sharesSold = 0;
             for (PortfolioTransaction t : input)
@@ -252,6 +301,21 @@ public class SecurityPosition
     public Money getFIFOPurchaseValue(String currencyCode)
     {
         return currency2record.get(currencyCode).getPurchaseValue();
+    }
+
+    public Money getMovingAveragePurchasePrice()
+    {
+        return currency2record.get(investment.getCurrencyCode()).getMovingAveragePurchasePrice();
+    }
+
+    public Money getMovingAveragePurchaseValue()
+    {
+        return currency2record.get(investment.getCurrencyCode()).getMovingAveragePurchaseValue();
+    }
+
+    public Money getMovingAveragePurchaseValue(String currencyCode)
+    {
+        return currency2record.get(currencyCode).getMovingAveragePurchaseValue();
     }
 
     public Money getProfitLoss()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -27,6 +27,10 @@ import name.abuchen.portfolio.money.Money;
 
     private List<LineItem> fifo = new ArrayList<>();
 
+    private long movingRelativeCost = 0;
+    private long movingRelativeNetCost = 0;
+    private long heldShares = 0;
+
     private long fees;
     private long taxes;
 
@@ -35,13 +39,18 @@ import name.abuchen.portfolio.money.Money;
     {
         long amount = converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
         fifo.add(new LineItem(t.getPosition().getShares(), amount, amount));
+	movingRelativeCost += amount;
+	movingRelativeNetCost += amount;
+	heldShares += t.getPosition().getShares();
     }
 
     @Override
     public void visit(CurrencyConverter converter, PortfolioTransaction t)
     {
-        fees += t.getUnitSum(Unit.Type.FEE, converter).getAmount();
-        taxes += t.getUnitSum(Unit.Type.TAX, converter).getAmount();
+	long fee = t.getUnitSum(Unit.Type.FEE, converter).getAmount();
+	long tax = t.getUnitSum(Unit.Type.TAX, converter).getAmount();
+        fees += fee;
+        taxes += tax;
 
         switch (t.getType())
         {
@@ -50,10 +59,25 @@ import name.abuchen.portfolio.money.Money;
                 long grossAmount = t.getMonetaryAmount(converter).getAmount();
                 long netAmount = t.getGrossValue(converter).getAmount();
                 fifo.add(new LineItem(t.getShares(), grossAmount, netAmount));
+		movingRelativeCost += grossAmount;
+		movingRelativeNetCost += netAmount;
+		heldShares += t.getShares();
                 break;
             case SELL:
             case DELIVERY_OUTBOUND:
                 long sold = t.getShares();
+
+		long remaining = heldShares - sold;
+		if (remaining <= 0) {
+			movingRelativeCost = 0;
+			movingRelativeNetCost = 0;
+			heldShares = 0;
+		} else {
+			movingRelativeCost *= remaining / (double) heldShares;
+			movingRelativeNetCost *= remaining / (double) heldShares;
+			heldShares = remaining;
+		}
+
                 for (LineItem entry : fifo)
                 {
                     if (entry.shares == 0)
@@ -113,6 +137,7 @@ import name.abuchen.portfolio.money.Money;
         taxes += t.getUnitSum(Unit.Type.TAX, converter).getAmount();
 
         t.setFifoCost(getFifoCost());
+	t.setMovingAverageCost(getMovingAverageCost());
         t.setTotalShares(getSharesHeld());
     }
 
@@ -136,6 +161,22 @@ import name.abuchen.portfolio.money.Money;
         for (LineItem entry : fifo)
             cost += entry.netAmount;
         return Money.of(getTermCurrency(), cost);
+    }
+
+    /**
+     * gross investment
+     */
+    public Money getMovingAverageCost()
+    {
+        return Money.of(getTermCurrency(), movingRelativeCost);
+    }
+
+    /**
+     * net investment, i.e. without fees and taxes
+     */
+    public Money getNetMovingAverageCost()
+    {
+        return Money.of(getTermCurrency(), movingRelativeNetCost);
     }
 
     public long getSharesHeld()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendTransaction.java
@@ -12,6 +12,7 @@ public class DividendTransaction extends Transaction
 
     private long totalShares;
     private Money fifoCost;
+    private Money movingAverageCost;
 
     public Account getAccount()
     {
@@ -40,6 +41,17 @@ public class DividendTransaction extends Transaction
         this.fifoCost = fifoCost;
     }
 
+    public Money getMovingAverageCost()
+    {
+        return movingAverageCost;
+    }
+
+    /* package */
+    void setMovingAverageCost(Money movingAverageCost)
+    {
+        this.movingAverageCost = movingAverageCost;
+    }
+
     /* package */
     void setTotalShares(long totalShares)
     {
@@ -55,6 +67,19 @@ public class DividendTransaction extends Transaction
 
         if (getShares() > 0)
             cost = fifoCost.getAmount() * (getShares() / (double) totalShares);
+
+        return getGrossValueAmount() / cost;
+    }
+
+    public double getPersonalDividendYieldMovingAverage()
+    {
+        if (movingAverageCost.getAmount() <= 0)
+            return 0;
+
+        double cost = movingAverageCost.getAmount();
+
+        if (getShares() > 0)
+            cost = movingAverageCost.getAmount() * (getShares() / (double) totalShares);
 
         return getGrossValueAmount() / cost;
     }


### PR DESCRIPTION
Überall wo bisher nach dem FIFO-Pronzip berechnet wurde, gibt es jetzt die Möglichkeit, stattdessen nach dem Prinzip des gleitenden Durchschnitts zu berechnen. FIFO bleibt Default.

- Im Wertpapier-Graphen kann man, analog zu "Einstandspreis (FIFO)", jetzt auch "Einstandspreis (gleitender Durchschnitt)" anzeigen lassen (mit etwas dunklerer Farbe)
- In der Vermögensaufstellung sowie in Performance/Wertpapiere gibt es zusätzlich folgende Spalten:
  - Einstandskurs (gleitender Durchschnitt)
  - Einstandspreis (gleitender Durchschnitt)
  - Performance/Kursgewinn (gleitender Durchschnitt, aktueller Bestand)
  - Performance/Kursgewinn % (gleitender Durchschnitt, aktueller Bestand)
  - Dividenden/Div% (gleitender Durchschnitt)

#440 