### PR TITLE
support partial number of shares.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
@@ -114,8 +114,9 @@ public class HoldingsPieChartView extends AbstractFinanceView
                                                     p.getValuation().getAmount(), //
                                                     colors.next(), //
                                                     name, percentage, Values.Share.format(p.getPosition().getShares()), //
-                                                    Values.Money.format(p.getValuation().divide(
-                                                                    (long) (p.getPosition().getShares() / Values.Share.divider()))), //
+                                                    Values.Money.format(p.getValuation()
+                                                                    .multiply((long) Values.Share.divider())
+                                                                    .divide((long) (p.getPosition().getShares()))), //
                                                     Values.Money.format(p.getValuation()), percentage));
                                 });
 


### PR DESCRIPTION
Das ist der Fix für [diesen Fehler](https://forum.portfolio-performance.info/t/diagramm-bestaende-zeigt-teils-falsche-kurse-in-tooltip-rechnung/3233) im Forum.
Damit werden auch Bruchstücke von Wertpapieren und der resultierende Stückpreis korrekt angezeigt.