### PR TITLE
Java 11 deprecated features

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
@@ -35,9 +35,8 @@ public class DetectDuplicatesActionTest
     {
         DetectDuplicatesAction action = new DetectDuplicatesAction();
 
-        new PropertyChecker<AccountTransaction>(AccountTransaction.class, "note", "forex", "monetaryAmount")
-                        .before((name, o, c) -> assertThat(name, action.process(o, account(c)).getCode(),
-                                        is(Code.WARNING)))
+        new PropertyChecker<AccountTransaction>(AccountTransaction.class, "note", "forex", "monetaryAmount").before(
+                        (name, o, c) -> assertThat(name, action.process(o, account(c)).getCode(), is(Code.WARNING)))
                         .after((name, o, c) -> assertThat(name, action.process(o, account(c)).getCode(), is(Code.OK)))
                         .run();
     }
@@ -126,8 +125,8 @@ public class DetectDuplicatesActionTest
 
         private void check(PropertyDescriptor change) throws Exception
         {
-            T instance = type.newInstance();
-            T other = type.newInstance();
+            T instance = type.getDeclaredConstructor().newInstance();
+            T other = type.getDeclaredConstructor().newInstance();
 
             for (PropertyDescriptor p : properties)
             {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,7 +73,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(640 / 9.308))));
         assertThat(grossValueUnit.getForex(), is(Money.of("NOK", Values.Amount.factorize(640))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.308), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.308), 10, RoundingMode.HALF_UP)));
 
         assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
                         is(transaction.getMonetaryAmount().getAmount()));
@@ -150,7 +151,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(20.35 / 1.0942))));
         assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(20.35))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.0942), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.0942), 10, RoundingMode.HALF_UP)));
 
         assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
                         is(transaction.getMonetaryAmount().getAmount()));
@@ -232,7 +233,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(214.28 / 1.1805))));
         assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(214.28))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.1805), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.1805), 10, RoundingMode.HALF_UP)));
 
         assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
                         is(transaction.getMonetaryAmount().getAmount()));
@@ -279,7 +280,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(1092.14))));
         assertThat(grossValueUnit.getForex(), is(Money.of("NOK", Values.Amount.factorize(10360))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.486), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.486), 10, RoundingMode.HALF_UP)));
     }
 
     @Test
@@ -359,7 +360,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(1305.95))));
         assertThat(grossValueUnit.getForex(), is(Money.of("GBP", Values.Amount.factorize(1100))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(0.8423), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(0.8423), 10, RoundingMode.HALF_UP)));
     }
 
     @Test
@@ -406,7 +407,7 @@ public class HelloBankPDFExtractorTest
         assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(5000 / 1.5181))));
         assertThat(grossValueUnit.getForex(), is(Money.of("AUD", Values.Amount.factorize(5000))));
         assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.5181), 10, BigDecimal.ROUND_HALF_UP)));
+                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.5181), 10, RoundingMode.HALF_UP)));
 
         assertThat(grossValueUnit.getAmount().getAmount() - tx.getUnitSum(Unit.Type.TAX).getAmount()
                         - tx.getUnitSum(Unit.Type.FEE).getAmount(), is(tx.getMonetaryAmount().getAmount()));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/IRRTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/IRRTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
@@ -22,8 +23,8 @@ public class IRRTest
                         LocalDate.of(2010, Month.DECEMBER, 31)), //
                         Arrays.asList(-200d, 210d));
 
-        result = new BigDecimal(result).setScale(8, BigDecimal.ROUND_HALF_UP).doubleValue();
-        double excel = new BigDecimal(0.050140747d).setScale(8, BigDecimal.ROUND_HALF_UP).doubleValue();
+        result = new BigDecimal(result).setScale(8, RoundingMode.HALF_UP).doubleValue();
+        double excel = new BigDecimal(0.050140747d).setScale(8, RoundingMode.HALF_UP).doubleValue();
 
         assertThat(result, is(excel));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/PseudoDerivateFunctionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/PseudoDerivateFunctionTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.junit.Test;
 
@@ -28,6 +29,6 @@ public class PseudoDerivateFunctionTest
 
         double result = p.compute(1d);
 
-        assertThat(new BigDecimal(result).setScale(5, BigDecimal.ROUND_HALF_UP).doubleValue(), is(1d));
+        assertThat(new BigDecimal(result).setScale(5, RoundingMode.HALF_UP).doubleValue(), is(1d));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/AEDExchangeRateProviderTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/AEDExchangeRateProviderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.number.OrderingComparison.comparesEqualTo;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 
 import org.junit.Test;
