### PR TITLE
IngDiBa tax at source without foreign currency

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -567,7 +567,39 @@ public class INGDiBaPDFExtractorTest
         assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.34))));
         assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(89.53))));
     }
+    
+    @Test
+    public void testDividendengutschrift4() throws IOException
+    {
+        INGDiBaExtractor extractor = new INGDiBaExtractor(new Client());
 
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "INGDiBa_Dividendengutschrift4.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("BE0974293251"));
+        assertThat(security.getWkn(), is("A2ASUV"));
+        assertThat(security.getName(), is("Anheuser-Busch InBev S.A./N.V."));
+
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().get().getSubject();
+
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(t.getAmount(), is(Values.Amount.factorize(38.5)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2019-05-09T00:00")));
+        assertThat(t.getShares(), is(Values.Share.factorize(55)));
+
+        assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.5))));
+        assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.0))));
+    }
+
+    
     @Test
     public void testGemeinschaftskontoDividendengutschrift1() throws IOException
     {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_Dividendengutschrift4.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBa_Dividendengutschrift4.txt
@@ -1,0 +1,38 @@
+ING-DiBa AG · 60628 Frankfurt am Main
+Depotinhaber: Vorname Nachname
+Herrn Direkt-Depot Nr.: 0000000000
+Vorname Nachname Datum: 10.05.2019
+Straße Nummer Seite: 1 von 2
+PLZ Ort
+Dividendengutschrift
+ISIN (WKN) BE0974293251 (A2ASUV)
+Wertpapierbezeichnung Anheuser-Busch InBev S.A./N.V.
+Actions au Port. o.N.
+Nominale 55,00 Stück
+Zins-/Dividendensatz 1,00 EUR
+Ex-Tag 07.05.2019
+Zahltag 09.05.2019
+Brutto EUR 55,00
+QuSt 30,00 % EUR 16,50
+Gesamtbetrag zu Ihren Gunsten EUR 38,50
+Abrechnungs-IBAN DE00 0000 0000 0000 0000 00
+Valuta 09.05.2019
+Jahressteuerbescheinigung folgt.
+Weitere steuerliche Informationen entnehmen Sie bitte der Rückseite.
+ING-DiBa AG · Theodor-Heuss-Allee 2 · 60486 Frankfurt am Main · Vorsitzender des Aufsichtsrates: Dr. Claus Dieter Hoffmann · Vorstand: Nick Jue (Vorsitzender),
+Bernd Geilen (stellv. Vorsitzender), Zeljko Kaurin, Dr. Joachim von Schorlemer, Norman Tambach · Sitz: Frankfurt am Main · AG Frankfurt am Main HRB 7727,
+Steuernummer: 047 220 2800 4 · USt-IdNr.: DE 114 103 475 · Internet: www.ing.de · E-Mail: info@ing.de · BIC: INGDDEFFXXX · Mitglied im Einlagensicherungsfonds
+Depotinhaber: Vorname Nachname
+Direkt-Depot Nr.: 0000000000
+Datum: 10.05.2019
+Seite: 2 von 2
+ISIN (WKN) BE0974293251 (A2ASUV)
+Anrechenbare ausländische Quellensteuer 8,25 EUR
+KapSt-pflichtiger Kapitalertrag 55,00 EUR
+Mit Sparer-Pauschbetrag verrechnet -55,00 EUR
+Sparer-Pauschbetrag vor Ertrag 800,00 EUR
+Sparer-Pauschbetrag nach Ertrag 745,00 EUR
+Verrechnungstopf ausländ. Quellenst. vor Ertrag 0,00 EUR
+Verrechnungstopf ausländ. Quellenst. nach Ertrag 8,25 EUR
+Bei Fragen besuchen Sie uns einfach unter www.ing.de/wertpapierwissen - da gibt es viele schnelle
+Antworten. Oder senden Sie uns eine E-Mail an info@ing.de .

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -445,6 +445,14 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
                             t.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, asAmount(v.get("tax")))));
                         else
                             t.addUnit(new Unit(Unit.Type.TAX, Money.of(currencyTx, asAmount(v.get("taxTx")))));
+                    })
+                    // Quellensteuer ohne Fremdwährung
+                    .section("tax", "currency") //
+                    .optional() //
+                    .match("QuSt \\d+,\\d+ % (?<currency>\\w{3}+) (?<tax>[\\d.,]*)")
+                    .assign((t, v) -> {
+                        String currency = asCurrencyCode(v.get("currency"));
+                        t.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, asAmount(v.get("tax")))));
                     });
 
     }


### PR DESCRIPTION
Aus https://forum.portfolio-performance.info/t/quellensteuer-bei-ing-import/5180/2

Gibt es hier noch eine schönere Lösung, als eine 2. Section einzufügen?
Es würde auch mit einer RegEx für die Quellensteuer gehen, aber dazu müsste es möglich sein an der Section Attribute anzugeben, die optional sind. Aktuell müssen alle angegeben Attribute vorhanden sein.