### PR TITLE
Feature performance calculation no neutral movements

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -689,6 +689,8 @@ public class Messages extends NLS
     public static String PerformanceChartLabelEntirePortfolio;
     public static String PerformanceChartLabelCPI;
     public static String PerformanceHeatmapToolTip;
+    public static String PerformanceRelevantTransactionsFooter;
+    public static String PerformanceRelevantTransactionsHeader;
     public static String PerformanceTabAssetsAtEnd;
     public static String PerformanceTabAssetsAtStart;
     public static String PerformanceTabCalculation;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -441,6 +441,7 @@ public class Messages extends NLS
     public static String LabelLanguageAutomatic;
     public static String LabelLayout;
     public static String LabelLayoutFull;
+    public static String LabelLayoutNonNeutral;
     public static String LabelLayoutReduced;
     public static String LabelLevelNameNumber;
     public static String LabelLevelNumber;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -441,8 +441,8 @@ public class Messages extends NLS
     public static String LabelLanguageAutomatic;
     public static String LabelLayout;
     public static String LabelLayoutFull;
-    public static String LabelLayoutNonNeutral;
     public static String LabelLayoutReduced;
+    public static String LabelLayoutRelevant;
     public static String LabelLevelNameNumber;
     public static String LabelLevelNumber;
     public static String LabelNamePlusCopy;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -913,6 +913,8 @@ LabelLayout = Layout
 
 LabelLayoutFull = Full
 
+LabelLayoutNonNeutral = Non-Neutral
+
 LabelLayoutReduced = Reduced
 
 LabelLevelNameNumber = {0} (Level {1})

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1381,6 +1381,10 @@ PerformanceChartLabelEntirePortfolio = Entire portfolio
 
 PerformanceHeatmapToolTip = Monthly rate of return displayed as heatmap\n\nTo calculate the montly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full month - even if the reporting interval ends or starts in the middle of a month.
 
+PerformanceRelevantTransactionsFooter = Total relevant transactions ({0})
+
+PerformanceRelevantTransactionsHeader = Relevant transactions since {0}
+
 PerformanceTabAssetsAtEnd = Assets at End
 
 PerformanceTabAssetsAtStart = Assets at Start

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -913,9 +913,9 @@ LabelLayout = Layout
 
 LabelLayoutFull = Full
 
-LabelLayoutNonNeutral = Non-Neutral
-
 LabelLayoutReduced = Reduced
+
+LabelLayoutRelevant = Relevant
 
 LabelLevelNameNumber = {0} (Level {1})
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1379,6 +1379,10 @@ PerformanceChartLabelEntirePortfolio = Gesamtportfolio
 
 PerformanceHeatmapToolTip = Monatsrenditen in einer Heatmap\n\nZur Berechnung der Monatsrendite wird der True-Time Weighted Rate of Return (TTWROR) herangezogen.\n\nDie Rendite bezieht sich immer auf den gesamten Monat - selbst wenn der Berichtszeitraum in der Mitte des Monats beginnt bzw. endet.
 
+PerformanceRelevantTransactionsFooter = Summe relevanter Bewegungen ({0})
+
+PerformanceRelevantTransactionsHeader = Relevante Bewegungen seit {0}
+
 PerformanceTabAssetsAtEnd = Verm\u00F6gensaufstellung (Ende)
 
 PerformanceTabAssetsAtStart = Verm\u00F6gensaufstellung (Anfang)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -911,9 +911,9 @@ LabelLayout = Layout
 
 LabelLayoutFull = Vollst\u00E4ndig
 
-LabelLayoutNonNeutral = Nicht performance-neutral
-
 LabelLayoutReduced = Reduziert
+
+LabelLayoutRelevant = Relevant
 
 LabelLevelNameNumber = {0} (Ebene {1})
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -911,6 +911,8 @@ LabelLayout = Layout
 
 LabelLayoutFull = Vollst\u00E4ndig
 
+LabelLayoutNonNeutral = Nicht performance-neutral
+
 LabelLayoutReduced = Reduziert
 
 LabelLevelNameNumber = {0} (Ebene {1})

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -212,7 +212,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         
         
         // footer
