### PR TITLE
payment date as date for ING dividends

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -499,7 +499,7 @@ public class INGDiBaPDFExtractorTest
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(t.getAmount(), is(Values.Amount.factorize(44.01)));
-        assertThat(t.getDateTime(), is(LocalDateTime.parse("2016-11-29T00:00")));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2016-12-15T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(66)));
 
         assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.24 + 8.87))));
@@ -561,7 +561,7 @@ public class INGDiBaPDFExtractorTest
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(t.getAmount(), is(Values.Amount.factorize(58.19)));
-        assertThat(t.getDateTime(), is(LocalDateTime.parse("2017-03-20T00:00")));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2017-03-22T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(35)));
 
         assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.34))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -292,7 +292,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date") //
-                        .match("Ex-Tag (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         .section("amount", "currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -291,10 +291,6 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                         .match("^Nominale (?<shares>[\\d.]+(,\\d+)?) .*")
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date") //
-                        .match("Zahltag (?<date>\\d+.\\d+.\\d{4}+)") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
-
                         .section("amount", "currency") //
                         .match("Gesamtbetrag zu Ihren Gunsten (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)") //
                         .assign((t, v) -> {
@@ -302,6 +298,10 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
                         })
+                        
+                        .section("date") //
+                        .match("Valuta (?<date>\\d+.\\d+.\\d{4}+)") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
                                                 
                         .wrap(TransactionItem::new);
         


### PR DESCRIPTION
Vor allem bei US-Aktien liegen Ex-Tag und Zahltag soweit auseinander, dass sie in unterschiedlichen Monaten liegen. Bei Ertragsgutschriften der ING wird bereits der Zahltag genommen und ich konnte keine andere Bank finden, bei der auch der Ex-Tag als Datum für die Dividenden-Gutschrift genommen wurde. Insofern ist es auch noch eine Angleichung an die anderen Banken.

Im Forum gab es hierzu letztes Jahr auch mal einen Beitrag:
https://forum.portfolio-performance.info/t/buchung-von-dividenden-am-ex-tag-oder-bei-gutschrift/1718/4