@@ -25,8 +26,8 @@ public class AEDExchangeRateProviderTest
         assertThat(usd_aed.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("3.6725")));
 
         ExchangeRateTimeSeries aed_usd = factory.getTimeSeries("AED", "USD");
-        assertThat(aed_usd.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(
-                        BigDecimal.ONE.divide(new BigDecimal("3.6725"), 10, BigDecimal.ROUND_HALF_DOWN)));
+        assertThat(aed_usd.lookupRate(LocalDate.now()).get().getValue(),
+                        comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("3.6725"), 10, RoundingMode.HALF_DOWN)));
 
         // EUR -> USD -> AED
         // default value EUR -> USD is 1.0836

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/GBXExchangeRateProviderTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/GBXExchangeRateProviderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.number.OrderingComparison.comparesEqualTo;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 
 import org.junit.Test;
@@ -27,8 +28,8 @@ public class GBXExchangeRateProviderTest
 
         // inverse of default EUR -> GBP
         ExchangeRateTimeSeries gbx_eur = factory.getTimeSeries("GBX", "EUR");
-        assertThat(gbx_eur.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(
-                        BigDecimal.ONE.divide(new BigDecimal("72.666"), 12, BigDecimal.ROUND_HALF_DOWN)));
+        assertThat(gbx_eur.lookupRate(LocalDate.now()).get().getValue(),
+                        comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("72.666"), 12, RoundingMode.HALF_DOWN)));
 
         // GBX -> GBP
         ExchangeRateTimeSeries gbx_gbp = factory.getTimeSeries("GBX", "GBP");

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 
 import org.hamcrest.number.IsCloseTo;
@@ -125,7 +126,7 @@ public class CurrencyTestCase
         // the one in EUR account and the one in USD account
 
         // must take the inverse of the exchange used within the transaction
-        BigDecimal rate = BigDecimal.ONE.divide(BigDecimal.valueOf(0.8237), 10, BigDecimal.ROUND_HALF_DOWN);
+        BigDecimal rate = BigDecimal.ONE.divide(BigDecimal.valueOf(0.8237), 10, RoundingMode.HALF_DOWN);
 
         assertThat(equityUSD.getPosition().getFIFOPurchaseValue(),
                         is(Money.of("USD", Math.round(454_60 * rate.doubleValue()) + 571_90)));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractModel.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.dialogs.transactions;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
@@ -73,7 +74,7 @@ public abstract class AbstractModel
      */
     /* package */ static String createCurrencyToolTip(BigDecimal exchangeRate, String term, String base)
     {
-        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
         StringBuilder tooltip = new StringBuilder();
         tooltip.append(Values.ExchangeRate.format(exchangeRate)) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -436,12 +436,12 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
 
     public BigDecimal getInverseExchangeRate()
     {
-        return BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+        return BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
     }
 
     public void setInverseExchangeRate(BigDecimal rate)
     {
-        setExchangeRate(BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN));
+        setExchangeRate(BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN));
     }
 
     public long getConvertedGrossValue()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -457,12 +457,12 @@ public class AccountTransactionModel extends AbstractModel
 
     public BigDecimal getInverseExchangeRate()
     {
-        return BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+        return BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
     }
 
     public void setInverseExchangeRate(BigDecimal rate)
     {
-        setExchangeRate(BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN));
+        setExchangeRate(BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN));
     }
 
     public long getGrossAmount()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
@@ -296,12 +296,12 @@ public class AccountTransferModel extends AbstractModel
 
     public BigDecimal getInverseExchangeRate()
     {
-        return BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+        return BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
     }
 
     public void setInverseExchangeRate(BigDecimal rate)
     {
-        setExchangeRate(BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN));
+        setExchangeRate(BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN));
     }
 
     public long getAmount()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/SecurityTransfer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/SecurityTransfer.java
