### PR TITLE
Enhancement while importing CSV files

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
@@ -3,9 +3,15 @@ package name.abuchen.portfolio.datatransfer.csv;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.FieldPosition;
@@ -457,45 +463,70 @@ public class CSVImporter
         return columns;
     }
 
+    public void processStream(InputStream stream) throws IOException
+    {
+        Reader reader = new InputStreamReader(stream, encoding);
+
+        CSVStrategy strategy = new CSVStrategy(delimiter, '"', CSVStrategy.COMMENTS_DISABLED,
+                        CSVStrategy.ESCAPE_DISABLED, false, false, false, false);
+
+        CSVParser parser = new CSVParser(reader, strategy);
+
+        for (int ii = 0; ii < skipLines; ii++)
+            parser.getLine();
+
+        List<String[]> input = new ArrayList<>();
+        String[] header = null;
+        String[] line = parser.getLine();
+        if (isFirstLineHeader)
+        {
+            header = line;
+        }
+        else
+        {
+            header = new String[line.length];
+            for (int ii = 0; ii < header.length; ii++)
+                header[ii] = MessageFormat.format(Messages.CSVImportGenericColumnLabel, ii + 1);
+            input.add(line);
+        }
+
+        while ((line = parser.getLine()) != null)
+            input.add(line);
+
+        this.columns = new CSVImporter.Column[header.length];
+        for (int ii = 0; ii < header.length; ii++)
+            this.columns[ii] = new Column(ii, header[ii]);
+
+        this.values = input;
+
+        mapToImportDefinition();
+    }
+
     public void processFile() throws IOException
     {
+        IOException buffer = null;
         try (FileInputStream stream = new FileInputStream(inputFile))
         {
-            Reader reader = new InputStreamReader(stream, encoding);
-
-            CSVStrategy strategy = new CSVStrategy(delimiter, '"', CSVStrategy.COMMENTS_DISABLED,
-                            CSVStrategy.ESCAPE_DISABLED, false, false, false, false);
-
-            CSVParser parser = new CSVParser(reader, strategy);
-
-            for (int ii = 0; ii < skipLines; ii++)
-                parser.getLine();
-
-            List<String[]> input = new ArrayList<>();
-            String[] header = null;
-            String[] line = parser.getLine();
-            if (isFirstLineHeader)
-            {
-                header = line;
-            }
+            processStream(stream);
+            return;
+        }
+        catch (IOException e)
+        {
+            buffer = e;
+        }
+        byte[] ptext = inputFile.toString().getBytes(StandardCharsets.UTF_8);
+        String str = new String(ptext, StandardCharsets.ISO_8859_1);
+        Path path = Paths.get(URI.create("file://" + str)); //$NON-NLS-1$
+        try (InputStream stream = Files.newInputStream(path))
+        {
+            processStream(stream);
+        }
+        catch (IOException e)
+        {
+            if (buffer != null)
+                throw buffer;
             else
-            {
-                header = new String[line.length];
-                for (int ii = 0; ii < header.length; ii++)
-                    header[ii] = MessageFormat.format(Messages.CSVImportGenericColumnLabel, ii + 1);
-                input.add(line);
-            }
-
-            while ((line = parser.getLine()) != null)
-                input.add(line);
-
-            this.columns = new CSVImporter.Column[header.length];
-            for (int ii = 0; ii < header.length; ii++)
-                this.columns[ii] = new Column(ii, header[ii]);
-
-            this.values = input;
-
-            mapToImportDefinition();
+                throw e;
         }
     }
 


### PR DESCRIPTION
Not sure, whether I am the only one with this issue, but I am unable to import CSV files, which have Umlaute in the filename. This pull request uses the nio library to convert the filename to UTF-8 charset before reading the stream.