### PR TITLE
Interest transactions should support taxes

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
@@ -204,7 +204,7 @@ public class AccountTransactionDialog extends AbstractTransactionDialog // NOSON
         //
 
         int widest = widest(securities != null ? securities.label : null, accounts.label, lblDate, shares.label,
-                        taxes.label, total.label, lblNote);
+                        taxes.label, total.label, lblNote, fxGrossAmount.label);
 
         FormDataFactory forms;
         if (securities != null)
@@ -279,7 +279,7 @@ public class AccountTransactionDialog extends AbstractTransactionDialog // NOSON
             grossAmount.setVisible(isFxVisible);
             forexTaxes.setVisible(isFxVisible && model().supportsShares());
             plusForexTaxes.setVisible(isFxVisible && model().supportsShares());
-            taxes.label.setVisible(!isFxVisible && model().supportsShares());
+            taxes.label.setVisible(!isFxVisible && model().supportsTaxUnits());
 
             // in case fx taxes have been entered
             if (!isFxVisible)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -205,7 +205,7 @@ public class AccountTransactionModel extends AbstractModel
 
     public boolean supportsTaxUnits()
     {
-        return type == AccountTransaction.Type.DIVIDENDS;
+        return type == AccountTransaction.Type.DIVIDENDS || type == AccountTransaction.Type.INTEREST;
     }
 
     public void setSource(Account account, AccountTransaction transaction)


### PR DESCRIPTION
Siehe: https://forum.portfolio-performance.info/t/besteuerung-der-zinsbuchungen/3054/4

Im Grunde musste nur die Sichtbarkeit des "Steuern" Feldes angepasst werden. Allerdings hat das dann optisch nicht schön ausgesehen, da das Input-Feld für "Bruttowert" noch nicht bei der Berechnung des "widest" labels berücksichtigt wurde. Daher der zusätzliche Parameter in Z. 207, AccountTransactionDialog.