@@ -9,7 +9,7 @@ import name.abuchen.portfolio.model.Security;
 
 public class SecurityTransfer extends ByteArrayTransfer
 {
-    private static final String TYPE_NAME = "local-security-transfer-format" + (new Long(System.currentTimeMillis())).toString(); //$NON-NLS-1$;
+    private static final String TYPE_NAME = "local-security-transfer-format" + (Long.valueOf(System.currentTimeMillis())).toString(); //$NON-NLS-1$;
 
     private static final int TYPEID = registerType(TYPE_NAME);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ScopedPreferenceStore.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ScopedPreferenceStore.java
@@ -1,19 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2008 IBM Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
- *     Yves YANG <yves.yang@soyatec.com> - 
- *          Initial Fix for Bug 138078 [Preferences] Preferences Store for i18n support
- *          
- *          
- * COPIED FROM ECLIPSE BECAUSE E4 PENDANT IS MISSING
+ * Copyright (c) 2004, 2008 IBM Corporation and others. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html Contributors:
+ * IBM Corporation - initial API and implementation Yves YANG
+ * <yves.yang@soyatec.com> - Initial Fix for Bug 138078 [Preferences]
+ * Preferences Store for i18n support COPIED FROM ECLIPSE BECAUSE E4 PENDANT IS
+ * MISSING
  * https://github.com/eclipse/eclipse.platform.ui/blob/7e26a4a0bc4b7b490bd7ed01366e5114230596ce/bundles/org.eclipse.ui.workbench/Eclipse%20UI/org/eclipse/ui/preferences/ScopedPreferenceStore.java
- * 
  *******************************************************************************/
 package name.abuchen.portfolio.ui.preferences;
 
@@ -244,19 +238,19 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
         }
         else if (obj instanceof Integer)
         {
-            return new Integer(defaults.getInt(key, INT_DEFAULT_DEFAULT));
+            return Integer.valueOf(defaults.getInt(key, INT_DEFAULT_DEFAULT));
         }
         else if (obj instanceof Double)
         {
-            return new Double(defaults.getDouble(key, DOUBLE_DEFAULT_DEFAULT));
+            return Double.valueOf(defaults.getDouble(key, DOUBLE_DEFAULT_DEFAULT));
         }
         else if (obj instanceof Float)
         {
-            return new Float(defaults.getFloat(key, FLOAT_DEFAULT_DEFAULT));
+            return Float.valueOf(defaults.getFloat(key, FLOAT_DEFAULT_DEFAULT));
         }
         else if (obj instanceof Long)
         {
-            return new Long(defaults.getLong(key, LONG_DEFAULT_DEFAULT));
+            return Long.valueOf(defaults.getLong(key, LONG_DEFAULT_DEFAULT));
         }
         else if (obj instanceof Boolean)
         {
@@ -369,7 +363,7 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
         this.searchContexts = scopes;
         if (scopes == null)
             return;
-        
+
         // Assert that the default was not included (we automatically add it to
         // the end)
         for (int i = 0; i < scopes.length; i++)
@@ -666,8 +660,8 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
 
     /*
      * (non-Javadoc)
-     * @see
-     * org.eclipse.jface.preference.IPreferenceStore#removePropertyChangeListener
+     * @see org.eclipse.jface.preference.IPreferenceStore#
+     * removePropertyChangeListener
      * (org.eclipse.jface.util.IPropertyChangeListener)
      */
     @Override
@@ -808,7 +802,7 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
                 getStorePreferences().putDouble(name, value);
             }
             dirty = true;
-            firePropertyChangeEvent(name, new Double(oldValue), new Double(value));
+            firePropertyChangeEvent(name, Double.valueOf(oldValue), Double.valueOf(value));
         }
         finally
         {
@@ -840,7 +834,7 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
                 getStorePreferences().putFloat(name, value);
             }
             dirty = true;
-            firePropertyChangeEvent(name, new Float(oldValue), new Float(value));
+            firePropertyChangeEvent(name, Float.valueOf(oldValue), Float.valueOf(value));
         }
         finally
         {
@@ -872,7 +866,7 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
                 getStorePreferences().putInt(name, value);
             }
             dirty = true;
-            firePropertyChangeEvent(name, new Integer(oldValue), new Integer(value));
+            firePropertyChangeEvent(name, Integer.valueOf(oldValue), Integer.valueOf(value));
         }
         finally
         {
@@ -904,7 +898,7 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
                 getStorePreferences().putLong(name, value);
             }
             dirty = true;
-            firePropertyChangeEvent(name, new Long(oldValue), new Long(value));
+            firePropertyChangeEvent(name, Long.valueOf(oldValue), Long.valueOf(value));
         }
         finally
         {
@@ -957,7 +951,8 @@ public class ScopedPreferenceStore extends EventManager implements IPreferenceSt
                 getStorePreferences().putBoolean(name, value);
             }
             dirty = true;
