### PR TITLE
Check for write method before calling it to prevent NullPointerException

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -37,9 +37,9 @@ public class SecurityTest
 
             if (p.getPropertyType() == String.class && p.getWriteMethod() != null)
                 p.getWriteMethod().invoke(source, UUID.randomUUID().toString());
-            else if (p.getPropertyType() == boolean.class)
+            else if (p.getPropertyType() == boolean.class && p.getWriteMethod() != null)
                 p.getWriteMethod().invoke(source, true);
-            else if (p.getPropertyType() == int.class)
+            else if (p.getPropertyType() == int.class && p.getWriteMethod() != null)
                 p.getWriteMethod().invoke(source, new Random().nextInt());
             else
                 skipped++;


### PR DESCRIPTION
Missing methods are still catched by incrementing skipped and checking it later on.