### PR TITLE
Unify Layout of Quarterly vs. Monthly Earning Chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsAccumulatedChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsAccumulatedChartTab.java
@@ -8,7 +8,7 @@ import org.swtchart.ISeries.SeriesType;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
 
-public class AccumulatedEarningsChartTab extends AbstractChartTab
+public class EarningsAccumulatedChartTab extends AbstractChartTab
 {
     @Override
     public String getLabel()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
@@ -21,13 +21,13 @@ import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 import name.abuchen.portfolio.ui.views.earnings.EarningsViewModel.Line;
 import name.abuchen.portfolio.util.TextUtil;
 
-public class EarningsChartTab extends AbstractChartTab
+public class EarningsPerMonthChartTab extends AbstractChartTab
 {
-    private class DividendChartToolTip extends TimelineChartToolTip
+    private class DividendPerMonthChartToolTip extends TimelineChartToolTip
     {
         private EarningsViewModel model;
 
-        public DividendChartToolTip(Chart chart, EarningsViewModel model)
+        public DividendPerMonthChartToolTip(Chart chart, EarningsViewModel model)
         {
             super(chart);
 
@@ -116,7 +116,7 @@ public class EarningsChartTab extends AbstractChartTab
     @Override
     protected void attachTooltipTo(Chart chart)
     {
-        DividendChartToolTip toolTip = new DividendChartToolTip(chart, model);
+        DividendPerMonthChartToolTip toolTip = new DividendPerMonthChartToolTip(chart, model);
         toolTip.enableCategory(true);
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
@@ -44,7 +44,7 @@ import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
 import name.abuchen.portfolio.ui.views.earnings.EarningsViewModel.Line;
 import name.abuchen.portfolio.util.TextUtil;
 
-public class EarningsMatrixTab implements EarningsTab
+public class EarningsPerMonthMatrixTab implements EarningsTab
 {
     @Inject
     private SelectionService selectionService;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
@@ -1,6 +1,5 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
@@ -1,8 +1,6 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
 import java.time.LocalDate;
-import java.time.Month;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,14 +24,11 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public class EarningsPerQuarterChartTab extends AbstractChartTab
 {
-
-    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy"); //$NON-NLS-1$
-
-    private class DividendPerQuarterToolTip extends TimelineChartToolTip
+    private class DividendPerQuarterChartToolTip extends TimelineChartToolTip
     {
         private EarningsViewModel model;
 
-        public DividendPerQuarterToolTip(Chart chart, EarningsViewModel model)
+        public DividendPerQuarterChartToolTip(Chart chart, EarningsViewModel model)
         {
             super(chart);
 
@@ -43,18 +38,26 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
         @Override
         protected void createComposite(Composite parent)
         {
-            final int hoveredQuarterIndex = (Integer) getFocusedObject();
-            LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
-            date = date.plusYears(hoveredQuarterIndex / 4);
-            int quarterWithinYear = (hoveredQuarterIndex % 4) + 1;
-
+            int quarter = (Integer) getFocusedObject();
             int totalNoOfMonths = model.getNoOfMonths();
 
-            IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().getSeries()[0];
+            List<Line> lines = model.getLines().stream() //
+                            .filter(line -> {
+                                for (int index = 0; index < totalNoOfMonths; index += 1) {
+                                    if ((line.getValue(index) != 0L) && (((int)(index % 12) / 3) == quarter))
+                                        return true;
+                                }
+                                return false;
+                            }).sorted((l1, l2) -> l1.getVehicle().getName() // sort
+                                                                            // alphabetically
+                                            .compareToIgnoreCase(l2.getVehicle().getName()))
+                            .collect(Collectors.toList());
+            
+            int noOfYears = (totalNoOfMonths / 12) + (totalNoOfMonths % 12 > quarter * 3 ? 1 : 0);
 
             final Composite container = new Composite(parent, SWT.NONE);
             container.setBackgroundMode(SWT.INHERIT_FORCE);
-            GridLayoutFactory.swtDefaults().numColumns(2).applyTo(container);
+            GridLayoutFactory.swtDefaults().numColumns(1 + noOfYears).applyTo(container);
 
             Color foregroundColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
             container.setForeground(foregroundColor);
@@ -64,62 +67,52 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
             topLeft.setForeground(foregroundColor);
             topLeft.setText(Messages.ColumnSecurity);
 
-            Label label = new Label(container, SWT.CENTER);
-            label.setBackground(barSeries.getBarColor());
-            label.setForeground(Colors.getTextColor(barSeries.getBarColor()));
-            String labelString = String.format("Q%d %s", quarterWithinYear, formatter.format(date)); //$NON-NLS-1$
-            label.setText(labelString);
-            GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
+            for (int year = 0; year < noOfYears; year++)
+            {
+                Label label = new Label(container, SWT.CENTER);
 
-            final int quarterBeginIndex = 3 * hoveredQuarterIndex;
-            final int quarterEndIndex = Math.min(3 * (hoveredQuarterIndex + 1), totalNoOfMonths);
-
-            // first: filter out
-            List<Line> lines = model.getLines().stream() //
-                            .filter(line -> {
-                                for (int index = quarterBeginIndex; index < quarterEndIndex; index += 1)
-                                {
-                                    if (line.getValue(index) != 0L)
-                                        return true;
-                                }
-                                return false;
-                            }).sorted((l1, l2) -> l1.getVehicle().getName() // sort
-                                                                            // alphabetically
-                                            .compareToIgnoreCase(l2.getVehicle().getName()))
-                            .collect(Collectors.toList());
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[year]).getBarColor();
+                label.setBackground(color);
+                label.setForeground(Colors.getTextColor(color));
+                label.setText(String.valueOf(model.getStartYear() + year));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
+            }
 
             lines.forEach(line -> {
                 Label l = new Label(container, SWT.NONE);
                 l.setForeground(foregroundColor);
                 l.setText(TextUtil.tooltip(line.getVehicle().getName()));
 
-                long value = 0;
-                for (int index = quarterBeginIndex; index < quarterEndIndex; index += 1)
+                for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
                 {
-                    value += line.getValue(index);
+                    int mLimit = m + 3;
+                    long value = 0;
+                    for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                        value += line.getValue(mQuarter);
+                    l = new Label(container, SWT.RIGHT);
+                    l.setForeground(foregroundColor);
+                    l.setText(Values.Amount.format(value));
+                    GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
                 }
-
-                l = new Label(container, SWT.RIGHT);
-                l.setForeground(foregroundColor);
-                l.setText(Values.Amount.format(value));
-                GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
             });
 
             Label l = new Label(container, SWT.NONE);
             l.setForeground(foregroundColor);
             l.setText(Messages.ColumnSum);
 
-            // compute total sum of dividends in quarter
-            long value = 0;
-            for (int index = quarterBeginIndex; index < quarterEndIndex; index += 1)
+            for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
             {
-                value += model.getSum().getValue(index);
+                int mLimit = m + 3;
+                long value = 0;
+                for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                    value += model.getSum().getValue(mQuarter);
+                l = new Label(container, SWT.RIGHT);
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[m / 12]).getBarColor();
+                l.setBackground(color);
+                l.setForeground(Colors.getTextColor(color));
+                l.setText(Values.Amount.format(value));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(l);
             }
-            l = new Label(container, SWT.RIGHT);
-            l.setBackground(barSeries.getBarColor());
-            l.setForeground(Colors.getTextColor(barSeries.getBarColor()));
-            l.setText(Values.Amount.format(value));
-            GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
         }
     }
 
@@ -132,94 +125,41 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
     @Override
     protected void attachTooltipTo(Chart chart)
     {
-        DividendPerQuarterToolTip toolTip = new DividendPerQuarterToolTip(chart, model);
+        DividendPerQuarterChartToolTip toolTip = new DividendPerQuarterChartToolTip(chart, model);
         toolTip.enableCategory(true);
     }
 
-    private void setCategorySeriesLabels()
+    private void updateCategorySeries()
     {
-        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
-
-        int nMonths = model.getNoOfMonths();
-
-        /*
-         * The number of month in a quarter. While most people will know this, I
-         * prefer named variables over the occurrence of magic numbers in the
-         * code.
-         */
-        int monthInQuarter = 3;
-
-        // How many quarters we are about to display. We show every started
-        // quarter, hence the Math.ceil
-        int nQuarters = (int) Math.ceil((double) nMonths / (double) monthInQuarter);
-
-        String[] labels = new String[nQuarters];
-
-        for (int quarter = 0; quarter < nQuarters; quarter++)
+        String[] labels = new String[4];
+        for (int ii = 0; ii < 4; ii++)
         {
-            // the fifth total quarter is the first quarter in the corresponding
-            // year
-            int quarterWithinYear = (quarter % 4) + 1;
-
-            // The caption looks like "Q<quarter within the year> <year>"
-            String label = String.format("Q%d %s", quarterWithinYear, formatter.format(date)); //$NON-NLS-1$
-            labels[quarter] = label;
-
-            // every four quarters we need to switch to the next year
-            if (quarterWithinYear == 4)
-            {
-                date = date.plusYears(1);
-            }
-
+            String label = String.format("Q%d", ii + 1); //$NON-NLS-1$
+            labels[ii] = label;
         }
-
         getChart().getAxisSet().getXAxis(0).setCategorySeries(labels);
     }
 
     @Override
     protected void createSeries()
     {
-        setCategorySeriesLabels();
-
-        int nMonths = model.getNoOfMonths();
-
-        /*
-         * The number of month in a quarter. While most people will know this, I
-         * prefer named variables over the occurrence of magic numbers in the
-         * code.
-         */
-        int monthInQuarter = 3;
-
-        // How many quarters we are about to display. We show every started
-        // quarter, hence the Math.ceil
-        int nQuarters = (int) Math.ceil((double) nMonths / (double) monthInQuarter);
-
-        double[] series = new double[nQuarters];
-
-        int quarterBeginIndex = 0;
-        int quarterEndIndex = Math.min(monthInQuarter, nMonths);
-
-        for (int quarter = 0; quarter < nQuarters; quarter++)
+        updateCategorySeries();
+        for (int index = 0; index < model.getNoOfMonths(); index += 12)
         {
+            int year = model.getStartYear() + (index / 12);
 
-            double quarterDividends = 0;
+            IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,
+                            String.valueOf(year));
 
-            for (int i = quarterBeginIndex; i < quarterEndIndex; i++)
+            double[] series = new double[Math.min(12, model.getNoOfMonths() - index)];
+            for (int ii = 0; ii < series.length; ii++)
             {
-
-                quarterDividends += model.getSum().getValue(i);
+                series[(int)ii / 3] = series[ii / 3] + model.getSum().getValue(index + ii) / Values.Amount.divider();
             }
+            barSeries.setYSeries(series);
 
-            series[quarter] = quarterDividends / Values.Amount.divider();
-
-            // Starting from here, we make sure to step into the next quarter
-            quarterBeginIndex = Math.min(quarterBeginIndex + monthInQuarter, nMonths);
-            quarterEndIndex = Math.min(quarterEndIndex + monthInQuarter, nMonths);
-
+            barSeries.setBarColor(getColor(year));
+            barSeries.setBarPadding(25);
         }
-
-        IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR, getLabel());
-        barSeries.setYSeries(series);
-        barSeries.setBarColor(Colors.DARK_BLUE);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
@@ -20,20 +20,20 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.views.earnings.EarningsViewModel.Line;
 import name.abuchen.portfolio.util.TextUtil;
 
-public class EarningsYearMatrixTab extends EarningsMatrixTab
+public class EarningsPerQuarterMatrixTab extends EarningsPerMonthMatrixTab
 {
     private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy"); //$NON-NLS-1$
 
     @Override
     public String getLabel()
     {
-        return Messages.LabelEarningsByYearAndVehicle;
+        return Messages.LabelEarningsByQuarterAndVehicle;
     }
 
     @Override
     public void addConfigActions(IMenuManager manager)
     {
-        // do not add configuration option from earnings / month tab
+        // do not add config option from divident / month tab
     }
 
     @Override
@@ -41,27 +41,78 @@ public class EarningsYearMatrixTab extends EarningsMatrixTab
     {
         createVehicleColumn(records, layout, true);
 
-        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
-        for (int index = 0; index < model.getNoOfMonths(); index += 12)
-        {
-            createYearColumn(records, layout, date, index);
-            date = date.plusYears(1);
-        }
+        createQuarterColumns(records, layout);
 
         createSumColumn(records, layout);
     }
 
-    private void createYearColumn(TableViewer records, TableColumnLayout layout, LocalDate start, int index)
+    private void createQuarterColumns(TableViewer records, TableColumnLayout layout)
+    {
+        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
+
+        int nMonths = model.getNoOfMonths();
+
+        /*
+         * The number of month in a quarter. While most people will know this, I
+         * prefer named variables over the occurrence of magic numbers in the
+         * code.
+         */
+        int monthInQuarter = 3;
+
+        // How many quarters we are about to display. We show every started
+        // quarter, hence the Math.ceil
+        int nQuarters = (int) Math.ceil((double) nMonths / (double) monthInQuarter);
+
+        int quarterBeginIndex = 0;
+        int quarterEndIndex = Math.min(monthInQuarter, nMonths);
+
+        for (int quarter = 0; quarter < nQuarters; quarter++)
+        {
+            // the fifth total quarter is the first quarter in the corresponding
+            // year
+            int quarterWithinYear = (quarter % 4) + 1;
+
+            // The caption looks like "Q<quarter within the year> <year>"
+            String columnCaption = String.format("Q%d %s", quarterWithinYear, formatter.format(date)); //$NON-NLS-1$
+
+            createQuarterColumn(records, layout, quarterBeginIndex, quarterEndIndex, columnCaption);
+
+            // Starting from here, we make sure to step into the next quarter
+            quarterBeginIndex = Math.min(quarterBeginIndex + monthInQuarter, nMonths);
+            quarterEndIndex = Math.min(quarterEndIndex + monthInQuarter, nMonths);
+
+            // every four quarters we need to switch to the next year
+            if (quarterWithinYear == 4)
+            {
+                date = date.plusYears(1);
+            }
+        }
+
+    }
+
+    /**
+     * @brief Creates a column collecting quarter-wise dividends. The quarter is
+     *        specified by the start and end position within the values array of
+     *        the Line within the DividendsViewModel.
+     * @param quarterBeginIndex
+     *            The start index of the quarter
+     * @param quarterEndIndex
+     *            The end index of the quarter
+     * @param columnCaption
+     *            The caption used for the column
+     */
+    private void createQuarterColumn(TableViewer records, TableColumnLayout layout, int quarterBeginIndex,
+                    int quarterEndIndex, String columnCaption)
     {
         ToLongFunction<EarningsViewModel.Line> valueFunction = line -> {
             long value = 0;
-            for (int ii = index; ii < index + 12 && ii < line.getNoOfMonths(); ii++)
-                value += line.getValue(ii);
+            for (int i = quarterBeginIndex; i < quarterEndIndex; i++)
+                value += line.getValue(i);
             return value;
         };
 
         TableViewerColumn column = new TableViewerColumn(records, SWT.RIGHT);
-        column.getColumn().setText(formatter.format(start));
+        column.getColumn().setText(columnCaption);
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -91,35 +91,23 @@ public class EarningsView extends AbstractFinanceView
     @Override
     protected String getDefaultTitle()
     {
-        return Messages.LabelDividends;
+        return model.getMode().getLabel();
     }
 
     @Override
     protected void addViewButtons(ToolBarManager toolBarManager)
     {
-        ActionContributionItem dividends = new ActionContributionItem( //
-                        new SimpleAction(Messages.LabelDividends, SWT.RADIO, a -> {
-                            model.setMode(EarningsViewModel.Mode.DIVIDENDS);
-                            updateIcons(toolBarManager);
-                        }));
-        dividends.setMode(ActionContributionItem.MODE_FORCE_TEXT);
-        toolBarManager.add(dividends);
-
-        ActionContributionItem interest = new ActionContributionItem( //
-                        new SimpleAction(Messages.LabelInterest, SWT.RADIO, a -> {
-                            model.setMode(EarningsViewModel.Mode.INTEREST);
-                            updateIcons(toolBarManager);
-                        }));
-        interest.setMode(ActionContributionItem.MODE_FORCE_TEXT);
-        toolBarManager.add(interest);
-
-        ActionContributionItem all = new ActionContributionItem( //
-                        new SimpleAction(Messages.LabelEarnings, SWT.RADIO, a -> {
-                            model.setMode(EarningsViewModel.Mode.ALL);
-                            updateIcons(toolBarManager);
-                        }));
-        all.setMode(ActionContributionItem.MODE_FORCE_TEXT);
-        toolBarManager.add(all);
+        for (EarningsViewModel.Mode mode : EarningsViewModel.Mode.values())
+        {
+            ActionContributionItem item = new ActionContributionItem( //
+                            new SimpleAction(mode.getLabel(), a -> {
+                                model.setMode(mode);
+                                updateIcons(toolBarManager);
+                                updateTitle(model.getMode().getLabel());
+                            }));
+            item.setMode(ActionContributionItem.MODE_FORCE_TEXT);
+            toolBarManager.add(item);
+        }
 
         updateIcons(toolBarManager);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -177,13 +177,13 @@ public class EarningsView extends AbstractFinanceView
     {
         folder = new CTabFolder(parent, SWT.BORDER);
 
-        createTab(folder, Images.VIEW_TABLE, EarningsMatrixTab.class);
-        createTab(folder, Images.VIEW_TABLE, EarningsQuarterMatrixTab.class);
-        createTab(folder, Images.VIEW_TABLE, EarningsYearMatrixTab.class);
-        createTab(folder, Images.VIEW_BARCHART, EarningsChartTab.class);
+        createTab(folder, Images.VIEW_TABLE, EarningsPerMonthMatrixTab.class);
+        createTab(folder, Images.VIEW_TABLE, EarningsPerQuarterMatrixTab.class);
+        createTab(folder, Images.VIEW_TABLE, EarningsPerYearMatrixTab.class);
+        createTab(folder, Images.VIEW_BARCHART, EarningsPerMonthChartTab.class);
         createTab(folder, Images.VIEW_BARCHART, EarningsPerQuarterChartTab.class);
         createTab(folder, Images.VIEW_BARCHART, EarningsPerYearChartTab.class);
-        createTab(folder, Images.VIEW_LINECHART, AccumulatedEarningsChartTab.class);
+        createTab(folder, Images.VIEW_LINECHART, EarningsAccumulatedChartTab.class);
         createTab(folder, Images.VIEW_TABLE, TransactionsTab.class);
 
         int tab = preferences.getInt(KEY_TAB);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
@@ -20,6 +20,7 @@ import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
 import name.abuchen.portfolio.util.Interval;
 
@@ -27,16 +28,23 @@ public class EarningsViewModel
 {
     public enum Mode
     {
-        DIVIDENDS(AccountTransaction.Type.DIVIDENDS), //
-        INTEREST(AccountTransaction.Type.INTEREST, AccountTransaction.Type.INTEREST_CHARGE), //
-        ALL(AccountTransaction.Type.DIVIDENDS, AccountTransaction.Type.INTEREST,
+        DIVIDENDS(Messages.LabelDividends, AccountTransaction.Type.DIVIDENDS), //
+        INTEREST(Messages.LabelInterest, AccountTransaction.Type.INTEREST, AccountTransaction.Type.INTEREST_CHARGE), //
+        ALL(Messages.LabelEarnings, AccountTransaction.Type.DIVIDENDS, AccountTransaction.Type.INTEREST,
                         AccountTransaction.Type.INTEREST_CHARGE);
 
+        private String label;
         private Set<AccountTransaction.Type> types;
 
-        private Mode(AccountTransaction.Type first, AccountTransaction.Type... rest)
+        private Mode(String label, AccountTransaction.Type first, AccountTransaction.Type... rest)
         {
+            this.label = label;
             this.types = EnumSet.of(first, rest);
+        }
+
+        public String getLabel()
+        {
+            return label;
         }
 
         public boolean isIncluded(AccountTransaction transaction)


### PR DESCRIPTION
Angleichen der Darstellung der quartalsweisen Erträgen basierend auf der monatlichen Darstellung.

[<h3 id='heading--current'>Aktuelle Ansicht</h2>](#heading--current)
![Current](https://user-images.githubusercontent.com/29358155/61483920-155f3a00-a99e-11e9-84fa-a5be03a36337.JPG)
[<h3 id='heading--new'>Neue Ansicht</h2>](#heading--new)
![New](https://user-images.githubusercontent.com/29358155/61483929-17c19400-a99e-11e9-99f0-1f8821c8873d.JPG)

VG
Marco