### PR TITLE
Multi Line Edit Note Fields - Adjusting Dialogs

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferDialog.java
@@ -20,6 +20,7 @@ import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
@@ -147,9 +148,14 @@ public class AccountTransferDialog extends AbstractTransactionDialog // NOSONAR
         amount.bindCurrency(Properties.targetAccountCurrency.name());
 
         // note
+
         Label lblNote = new Label(editArea, SWT.LEFT);
         lblNote.setText(Messages.ColumnNote);
-        Text valueNote = new Text(editArea, SWT.BORDER);
+        Text valueNote = new Text(editArea, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+        FormData formData = new FormData();
+        formData.width = 450;
+        formData.height = 100;
+        valueNote.setLayoutData(formData);
         IObservableValue<?> targetNote = WidgetProperties.text(SWT.Modify).observe(valueNote);
         @SuppressWarnings("unchecked")
         IObservableValue<?> noteObservable = BeanProperties.value(Properties.note.name()).observe(model);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.dialogs.transactions;
 
+import org.eclipse.swt.layout.FormData;
 import static name.abuchen.portfolio.ui.util.FormDataFactory.startingWith;
 import static name.abuchen.portfolio.ui.util.SWTHelper.amountWidth;
 import static name.abuchen.portfolio.ui.util.SWTHelper.currencyWidth;
@@ -187,11 +188,15 @@ public class SecurityTransactionDialog extends AbstractTransactionDialog // NOSO
 
         Label lblNote = new Label(editArea, SWT.LEFT);
         lblNote.setText(Messages.ColumnNote);
-        Text valueNote = new Text(editArea, SWT.BORDER);
-        IObservableValue<?> targetObservable = WidgetProperties.text(SWT.Modify).observe(valueNote);
+        Text valueNote = new Text(editArea, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+        FormData formData = new FormData();
+        formData.width = 450;
+        formData.height = 100;
+        valueNote.setLayoutData(formData);
+        IObservableValue<?> targetNote = WidgetProperties.text(SWT.Modify).observe(valueNote);
         @SuppressWarnings("unchecked")
         IObservableValue<?> noteObservable = BeanProperties.value(Properties.note.name()).observe(model);
-        context.bindValue(targetObservable, noteObservable);
+        context.bindValue(targetNote, noteObservable);
 
         //
         // form layout

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferDialog.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
@@ -132,11 +133,15 @@ public class SecurityTransferDialog extends AbstractTransactionDialog
 
         Label lblNote = new Label(editArea, SWT.LEFT);
         lblNote.setText(Messages.ColumnNote);
-        Text valueNote = new Text(editArea, SWT.BORDER);
+        Text valueNote = new Text(editArea, SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL);
+        FormData formData = new FormData();
+        formData.width = 450;
+        formData.height = 100;
+        valueNote.setLayoutData(formData);
         IObservableValue<?> targetNote = WidgetProperties.text(SWT.Modify).observe(valueNote);
         @SuppressWarnings("unchecked")
-        IObservableValue<?> modelNote = BeanProperties.value(Properties.note.name()).observe(model);
-        context.bindValue(targetNote, modelNote);
+        IObservableValue<?> noteObservable = BeanProperties.value(Properties.note.name()).observe(model);
+        context.bindValue(targetNote, noteObservable);
 
         //
         // form layout

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.wizards.security;
 
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -7,6 +8,7 @@ import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -113,6 +115,11 @@ public class SecurityMasterDataPage extends AbstractPage
         deco.setImage(image);
         deco.show();
 
-        bindings.bindStringInput(container, Messages.ColumnNote, "note"); //$NON-NLS-1$
+        Text valueNote = bindings.bindStringInput(container, Messages.ColumnNote, "note", SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL, SWT.DEFAULT); //$NON-NLS-1$
+        GridData gridData = new GridData();
+        gridData.widthHint = 450;
+        gridData.heightHint = 100;
+        valueNote.setLayoutData(gridData);
+
     }
 }


### PR DESCRIPTION
- Enable multi line edit note fileds at securities and related security-; transfer and account transactions.
- Missing is the mouse over description as the line breaks not displayed properly (more or less except at the watchlist).
- The line break is indicated at the xml file by `&#xd;` + \n

The result looks like the following example:
![multiedit](https://user-images.githubusercontent.com/29358155/52538849-db976100-2d77-11e9-9532-205b4a9b5e9d.JPG)

Ich habe aber noch nicht herausgefunden warum der Zeilenumbruch aus dem String nicht in das Tooltip übernommen wird.

In Orientierung an https://github.com/buchen/portfolio/projects/1#card-1891942