### PR TITLE
show favorite currencies on top.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -69,16 +69,32 @@ public class StatementOfAssetsView extends AbstractFinanceView
             @Override
             public void menuAboutToShow(IMenuManager manager)
             {
+                // put list of favorite units on top
+                List<CurrencyUnit> allUnits = getClient().getUsedCurrencies();
+                // add a separator marker
+                allUnits.add(null);
+                // then all available units
                 List<CurrencyUnit> available = CurrencyUnit.getAvailableCurrencyUnits();
                 Collections.sort(available);
-                for (final CurrencyUnit unit : available)
+                allUnits.addAll(available);
+                // now show the list
+                for (final CurrencyUnit unit : allUnits)
                 {
-                    Action action = new SimpleAction(unit.getLabel(), a -> {
-                        setLabel(unit.getCurrencyCode());
-                        getClient().setBaseCurrency(unit.getCurrencyCode());
-                    });
-                    action.setChecked(getClient().getBaseCurrency().equals(unit.getCurrencyCode()));
-                    manager.add(action);
+                    // is this a unit or a separator?
+                    if (unit != null)
+                    {
+                        Action action = new SimpleAction(unit.getLabel(), a -> {
+                            setLabel(unit.getCurrencyCode());
+                            getClient().setBaseCurrency(unit.getCurrencyCode());
+                        });
+                        action.setChecked(getClient().getBaseCurrency().equals(unit.getCurrencyCode()));
+                        manager.add(action);
+                    }
+                    else
+                    {
+                        // add a separator
+                        manager.add(new Separator());
+                    }
                 }
             }
         };

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -6,6 +6,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -186,6 +187,53 @@ public class Client
         securities.remove(security);
 
         propertyChangeSupport.firePropertyChange("securities", security, null); //$NON-NLS-1$
+    }
+    
+    /**
+     * Gets a list of used {@link CurrencyUnit}s.
+     * 
+     * @return list
+     */
+    public List<CurrencyUnit> getUsedCurrencies()
+    {
+        // collect all used currency codes
+        HashSet<String> hsUsedCodes = new HashSet<String>();
+        // first client and all accounts
+        hsUsedCodes.add(baseCurrency);
+        for (Account account : accounts)
+        {
+            hsUsedCodes.add(account.getCurrencyCode());
+            for (AccountTransaction t : account.getTransactions())
+            {
+                hsUsedCodes.add(t.getCurrencyCode());
+            }
+        }
+        // then portfolios
+        for (Portfolio portfolio : portfolios)
+        {
+            for (PortfolioTransaction t : portfolio.getTransactions())
+            {
+                hsUsedCodes.add(t.getCurrencyCode());
+            }
+        }
+        // then from all securities
+        for (Security security : securities)
+        {
+            hsUsedCodes.add(security.getCurrencyCode());
+        }
+        // now get the currency units
+        List<CurrencyUnit> lUnits = new ArrayList<CurrencyUnit>();
+        for (String code : hsUsedCodes)
+        {
+            CurrencyUnit unit = CurrencyUnit.getInstance(code);
+            if (unit != null)
+            {
+                lUnits.add(unit);
+            }
+        }
+        // sort list to allow using it as a favorite list
+        Collections.sort(lUnits);
+        return lUnits;
     }
 
     public List<Watchlist> getWatchlists()


### PR DESCRIPTION
Damit werden die benutzten Währungen im Auswahlmenü des DropDownButtons ganz oben angezeigt.
Darunter folgen dann alle Währungen alphabetisch sortiert.
Das die benutzten dort auch noch einmal auftauchen ist kein Problem, da ein Nutzer eventuell auch nur alphabetisch unten sucht.
So muss man zum Beispiel für US-Dollar nicht bis ganz nach unten scrollen, sondern kann ihn ganz oben auswählen (wenn er denn benutzt wurde).

Später möchte ich auch weitere Dialoge ähnlich ergänzen, damit man schnell zwischen Währungen umschalten kann. Das Dropdown wird momentan nur in der Vermögensansicht benutzt.