### PR TITLE
allow more foreign currencies in viac pdf extractor buy transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacKauf05.txt
@@ -1,0 +1,28 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Ort
+Basel, 07.01.2019
+Börsenabrechnung - Kauf
+Wir haben fÃ¼r Sie folgenden Auftrag ausgefÃ¼hrt:
+Order: Kauf
+1.024 Ant CSIF Europe ex CH
+ISIN: CH0037606552
+Kurs: EUR 620.57
+Betrag EUR 635.26
+Umrechnungskurs CHF/EUR 1.1322 CHF 719.24
+Verrechneter Betrag: Valuta 07.01.2019 CHF 719.24
+S. E. & O.
+Freundliche GrÃ¼sse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift
+

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
@@ -56,10 +56,10 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
     @SuppressWarnings("nls")
     private void addBuyTransaction()
     {
-        DocumentType type = new DocumentType("Börsenabrechnung - Kauf");
+        DocumentType type = new DocumentType("abrechnung - Kauf");
         this.addDocumentTyp(type);
 
-        Block block = new Block("Börsenabrechnung - Kauf");
+        Block block = new Block("B.rsenabrechnung - Kauf");
         type.addBlock(block);
         block.set(new Transaction<BuySellEntry>()
 
@@ -98,7 +98,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
 
                         .section("forex", "forexCurrency", "amount", "currency", "exchangeRate").optional() //
                         .match("Betrag (?<forexCurrency>\\w{3}+) (?<forex>[\\d+',.]*)")
-                        .match("Umrechnungskurs CHF/USD (?<exchangeRate>[\\d+',.]*) (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)")
+                        .match("Umrechnungskurs CHF/\\w{3}+ (?<exchangeRate>[\\d+',.]*) (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)")
                         .assign((t, v) -> {
 
                             Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));


### PR DESCRIPTION
The VIAC PDF extractor currently only supports USD as foreign
currencies. In reality there can be other foreign currencies as well.

This change allows for any foreign currency in the VIAC PDF extractor
and adds a test for this case.