### PR TITLE
allow future dates in statement of assets view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
@@ -21,6 +21,14 @@ public class DateSelectionDialog extends Dialog
     private LocalDate selection = LocalDate.now();
     private Predicate<LocalDate> validator;
 
+    public DateSelectionDialog(Shell parentShell)
+    {
+        // allow all dates
+        this(parentShell, (LocalDate date) -> {
+            return true;
+        });
+    }
+
     public DateSelectionDialog(Shell parentShell, Predicate<LocalDate> validator)
     {
         super(parentShell);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -123,8 +123,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
                             manager.add(action);
 
                             manager.add(new SimpleAction(Messages.MenuPickOtherDate, a -> {
-                                DateSelectionDialog dialog = new DateSelectionDialog(getActiveShell(),
-                                                date -> !date.isAfter(LocalDate.now()));
+                                DateSelectionDialog dialog = new DateSelectionDialog(getActiveShell());
                                 dialog.setSelection(snapshotDate);
                                 if (dialog.open() != DateSelectionDialog.OK)
                                     return;


### PR DESCRIPTION
Currently transactions can be added with a future date.
But it is not possible to show them in the statement of assets view as the date selection is limited to past dates and the current date.
This pull requests allows transactions with a future date to be shown.