### PR TITLE
Dividend headline ING less specific

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -600,4 +600,37 @@ public class INGDiBaPDFExtractorTest
         assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR,
                         Values.Amount.factorize(79.46 + 7.15 + 4.37 + 79.46 + 7.15 + 4.37))));
     }
+    
+    @Test
+    public void testNVDividendengutschrift1() throws IOException
+    {
+        INGDiBaExtractor extractor = new INGDiBaExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "INGDiBa_NV_Dividendengutschrift.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("GB0007980591"));
+        assertThat(security.getWkn(), is("850517"));
+        assertThat(security.getName(), is("BP PLC Registered Shares DL -,25"));
+
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().get().getSubject();
+
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(t.getAmount(), is(Values.Amount.factorize(61.85)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2018-12-21T00:00")));
+        assertThat(t.getShares(), is(Values.Share.factorize(700)));
+
+        assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(61.85))));
+        assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR,
+                        Values.Amount.factorize(0.0))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_NV_Dividendengutschrift.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_NV_Dividendengutschrift.txt
@@ -1,0 +1,36 @@
+PDF Author: 'ING-DiBa'
+PDFBox Version: 1.8.16
+-----------------------------------------
+ING-DiBa AG · 60628 Frankfurt am Main
+Depotinhaber: Max Mustermann
+Frau Direkt-Depot Nr.: 0123456789
+Marta Mustermann Datum: 02.01.2019
+z. Hd. Eheleute Mustermann Seite: 1 von 2
+Musterstraße 20
+12345 Musterstadt
+Dividendengutschrift b. NV-Bescheinigung Nr. 1111111111111111
+ISIN (WKN) GB0007980591 (850517)
+Wertpapierbezeichnung BP PLC Registered Shares DL -,25
+Nominale 700,00 Stück
+Zins-/Dividendensatz 0,080251 GBP
+Ex-Tag 08.11.2018
+Zahltag 21.12.2018
+Brutto GBP 56,18
+Zwischensumme GBP 56,18
+Umg. z. Dev.-Kurs (0,908365) EUR 61,85
+Gesamtbetrag zu Ihren Gunsten EUR 61,85
+Abrechnungs-IBAN DE27 5001 0517 5551 9859 93
+Valuta 21.12.2018
+Weitere steuerliche Informationen entnehmen Sie bitte der Rückseite.
+ING-DiBa AG · Theodor-Heuss-Allee 2 · 60486 Frankfurt am Main · Vorsitzender des Aufsichtsrates: Dr. Claus Dieter Hoffmann · Vorstand: Nick Jue (Vorsitzender),
+Bernd Geilen (stellv. Vorsitzender), Zeljko Kaurin, Remco Nieland, Dr. Joachim von Schorlemer · Sitz: Frankfurt am Main · AG Frankfurt am Main HRB 7727,
+Steuernummer: 047 220 2800 4 · USt-IdNr.: DE 114 103 475 · Internet: www.ing.de · E-Mail: info@ing.de · BIC: INGDDEFFXXX · Mitglied im Einlagensicherungsfonds
+Depotinhaber: Marta Mustermann
+Direkt-Depot Nr.: 0123456789
+Datum: 02.01.2019
+Seite: 2 von 2
+ISIN (WKN) GB0007980591 (850517)
+KapSt-pflichtiger Kapitalertrag 61,85 EUR
+Die Abrechnung ist aus steuerlicher Sicht im Vorjahr einzuordnen
+Bei Fragen besuchen Sie uns einfach unter www.ing.de/wertpapierwissen - da gibt es viele schnelle
+Antworten. Oder senden Sie uns eine E-Mail an info@ing.de .

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -272,7 +272,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
         final DocumentType type = new DocumentType("Dividendengutschrift", isJointAccount);
         this.addDocumentTyp(type);
 
-        Block block = new Block("Dividendengutschrift");
+        Block block = new Block("Dividendengutschrift.*");
         type.addBlock(block);
         Transaction<AccountTransaction> transaction = new Transaction<AccountTransaction>()
 


### PR DESCRIPTION
Dividenden Gutschriften mit NV-Vermerk.
Aus https://forum.portfolio-performance.info/t/ing-diba-dividendengutschrift-mit-nv-bescheinungen-nicht-moeglich/2045/6