-            firePropertyChangeEvent(name, oldValue ? Boolean.TRUE : Boolean.FALSE, value ? Boolean.TRUE : Boolean.FALSE);
+            firePropertyChangeEvent(name, oldValue ? Boolean.TRUE : Boolean.FALSE,
+                            value ? Boolean.TRUE : Boolean.FALSE);
         }
         finally
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNodeTransfer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNodeTransfer.java
@@ -8,7 +8,7 @@ import org.eclipse.swt.dnd.TransferData;
 public class TaxonomyNodeTransfer extends ByteArrayTransfer
 {
     private static final String TYPE_NAME = "local-taxonomy-node-transfer-format" //$NON-NLS-1$
-                    + (new Long(System.currentTimeMillis())).toString();
+                    + (Long.valueOf(System.currentTimeMillis())).toString();
 
     private static final int TYPEID = registerType(TYPE_NAME);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
@@ -430,7 +430,7 @@ public class IBFlexStatementExtractor implements Extractor
                 {
                     fxRateToBase = new BigDecimal(1);
                 }
-                BigDecimal inverseRate = BigDecimal.ONE.divide(fxRateToBase, 10, BigDecimal.ROUND_HALF_DOWN);
+                BigDecimal inverseRate = BigDecimal.ONE.divide(fxRateToBase, 10, RoundingMode.HALF_DOWN);
 
                 BigDecimal baseCurrencyMoney = BigDecimal.valueOf(amount.doubleValue() * Values.Amount.factor())
                                 .divide(inverseRate, RoundingMode.HALF_DOWN);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -167,7 +168,7 @@ import name.abuchen.portfolio.money.Money;
             Money forex = Money.of(transaction.getSecurity().getCurrencyCode(), Math
                             .round(exchangeRate.multiply(BigDecimal.valueOf(grossValue.getAmount())).doubleValue()));
 
-            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
             transaction.addUnit(new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -241,7 +241,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                 Math.round(accountMoneyValue.doubleValue()));
                                 // replace BRUTTO (which is in foreign currency)
                                 // with the value in transaction currency
-                                BigDecimal inverseRate = BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN);
+                                BigDecimal inverseRate = BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN);
                                 Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, accountMoney, currentMonetaryAmount,
                                                 inverseRate);
 
@@ -544,7 +544,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         .match("Brutto in (\\w{3}+) (?<amount>[\\d.]+,\\d+) (?<currency>\\w{3}+)") //
                         .assign((t, v) -> {
                             BigDecimal rate = asExchangeRate(v.get("exchangeRate"));
-                            BigDecimal inverseRate = BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN);
+                            BigDecimal inverseRate = BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN);
 
                             type.getCurrentContext().put("exchangeRate", inverseRate.toPlainString());
 
@@ -573,7 +573,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                                 Money txTax = Money.of(t.getCurrencyCode(),
                                                 BigDecimal.valueOf(tax.getAmount()).multiply(exchangeRate)
-                                                                .setScale(0, BigDecimal.ROUND_HALF_UP).longValue());
+                                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
                                 t.addUnit(new Unit(Unit.Type.TAX, txTax));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -86,7 +87,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                             t.setMonetaryAmount(amount);
 
                             BigDecimal exchangeRate = BigDecimal.ONE.divide( //
-                                            asExchangeRate(v.get("exchangeRate")), 10, BigDecimal.ROUND_HALF_DOWN);
+                                            asExchangeRate(v.get("exchangeRate")), 10, RoundingMode.HALF_DOWN);
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
 
                             Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, forex, exchangeRate);
@@ -162,7 +163,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                             t.setMonetaryAmount(amount);
 
                             BigDecimal exchangeRate = BigDecimal.ONE.divide( //
-                                            asExchangeRate(v.get("exchangeRate")), 10, BigDecimal.ROUND_HALF_DOWN);
+                                            asExchangeRate(v.get("exchangeRate")), 10, RoundingMode.HALF_DOWN);
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
 
                             Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, forex, exchangeRate);
@@ -240,7 +241,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
                             BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
-                                            BigDecimal.ROUND_HALF_DOWN);
+                                            RoundingMode.HALF_DOWN);
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")),
                                             Math.round(t.getAmount() / exchangeRate.doubleValue()));
                             Unit unit = new Unit(Unit.Type.GROSS_VALUE, t.getMonetaryAmount(), forex, exchangeRate);
