### PR TITLE
Rebuild "Earnings" to "Earnings & Expenses"

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -495,12 +495,15 @@ public class Messages extends NLS
     public static String LabelEarningsPerQuarter;
     public static String LabelEarningsPerYear;
     public static String LabelEarningsSelectStartYear;
+    public static String LabelEarningsExpenses;
+    public static String LabelExpenses;
     public static String LabelError;
     public static String LabelEurostatRegion;
     public static String LabelExchange;
     public static String LabelExchangeRate;
     public static String LabelExchangeRates;
     public static String LabelExport;
+    public static String LabelFees;
     public static String LabelFullClassification;
     public static String LabelIncludeSecuritiesInPieChart;
     public static String LabelIncludeUnassignedCategoryInCharts;
@@ -601,6 +604,7 @@ public class Messages extends NLS
     public static String LabelStatementOfAssetsHoldings;
     public static String LabelSuffix_HICP;
     public static String LabelSuffix_PreTax;
+    public static String LabelTaxes;
     public static String LabelTaxonomies;
     public static String LabelTaxonomyTemplates;
     public static String LabelToday;
@@ -934,5 +938,6 @@ public class Messages extends NLS
     }
 
     private Messages()
-    {}
+    {
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
@@ -428,7 +428,7 @@ public final class Navigation
         performance.add(new Item(Messages.ClientEditorLabelChart, PerformanceChartView.class));
         performance.add(new Item(Messages.ClientEditorLabelReturnsVolatility, ReturnsVolatilityChartView.class));
         performance.add(new Item(Messages.LabelSecurities, SecuritiesPerformanceView.class));
-        performance.add(new Item(Messages.ColumnEarnings, EarningsView.class));
+        performance.add(new Item(Messages.LabelEarningsExpenses, EarningsView.class));
 
         Item allTrades = new Item(Messages.LabelTrades, TradeDetailsView.class);
         allTrades.addTag(Tag.HIDE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -997,6 +997,13 @@ LabelEarningsPerYear = Year
 
 LabelEarningsSelectStartYear = Earnings starting with year:
 
+LabelEarningsExpenses = Earnings \u0026 Expenses
+
+LabelExpenses = Expenses
+
+LabelExpenses = Ausgaben
+
+
 LabelError = Error
 
 LabelEurostatRegion = Region
@@ -1008,6 +1015,8 @@ LabelExchangeRate = Exchange Rate
 LabelExchangeRates = Exchange Rates
 
 LabelExport = Export ''{0}''
+
+LabelFees = Fees
 
 LabelFullClassification = Full Classification
 
@@ -1208,6 +1217,8 @@ LabelSuffix_PreTax = \ (before taxes)
 LabelTTWROR = True Time-Weighted Rate of Return
 
 LabelTTWROROneDay = Last Day
+
+LabelTaxes = Taxes
 
 LabelTaxonomies = Taxonomies
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -995,6 +995,10 @@ LabelEarningsPerYear = Jahr
 
 LabelEarningsSelectStartYear = Ertr\u00E4ge ab Jahr:
 
+LabelEarningsExpenses = Einnahmen \u0026 Ausgaben
+
+LabelExpenses = Ausgaben
+
 LabelError = Fehler
 
 LabelExchange = B\u00F6rsenplatz
@@ -1004,6 +1008,8 @@ LabelExchangeRate = Wechselkurs
 LabelExchangeRates = Wechselkurse
 
 LabelExport = ''{0}'' exportieren
+
+LabelFees = Geb\u00FChren 
 
 LabelFullClassification = Komplette Klassifizierung
 
@@ -1206,6 +1212,8 @@ LabelTTWROR = True Time-Weighted Rate of Return
 LabelTTWROROneDay = Letzter Tag
 
 LabelTaxonomies = Klassifizierungen
+
+LabelTaxes = Steuern
 
 LabelTaxonomyTemplates = Vorlagen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/AbstractChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/AbstractChartTab.java
@@ -1,7 +1,9 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
 import java.text.DateFormatSymbols;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -9,6 +11,8 @@ import org.eclipse.jface.resource.ColorDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
@@ -17,12 +21,16 @@ import org.eclipse.swt.widgets.Display;
 import org.swtchart.Chart;
 import org.swtchart.IAxis;
 import org.swtchart.IAxis.Position;
+import org.swtchart.ICustomPaintListener;
+import org.swtchart.IPlotArea;
 import org.swtchart.ISeries;
 
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 
 public abstract class AbstractChartTab implements EarningsTab
 {
+    private List<PaintListener> customBehindPaintListener = new ArrayList<>();
+
     private static final int[][] FIVE_COLORS = new int[][] { //
                     new int[] { 114, 124, 201 }, //
                     new int[] { 250, 115, 92 }, //
@@ -69,6 +77,7 @@ public abstract class AbstractChartTab implements EarningsTab
         chart.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
         chart.getTitle().setVisible(false);
         chart.getLegend().setPosition(SWT.BOTTOM);
+        chart.getPlotArea().addPaintListener(event -> customBehindPaintListener.forEach(l -> l.paintControl(event)));
 
         IAxis xAxis = chart.getAxisSet().getXAxis(0);
         xAxis.getTitle().setVisible(false);
@@ -80,6 +89,10 @@ public abstract class AbstractChartTab implements EarningsTab
         yAxis.setPosition(Position.Secondary);
 
         xAxis.enableCategory(true);
+
+        // add paint listeners
+        IPlotArea plotArea = (IPlotArea) chart.getPlotArea();
+        plotArea.addCustomPaintListener(new PaintBehindListener());
 
         // format symbols returns 13 values as some calendars have 13 months
         xAxis.setCategorySeries(Arrays.copyOfRange(new DateFormatSymbols().getMonths(), 0, 12));
@@ -93,6 +106,26 @@ public abstract class AbstractChartTab implements EarningsTab
         model.addUpdateListener(this::updateChart);
 
         return chart;
+    }
+
+    private class PaintBehindListener implements ICustomPaintListener
+    {
+        @Override
+        public void paintControl(PaintEvent e)
+        {
+            int y = chart.getAxisSet().getYAxis(0).getPixelCoordinate(0);
+            e.gc.setLineWidth(3);
+            e.gc.setForeground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
+            e.gc.setLineStyle(SWT.LINE_SOLID);
+            e.gc.drawLine(0, y, e.width, y);
+            e.gc.setLineWidth(1);
+        }
+
+        @Override
+        public boolean drawBehindSeries()
+        {
+            return true;
+        }
     }
 
     protected void attachTooltipTo(Chart chart)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -25,6 +25,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.util.TextUtil;
 
 public class EarningsView extends AbstractFinanceView
 {
@@ -100,7 +101,7 @@ public class EarningsView extends AbstractFinanceView
         for (EarningsViewModel.Mode mode : EarningsViewModel.Mode.values())
         {
             ActionContributionItem item = new ActionContributionItem( //
-                            new SimpleAction(mode.getLabel(), a -> {
+                            new SimpleAction(TextUtil.tooltip(mode.getLabel()), a -> {
                                 model.setMode(mode);
                                 updateIcons(toolBarManager);
                                 updateTitle(model.getMode().getLabel());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/TransactionsTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/TransactionsTab.java
@@ -15,20 +15,24 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
+import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.selection.SecuritySelection;
 import name.abuchen.portfolio.ui.selection.SelectionService;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
@@ -120,6 +124,34 @@ public class TransactionsTab implements EarningsTab
         ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getDateTime()).attachTo(column, SWT.UP);
         support.addColumn(column);
 
+        column = new Column(Messages.ColumnTransactionType, SWT.LEFT, 80);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                return ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction()).getType()
+                                                .toString()
+                                : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction()).getType()
+                                                .toString();
+            }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
+            }
+        });
+        ColumnViewerSorter
+                        .create(element -> ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                        ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getType()
+                                        : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getType())
+                        .attachTo(column);
+        support.addColumn(column);
+
         column = new Column(Messages.ColumnSecurity, SWT.None, 250);
         column.setLabelProvider(new ColumnLabelProvider()
         {
@@ -151,6 +183,12 @@ public class TransactionsTab implements EarningsTab
             {
                 return ((TransactionPair<?>) element).getTransaction().getShares();
             }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
+            }
         });
         ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getShares()).attachTo(column);
         support.addColumn(column);
@@ -161,12 +199,25 @@ public class TransactionsTab implements EarningsTab
             @Override
             public String getText(Object element)
             {
-                return Values.Money.format(
-                                ((AccountTransaction) ((TransactionPair<?>) element).getTransaction()).getGrossValue(),
-                                client.getBaseCurrency());
+                Money transactionGrossValue = ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction()).getGrossValue()
+                                : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction()).getGrossValue();
+                return Values.Money.format(transactionGrossValue, client.getBaseCurrency());
+            }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
             }
         });
