### PR TITLE
fixes issue with VIAC PDF import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf03.txt
@@ -1,0 +1,28 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Stadt
+Basel, 07.01.2019
+Börsenabrechnung - Kauf
+Wir haben für Sie folgenden Auftrag ausgeführt:
+Order: Kauf
+1.924 Ant iShares Core S&P500
+ISIN: IE00B5BMR087
+Kurs: USD 500.51
+Betrag USD 1'001.02
+Umrechnungskurs CHF/USD 0.99838 CHF 999.40
+Stempelsteuer CHF 1.68
+Verrechneter Betrag: Valuta 07.01.2019 CHF 1'001.08
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf04.txt
@@ -1,0 +1,27 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Stadt
+Basel, 07.01.2019
+Börsenabrechnung - Kauf
+Wir haben für Sie folgenden Auftrag ausgeführt:
+Order: Kauf
+1.766 Ant CSIF SMI
+ISIN: CH0033782431
+Kurs: CHF 1'068.63
+Betrag CHF 1'886.94
+
+Verrechneter Betrag: Valuta 07.01.2019 CHF 1'886.94
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
@@ -113,6 +113,87 @@ public class ViacPDFExtractorTest
     }
 
     @Test
+    public void testKauf03()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacKauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.orElseThrow(IllegalArgumentException::new)).getSecurity();
+        assertThat(security.getIsin(), is("IE00B5BMR087"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+        assertThat(security.getName(), is("iShares Core S&P500"));
+
+        // check transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(1001.08))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-07T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.924)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("CHF", Values.Amount.factorize(1.68))));
+
+        Unit gross = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
+                        .orElseThrow(IllegalArgumentException::new);
+        assertThat(gross.getAmount(), is(Money.of("CHF", Values.Amount.factorize(999.40))));
+        assertThat(gross.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1001.02))));
+    }
+
+    @Test
+    public void testKauf04()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacKauf04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.orElseThrow(IllegalArgumentException::new)).getSecurity();
+        assertThat(security.getIsin(), is("CH0033782431"));
+        assertThat(security.getCurrencyCode(), is("CHF"));
+        assertThat(security.getName(), is("CSIF SMI"));
+
+        // check transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(1886.94))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-07T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.766)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("CHF", 0L)));
+    }
+
+    @Test
     public void testInterest01()
     {
         Client client = new Client();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
@@ -52,7 +52,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
                         })
 
                         .section("date", "amount", "currency") //
-                        .match("Verrechneter Betrag: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>[\\d+,.]*)")
+                        .match("Verrechneter Betrag: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)")
                         .assign((t, v) -> {
                             t.setDate(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -60,7 +60,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
                         })
 
                         .section("tax", "currency").optional() //
-                        .match("Stempelsteuer (?<currency>\\w{3}+) (?<tax>[\\d+,.]*)") //
+                        .match("Stempelsteuer (?<currency>\\w{3}+) (?<tax>[\\d+',.]*)") //
                         .assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             if (tax.getCurrencyCode().equals(t.getAccountTransaction().getCurrencyCode()))
@@ -69,8 +69,8 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
                         })
 
                         .section("forex", "forexCurrency", "amount", "currency", "exchangeRate").optional() //
-                        .match("Betrag (?<forexCurrency>\\w{3}+) (?<forex>[\\d+,.]*)")
-                        .match("Umrechnungskurs CHF/USD (?<exchangeRate>[\\d+,.]*) (?<currency>\\w{3}+) (?<amount>[\\d+,.]*)")
+                        .match("Betrag (?<forexCurrency>\\w{3}+) (?<forex>[\\d+',.]*)")
+                        .match("Umrechnungskurs CHF/USD (?<exchangeRate>[\\d+',.]*) (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)")
                         .assign((t, v) -> {
 
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
@@ -111,7 +111,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
                         .section("date", "amount", "currency") //
                         .find("Zins") //
                         .match("Am (?<date>\\d+.\\d+.\\d{4}+) haben wir Ihrem Konto gutgeschrieben:") //
-                        .match("Zinsgutschrift: (?<currency>\\w{3}+) (?<amount>[\\d+,.]*)") //
+                        .match("Zinsgutschrift: (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -138,7 +138,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
 
                         .section("date", "amount", "currency") //
                         .find("Belastung") //
-                        .match("Verrechneter Betrag: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>-?[\\d+,.]*)") //
+                        .match("Verrechneter Betrag: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>-?[\\d+',.]*)") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));


### PR DESCRIPTION
This PR fixes an issue with the import of VIAC PDFs for buy orders >= CHF 1k (e.g. CHF 1'500.00). Switzerland uses `'` as the thousands separator but the RegEx parsing VIAC PDFs didn't allow for them.

By allowing `'` for currencies in the VIAC regexes this issue is fixed. Also added more test cases covering this issue.