### PR TITLE
Apache Maven 3.5.4 adjustments

### DIFF
--- a/name.abuchen.portfolio/pom.xml
+++ b/name.abuchen.portfolio/pom.xml
@@ -23,15 +23,17 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.0.0</version>
 			</plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -2,10 +2,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<prerequisites>
-		<maven>3.0</maven>
-	</prerequisites>
-
 	<groupId>name.abuchen.portfolio</groupId>
 	<artifactId>portfolio-app</artifactId>
 	<version>0.34.1</version>
@@ -156,6 +152,29 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M2</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.0</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>1.8</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>


### PR DESCRIPTION
Neuer Versuch mit eigener Branch anstelle über meinen Master zu Pull #1026 , wg. fehlener editierbarkeit da der Eintrag zu den gebannten Plugins nicht entfernt werden konnte.

- Change MAVEN prerequisites to Maven Enforcer plugin according to https://maven.apache.org/enforcer/maven-enforcer-plugin/faq.html
https://maven.apache.org/docs/3.5.0/release-notes.html

- add version tag for MAVEN plugin according to mvn compiler warning message (release 3.5.4)
> [WARNING] Some problems were encountered while building the effective model for name.abuchen.portfolio:name.abuchen.portfolio:eclipse-plugin:0.34.1-SNAPSHOT
> [WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ name.abuchen.portfolio:name.abuchen.portfolio:[unknown-version], .\name.abuchen.portfolio\pom.xml, line 27, column 21
> [WARNING]
> [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
> [WARNING]
> [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.