@@ -258,7 +259,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         .match("Devisenkurs: (?<localCurrency>\\w{3}+)/(?<forexCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)")
                         .assign((t, v) -> {
                             BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
-                                            BigDecimal.ROUND_HALF_DOWN);
+                                            RoundingMode.HALF_DOWN);
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
                             Money localAmount = Money.of(v.get("localCurrency"), Math.round(forex.getAmount()
                                             / Double.parseDouble(v.get("exchangeRate").replace(',', '.'))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -94,7 +94,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                 t.setMonetaryAmount(accountMoney); // in EUR 
                                 
                                 // replace BRUTTO (which is in foreign currency) with the value in transaction currency
-                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                                 Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, accountMoney, currentMonetaryAmount, inverseRate);
                                 t.getPortfolioTransaction().addUnit(grossValue);
                             

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -18,7 +19,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
     public DeutscheBankPDFExtractor(Client client)
     {
         super(client);
-        
+
         addBankIdentifier("Deutsche Bank"); //$NON-NLS-1$
         addBankIdentifier("DB Privat- und Firmenkundenbank AG"); //$NON-NLS-1$
 
@@ -143,7 +144,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                         .optional().match("Provision.*(?<currency>\\w{3}+) -(?<provision>[\\d.]+,\\d+)")
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, //
                                         Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("provision"))))))
-                        
+
                         .section("charges", "currency") //
                         .optional().match("Fremde Spesen und Auslagen (?<currency>\\w{3}+) -(?<charges>[\\d.]+,\\d+)")
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, //
@@ -223,7 +224,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                             asAmount(v.get("grossValue")));
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forexSum")));
                             BigDecimal exchangeRate = BigDecimal.ONE.divide( //
-                                            asExchangeRate(v.get("exchangeRate")), 10, BigDecimal.ROUND_HALF_DOWN);
+                                            asExchangeRate(v.get("exchangeRate")), 10, RoundingMode.HALF_DOWN);
                             Unit unit = new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate);
 
                             // add gross value unit only if currency code of

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -184,20 +185,18 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .section("shares") //
                         .match("^Ausgeführt *(?<shares>[\\.\\d]+(,\\d*)?) *St\\..*") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-                        
-                        .oneOf(
-                                        section -> section.attributes("amount", "currency") //
+
+                        .oneOf(section -> section.attributes("amount", "currency") //
                                         .match(".* Endbetrag *(?<currency>\\w{3}+) *(?<amount>[\\d.-]+,\\d+)") //
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
-                                        }), 
-                                        section -> section.attributes("amount", "currency") //
-                                        .match(".* Endbetrag *(?<amount>[\\d.-]+,\\d+)\\s(?<currency>\\w{3}+)") //
-                                        .assign((t, v) -> {
-                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                                            t.setAmount(asAmount(v.get("amount")));
-                        }))
+                                        }), section -> section.attributes("amount", "currency") //
+                                                        .match(".* Endbetrag *(?<amount>[\\d.-]+,\\d+)\\s(?<currency>\\w{3}+)") //
+                                                        .assign((t, v) -> {
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                        }))
 
                         .section("fee", "currency").optional() //
                         .match(".* Provision *(?<currency>\\w{3}+) *(?<fee>[\\d.-]+,\\d+)")
@@ -454,13 +453,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 // inverse exchange rate (in EUR/Fx)
                                 BigDecimal exchangeRate = asExchangeRate(context.get("exchangeRate"));
                                 BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                                BigDecimal.ROUND_HALF_DOWN);
+                                                RoundingMode.HALF_DOWN);
 
                                 // get gross amount and calculate equivalent in
                                 // EUR
                                 Money mAmountGrossFx = Money.of(currencyCodeFx, asAmount(v.get("amountGrossFx")));
                                 BigDecimal amountGrossFxInEUR = BigDecimal.valueOf(mAmountGrossFx.getAmount())
-                                                .divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN);
+                                                .divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                                 Money mAmountGrossFxInEUR = Money.of(currencyCode, amountGrossFxInEUR.longValue());
                                 t.addUnit(new Unit(Unit.Type.GROSS_VALUE, mAmountGrossFxInEUR, mAmountGrossFx,
                                                 inverseRate));
