### PR TITLE
Minor PDF wizard adjustment - extractor identification

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/PDFImportAssistant.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/PDFImportAssistant.java
@@ -1,8 +1,6 @@
 package name.abuchen.portfolio.ui.wizards.datatransfer;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.datatransfer.Extractor;
 import name.abuchen.portfolio.datatransfer.pdf.AbstractPDFExtractor;
@@ -30,19 +28,9 @@ public class PDFImportAssistant
                 return extractor;
         }
 
-        // PDF import assistant - Level 2 - Precheck if specific securities
-        // could cause faulty detection
-        // ISIN DE0005088108 = Baader Bank Aktie detect the bank
-        // identifier "Baader Bank"
-        Matcher matcherISIN = Pattern.compile(
-                        "DE0005088108|DE0005428007|DE000CBK1001|FR0000131104|INE007B01023|DE000FTG1111|CH0001351862|CH0001350328|CH0001354296|CH0001352720|CH0001350112|CH0318681860|CH0001343885|FR0000131104|INE007B01023") //$NON-NLS-1$
-                        .matcher(text);
-
-        if (matcherISIN.find())
-            return null;
-
-        // PDF import assistent - Level 3 - use bank identifier
-
+        // PDF import assistent - Level 2 - use bank identifier
+        int countIdentifier = 0;
+        Extractor latestExtractor = null;
         for (Extractor extractor : extractors)
         {
             if (!(extractor instanceof AbstractPDFExtractor))
@@ -59,10 +47,14 @@ public class PDFImportAssistant
                     continue;
 
                 if (text.contains(identifier))
-                    return extractor;
+                {
+                    countIdentifier++;
+                    latestExtractor = extractor;
+                }
             }
-
         }
+        if (countIdentifier == 1)
+            return (latestExtractor);
 
         return null;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -23,7 +23,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier(""); //$NON-NLS-1$
+        addBankIdentifier("onvista bank"); //$NON-NLS-1$
 
         addBuyTransaction();
         addSellTransaction();
@@ -81,8 +81,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "time", "amount", "currency") //
-                        .match("Handelstag (?<date>\\d+.\\d+.\\d{4}+) (.*)")
-                        .match("Handelszeit (?<time>\\d+:\\d+)(.*)")
+                        .match("Handelstag (?<date>\\d+.\\d+.\\d{4}+) (.*)").match("Handelszeit (?<time>\\d+:\\d+)(.*)")
                         .find("Wert(\\s+)Konto-Nr. Betrag zu Ihren Lasten(\\s*)$")
                         // 14.01.2015 172306238 EUR 59,55
                         // Wert Konto-Nr. Betrag zu Ihren Lasten
@@ -95,7 +94,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(BuySellEntryItem::new);
-        
+
         addFeesSectionsTransaction(pdfTransaction);
     }
 
@@ -136,8 +135,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "time", "amount", "currency") //
-                        .match("Handelstag (?<date>\\d+.\\d+.\\d{4}+) (.*)")
-                        .match("Handelszeit (?<time>\\d+:\\d+)(.*)")
+                        .match("Handelstag (?<date>\\d+.\\d+.\\d{4}+) (.*)").match("Handelszeit (?<time>\\d+:\\d+)(.*)")
                         .find("Wert(\\s+)Konto-Nr. Betrag zu Ihren Gunsten(\\s*)$")
                         .match("(\\d+.\\d+.\\d{4}+) (\\d{6,12}) (?<currency>\\w{3}+) (?<amount>\\d{1,3}(\\.\\d{3})*(,\\d{2})?)")
                         .assign((t, v) -> {
@@ -909,7 +907,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             }
         });
         this.addDocumentTyp(type);
-        
+
         // 31.10. 31.10. REF: 000017304356 37,66
         Block block = new Block("^\\d+\\.\\d+\\.\\s+\\d+\\.\\d+\\.\\s+REF:\\s+\\d+\\s+[\\d.-]+,\\d+[+-]?(.*)");
         type.addBlock(block);
@@ -985,14 +983,15 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                             && t.getType() != AccountTransaction.Type.BUY
                                             && t.getType() != AccountTransaction.Type.SELL
                                             && t.getType() != AccountTransaction.Type.TAX_REFUND)
-                                                return new TransactionItem(t);
+                                return new TransactionItem(t);
                             return null;
                         });
     }
 
     private void addAccountStatementTransaction2017()
     {
-        // this seems to be the new format of account statements from the year 2017
+        // this seems to be the new format of account statements from the year
+        // 2017
         final DocumentType type = new DocumentType("Kontoauszug Nr.", (context, lines) -> {
             Pattern pYear = Pattern.compile("^Kontoauszug Nr. (\\d{4}) / .*\\.(\\d{4})$");
             Pattern pCurrency = Pattern.compile("^(\\w{3}+) - Verrechnungskonto: .*$");
@@ -1092,7 +1091,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                             return null;
                         });
     }
-    
+
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T pdfTransaction)
     {
         pdfTransaction.section("tax", "withheld", "sign").optional() //
@@ -1234,7 +1233,8 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "currency").optional()
                         .find("Wert(\\s+)Konto-Nr.(\\s+)Abrechnungs-Nr.(\\s+)Betrag zu Ihren Gunsten(\\s*)$")
-                        // Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
+                        // Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren
+                        // Gunsten
                         // 06.05.2013 172306238 56072633 EUR 3,05
                         .match("(^|\\s+)(?<date>\\d+\\.\\d+\\.\\d{4}+)(\\s)(\\d+)?(\\s)?(\\d+)?(\\s)(?<currency>\\w{3}+) (\\d{1,3}(\\.\\d{3})*(,\\d{2})?)")
                         .assign((t, v) -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -23,6 +23,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
+        addBankIdentifier(""); //$NON-NLS-1$
         addBankIdentifier("onvista bank"); //$NON-NLS-1$
 
         addBuyTransaction();


### PR DESCRIPTION
- Remove detection based on ISIN
- Multiple identifiers will trigger the legacy mode (eg. onvista vs. comdirect, onvista vs. außerbörslich Baader Bank etc.)
- Special case OnVista as the existing example does not have a footer, the false/positiv detection of a bank identifier is not fixed.

Siehe https://forum.portfolio-performance.info/t/onvista-wertpapierertrag-funktioniert-nicht-mehr/4107 oder bspw. https://forum.portfolio-performance.info/t/pdf-import-von-onvista-funktioniert-nicht/2076