### PR TITLE
add support for VIAC credit note PDF extraction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacCreditNote01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacCreditNote01.txt
@@ -1,0 +1,24 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Stadt
+Basel, 15.01.2019
+Einzahlung 3a
+Gutschrift vom 15.01.2019:
+Zahlungseingang von: Einzahlung ABCD
+Referenznummer: 01 2344 5678 9012 345 6789
+Zahlungseingang: Betrag CHF 2'150.00
+Gutschrift: Valuta 15.01.2019 CHF 2'150.00
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacCreditNote02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacCreditNote02.txt
@@ -1,0 +1,24 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Stadt
+Basel, 15.01.2020
+Einzahlung 3a
+Gutschrift vom 15.01.2020:
+Zahlungseingang von: Einzahlung ABCD
+Referenznummer: 01 2344 5678 9012 345 6789
+Zahlungseingang: Betrag CHF 150.00
+Gutschrift: Valuta 15.01.2020 CHF 150.00
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
@@ -161,4 +161,54 @@ public class ViacPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-31T00:00")));
     }
+
+    @Test
+    public void testCreditNote01()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacCreditNote01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(2150.00))));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-15T00:00")));
+    }
+
+    @Test
+    public void testCreditNote02()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacCreditNote02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(150.00))));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-15T00:00")));
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
@@ -20,9 +20,37 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
 
         addBankIdentifier("Terzo"); //$NON-NLS-1$
 
+        addDepositTransaction();
         addBuyTransaction();
         addInterestTransaction();
         addFeeTransaction();
+    }
+
+    @SuppressWarnings("nls")
+    private void addDepositTransaction()
+    {
+        DocumentType type = new DocumentType("Einzahlung 3a");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("Einzahlung 3a");
+        type.addBlock(block);
+        block.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> {
+                            AccountTransaction transaction = new AccountTransaction();
+                            transaction.setType(AccountTransaction.Type.DEPOSIT);
+                            return transaction;
+                        })
+
+                        .section("date", "amount", "currency") //
+                        .find("Einzahlung 3a") //
+                        .match("Gutschrift: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>-?[\\d+',.]*)") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        })
+                        .wrap(TransactionItem::new));
     }
 
     @SuppressWarnings("nls")


### PR DESCRIPTION
Adds support to extract VIAC PDFs for deposits. 

This also already handles the issue in #1157 with the thousands separator.