-        ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getMonetaryAmount()).attachTo(column);
+        ColumnViewerSorter
+                        .create(element -> ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                        ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getGrossValue()
+                                        : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getGrossValue())
+                        .attachTo(column);
         support.addColumn(column);
 
         column = new Column(Messages.ColumnTaxes, SWT.RIGHT, 80);
@@ -175,11 +226,55 @@ public class TransactionsTab implements EarningsTab
             @Override
             public String getText(Object element)
             {
-                return Values.Money.format(((TransactionPair<?>) element).getTransaction().getUnitSum(Unit.Type.TAX),
-                                client.getBaseCurrency());
+                Money transactionTaxes = ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                .getUnitSum(Unit.Type.TAX)
+                                : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                .getUnitSum(Unit.Type.TAX);
+                return Values.Money.format(transactionTaxes, client.getBaseCurrency());
+            }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
             }
         });
-        ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getUnitSum(Unit.Type.TAX))
+        ColumnViewerSorter
+                        .create(element -> ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                        ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getUnitSum(Unit.Type.TAX)
+                                        : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getUnitSum(Unit.Type.TAX))
+                        .attachTo(column);
+        support.addColumn(column);
+
+        column = new Column(Messages.ColumnFees, SWT.RIGHT, 80);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Money transactionFees = ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                .getUnitSum(Unit.Type.FEE)
+                                : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                .getUnitSum(Unit.Type.FEE);
+                return Values.Money.format(transactionFees, client.getBaseCurrency());
+            }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
+            }
+        });
+        ColumnViewerSorter
+                        .create(element -> ((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                                        ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getUnitSum(Unit.Type.FEE)
+                                        : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction())
+                                                        .getUnitSum(Unit.Type.FEE))
                         .attachTo(column);
         support.addColumn(column);
 
@@ -191,6 +286,12 @@ public class TransactionsTab implements EarningsTab
             {
                 return Values.Money.format(((TransactionPair<?>) element).getTransaction().getMonetaryAmount(),
                                 client.getBaseCurrency());
+            }
+
+            @Override
+            public Color getForeground(Object element)
+            {
+                return colorFor(element);
             }
         });
         ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getMonetaryAmount()).attachTo(column);