@@ -488,13 +487,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 // inverse exchange rate (in EUR/Fx)
                                 BigDecimal exchangeRate = asExchangeRate(context.get("exchangeRate"));
                                 BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                                BigDecimal.ROUND_HALF_DOWN);
+                                                RoundingMode.HALF_DOWN);
 
                                 // get foreign taxes and calculate equivalent in
                                 // EUR
                                 Money mTaxesFx = Money.of(currencyCodeFx, asAmount(v.get("amountFx")));
                                 BigDecimal taxesFxInEUR = BigDecimal.valueOf(mTaxesFx.getAmount()).divide(exchangeRate,
-                                                10, BigDecimal.ROUND_HALF_DOWN);
+                                                10, RoundingMode.HALF_DOWN);
                                 Money mTaxesFxInEUR = Money.of(currencyCode, taxesFxInEUR.longValue());
                                 t.addUnit(new Unit(Unit.Type.TAX, mTaxesFxInEUR, mTaxesFx, inverseRate));
                             }
@@ -559,20 +558,17 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                             {
                                 t.setShares(asShares(v.get("shares")));
                             }
-                        })
-                        .oneOf(
-                                        section -> section.attributes("amount", "currency") //
+                        }).oneOf(section -> section.attributes("amount", "currency") //
                                         .match(".* Endbetrag *(?<currency>\\w{3}+) *(?<amount>[\\d.-]+,\\d+)") //
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
-                                        }), 
-                                        section -> section.attributes("amount", "currency") //
-                                        .match(".* Endbetrag *(?<amount>[\\d.-]+,\\d+)\\s(?<currency>\\w{3}+)") //
-                                        .assign((t, v) -> {
-                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                                            t.setAmount(asAmount(v.get("amount")));
-                        }))
+                                        }), section -> section.attributes("amount", "currency") //
+                                                        .match(".* Endbetrag *(?<amount>[\\d.-]+,\\d+)\\s(?<currency>\\w{3}+)") //
+                                                        .assign((t, v) -> {
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                        }))
 
                         .section("fee", "currency").optional()
                         //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
@@ -91,13 +92,13 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                             long gross = asAmount(v.get("gross"));
                             String currency = asCurrencyCode(v.get("currency"));
                             BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(v.get("exchangeRate")), 10,
-                                            BigDecimal.ROUND_HALF_UP);
+                                            RoundingMode.HALF_UP);
 
                             PortfolioTransaction tx = t.getPortfolioTransaction();
                             if (currency.equals(tx.getSecurity().getCurrencyCode()))
                             {
                                 long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                                .setScale(0, RoundingMode.HALF_UP).longValue();
 
                                 tx.addUnit(new Unit(Unit.Type.GROSS_VALUE,
                                                 Money.of(tx.getCurrencyCode(), convertedGross),
@@ -178,26 +179,26 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                             long tax = asAmount(v.get("tax"));
                             String currency = asCurrencyCode(v.get("currency"));
                             BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(v.get("exchangeRate")), 10,
-                                            BigDecimal.ROUND_HALF_UP);
+                                            RoundingMode.HALF_UP);
 
                             PortfolioTransaction tx = t.getPortfolioTransaction();
                             if (currency.equals(tx.getSecurity().getCurrencyCode()))
                             {
                                 long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                                .setScale(0, RoundingMode.HALF_UP).longValue();
                                 tx.addUnit(new Unit(Unit.Type.GROSS_VALUE,
                                                 Money.of(tx.getCurrencyCode(), convertedGross),
                                                 Money.of(currency, gross), exchangeRate));
 
                                 long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                                .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                                .setScale(0, RoundingMode.HALF_UP).longValue();
                                 tx.addUnit(new Unit(Unit.Type.TAX, Money.of(tx.getCurrencyCode(), convertedTax),
                                                 Money.of(currency, tax), exchangeRate));
                             }
                             else
                             {
                                 long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                                .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                                .setScale(0, RoundingMode.HALF_UP).longValue();
                                 tx.addUnit(new Unit(Unit.Type.TAX, Money.of(tx.getCurrencyCode(), convertedTax)));
                             }
                         })
