### PR TITLE
Make sure that no stale tooltips are shown

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/InfoToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/InfoToolTip.java
@@ -20,7 +20,7 @@ public final class InfoToolTip extends ToolTip
 
     private InfoToolTip(Control control, Supplier<String> message)
     {
-        super(control, ToolTip.NO_RECREATE, false);
+        super(control, ToolTip.RECREATE, false);
         this.control = control;
         this.message = message;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
@@ -57,6 +57,7 @@ public class MaxDrawdownDurationWidget extends AbstractIndicatorWidget<Performan
                                         formatter.format(maxDDDuration.getEnd()))
                         + "\n\n" //$NON-NLS-1$
                         + MessageFormat.format(Messages.TooltipMaxDurationLowToHigh, recoveryTime.getDays())
+                        + "\n" //$NON-NLS-1$
                         + MessageFormat.format(recoveryTimeSupplement, formatter.format(recoveryTime.getStart()),
                                         formatter.format(recoveryTime.getEnd())));
     }


### PR DESCRIPTION
**WARNING** This seems to be a dirty workaround to me. I'd be happy to see better solutions for this problem.

When tooltips are updated, sometimes the user will see an old version of the tooltip after displaying the new one once. Make sure that the user always sees the most recent one by forcing recreation on every
mouse move.

While here, improve readability of the MaxDrawdownDurationWidget tooltip.

Fixes #1074