### PR TITLE
Add column to classification views (e.g. asset allocation view) showing percentage of total, i.e. how many % of total assets are invested in an asset class

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -201,6 +201,7 @@ public class Messages extends NLS
     public static String ColumnNote;
     public static String ColumnNumberOfTransactions;
     public static String ColumnOffsetAccount;
+    public static String ColumnPctOfTotal;
     public static String ColumnPeer;
     public static String ColumnPerShare;
     public static String ColumnPerShare_Description;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -445,6 +445,8 @@ ColumnNumberOfTransactions = # transactions
 
 ColumnOffsetAccount = Offset Account
 
+ColumnPctOfTotal = % of total
+
 ColumnPeer = Deposit Account or Securities Account
 
 ColumnPerShare = per share

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -443,6 +443,8 @@ ColumnNumberOfTransactions = # Buchungen
 
 ColumnOffsetAccount = Gegenkonto
 
+ColumnPctOfTotal = % am GV
+
 ColumnPeer = Depot oder Konto
 
 ColumnPerShare = pro Aktie

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -383,6 +383,8 @@ ColumnNote = Nota
 
 ColumnOffsetAccount = Cuenta de contrapartida
 
+ColumnPctOfTotal = % del total
+
 ColumnPerShare = por acci\u00F3n
 
 ColumnPerShare_Description = Para las transacciones de compra / venta / entrega, esta columna contiene el valor por acci\u00F3n.\n\nPara transacciones de dividendos esta columna contiene el dividendo bruto por acci\u00F3n.

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -524,6 +524,28 @@ import name.abuchen.portfolio.ui.views.columns.NoteColumn;
         });
         support.addColumn(column);
 
+        // Column which shows percentage of this asset class in relationship to total assets  
+        column = new Column("amGV%", Messages.ColumnPctOfTotal, SWT.RIGHT, 60); //$NON-NLS-1$
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                TaxonomyNode node = (TaxonomyNode) element;
+                // Divide amount in this asset class by amount of total assets (root of asset class tree)
+                long actual = node.getActual().getAmount();
+                long total = node.getRoot().getActual().getAmount();
+
+                if (total == 0)
+                    return Values.Percent.format(0d);
+                else
+                    // Might consider to use PercentShort here (i.e. "51.1%" instead of "51.13%") as higher accuracy seems distracting to me here
+                    return Values.Percent.format((double) actual / (double) total);
+            }
+        });
+        support.addColumn(column);
+        
+        
         column = new Column("act", Messages.ColumnActualValue, SWT.RIGHT, 100); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNode.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNode.java
@@ -238,6 +238,14 @@ public abstract class TaxonomyNode implements Adaptable
         return parent == null;
     }
 
+    public TaxonomyNode getRoot()
+    {
+        if(parent == null){
+            return this;
+        }
+        return parent.getRoot();
+    }
+    
     public List<TaxonomyNode> getChildren()
     {
         return children;


### PR DESCRIPTION
Fügt eine Spalte hinzu, die im Asset Allocation-View (und anderen Klassifikationsviews) zusätzlich den prozentualen Anteil der jeweiligen Klasse am Gesamtvermögen ausgibt. Siehe auch meine Anfrage hier https://forum.portfolio-performance.info/t/prozentualer-anteil-am-gesamtvermoegen-in-asset-allocation/4990 
Mir ist bewusst, dass man in der Vermögensaufstellung den Anteil der Top-Level-Kategorie ("Risikobehafteter Portfolioanteil" / "Risikofreier Portfolioanteil") am Gesamtvermögen sehen kann, für mich sind aber die Anteile der Unterklassen (wie z.B. "Aktien Large Caps Value" im Kommer-Beispieldepot) wichtig. Vielleicht ist es ja auch für andere nützlich.
Zur Implementation: da ich mich mit dem Objektmodell von PP noch nicht auskenne, habe ich kurzerhand getRoot() implementiert, um an das Gesamtvermögen zu kommen - wenn es bessere Lösungen gibt, gerne ändern.

![image](https://user-images.githubusercontent.com/5220023/59152694-b2e35780-8a49-11e9-9e1e-24e4816b6512.png)