@@ -244,19 +245,19 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 if (exchangeRateString != null)
                 {
                     BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(exchangeRateString), 10,
-                                    BigDecimal.ROUND_HALF_UP);
+                                    RoundingMode.HALF_UP);
 
                     if (currency.equals(t.getSecurity().getCurrencyCode()))
                     {
                         long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                        .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                        .setScale(0, RoundingMode.HALF_UP).longValue();
                         t.addUnit(new Unit(Unit.Type.TAX, Money.of(t.getCurrencyCode(), convertedTax),
                                         Money.of(currency, tax), exchangeRate));
                     }
                     else
                     {
                         long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                        .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                        .setScale(0, RoundingMode.HALF_UP).longValue();
                         t.addUnit(new Unit(Unit.Type.TAX, Money.of(t.getCurrencyCode(), convertedTax)));
                     }
                 }
@@ -334,10 +335,10 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                                 if (exchangeRateString != null)
                                 {
                                     BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(exchangeRateString),
-                                                    10, BigDecimal.ROUND_HALF_UP);
+                                                    10, RoundingMode.HALF_UP);
 
                                     long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                    .setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+                                                    .setScale(0, RoundingMode.HALF_UP).longValue();
                                     t.addUnit(new Unit(Unit.Type.GROSS_VALUE,
                                                     Money.of(t.getCurrencyCode(), convertedGross),
                                                     Money.of(currency, gross), exchangeRate));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.ResourceBundle;
@@ -117,10 +118,8 @@ public class PortfolioTransaction extends Transaction
             BigDecimal exchangeRate = grossValue.isPresent() ? grossValue.get().getExchangeRate()
                             : converter.getRate(getDateTime(), getCurrencyCode()).getValue();
 
-            return Money.of(converter.getTermCurrency(),
-                            BigDecimal.ONE.divide(exchangeRate, 10, BigDecimal.ROUND_HALF_DOWN)
-                                            .multiply(BigDecimal.valueOf(getAmount()))
-                                            .setScale(0, BigDecimal.ROUND_HALF_DOWN).longValue());
+            return Money.of(converter.getTermCurrency(), BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN)
+                            .multiply(BigDecimal.valueOf(getAmount())).setScale(0, RoundingMode.HALF_DOWN).longValue());
         }
         else
         {
@@ -220,7 +219,7 @@ public class PortfolioTransaction extends Transaction
     @Override
     public String toString()
     {
-        return String.format("%s %-17s %s %9s %s", Values.DateTime.format(this.getDateTime()), type.name(), getCurrencyCode(), //$NON-NLS-1$
-                        Values.Amount.format(getAmount()), getSecurity().getName());
+        return String.format("%s %-17s %s %9s %s", Values.DateTime.format(this.getDateTime()), type.name(), //$NON-NLS-1$
+                        getCurrencyCode(), Values.Amount.format(getAmount()), getSecurity().getName());
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/ExchangeRate.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/ExchangeRate.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.money;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -32,7 +33,7 @@ public class ExchangeRate implements Comparable<ExchangeRate>
     {
         this(Objects.requireNonNull(time).toLocalDate(), value);
     }
-    
+
     public ExchangeRate(LocalDate time, BigDecimal value)
     {
         Objects.requireNonNull(time);
@@ -104,6 +105,6 @@ public class ExchangeRate implements Comparable<ExchangeRate>
 
     public static BigDecimal inverse(BigDecimal rate)
     {
-        return BigDecimal.ONE.divide(rate, 10, BigDecimal.ROUND_HALF_DOWN);
+        return BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_DOWN);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/InverseExchangeRateTimeSeries.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/InverseExchangeRateTimeSeries.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.money.impl;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,7 +69,7 @@ public class InverseExchangeRateTimeSeries implements ExchangeRateTimeSeries
 
         if (answer.isPresent())
         {
-            BigDecimal reverse = BigDecimal.ONE.divide(answer.get().getValue(), 10, BigDecimal.ROUND_HALF_DOWN);
+            BigDecimal reverse = BigDecimal.ONE.divide(answer.get().getValue(), 10, RoundingMode.HALF_DOWN);
             return Optional.of(new ExchangeRate(answer.get().getTime(), reverse));
         }
         else

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/EurostatHICPQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/EurostatHICPQuoteFeed.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.online.impl;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.DecimalFormat;
@@ -199,15 +200,16 @@ public final class EurostatHICPQuoteFeed implements QuoteFeed
 
                 if (q != null)
                 {
-                    T price = klass.newInstance();
+                    T price = klass.getDeclaredConstructor().newInstance();
                     price.setDate(ts);
                     price.setValue(Values.Quote.factorize(q));
                     answer.add(price);
                 }
             }
         }
-        catch (IOException | InstantiationException | IllegalAccessException | NumberFormatException
-                        | IndexOutOfBoundsException e)
+        catch (IOException | InstantiationException | IllegalAccessException | IndexOutOfBoundsException
+                        | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                        | SecurityException e)
         {
             errors.add(e);
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -300,15 +301,16 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
 
                 if (ts != null && q != null)
                 {
-                    T price = klass.newInstance();
+                    T price = klass.getDeclaredConstructor().newInstance();
                     price.setDate(LocalDateTime.ofEpochSecond(ts, 0, ZoneOffset.UTC).toLocalDate());
                     price.setValue(Values.Quote.factorize(q));
                     answer.add(price);
                 }
             }
         }
