### PR TITLE
Bug: Buchungen für Sparplan mit Start in Zukunft

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.model;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.time.LocalDate;
@@ -187,9 +189,12 @@ public class InvestmentPlanTest
         assertThat(investmentPlan.getTransactions(), hasSize(previousTransactionCount));
         
         // generation resumes at start date
-        investmentPlan.setStart(LocalDate.now().minusMonths(1).minusDays(10));
+        LocalDate resumeDate = LocalDate.now().minusMonths(1).minusDays(10);
+        investmentPlan.setStart(resumeDate);
         investmentPlan.generateTransactions(new TestCurrencyConverter());
         assertThat(investmentPlan.getTransactions(), hasSize(previousTransactionCount+2));
+        LocalDate firstNewDate = investmentPlan.getTransactions().get(previousTransactionCount).getDateTime().toLocalDate();
+        assertThat(firstNewDate, is(resumeDate));
     }
 
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -225,6 +225,10 @@ public class InvestmentPlan implements Named, Adaptable
         // the transaction date might be edited (or moved to the next months b/c
         // of public holidays) -> determine the "normalized" date by comparing
         // the three months around the current transactionDate
+        
+        if (previousDate.isBefore(start.toLocalDate())) {
+            previousDate = start.toLocalDate();
+        }
 
         if (transactionDate.getDayOfMonth() != start.getDayOfMonth())
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -226,10 +226,6 @@ public class InvestmentPlan implements Named, Adaptable
         // of public holidays) -> determine the "normalized" date by comparing
         // the three months around the current transactionDate
         
-        if (previousDate.isBefore(start.toLocalDate())) {
-            previousDate = start.toLocalDate();
-        }
-
         if (transactionDate.getDayOfMonth() != start.getDayOfMonth())
         {
             int daysBetween = Integer.MAX_VALUE;
@@ -257,6 +253,11 @@ public class InvestmentPlan implements Named, Adaptable
         // 31st, but the month has only 30 days)
         next = next.withDayOfMonth(Math.min(next.lengthOfMonth(), start.getDayOfMonth()));
 
+        if (next.isBefore(start.toLocalDate())) {
+            // start date was recently changed, use this value instead
+            next = start.toLocalDate();
+        }
+        
         // do not generate a investment plan transaction on a public holiday
         TradeCalendar tradeCalendar = new TradeCalendar();
         while (tradeCalendar.isHoliday(next))


### PR DESCRIPTION
Wenn ein Sparplan bereits Buchungen hat und der Start in die Zukunft verlegt wird (um das Sparen zu pausieren), dann werden trotzdem Buchungen erstellt.

Test-case und Bugfix im Pull Request.