### PR TITLE
ECB exchange rate source has changed from http https

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBUpdater.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBUpdater.java
@@ -30,7 +30,7 @@ import name.abuchen.portfolio.util.Dates;
  */
 /* package */class ECBUpdater
 {
-    private static final String SOURCE_URL = "http://www.ecb.europa.eu/stats/eurofxref/"; //$NON-NLS-1$
+    private static final String SOURCE_URL = "https://www.ecb.europa.eu/stats/eurofxref/"; //$NON-NLS-1$
 
     private enum Feeds
     {


### PR DESCRIPTION
According to https://forum.portfolio-performance.info/t/waehrungskurse-werden-nicht-aktualisiert/2943/26 the ECB has shifted their exchange rates from http to https