### PR TITLE
rework calculation of periodicity

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/labels.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/labels.properties
@@ -9,5 +9,6 @@ dividends.NONE        = none
 dividends.ANNUAL      = annual
 dividends.SEMIANNUAL  = semiannual
 dividends.QUARTERLY   = quarterly
+dividends.MONTHLY     = monthly
 dividends.IRREGULAR   = irregular
 dividends.INDEFINITE  = indefinite

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/labels_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/labels_de.properties
@@ -9,5 +9,6 @@ dividends.NONE        = keine
 dividends.ANNUAL      = j\u00E4hrlich 
 dividends.SEMIANNUAL  = halbj\u00E4hrlich 
 dividends.QUARTERLY   = quartalsweise
+dividends.MONTHLY     = monatlich
 dividends.IRREGULAR   = unregelm\u00E4\u00DFig
 dividends.INDEFINITE  = unbestimmt

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
@@ -11,6 +11,12 @@ import name.abuchen.portfolio.money.CurrencyConverter;
 {
     private String termCurrency;
 
+    /**
+     * Finish up all calculations.
+     */
+    public void finish()
+    {}
+    
     public String getTermCurrency()
     {
         return termCurrency;
@@ -63,6 +69,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
             T thing = type.newInstance();
             thing.setTermCurrency(converter.getTermCurrency());
             thing.visitAll(converter, transactions);
+            thing.finish();
             return thing;
         }
         catch (Exception e)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -1,6 +1,11 @@
 package name.abuchen.portfolio.snapshot.security;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -10,13 +15,173 @@ import name.abuchen.portfolio.util.Dates;
 
 /* package */class DividendCalculation extends Calculation
 {
-    private MutableMoney sum;
-    private int numOfEvents;
+    /**
+     * A dividend payment.
+     *
+     * @author SB
+     */
+    private static class DividendPayment implements Comparable<DividendPayment>
+    {
+        /**
+         * Amount of the payment.
+         */
+        public final Money amount;
+        /**
+         * Date of the payment.
+         */
+        public final LocalDate date;
+        /**
+         * Year of the payment.
+         */
+        public final int year;
+
+        /**
+         * Constructs an instance.
+         *
+         * @param converter
+         *            currency converter
+         * @param t
+         *            {@link DividendTransaction}
+         */
+        public DividendPayment(CurrencyConverter converter, DividendTransaction t)
+        {
+            this.amount = t.getGrossValue().with(converter.at(t.getDateTime()));
+            LocalDateTime time = t.getDateTime();
+            this.year = time.getYear();
+            this.date = time.toLocalDate();
+        }
+
+        @Override
+        public int compareTo(DividendPayment o)
+        {
+            return this.date.compareTo(o.date);
+        }
+    }
 
     private LocalDate firstPayment;
     private LocalDate lastPayment;
+    private final List<DividendPayment> payments = new ArrayList<DividendPayment>();
+    private Periodicity periodicity;
+    private MutableMoney sum;
 
-    private int regularEvents;
+    @Override
+    public void finish()
+    {
+        // first sort
+        Collections.sort(payments);
+        // default is unknown periodicity
+        this.periodicity = Periodicity.UNKNOWN;
+        // check payments?
+        if (!payments.isEmpty())
+        {
+            // get first and last payment
+            firstPayment = payments.get(0).date;
+            lastPayment = payments.get(payments.size() - 1).date;
+
+            HashMap<Integer, MutableMoney> hmSumPerYear = new HashMap<Integer, MutableMoney>();
+            // sum up dividends
+            for (DividendPayment p : payments)
+            {
+                // add total sum
+                sum.add(p.amount);
+                // add sum per year
+                MutableMoney m = hmSumPerYear.get(p.year);
+                if (m == null)
+                {
+                    // construct if missing
+                    m = MutableMoney.of(sum.getCurrencyCode());
+                    hmSumPerYear.put(p.year, m);
+                }
+                m.add(p.amount);
+            }
+
+            int significantCount = 0;
+            // now walk through individual years
+            for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
+            {
+                int count = 0;
+                // first calc sum for year
+                MutableMoney m = MutableMoney.of(sum.getCurrencyCode());
+                for (DividendPayment p : payments)
+                {
+                    if (p.year == year)
+                    {
+                        m.add(p.amount);
+                        count++;
+                    }
+                }
+                double sum = m.getAmount();
+                // expected amount
+                double expectedAmount = sum / count;
+                // then calc significance
+                for (DividendPayment p : payments)
+                {
+                    if (p.year == year)
+                    {
+                        // check if dividend contributes the expected amount (if
+                        // it is not a very small extraordinary payment)
+                        double significance = (p.amount.getAmount()) / expectedAmount;
+                        if (significance > 0.3)
+                        {
+                            significantCount++;
+                        }
+                    }
+                }
+            }
+            // determine periodicity?
+            if (significantCount > 0)
+            {
+                // days in current time range
+                int days = Dates.daysBetween(firstPayment, lastPayment);
+                long daysBetweenPayments = Math.round(days / (double) (significantCount - 1));
+                // just check payments inbetween one year
+                if (daysBetweenPayments < 430)
+                {
+                    if (daysBetweenPayments > 270)
+                    {
+                        this.periodicity = Periodicity.ANNUAL;
+                    }
+                    else if (daysBetweenPayments > 130)
+                    {
+                        this.periodicity = Periodicity.SEMIANNUAL;
+                    }
+                    else if (daysBetweenPayments > 60)
+                    {
+                        this.periodicity = Periodicity.QUARTERLY;
+                    }
+                    else if (daysBetweenPayments > 20)
+                    {
+                        this.periodicity = Periodicity.MONTHLY;
+                    }
+                }
+            }
+        }
+        else
+        {
+            // no payments
+            this.periodicity = Periodicity.NONE;
+        }
+    }
+
+    public LocalDate getLastDividendPayment()
+    {
+        return lastPayment;
+    }
+
+    public int getNumOfEvents()
+    {
+        return payments.size();
+    }
+
+    public Periodicity getPeriodicity()
+    {
+        return periodicity;
+    }
+
+    public Money getSum()
+    {
+        return sum.toMoney();
+    }
 
     @Override
     public void setTermCurrency(String termCurrency)
@@ -28,59 +193,7 @@ import name.abuchen.portfolio.util.Dates;
     @Override
     public void visit(CurrencyConverter converter, DividendTransaction t)
     {
-        sum.add(t.getGrossValue().with(converter.at(t.getDateTime())));
-        numOfEvents++;
-
-        if (t.getShares() > 0
-                        && (lastPayment == null || Dates.daysBetween(lastPayment, t.getDateTime().toLocalDate()) > 30))
-        {
-            regularEvents++;
-        }
-
-        if (firstPayment == null)
-            firstPayment = t.getDateTime().toLocalDate();
-        lastPayment = t.getDateTime().toLocalDate();
-    }
-
-    public Money getSum()
-    {
-        return sum.toMoney();
-    }
-
-    public int getNumOfEvents()
-    {
-        return numOfEvents;
-    }
-
-    public LocalDate getLastDividendPayment()
-    {
-        return lastPayment;
-    }
-
-    public Periodicity getPeriodicity()
-    {
-        if (firstPayment == null)
-            return Periodicity.NONE;
-
-        if (regularEvents == 0)
-            return Periodicity.NONE;
-
-        if (regularEvents == 1)
-            return Periodicity.UNKNOWN;
-
-        int days = Dates.daysBetween(firstPayment, lastPayment);
-
-        long daysBetweenPayments = Math.round(days / (double) (regularEvents - 1));
-
-        if (daysBetweenPayments > 400)
-            return Periodicity.UNKNOWN;
-        else if (daysBetweenPayments > 300)
-            return Periodicity.ANNUAL;
-        else if (daysBetweenPayments > 150)
-            return Periodicity.SEMIANNUAL;
-        else if (daysBetweenPayments > 75)
-            return Periodicity.QUARTERLY;
-        else
-            return Periodicity.UNKNOWN;
+        // construct new payment and add it to the list
+        payments.add(new DividendPayment(converter, t));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
@@ -28,7 +28,7 @@ public final class SecurityPerformanceRecord implements Adaptable
 {
     public enum Periodicity
     {
-        UNKNOWN, NONE, INDEFINITE, ANNUAL, SEMIANNUAL, QUARTERLY, IRREGULAR;
+        UNKNOWN, NONE, INDEFINITE, ANNUAL, SEMIANNUAL, QUARTERLY, MONTHLY, IRREGULAR;
 
         private static final ResourceBundle RESOURCES = ResourceBundle
                         .getBundle("name.abuchen.portfolio.snapshot.labels"); //$NON-NLS-1$


### PR DESCRIPTION
rework calculation of periodicity, allows for additional (insignificant) payments during a year - like after last tax adjustments in Germany in January 2018, add monthly periodicity.
----

Ich habe mich mal an die Berechnung der Periodizität gesetzt.
Jetzt hat die Berechnung etwas Toleranz eingebaut, wenn es zusätzliche Zahlungen gibt, die aber zur Dividende kaum beitragen.
Zum Beispiel gab es im Januar diesen Jahres sehr kleine Ausgleichszahlungen aufgrund der Steuerreform, die aber nicht ins Gewicht fallen (beim DWS Top Dividende 0,13 € vs. 3,20 € normale Dividende). Diese begründen keine andere Periodizität, diese bleibt trotzdem jährlich.
Erst wenn sie signifikant zur Jahresdividende beitragen, ändert sich diese dann.

Damit sollte auch der Pull Request #926 sauberer rechnen.