-        catch (IOException | InstantiationException | IllegalAccessException | NumberFormatException
-                        | IndexOutOfBoundsException e)
+        catch (IOException | InstantiationException | IllegalAccessException | IndexOutOfBoundsException
+                        | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+                        | SecurityException e)
         {
             errors.add(e);
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooHelper.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooHelper.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.online.impl;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
@@ -28,7 +29,7 @@ import name.abuchen.portfolio.money.Values;
         if ("N/A".equals(s)) //$NON-NLS-1$
             return -1;
         BigDecimal v = (BigDecimal) FMT_PRICE.get().parse(s);
-        return v.multiply(Values.Quote.getBigDecimalFactor()).setScale(0, BigDecimal.ROUND_HALF_UP).longValue();
+        return v.multiply(Values.Quote.getBigDecimalFactor()).setScale(0, RoundingMode.HALF_UP).longValue();
     }
 
     static int asNumber(String s) throws ParseException

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
@@ -17,8 +17,9 @@ import name.abuchen.portfolio.money.CurrencyConverter;
      * Finish up all calculations.
      */
     public void finish()
-    {}
-    
+    {
+    }
+
     /**
      * Gets the underlying {@link Security}.
      * 
@@ -28,7 +29,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     {
         return this.security;
     }
-    
+
     /**
      * Sets the underlying {@link Security}.
      * 
@@ -39,7 +40,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     {
         this.security = security;
     }
-    
+
     public String getTermCurrency()
     {
         return termCurrency;
@@ -51,19 +52,24 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     }
 
     public void visit(CurrencyConverter converter, DividendInitialTransaction t)
-    {}
+    {
+    }
 
     public void visit(CurrencyConverter converter, DividendFinalTransaction t)
-    {}
+    {
+    }
 
     public void visit(CurrencyConverter converter, DividendTransaction t)
-    {}
+    {
+    }
 
     public void visit(CurrencyConverter converter, PortfolioTransaction t)
-    {}
+    {
+    }
 
     public void visit(CurrencyConverter converter, AccountTransaction t)
-    {}
+    {
+    }
 
     public final void visitAll(CurrencyConverter converter, List<? extends Transaction> transactions)
     {
@@ -89,7 +95,7 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     {
         try
         {
-            T thing = type.newInstance();
+            T thing = type.getDeclaredConstructor().newInstance();
             thing.setSecurity(security);
             thing.setTermCurrency(converter.getTermCurrency());
             thing.visitAll(converter, transactions);


### PR DESCRIPTION
Anpassung einiger Funktionen da diese mit Java 11 als "veraltet" markiert wurden.
i.V.m. #1073

Fehlende. externe SE 11 Kompatibilität lt. MAVEN:

> `WARNING: An illegal reflective access operation has occurred`
> `WARNING: Illegal reflective access by org.eclipse.ecf.provider.filetransfer.httpclient4.SNIAwareHttpClient$1 (file:/xxx/.m2/repository/org/eclipse/tycho/tycho-bundles-external/1.3.0/eclipse/plugins/org.eclipse.ecf.provider.filetransfer.httpclient4_1.1.300.v20180301-0132.jar) to method sun.security.ssl.SSLSocketImpl.setHost(java.lang.String)`
>
>> see also https://bugs.eclipse.org/bugs/show_bug.cgi?id=535689


> `WARNING: An illegal reflective access operation has occurred`
> `WARNING: Illegal reflective access by com.thoughtworks.xstream.core.util.Fields (file:/xxx/.m2/repository/org/apache/servicemix/bundles/org.apache.servicemix.bundles.xstream/1.4.8_1/org.apache.servicemix.bundles.xstream-1.4.8_1.jar) to field java.util.TreeMap.comparator`