@@ -239,4 +340,15 @@ public class TransactionsTab implements EarningsTab
         ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getNote()).attachTo(column);
         support.addColumn(column);
     }
+
+    private Color colorFor(Object element)
+    {
+        return (((TransactionPair<?>) element).getTransaction() instanceof AccountTransaction
+                        ? ((AccountTransaction) ((TransactionPair<?>) element).getTransaction()).getType().isCredit() //
+                        : ((PortfolioTransaction) ((TransactionPair<?>) element).getTransaction()).getType()
+                                        .isPurchase())
+                                                        ? Colors.DARK_GREEN
+                                                        : Colors.DARK_RED;
+    }
+
 }


### PR DESCRIPTION
Änderung des Performance Berichts "Einnahmen" in "Einnahmen und Ausgaben".
Dividenden und Zinsen werden nun immer ohne Steuer ausgewiesen, dafür werden die Gebühren und Steuern aus den Wertpapiertransaktionen als auch den Buchungsvorfällen.

Es fehlt die Überarbeitung des Transaktionens-Tabs. Hier habe ich keine Ahnung wie ich A) (ist sicher einfach) eine Spalte f. Gebühren erfassen kann und B) bei den Buchungen wie TAXES oder TAXES_REFUND den Wert nur in die Spalte f. Steuern zu verschieben. Hier brauche ich Hilfe.

Basierend auf #1185 (Gebühren) und bspw. der Interactive Broker respektive Comdirect Debatte, dass die Steuerbuchungen als getrennte Buchung erfasst werden
https://forum.portfolio-performance.info/t/interactive-broker/276/78

![Earnings and Expenses](https://user-images.githubusercontent.com/29358155/63715613-60ddf100-c844-11e9-870c-c38ec50a35ee.png)
