### PR TITLE
Dashboard/total account

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -782,6 +782,8 @@ public class Messages extends NLS
     public static String PDFImportDebugAuthor;
     public static String PDFImportErrorParsingDocument;
     public static String PerformanceChartLabelEntirePortfolio;
+    public static String PerformanceChartLabelTotalAccounts;
+    public static String PerformanceChartLabelTotalPortfolios;
     public static String PerformanceChartLabelCPI;
     public static String PerformanceHeatmapToolTip;
     public static String PerformanceRelevantTransactionsFooter;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -479,6 +479,7 @@ public class Messages extends NLS
     public static String LabelDateXToY;
     public static String LabelDefaultReferenceAccountName;
     public static String LabelDelta;
+    public static String LabelDenominator;    
     public static String LabelDoImport;
     public static String LabelDoNotImport;
     public static String LabelEarnings;
@@ -517,6 +518,7 @@ public class Messages extends NLS
     public static String LabelNo;
     public static String LabelNoName;
     public static String LabelNotAvailable;
+    public static String LabelNumerator;    
     public static String LabelNumberDataSeries;
     public static String LabelOneOfX;
     public static String LabelOpenTrade;
@@ -536,6 +538,7 @@ public class Messages extends NLS
     public static String LabelQuote;
     public static String LabelQuoteFeed;
     public static String LabelQuoteFeedProvider;
+    public static String LabelRatio;
     public static String LabelRefresh;
     public static String LabelReportingAddPeriod;
     public static String LabelReportingDialogDays;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1575,6 +1575,10 @@ PerformanceChartLabelCPI = Consumer Price Index
 
 PerformanceChartLabelEntirePortfolio = Entire portfolio
 
+PerformanceChartLabelTotalAccounts = All accounts
+
+PerformanceChartLabelTotalPortfolios = All portfolios
+
 PerformanceHeatmapToolTip = Monthly rate of return displayed as heatmap\n\nTo calculate the montly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full month - even if the reporting interval ends or starts in the middle of a month.
 
 PerformanceRelevantTransactionsFooter = Total relevant transactions ({0})

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -961,6 +961,8 @@ LabelDefaultReferenceAccountName = Reference account
 
 LabelDelta = Delta (for reporting period)
 
+LabelDenominator = Denominator
+
 LabelDividendPerShare = dividend payment per shares
 
 LabelDividends = Dividends
@@ -1081,6 +1083,8 @@ LabelNoName = No Name
 
 LabelNotAvailable = n/a
 
+LabelNumerator = Numerator
+
 LabelNumberDataSeries = {0} data series
 
 LabelOneOfX = (1 of {0})
@@ -1118,6 +1122,8 @@ LabelQuote = Quote
 LabelQuoteFeed = Quote Feed
 
 LabelQuoteFeedProvider = Provider
+
+LabelRatio = Ratio
 
 LabelRefresh = Check again
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1569,6 +1569,10 @@ PerformanceChartLabelCPI = Verbraucherpreisindex
 
 PerformanceChartLabelEntirePortfolio = Gesamtportfolio
 
+PerformanceChartLabelTotalAccounts = Alle Konten
+
+PerformanceChartLabelTotalPortfolios = Alle Depots
+
 PerformanceHeatmapToolTip = Monatsrenditen in einer Heatmap\n\nZur Berechnung der Monatsrendite wird der True-Time Weighted Rate of Return (TTWROR) herangezogen.\n\nDie Rendite bezieht sich immer auf den gesamten Monat - selbst wenn der Berichtszeitraum in der Mitte des Monats beginnt bzw. endet.
 
 PerformanceRelevantTransactionsFooter = Summe relevanter Bewegungen ({0})

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -959,6 +959,8 @@ LabelDefaultReferenceAccountName = Verrechnungskonto
 
 LabelDelta = Delta (im Berichtszeitraum)
 
+LabelDenominator = Nenner
+
 LabelDividendPerShare = Dividende pro St\u00FCck
 
 LabelDividends = Dividenden
@@ -1077,6 +1079,8 @@ LabelNoName = Ohne Namen
 
 LabelNotAvailable = n/a
 
