### PR TITLE
add support for VIAC dividend PDFs

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend01.txt
@@ -1,0 +1,28 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Nummer
+PLZ Ort
+Basel, 21.05.2019
+Dividendenausschuttung
+Wir haben fÃ¼r Sie folgende AusschÃ¼ttung verbucht:
+Dividendenart: Ordentliche Dividende
+0.242 Ant CSIF Pacific ex Japan
+ISIN: CH0030849654
+Ausschuttung: CHF 0.18
+Betrag CHF 0.04
+ 
+Gutgeschriebener Betrag: Valuta 21.05.2019 CHF 0.04
+S. E. & O.
+Freundliche GrÃ¼sse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend02.txt
@@ -1,0 +1,28 @@
+PDF Author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragsnummer Anrede
+Portfolio Portfolio Vorname Nachname
+Strasse Nummer
+PLZ Ort
+Basel, 21.05.2019
+Dividendenausschuttung
+Wir haben fÃ¼r Sie folgende AusschÃ¼ttung verbucht:
+Dividendenart: Ordentliche Dividende
+0.176 Ant CSIF Canada
+ISIN: CH0030849613
+Ausschuttung: CAD 1.12
+Betrag CAD 0.20
+Umrechnungskurs CHF/CAD 0.7466 CHF 0.15
+Gutgeschriebener Betrag: Valuta 21.05.2019 CHF 0.15
+S. E. & O.
+Freundliche GrÃ¼sse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.hamcrest.number.IsCloseTo;
 import org.junit.Test;
 
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
@@ -291,5 +292,71 @@ public class ViacPDFExtractorTest
                         is(Money.of("CHF", Values.Amount.factorize(150.00))));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-15T00:00")));
+    }
+
+    @Test
+    public void testDividend01()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacDividend01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("CH0030849654"));
+        assertThat(security.getName(), is("CSIF Pacific ex Japan"));
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(0.04))));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.242)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-05-21T00:00")));
+
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", Values.Amount.factorize(0))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(0.04))));
+    }
+
+    @Test
+    public void testDividend02()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacDividend02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("CH0030849613"));
+        assertThat(security.getName(), is("CSIF Canada"));
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(0.15))));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.176)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-05-21T00:00")));
+
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", Values.Amount.factorize(0))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(0.15))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).get().getForex(), is(Money.of("CAD", Values.Amount.factorize(0.20))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).get().getExchangeRate().doubleValue(), IsCloseTo.closeTo(0.7466, 0.000001));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
@@ -24,6 +24,7 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
         addBuyTransaction();
         addInterestTransaction();
         addFeeTransaction();
+        addDividendsTransaction();
     }
 
     @SuppressWarnings("nls")
@@ -172,6 +173,63 @@ public class ViacPDFExtractor extends SwissBasedPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
+                        .wrap(TransactionItem::new));
+    }
+
+    @SuppressWarnings("nls")
+    private void addDividendsTransaction()
+    {
+        DocumentType type = new DocumentType("Dividendenaussch");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("Dividendenaussch.ttung");
+        type.addBlock(block);
+        block.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> {
+                            AccountTransaction transaction = new AccountTransaction();
+                            transaction.setType(AccountTransaction.Type.DIVIDENDS);
+                            return transaction;
+                        })
+
+                        .section("shares", "name", "isin", "currency") //
+                        .find("Dividendenart: Ordentliche Dividende") //
+                        .match("(?<shares>[\\d+,.]*) Ant (?<name>.*)$") //
+                        .match("ISIN: (?<isin>\\S*)") //
+                        .match("Aussch.ttung: (?<currency>\\w{3}+) .*")
+                        .assign((t, v) -> {
+                            t.setSecurity(getOrCreateSecurity(v));
+                            t.setShares(asShares(v.get("shares")));
+                        })
+
+                        .section("date", "amount", "currency") //
+                        .match("Gutgeschriebener Betrag: Valuta (?<date>\\d+.\\d+.\\d{4}+) (?<currency>\\w{3}+) (?<amount>-?[\\d+',.]*)") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        })
+
+                        .section("forex", "forexCurrency", "amount", "currency", "exchangeRate").optional() //
+                        .match("Betrag (?<forexCurrency>\\w{3}+) (?<forex>[\\d+',.]*)")
+                        .match("Umrechnungskurs CHF/\\w{3}+ (?<exchangeRate>[\\d+',.]*) (?<currency>\\w{3}+) (?<amount>[\\d+',.]*)")
+                        .assign((t, v) -> {
+
+                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
+                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                            Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
+
+                            // only add gross value with forex if the security
+                            // is actually denoted in the foreign currency
+                            // (often users actually have the quotes in their
+                            // home country currency)
+                            if (forex.getCurrencyCode()
+                                            .equals(t.getSecurity().getCurrencyCode()))
+                            {
+                                t.addUnit(new Unit(Unit.Type.GROSS_VALUE, gross, forex, exchangeRate));
+                            }
+                        })
+
                         .wrap(TransactionItem::new));
     }
 


### PR DESCRIPTION
Adds support for dividend PDFs from VIAC. 

With these changes I still see one issue: CSIF Pacific ex Japan currency is generally USD. However the dividend PDF for some reason denotes the dividend in CHF. 

This leads to an error in the import. Any special handling that should be added for this case?