### PR TITLE
Flatex Formatanpassungen Käufe / Ertragsgutschriften ab 2019

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -374,7 +374,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(tx.size(), is(1));
         
         assertThat(tx, hasItem(allOf( //
-                        hasProperty("dateTime", is(LocalDateTime.parse("2018-01-09T00:00"))), //
+                        hasProperty("dateTime", is(LocalDateTime.parse("2018-01-09T15:00"))), //
                         hasProperty("type", is(PortfolioTransaction.Type.BUY)), //
                         hasProperty("monetaryAmount",
                                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.16)))))));
@@ -586,10 +586,45 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
         assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(1279.55)));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-17T00:00")));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-17T17:52")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(8.61))));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(61)));
+    }
+    
+    @Test
+    public void testWertpapierKauf15_Fonds2019() throws IOException
+    {
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatexKauf15_Fonds2019.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("IE00BKM4GZ66"));
+        assertThat(security.getWkn(), is("A111X9"));
+        assertThat(security.getName(), is("IS C.MSCI EMIMI U.ETF DLA"));
+
+        item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(760.09)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-04-10T17:30")));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of("EUR", Values.Amount.factorize(8.41))));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(29)));
     }
 
     @Test
@@ -740,6 +775,39 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.12))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(15)));
+    }
+    
+    @Test
+    public void testErtragsgutschrift4_Fonds2019() throws IOException
+    {
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatexErtragsgutschrift4_Fonds2019.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("IE00B945VV12"));
+        assertThat(security.getWkn(), is("A1T8FS"));
+        assertThat(security.getName(), is("VANG.FTSE DEV.EU.UETF EOD"));
+
+        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getSecurity(), is(security));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-04-10T00:00")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(36.07)));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(197)));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexErtragsgutschrift4_Fonds2019.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexErtragsgutschrift4_Fonds2019.txt
@@ -1,0 +1,53 @@
+PDF author: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+flatex Bank AG
+Postfach 100551
+41405 Neuss
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+flatex Bank AG -  Rotfeder-Ring 7 - 60327 Frankfurt am Main
+0102262000001177823300
+Herrn
+Max Mustermann 
+-
+Musterstr. 123
+12345 Mustarstradt 
+             Frankfurt, 10.04.2019
+Ertragsmitteilung - ausschüttender/teilthesaurierender Fonds
+Ihre Depotnummer: 1234567890
+Depotinhaber    : Mustermann, Max
+Nr.1609141241                  VANG.FTSE DEV.EU.UETF EOD (IE00B945VV12/A1T8FS)
+St.             :           197,00    Bruttoausschüttung
+                                      pro Stück          :       0,1831170 EUR
+Extag           :       28.03.2019    Bruttoausschüttung :           36,07 EUR
+Valuta          :       10.04.2019
+                                      Bemessungsgrundlage:            0,00 EUR
+                                     *Einbeh. Steuer     :            0,00 EUR
+Teilfreist.-satz:            30,00 %  Teilfreistellung   :           10,82 EUR
+                                      Endbetrag          :           36,07 EUR
+* Enthalten sind folgende Steuern (negative Werte bedeuten Steuererstattung)
+                                    Kapitalertragsteuer  :            0,00 EUR
+                                    Solidaritätszuschlag :            0,00 EUR
+                                    Kirchensteuer        :            0,00 EUR
+  Details dazu inkl. evtl. angerechneter ausländischer Quellensteuer finden
+  Sie im Steuerreport unter der Transaktion-Nr.: 1234567890  .
+Die Verrechnung des Endbetrag erfolgt über Ihr Konto Nr.: 1234567890.
+Fondsinformationen:
+steuerpflichtiger Ertrag                                 :           25,25 EUR
+   davon ausländische Erträge mit anrechenb. QSt         :            0,00 EUR
+         ausländische Erträge mit anrechenb. fikt. QSt   :            0,00 EUR
+anrechenbare ausländische Quellensteuer**                :            0,00 EUR
+**  ggf. mit einbeh. Steuer verrechnet und/oder Quellensteuer-Topf zugeführt
+Die  Gutschrift erfolgt  unter Vorbehalt  des  Eingangs.  Einwendungen  müssen
+unverzüglich  nach  Zugang  erhoben  werden.  Die  Unterlassung  rechtzeitiger
+Einwendung gilt als Genehmigung.
+Dieser   Beleg   ist    keine   Steuerbescheinigung.    Kapitalerträge   sind
+einkommensteuerpflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Frank Niehage (Vorsitzender), Jörn Engelmann
+2000001177823300 0113102260000101

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexKauf15_Fonds2019.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexKauf15_Fonds2019.txt
@@ -1,0 +1,67 @@
+PDF Author: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+flatex Bank AG
+Postfach 100551
+41405 Neuss
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+flatex Bank AG -  Rotfeder-Ring 7 - 60327 Frankfurt am Main
+        Frankfurt, 10.04.2019
+0202272000001178205660
+Herr Auftragsdatum      10.04.2019n
+ZZZZZ ZZZZ Handelstag         10.04.2019xan
+ZZZZ ZZ Ausführungszeit    17:30 Uhr. 
+ZZZZ ZZZZZ Valuta             12.04.2019
+Auftragsnummer     121625906/1
+Ausf.platz/-art    Tradegate
+Wertpapierabrechnung Kauf Fonds/Zertifikate
+Ihre Depotnummer: 7777777777
+Depotinhaber:     ZZZZ, ZZZZZ
+Nr.121625906/1     Kauf        IS C.MSCI EMIMI U.ETF DLA (IE00BKM4GZ66/A111X9)
+Ausgeführt    :              29 St.     Kurswert      :             751,68 EUR
+Kurs          :       25,920000 EUR     Provision     :               5,90 EUR
+Devisenkurs   :        1,000000         Eigene Spesen :               0,00 EUR
+                                       *Fremde Spesen :               2,51 EUR
+Verwahrart    : Wertpapierrechnung
+Lagerstelle   : Clearstream Lux.
+Lagerland     : Großbritannien          Bemessungs-
+                                        grundlage     :               0,00 EUR
+Gewinn/Verlust:            0,00 EUR   **Einbeh. Steuer:               0,00 EUR
+                                        Endbetrag     :            -760,09 EUR
+*   Enthalten sind folgende Gebühren    Courtage      :               0,00 EUR
+                                        Tradingbegühr :               0,00 EUR
+                                        Regulierung   :               2,44 EUR
+                                        Schlussnoten  :               0,07 EUR
+                                        LS-Umlegung   :               0,00 EUR
+                                        Sonstige      :               0,00 EUR
+**  Enthalten sind folgende Steuern (negative Werte bedeuten Steuererstattung)
+                                 Kapitalerstragsteuer :               0,00 EUR
+                                 Solidaritätszuschlag :               0,00 EUR
+                                 Kirchensteuer        :               0,00 EUR
+    Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
+    1609519682.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: 7777777777
+Die Wertpapiere sowie den Gegenwert werden wir entsprechend der Abrechnung mit
+dem angegebenen Valutatag buchen. Bitte prüfen Sie diese Abrechnung auf
+______________________________________________________________________________
+                                                                     Seite 1/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Frank Niehage (Vorsitzender), Jörn Engelmann
+2000001178205660 0113202270000102
+Richtigkeit und Vollständigkeit. Etwaige Einwendungen gegen diese Abrechnung
+müssen unverzüglich nach Zugang bei der Bank erhoben werden. Die
+Unterlassung rechtzeitiger Einwendung gilt als Genehmigung. Bitte beachten
+Sie mögliche Hinweise des Emittenten hinsichtlich vorzeitiger Fälligstellung,
+beispielsweise wegen Knock-Out, in den jeweiligen Optionsscheinbedingungen und
+informieren Sie sich rechtzeitig, welche spezielle Fälligkeitsregelung auf die
+von Ihnen gehaltenen Wertpapiere zutreffen. Kapitalerträge sind ESt-pflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Frank Niehage (Vorsitzender), Jörn Engelmann
+2000001178205660 0113202270000202


### PR DESCRIPTION
noch ein kleiner Nachschlag für die aktuellen Flatex-PDFs, siehe:
https://forum.portfolio-performance.info/t/pdf-import-von-der-flatex-bank-funktioniert-nicht-mehr/4889
und
https://github.com/buchen/portfolio/issues/1153