-        MutableMoney totalNonNeutralTransactions = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(2, 6));
+        MutableMoney totalNonNeutralTransactions = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(1, 6));
         signs[6].setText(categories.get(7).getSign());
         labels[6].setText(categories.get(7).getLabel());
         values[6].setText(Values.Money.format(totalNonNeutralTransactions.toMoney(), getClient().getBaseCurrency()));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -28,7 +28,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
 {
     enum TableLayout
     {
-        FULL(Messages.LabelLayoutFull), REDUCED(Messages.LabelLayoutReduced), NONNEUTRAL(Messages.LabelLayoutNonNeutral);
+        FULL(Messages.LabelLayoutFull), REDUCED(Messages.LabelLayoutReduced), RELEVANT(Messages.LabelLayoutRelevant);
 
         private String label;
 
@@ -103,7 +103,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
             case REDUCED:
                 createTable(5);
                 break;
-            case NONNEUTRAL:
+            case RELEVANT:
                 createTable(7);
                 break;
             default:
@@ -186,7 +186,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
             case REDUCED:
                 fillInReducedValues(snapshot);
                 break;
-            case NONNEUTRAL:
+            case RELEVANT:
                 fillInOnlyRelevantValues(snapshot);
                 break;
             default:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -185,7 +185,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
                 fillInReducedValues(snapshot);
                 break;
             case NONNEUTRAL:
-                fillInNonNeutralValues(snapshot);
+                fillInOnlyRelevantValues(snapshot);
                 break;
             default:
                 throw new IllegalArgumentException();
@@ -194,7 +194,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         container.layout();
     }
 
-    private void fillInNonNeutralValues(final ClientPerformanceSnapshot snapshot)
+    private void fillInOnlyRelevantValues(final ClientPerformanceSnapshot snapshot)
     {
         
         List<ClientPerformanceSnapshot.Category> categories = snapshot.getCategories();
@@ -216,6 +216,8 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         signs[6].setText(categories.get(7).getSign());
         labels[6].setText(categories.get(7).getLabel());
         values[6].setText(Values.Money.format(totalNonNeutralTransactions.toMoney(), getClient().getBaseCurrency()));
+        MutableMoney totalRelevantTransactions = sumCategoryValuations(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(1, 6));
+        values[6].setText(Values.Money.format(totalRelevantTransactions.toMoney(), getClient().getBaseCurrency()));
     }
     
     /**
@@ -224,7 +226,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
      * @param categories The categories for which the total value is computed
      * @return
      */
-    private MutableMoney sumCategoryValuates(String currencyCode, List<ClientPerformanceSnapshot.Category> categories) {
+    private MutableMoney sumCategoryValuations(String currencyCode, List<ClientPerformanceSnapshot.Category> categories) {
         
         MutableMoney totalMoney = MutableMoney.of(currencyCode);
         
@@ -264,7 +266,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
     {
         List<ClientPerformanceSnapshot.Category> categories = snapshot.getCategories();
         
-        MutableMoney misc = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(2, 6));
+        MutableMoney misc = sumCategoryValuations(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(2, 6));
 
         filInValues(0, categories.subList(0, 2));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -262,12 +262,9 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
 
     private void fillInReducedValues(ClientPerformanceSnapshot snapshot)
     {
-        MutableMoney misc = MutableMoney.of(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode());
-
         List<ClientPerformanceSnapshot.Category> categories = snapshot.getCategories();
-
         
-        misc = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(2, 6));
+        MutableMoney misc = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(2, 6));
 
         filInValues(0, categories.subList(0, 2));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -1,7 +1,9 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.function.Supplier;
+import java.text.MessageFormat;
 
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -199,8 +201,10 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         
         List<ClientPerformanceSnapshot.Category> categories = snapshot.getCategories();
         
-        // header
-        labels[0].setText(categories.get(0).getLabel());
+        // header 
+        LocalDate startDate = snapshot.getStartClientSnapshot().getTime();
+        String header =  MessageFormat.format(Messages.PerformanceRelevantTransactionsHeader, Values.Date.format(startDate));
+        labels[0].setText(header);
         
         
         for (int i = 1; i < 6; i++) {
@@ -212,10 +216,13 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         
         
         // footer
-        MutableMoney totalNonNeutralTransactions = sumCategoryValuates(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(1, 6));
         signs[6].setText(categories.get(7).getSign());
-        labels[6].setText(categories.get(7).getLabel());
-        values[6].setText(Values.Money.format(totalNonNeutralTransactions.toMoney(), getClient().getBaseCurrency()));
+        
+        
+        LocalDate endDate = snapshot.getEndClientSnapshot().getTime();
+        String footer = MessageFormat.format(Messages.PerformanceRelevantTransactionsFooter,Values.Date.format(endDate));
+        labels[6].setText(footer);
+        
         MutableMoney totalRelevantTransactions = sumCategoryValuations(snapshot.getValue(CategoryType.INITIAL_VALUE).getCurrencyCode(), categories.subList(1, 6));
         values[6].setText(Values.Money.format(totalRelevantTransactions.toMoney(), getClient().getBaseCurrency()));
     }


### PR DESCRIPTION
Ich habe eine weitere Option für das Widget "Performanceberechnung" geschrieben.  Mich interessiert häufig nur, was meine nicht-neutralen Bewegungen sind (was ich naiv unter "performance" verstehe).
Das Ganze sieht dann wie folgt aus:
![non-neutral](https://user-images.githubusercontent.com/8068018/43596524-d4856022-967f-11e8-89f8-9b3c8797d4e3.png)


Ich habe im Rahmen dieses pull requests den Code für die "reduced" Option etwas verändert; meiner Meinung nach ist der Code eleganter geworden.


Achtung: Ich habe keine spanische Übersetzung für den Namen der Option nicht hinzugefügt.




