### PR TITLE
rework classification tooltip in donut diagram

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutViewer.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 import javax.inject.Inject;
@@ -14,6 +15,7 @@ import org.eclipse.swt.widgets.Control;
 
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
 
@@ -56,8 +58,9 @@ import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
 
     private final class LoadDataFunction extends BrowserFunction
     {
+        private static final String CAPTION_CLASSIFICATION = "%s  (%s)"; //$NON-NLS-1$
         private static final String CAPTION_CLASSIFIED = "<b>%s  %s  (%s)</b><br>%s"; //$NON-NLS-1$
-        private static final String CAPTION_UNCLASSIFIED = "<b>%s  %s  (%s)</b>"; //$NON-NLS-1$
+        private static final String CAPTION_CLASSIFIED2 = "<b>%s  %s  (%s)</b><br>%s<br>%s"; //$NON-NLS-1$
         private static final String ENTRY = "{\"label\":\"%s\"," //$NON-NLS-1$
                         + "\"value\":%s," //$NON-NLS-1$
                         + "\"color\":\"%s\"," //$NON-NLS-1$
@@ -131,48 +134,128 @@ import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
         {
             String name = StringEscapeUtils.escapeJson(node.getName());
             String percentage = Values.Percent2.format(node.getActual().getAmount() / (double) total);
-            Classification cl = getClassification(node);
-            String caption;
-            if (cl != null)
+            // get classification nodes
+            TaxonomyNode taxn = getClassificationNode(node);
+            TaxonomyNode taxRoot = getRootClassificationNode(node);
+            // get classification caption for root node
+            String captionClassificationRoot = formatClassification(taxRoot, total);
+            // detect no classification
+            if (captionClassificationRoot == null)
             {
-                caption = String.format(CAPTION_CLASSIFIED, name, Values.Money.format(node.getActual()), percentage, //
-                                cl.getPathName(false));
+                captionClassificationRoot = Messages.LabelWithoutClassification;
+            }
+            String captionClassification = null;
+            // only use another entry if classification node is not the root of
+            // the classification
+            if (!Objects.equals(taxRoot, taxn))
+            {
+                captionClassification = formatClassification(taxn, total);
+            }
+            // build caption depending on available nodes
+            String caption;
+            if (captionClassification != null)
+            {
+                caption = String.format(CAPTION_CLASSIFIED2, name, Values.Money.format(node.getActual()), percentage, //
+                                captionClassification, captionClassificationRoot);
             }
             else
             {
-                caption = String.format(CAPTION_UNCLASSIFIED, name, Values.Money.format(node.getActual()), percentage);
+                caption = String.format(CAPTION_CLASSIFIED, name, Values.Money.format(node.getActual()), percentage, //
+                                captionClassificationRoot);
             }
             joiner.add(String.format(ENTRY, name, //
                             node.getActual().getAmount(), //
                             color, //
                             caption, //
                             percentage));
-
         }
         
         /**
-         * Gets the {@link Classification} for the given node (or form its
-         * parent if the node has none).
+         * Format the {@link Classification} of the given {@link TaxonomyNode}
+         * to a {@link String}.
+         * 
+         * @param taxn
+         *            {@link TaxonomyNode} (can be null)
+         * @param total
+         *            total amount
+         * @return {@link String} on success, else null
+         */
+        private String formatClassification(TaxonomyNode taxn, double total)
+        {
+            // check if node is valid
+            if ((taxn != null) && (taxn.getParent() != null) && !taxn.getParent().isRoot())
+            {
+                // check if it actually has a classification
+                Classification cl = taxn.getClassification();
+                if (cl != null)
+                {
+                    return String.format(CAPTION_CLASSIFICATION, cl.getPathName(false),
+                                    Values.Percent2.format(taxn.getActual().getAmount() / total));
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Gets the {@link Classification} node for the given node (or from its
+         * parents if the node has none).
          * 
          * @param node
          *            {@link TaxonomyNode}
          * @return {@link Classification} on success, else null
          */
-        private Classification getClassification(TaxonomyNode node)
+        private TaxonomyNode getClassificationNode(TaxonomyNode node)
         {
             // first try to get classification from the current node
             Classification cl = node.getClassification();
             if (cl != null)
             {
-                return cl;
+                return node;
             }
             // then try the parent node
             TaxonomyNode parent = node.getParent();
             if (parent != null)
             {
-                return getClassification(parent);
+                return getClassificationNode(parent);
             }
             return null;
         }
+        
+        /**
+         * Gets the root {@link Classification} node for the given node.
+         * 
+         * @param node
+         *            {@link TaxonomyNode}
+         * @return {@link Classification} on success, else null
+         */
+        private TaxonomyNode getRootClassificationNode(TaxonomyNode node)
+        {
+            // check if node has a parent
+            TaxonomyNode parent = node.getParent();
+            boolean parentIsRoot=false;
+            if ((parent != null))
+            {
+                if (!parent.isRoot())
+                {
+                    // try to walk further up
+                    TaxonomyNode tn = getRootClassificationNode(parent);
+                    if (tn != null)
+                    {
+                        return tn;
+                    }
+                }
+                else
+                {
+                    parentIsRoot = true;
+                }
+            }
+            // then try current node
+            if (!parentIsRoot && (node.getClassification() != null))
+            {
+                return node;
+            }
+            return null;
+        }
+
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNode.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNode.java
@@ -96,6 +96,12 @@ public abstract class TaxonomyNode implements Adaptable
             else
                 return super.adapt(type);
         }
+        
+        @Override
+        public String toString()
+        {
+            return getName();
+        }
     }
 
     /* protected */static class AssignmentNode extends TaxonomyNode


### PR DESCRIPTION
Show classification node with percentage and root classification node with percentage.
and provide TaxonomyNode with a toString to make debugging easier.

Looks like that for a classification with multiple levels:
![javaw_2019-04-02_21-24-36](https://user-images.githubusercontent.com/670885/55430314-148cce80-558e-11e9-85c3-f460c5a08670.png)

And like that for a single level:
![javaw_2019-04-02_21-27-41](https://user-images.githubusercontent.com/670885/55430354-28d0cb80-558e-11e9-9ff1-58a42f8bfe15.png)

Overall it allows using a donut diagram for single level classifications easily and provides some more insight for classifications with multiple levels.