+LabelNumerator = Z\u00E4hler
+
 LabelNumberDataSeries = {0} Datenreihe{0,choice,0#n|1#|1<n}
 
 LabelOneOfX = (1 von {0})
@@ -1114,6 +1118,8 @@ LabelQuote = Kursnotierung
 LabelQuoteFeed = Kurslieferant
 
 LabelQuoteFeedProvider = Lieferant
+
+LabelRatio = Verh\u00E4ltnis
 
 LabelRefresh = Erneut pr\u00FCfen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1403,6 +1403,10 @@ PerformanceChartLabelCPI = \u00CDndice de Precios al Consumidor
 
 PerformanceChartLabelEntirePortfolio = Cartera completa
 
+PerformanceChartLabelTotalAccounts = Dep\u00F3sitos completa
+
+PerformanceChartLabelTotalPortfolios = Carteras completa
+
 PerformanceHeatmapToolTip = tasa mensual de retorno muestra como mapa de calor\n\nPara calcular la tasa mensual de rendimiento, se utiliza la tasa ponderada en tiempo real de retorno (TTWROR)\ntasa \nLa de rendimiento se calcula siempre por el mes completo -. incluso si el intervalo del informe termina o comienza en la mitad de un mes.
 
 PerformanceTabAssetsAtEnd = Activos al final

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -849,6 +849,8 @@ LabelDefaultReferenceAccountName = Cuenta de referencia
 
 LabelDelta = Delta (por per\u00EDodo de reporte)
 
+LabelDenominator = Denominador
+
 LabelDividendPerShare = pago de dividendos por acci\u00F3n
 
 LabelDividends = Dividendos
@@ -947,6 +949,8 @@ LabelNoName = Sin nombre
 
 LabelNotAvailable = N/A
 
+LabelNumerator = Numerador
+
 LabelOneOfX = (1 de {0})
 
 LabelOrderByTaxonomy = Ordenar por Clasificaci\u00F3n
@@ -976,6 +980,8 @@ LabelQuote = Cotizaci\u00F3n
 LabelQuoteFeed = Fuente de Cotizaci\u00F3n
 
 LabelQuoteFeedProvider = Proveedor
+
+LabelRatio = proporci\u00F3n
 
 LabelRefresh = Revisar otra vez
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
@@ -52,4 +52,11 @@ public abstract class AbstractIndicatorWidget<D> extends WidgetDelegate<D>
     {
         this.title.setText(TextUtil.tooltip(getWidget().getLabel()));
     }
+    
+    @Override    
+    public void updateLabel()
+    {       
+        String label = WidgetFactory.valueOf(getWidget().getType()).getLabel() + ", " + get(DataSeriesConfig.class).getDataSeries().getLabel(); //$NON-NLS-1$
+        getWidget().setLabel(label);
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
@@ -15,12 +15,9 @@ public abstract class AbstractIndicatorWidget<D> extends WidgetDelegate<D>
     protected Label title;
     protected Label indicator;
 
-    public AbstractIndicatorWidget(Widget widget, DashboardData dashboardData, boolean supportsBenchmarks)
+    public AbstractIndicatorWidget(Widget widget, DashboardData dashboardData)
     {
         super(widget, dashboardData);
-
-        addConfig(new DataSeriesConfig(this, supportsBenchmarks));
-        addConfig(new ReportingPeriodConfig(this));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfig.java
@@ -133,11 +133,7 @@ public class DataSeriesConfig implements WidgetConfig
         dataSeries = result.get(0);
         delegate.getWidget().getConfiguration().put(Dashboard.Config.DATA_SERIES.name(), dataSeries.getUUID());
 
-        // construct label to indicate the data series (user can manually change
-        // the label later)
-        String label = WidgetFactory.valueOf(delegate.getWidget().getType()).getLabel() + ", " + dataSeries.getLabel(); //$NON-NLS-1$
-        delegate.getWidget().setLabel(label);
-
+        delegate.updateLabel();
         delegate.update();
         delegate.getClient().touch();
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfig.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.eclipse.jface.action.IMenuManager;
@@ -17,23 +18,79 @@ import name.abuchen.portfolio.ui.views.dataseries.DataSeriesSelectionDialog;
 
 public class DataSeriesConfig implements WidgetConfig
 {
+    public static class Builder
+    {
+        private WidgetDelegate<?> delegate;
+        private String groupName = Messages.LabelDataSeries;
+        private DataSeries.Type defaultDataSeriesType = DataSeries.Type.CLIENT;
+        private boolean supportsBenchmarks = true;
+
+        public Builder(WidgetDelegate<?> delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        public Builder withGroupName(String groupName)
+        {
+            this.groupName = groupName;
+            return this;
+        }
+
+        public Builder withDefaultDataSeries(DataSeries.Type type)
+        {
+            this.defaultDataSeriesType = type;
+            return this;
+        }
+
+        public Builder withBenchmarkDataSeries(boolean supportsBenchmarks)
+        {
+            this.supportsBenchmarks = supportsBenchmarks;
+            return this;
+        }
+        
+        public DataSeriesConfig build()
+        {
+            Objects.requireNonNull(groupName);
+            Objects.requireNonNull(defaultDataSeriesType);
+
+            DataSeriesConfig config = new DataSeriesConfig(delegate, defaultDataSeriesType);
+            config.setGroupName(groupName);
+            config.setBenchmarkDataSeries(supportsBenchmarks);
+            return config;
+        }
+    }
+
     private final WidgetDelegate<?> delegate;
-    private final boolean supportsBenchmarks;
-
+    private String groupName;
     private DataSeries dataSeries;
+    private boolean supportsBenchmarks = true;
 
-    public DataSeriesConfig(WidgetDelegate<?> delegate, boolean supportsBenchmarks)
+    public DataSeriesConfig(WidgetDelegate<?> delegate, DataSeries.Type defaultDataSeriesType)
     {
         this.delegate = delegate;
-        this.supportsBenchmarks = supportsBenchmarks;
 
         String uuid = delegate.getWidget().getConfiguration().get(Dashboard.Config.DATA_SERIES.name());
         if (uuid != null && !uuid.isEmpty())
             dataSeries = delegate.getDashboardData().getDataSeriesSet().lookup(uuid);
-        if (dataSeries == null)
+        if (dataSeries == null)        
             dataSeries = delegate.getDashboardData().getDataSeriesSet().getAvailableSeries().stream()
-                            .filter(ds -> ds.getType().equals(DataSeries.Type.CLIENT)).findAny()
-                            .orElseThrow(IllegalArgumentException::new);
+                .filter(ds -> ds.getType().equals(defaultDataSeriesType)).findAny()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+    
+    public static Builder create(WidgetDelegate<?> delegate)
+    {
+        return new DataSeriesConfig.Builder(delegate);
+    }
+    
+    void setGroupName(String groupName)
+    {
+        this.groupName = groupName;
+    }
+
+    void setBenchmarkDataSeries(boolean supportsBenchmarks)
+    {
+        this.supportsBenchmarks = supportsBenchmarks;
     }
 
     public DataSeries getDataSeries()
@@ -46,7 +103,7 @@ public class DataSeriesConfig implements WidgetConfig
     {
         manager.appendToGroup(DashboardView.INFO_MENU_GROUP_NAME, new LabelOnly(dataSeries.getLabel()));
 
-        MenuManager subMenu = new MenuManager(Messages.LabelDataSeries);
+        MenuManager subMenu = new MenuManager(groupName);
         subMenu.add(new LabelOnly(dataSeries.getLabel()));
         subMenu.add(new Separator());
         subMenu.add(new SimpleAction(Messages.MenuSelectDataSeries, a -> doAddSeries(false)));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfigSerializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DataSeriesConfigSerializer.java
@@ -1,0 +1,54 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import name.abuchen.portfolio.ui.views.dataseries.DataSeriesSerializer;
+import name.abuchen.portfolio.ui.views.dataseries.DataSeriesSet;
+
+/**
+ * Convert a list of DataSeriesConfig object to a string and re-create again
+ * from a string.
+ */
+public class DataSeriesConfigSerializer
+{
+    public List<DataSeriesConfig> fromString(WidgetDelegate<?> delegate, String config)
+    {
+        DataSeriesSerializer ds = new DataSeriesSerializer();
+        List<DataSeriesConfig> configs = new ArrayList<>();
+        DataSeriesSet set = delegate.getDashboardData().getDataSeriesSet();
+
+        if (config != null && config.trim().length() > 0)
+        {
+            String[] items = config.split("\\$"); //$NON-NLS-1$
+            for (String item : items)
+            {
+                String[] data = item.split("\\|"); //$NON-NLS-1$
+                boolean benchmark = Boolean.parseBoolean(data[0]);
+                String uuid = ds.fromString(set, data[1]).get(0).getUUID();
+                configs.add(DataSeriesConfig.create(delegate).withDataSeries(uuid)
+                                .withBenchmarkDataSeries(benchmark).build());
+            }
+        }
+
+        if (configs.isEmpty())
+            configs.add(DataSeriesConfig.create(delegate).build());
+
+        return configs;
+    }
+
+    public String toString(List<DataSeriesConfig> configs)
+    {
+        DataSeriesSerializer ds = new DataSeriesSerializer();
+        StringBuilder buf = new StringBuilder();
+        for (DataSeriesConfig c : configs)
+        {
+            if (buf.length() > 0)
+                buf.append('$');
+            buf.append(Boolean.toString(c.getSupportsBenchmarkDataSeries())).append('|');
+            buf.append(ds.toString(Collections.singletonList(c.getDataSeries())));
+        }
+        return buf.toString();
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/IndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/IndicatorWidget.java
@@ -83,7 +83,10 @@ public class IndicatorWidget<N extends Number> extends AbstractIndicatorWidget<N
 
     public IndicatorWidget(Widget widget, DashboardData dashboardData, boolean supportsBenchmarks)
     {
-        super(widget, dashboardData, supportsBenchmarks);
+        super(widget, dashboardData);
+
+        addConfig(DataSeriesConfig.create(this).withBenchmarkDataSeries(supportsBenchmarks).build());
+        addConfig(new ReportingPeriodConfig(this));
     }
 
     public static <N extends Number> Builder<N> create(Widget widget, DashboardData dashboardData)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
@@ -25,7 +25,10 @@ public class MaxDrawdownDurationWidget extends AbstractIndicatorWidget<Performan
 
     public MaxDrawdownDurationWidget(Widget widget, DashboardData dashboardData)
     {
-        super(widget, dashboardData, true);
+        super(widget, dashboardData);
+
+        addConfig(DataSeriesConfig.create(this).withBenchmarkDataSeries(true).build());
+        addConfig(new ReportingPeriodConfig(this));
     }
 
     public String getToolTip()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiDataSeriesConfigConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiDataSeriesConfigConfig.java
@@ -1,0 +1,106 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.swt.widgets.Display;
+
+import name.abuchen.portfolio.model.Dashboard;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.LabelOnly;
+import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
+import name.abuchen.portfolio.ui.views.dataseries.DataSeriesSelectionDialog;
+
+public class MultiDataSeriesConfigConfig implements WidgetConfig
+{
+    private final WidgetDelegate<?> delegate;
+    private List<DataSeriesConfig> configs = new ArrayList<>();
+    
+    public MultiDataSeriesConfigConfig(WidgetDelegate<?> delegate)
+    {
+        this.delegate = delegate;
+    }
+    
+    public void load(List<DataSeriesConfig> dsConfigs)
+    {
+        String config = delegate.getWidget().getConfiguration().get(Dashboard.Config.DATA_SERIES.name());
+        if (config != null && !config.isEmpty())
+        {
+            for(DataSeriesConfig c : new DataSeriesConfigSerializer().fromString(delegate, config))
+                configs.add(c);
+        }
+        else
+        {
+            dsConfigs.forEach(p -> configs.add(p));
+            update();
+        }
+    }
+    
+    public List<DataSeries> getDataSeries()
+    {
+        return configs.stream().map(c -> c.getDataSeries()).collect(Collectors.toList());
+    }
+
+    @Override
+    public void menuAboutToShow(IMenuManager manager)
+    {
+        for (int aa = 0; aa < configs.size(); aa++)
+        {
+            final int bb = aa;
+            
+            manager.appendToGroup(DashboardView.INFO_MENU_GROUP_NAME, new LabelOnly(configs.get(aa).getDataSeries().getLabel()));
+
+            MenuManager subMenu = new MenuManager(configs.get(aa).getGroupName());
+            
+            subMenu.add(new LabelOnly(configs.get(aa).getDataSeries().getLabel()));
+            subMenu.add(new Separator());
+            subMenu.add(new SimpleAction(Messages.MenuSelectDataSeries, a -> doAddSeries(bb, false)));
+
+            if (configs.get(aa).getSupportsBenchmarkDataSeries())
+                subMenu.add(new SimpleAction(Messages.MenuSelectBenchmarkDataSeries, a -> doAddSeries(bb, true)));
+
+            manager.add(subMenu);
+        }
+    }    
+    
+    private void update()
+    {
+        delegate.getWidget().getConfiguration().put(Dashboard.Config.DATA_SERIES.name(),
+                        new DataSeriesConfigSerializer().toString(configs));
+        delegate.updateLabel();
+    }
+    
+    private void doAddSeries(int index, boolean showOnlyBenchmark)
+    {
+        List<DataSeries> list = delegate.getDashboardData().getDataSeriesSet().getAvailableSeries().stream()
+                        .filter(ds -> ds.isBenchmark() == showOnlyBenchmark).collect(Collectors.toList());
+
+        DataSeriesSelectionDialog dialog = new DataSeriesSelectionDialog(Display.getDefault().getActiveShell());
+        dialog.setElements(list);
+        dialog.setMultiSelection(false);
+
+        if (dialog.open() != DataSeriesSelectionDialog.OK)
+            return;
+
+        List<DataSeries> result = dialog.getResult();
+        if (result.isEmpty())
+            return;
+
+        configs.set(index, new DataSeriesConfig.Builder(delegate).withDataSeries(result.get(0).getUUID()).withBenchmarkDataSeries(showOnlyBenchmark).build());
+        
+        update();        
+        delegate.update();
+        delegate.getClient().touch();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return null;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiIndicatorWidget.java
@@ -157,17 +157,23 @@ public class MultiIndicatorWidget<N extends Number> extends AbstractIndicatorWid
 
     @Override
     public void update(N value)
-    {
-//        if (titleProvider != null)
-//            getWidget().setLabel(titleProvider.apply(
-//                        getAll(DataSeriesConfig.class).map(DataSeriesConfig::getDataSeries).collect(Collectors.toList()),
-//                        get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now())));        
-        
-        title.setText(getWidget().getLabel());      
+    {   
+        super.update(value);
         indicator.setText(formatter.format(value));
 
         if (isValueColored)
             indicator.setForeground(Display.getDefault()
                             .getSystemColor(value.doubleValue() < 0 ? SWT.COLOR_DARK_RED : SWT.COLOR_DARK_GREEN));
     }    
+    
+    @Override
+    public void updateLabel()
+    { 
+        if (titleProvider != null)
+            getWidget().setLabel(titleProvider.apply(
+                            getAll(DataSeriesConfig.class).map(DataSeriesConfig::getDataSeries).collect(Collectors.toList()),
+                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now())));  
+        else
+            super.updateLabel();
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MultiIndicatorWidget.java
@@ -1,0 +1,191 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+
+import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.util.InfoToolTip;
+import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
+import name.abuchen.portfolio.util.Interval;
+
+public class MultiIndicatorWidget<N extends Number> extends WidgetDelegate<N>
+{
+    public static class Builder<N extends Number>
+    {
+        private Widget widget;
+        private DashboardData dashboardData;
+        private int numSeries;
+        private Values<N> formatter;
+        private BiFunction<List<DataSeries>, Interval, N> provider;
+        private BiFunction<List<DataSeries>, Interval, String> tooltip;
+        private boolean supportsBenchmarks = true;
+        private boolean isValueColored = true;
+
+        public Builder(Widget widget, DashboardData dashboardData)
+        {
+            this.widget = widget;
+            this.dashboardData = dashboardData;
+        }
+
+        Builder<N> forSeries(int number)
+        {
+            this.numSeries = number;
+            return this;
+        }
+
+        Builder<N> with(Values<N> formatter)
+        {
+            this.formatter = formatter;
+            return this;
+        }
+
+        Builder<N> with(BiFunction<List<DataSeries>, Interval, N> provider)
+        {
+            this.provider = provider;
+            return this;
+        }
+
+        Builder<N> withTooltip(BiFunction<List<DataSeries>, Interval, String> tooltip)
+        {
+            this.tooltip = tooltip;
+            return this;
+        }
+
+        Builder<N> withBenchmarkDataSeries(boolean supportsBenchmarks)
+        {
+            this.supportsBenchmarks = supportsBenchmarks;
+            return this;
+        }
+
+        Builder<N> withColoredValues(boolean isValueColored)
+        {
+            this.isValueColored = isValueColored;
+            return this;
+        }
+
+        MultiIndicatorWidget<N> build()
+        {
+            Objects.requireNonNull(formatter);
+            Objects.requireNonNull(provider);
+
+            MultiIndicatorWidget<N> multiIndicatorWidget = new MultiIndicatorWidget<>(widget, dashboardData, numSeries,
+                            supportsBenchmarks);
+            multiIndicatorWidget.setFormatter(formatter);
+            multiIndicatorWidget.setProvider(provider);
+            multiIndicatorWidget.setTooltip(tooltip);
+            multiIndicatorWidget.setValueColored(isValueColored);
+            return multiIndicatorWidget;
+        }
+    }
+
+    protected Label title;
+    protected Label indicator;
+
+    private Values<N> formatter;
+    private BiFunction<List<DataSeries>, Interval, N> provider;
+    private BiFunction<List<DataSeries>, Interval, String> tooltip;
+    private boolean isValueColored = true;
+
+    public MultiIndicatorWidget(Widget widget, DashboardData dashboardData, int amount, boolean supportsBenchmarks)
+    {
+        super(widget, dashboardData);
+
+        for (int aa = 0; aa < amount; aa++)
+        {
+            addConfig(new DataSeriesConfig(this, supportsBenchmarks));
+        }
+
+        addConfig(new ReportingPeriodConfig(this));
+    }
+
+    @Override
+    public Control getTitleControl()
+    {
+        return title;
+    }
+
+    public static <N extends Number> Builder<N> create(Widget widget, DashboardData dashboardData)
+    {
+        return new MultiIndicatorWidget.Builder<>(widget, dashboardData);
+    }
+
+    void setFormatter(Values<N> formatter)
+    {
+        this.formatter = formatter;
+    }
+
+    void setProvider(BiFunction<List<DataSeries>, Interval, N> provider)
+    {
+        this.provider = provider;
+    }
+
+    void setTooltip(BiFunction<List<DataSeries>, Interval, String> tooltip)
+    {
+        this.tooltip = tooltip;
+    }
+
+    void setValueColored(boolean isValueColored)
+    {
+        this.isValueColored = isValueColored;
+    }
+
+    @Override
+    public Composite createControl(Composite parent, DashboardResources resources)
+    {
+        Composite container = new Composite(parent, SWT.NONE);
+        container.setBackground(parent.getBackground());
+        GridLayoutFactory.fillDefaults().numColumns(1).margins(5, 5).applyTo(container);
+
+        title = new Label(container, SWT.NONE);
+        title.setText(getWidget().getLabel());
+        title.setBackground(container.getBackground());
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(title);
+
+        indicator = new Label(container, SWT.NONE);
+        indicator.setFont(resources.getKpiFont());
+        indicator.setBackground(container.getBackground());
+        indicator.setText(""); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(indicator);
+
+        if (tooltip != null)
+            InfoToolTip.attach(indicator, () -> tooltip.apply(
+                            getAll(DataSeriesConfig.class).map(DataSeriesConfig::getDataSeries)
+                                            .collect(Collectors.toList()),
+                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now())));
+
+        return container;
+    }
+
+    @Override
+    public Supplier<N> getUpdateTask()
+    {
+        return () -> provider.apply(
+                        getAll(DataSeriesConfig.class).map(DataSeriesConfig::getDataSeries)
+                                        .collect(Collectors.toList()),
+                        get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
+    }
+
+    @Override
+    public void update(N value)
+    {
+        title.setText(getWidget().getLabel());
+        indicator.setText(formatter.format(value));
+
+        if (isValueColored)
+            indicator.setForeground(Display.getDefault()
+                            .getSystemColor(value.doubleValue() < 0 ? SWT.COLOR_DARK_RED : SWT.COLOR_DARK_GREEN));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -66,7 +66,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         super(widget, dashboardData);
 
         addConfig(new ReportingPeriodConfig(this));
-        addConfig(new DataSeriesConfig(this, false));
+        addConfig(DataSeriesConfig.create(this).withBenchmarkDataSeries(false).build());
         addConfig(new LayoutConfig(this));
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
@@ -90,6 +90,15 @@ public abstract class WidgetDelegate<D>
     public abstract Supplier<D> getUpdateTask();
 
     public abstract void update(D data);
+    
+    /**
+     * Call to update the label of the widget
+     */
+    public void updateLabel()
+    {
+        // get default label of the widget
+        getWidget().setLabel(WidgetFactory.valueOf(getWidget().getType()).getLabel());        
+    }
 
     /**
      * Returns the title control to which context menu and default tooltip are

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.swt.widgets.Composite;
@@ -54,6 +55,11 @@ public abstract class WidgetDelegate<D>
     {
         return type.cast(config.stream().filter(c -> type.equals(c.getClass())).findAny()
                         .orElseThrow(IllegalArgumentException::new));
+    }
+
+    public <C extends WidgetConfig> Stream<C> getAll(Class<C> type)
+    {
+        return config.stream().filter(c -> type.equals(c.getClass())).map(type::cast);
     }
 
     public <C extends WidgetConfig> Optional<C> optionallyGet(Class<C> type)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.swt.widgets.Composite;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -59,12 +59,22 @@ public enum WidgetFactory
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
     
-    RATIO("Ratio", Messages.LabelStatementOfAssets, //
+    RATIO(Messages.LabelRatio, Messages.LabelStatementOfAssets, //
                     (widget, data) -> MultiIndicatorWidget.<Double>create(widget, data) //
-                    .forSeries(2)
+                    .withDataSeries(delegate -> DataSeriesConfig.create(delegate)
+                                    .withGroupName(Messages.LabelNumerator)
+                                    .withDefaultDataSeries(DataSeries.Type.ACCOUNTS_TOTAL)
+                                    .withBenchmarkDataSeries(false)
+                                    .build())                    
+                    .withDataSeries(delegate -> DataSeriesConfig.create(delegate)
+                                    .withGroupName(Messages.LabelDenominator)
+                                    .withDefaultDataSeries(DataSeries.Type.PORTFOLIOS_TOTAL)
+                                    .withBenchmarkDataSeries(false)
+                                    .build())
+                    .withTitle((dsList, period) -> 
+                        Messages.LabelRatio + ": " + dsList.get(0).getLabel() + " / " + dsList.get(1).getLabel()) //$NON-NLS-1$ //$NON-NLS-2$
                     .with(Values.Percent2) //
-                    .with((dsList, period) -> {
-                        
+                    .with((dsList, period) -> {                        
                         PerformanceIndex index = data.calculate(dsList.get(0), period);
                         int length = index.getTotals().length;
                         long numerator = index.getTotals()[length - 1];

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -58,6 +58,24 @@ public enum WidgetFactory
                                     }) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
+    
+    RATIO("Ratio", Messages.LabelStatementOfAssets, //
+                    (widget, data) -> MultiIndicatorWidget.<Double>create(widget, data) //
+                    .forSeries(2)
+                    .with(Values.Percent2) //
+                    .with((dsList, period) -> {
+                        
+                        PerformanceIndex index = data.calculate(dsList.get(0), period);
+                        int length = index.getTotals().length;
+                        long numerator = index.getTotals()[length - 1];
+                        
+                        index = data.calculate(dsList.get(1), period);
+                        length = index.getTotals().length;
+                        long denominator = index.getTotals()[length - 1];
+                                                
+                        return (double) numerator / denominator;
+                    }) //
+                    .build()),
 
     DELTA(Messages.LabelAbsoluteDelta, Messages.LabelStatementOfAssets, //
                     (widget, data) -> IndicatorWidget.<Long>create(widget, data) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -21,7 +21,7 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
 
         addConfig(new ColorSchemaConfig(this));
         addConfig(new HeatmapOrnamentConfig(this));
-        addConfig(new DataSeriesConfig(this, true));
+        addConfig(DataSeriesConfig.create(this).withBenchmarkDataSeries(true).build());
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -49,8 +49,10 @@ public final class DataSeries
         SECURITY_BENCHMARK("[b]Security", i -> ((Security) i).getUUID()), //$NON-NLS-1$
         ACCOUNT("Account", i -> ((Account) i).getUUID()), //$NON-NLS-1$
         ACCOUNT_PRETAX("Account-PreTax", i -> ((Account) i).getUUID()), //$NON-NLS-1$
+        ACCOUNTS_TOTAL("Accounts-", i -> ((ClientDataSeries) i).name().toLowerCase(Locale.US)), //$NON-NLS-1$
         PORTFOLIO("Portfolio", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
         PORTFOLIO_PRETAX("Portfolio-PreTax", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
+        PORTFOLIOS_TOTAL("Portfolios-", i -> ((ClientDataSeries) i).name().toLowerCase(Locale.US)), //$NON-NLS-1$
         PORTFOLIO_PLUS_ACCOUNT("[+]Portfolio", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
         PORTFOLIO_PLUS_ACCOUNT_PRETAX("[+]Portfolio-PreTax", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
         CLASSIFICATION("Classification", i -> ((Classification) i).getId()), //$NON-NLS-1$
@@ -201,9 +203,11 @@ public final class DataSeries
             case SECURITY_BENCHMARK:
                 return Images.SECURITY.image();
             case ACCOUNT:
+            case ACCOUNTS_TOTAL:
             case ACCOUNT_PRETAX:
                 return Images.ACCOUNT.image();
             case PORTFOLIO:
+            case PORTFOLIOS_TOTAL:
             case PORTFOLIO_PRETAX:
             case PORTFOLIO_PLUS_ACCOUNT:
             case PORTFOLIO_PLUS_ACCOUNT_PRETAX:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
@@ -134,6 +134,9 @@ public class DataSeriesCache
 
                 case PORTFOLIO_PRETAX:
                     return calculatePortfolioPretax(series, reportingPeriod, warnings);
+                    
+                case PORTFOLIOS_TOTAL:
+                    return PerformanceIndex.forAllPortfolios(client, converter, reportingPeriod, warnings);
 
                 case PORTFOLIO_PLUS_ACCOUNT:
                     return PerformanceIndex.forPortfolioPlusAccount(client, converter, (Portfolio) series.getInstance(),
@@ -148,6 +151,9 @@ public class DataSeriesCache
 
                 case ACCOUNT_PRETAX:
                     return calculateAccountPretax(series, reportingPeriod, warnings);
+                                        
+                case ACCOUNTS_TOTAL:
+                    return PerformanceIndex.forAllAccounts(client, converter, reportingPeriod, warnings);
 
                 case CLASSIFICATION:
                     Classification classification = (Classification) series.getInstance();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
@@ -73,7 +73,7 @@ public class DataSeriesSet
     {
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS, Messages.LabelTotalSum,
                         Colors.TOTALS.getRGB()));
-
+        
         DataSeries series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TRANSFERALS,
                         Messages.LabelTransferals, Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY).getRGB());
         series.setLineChart(false);
@@ -238,7 +238,8 @@ public class DataSeriesSet
             availableSeries.add(new DataSeries(DataSeries.Type.SECURITY, security, security.getName(), //
                             wheel.next()));
         }
-
+        
+        // portfolios
         for (Portfolio portfolio : client.getPortfolios())
             availableSeries.add(new DataSeries(DataSeries.Type.PORTFOLIO, portfolio, portfolio.getName(), //
                             wheel.next()));
@@ -251,12 +252,19 @@ public class DataSeriesSet
                             wheel.next());
             availableSeries.add(series);
         }
-
+        
+        // sum of portfolios
+        availableSeries.add(new DataSeries(DataSeries.Type.PORTFOLIOS_TOTAL, ClientDataSeries.TOTALS, Messages.PerformanceChartLabelTotalPortfolios, wheel.next()));
+        
         addCustomClientFilters(client, preferences, false, wheel);
 
+        // accounts
         for (Account account : client.getAccounts())
             availableSeries.add(new DataSeries(DataSeries.Type.ACCOUNT, account, account.getName(), wheel.next()));
 
+        // sum of accounts
+        availableSeries.add(new DataSeries(DataSeries.Type.ACCOUNTS_TOTAL, ClientDataSeries.TOTALS, Messages.PerformanceChartLabelTotalAccounts, wheel.next()));
+        
         for (Taxonomy taxonomy : client.getTaxonomies())
         {
             taxonomy.foreach(new Taxonomy.Visitor()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -81,10 +81,24 @@ public class PerformanceIndex
         return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
     }
 
+    public static PerformanceIndex forAllAccounts(Client client, CurrencyConverter converter,
+                    Interval reportInterval, List<Exception> warnings)
+    {
+        Client pseudoClient = new PortfolioClientFilter(Collections.emptyList(), client.getAccounts()).filter(client);
+        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
+    }
+
     public static PerformanceIndex forPortfolio(Client client, CurrencyConverter converter, Portfolio portfolio,
                     Interval reportInterval, List<Exception> warnings)
     {
         Client pseudoClient = new PortfolioClientFilter(portfolio).filter(client);
+        return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
+    }
+
+    public static PerformanceIndex forAllPortfolios(Client client, CurrencyConverter converter,
+                    Interval reportInterval, List<Exception> warnings)
+    {
+        Client pseudoClient = new PortfolioClientFilter(client.getActivePortfolios(), Collections.emptyList()).filter(client);
         return PerformanceIndex.forClient(pseudoClient, converter, reportInterval, warnings);
     }
 


### PR DESCRIPTION
Um einen Überblick über mein investiertes Geld und liquiden Mitteln zu bekommen, habe ich schon seit längerem die entsprechenden Beträge als 'Gesamtsumme'-Widget im Dashboard angezeigt. Dies ging bisher leider nur jeweils pro Depot und dazugehörigem Referenzkonto und diente nur der groben Übersicht.

Nun wollte ich mir direkt die Cashqoute anzeigen lassen. Habe hierzu 2 weitere Datenreihen hinzugefügt, welche sich aus jeweils allen Konten und Depots berechnen.
Das Widget selbst, bildet aus den beiden Reihen (und natürlich jeder anderen) den Quotienten. 
Habe versucht es sehr allgemeingültig zu halten, sodass alles über die WidgetFactory einstellbar ist (Man könnte im Prinzip alle Rechenoperationen o.Ä. hierrüber realisieren). Hierfür musste ich hauptsächlich die DataSeriesConfig anpassen.

Anmerkung:
Für das Gesamte Barvermögen gibt es bereits eine Asset Klasse, auch hätte ich einen neue Klasse mit allen Konten erstellen können, nur einen Sammler für alle anderen Klassen konnte ich nicht finden. 
Allgemein stört mich der Wust an Einträgen bei der Auswahl der Daten (Depot, Depot vor Steuern, Depot+Konto, Depot+Konto vor Steuern). Zumal dann eh nicht die kombi dabei ist, welche man gerade benötigt. Ideal wäre, einfach per mehrfach Selektion die gewünschten Reihen auszuwählen. Habe auch gesehen, dass dies im Code eigentlich schon vorbereitet ist. Gibt es einen Grund dies nicht so zu tun?

PS: Bin dem Spanisch nicht mächtig, hoffe ich habe richtig geraten ;)
