### PR TITLE
Try PDF decryption if PDF document security is enabled

### DIFF
--- a/name.abuchen.portfolio/META-INF/MANIFEST.MF
+++ b/name.abuchen.portfolio/META-INF/MANIFEST.MF
@@ -38,6 +38,7 @@ Import-Package: com.google.common.base;version="27.1.0",
  org.apache.commons.lang3;version="3.4.0",
  org.apache.pdfbox.pdmodel;version="1.8.7",
  org.apache.pdfbox.util;version="1.8.7",
+ org.bouncycastle;version="1.59.0",
  org.eclipse.e4.core.di.annotations,
  org.eclipse.e4.core.di.extensions;version="0.15.0",
  org.eclipse.osgi.util;version="1.1.0",
@@ -51,6 +52,7 @@ Bundle-ClassPath: .
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.apache.httpcomponents.httpclient;bundle-version="4.3.6",
- org.apache.httpcomponents.httpcore;bundle-version="4.3.3"
+ org.apache.httpcomponents.httpcore;bundle-version="4.3.3",
+ org.apache.pdfbox
 Automatic-Module-Name: name.abuchen.portfolio
 Eclipse-ExtensibleAPI: true

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+import org.apache.pdfbox.exceptions.CryptographyException;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.util.PDFTextStripper;
@@ -73,12 +74,22 @@ public class PDFInputFile extends Extractor.InputFile
     {
         try (PDDocument document = PDDocument.load(getFile()))
         {
+            boolean isProtected = document.isEncrypted();
+            if (isProtected)
+            {
+                document.decrypt(""); //$NON-NLS-1$
+                document.setAllSecurityToBeRemoved(true);
+            }
             PDDocumentInformation pdd = document.getDocumentInformation();
             author = pdd.getAuthor() == null ? "" : pdd.getAuthor(); //$NON-NLS-1$
 
             PDFTextStripper textStripper = new PDFTextStripper();
             textStripper.setSortByPosition(true);
             text = textStripper.getText(document);
+        }
+        catch (CryptographyException e)
+        {
+            // TODO Auto-generated catch block
         }
     }
 }

--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -25,6 +25,19 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcprov-jdk15on</artifactId>
+			<version>1.62</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcmail-jdk15</artifactId>
+			<version>1.46</version>
+		</dependency>
+	</dependencies>
+
 	<prerequisites>
 		<maven>3.5.2</maven>
 	</prerequisites>

--- a/portfolio-target-definition/portfolio-target-definition.target
+++ b/portfolio-target-definition/portfolio-target-definition.target
@@ -20,6 +20,9 @@
 		<unit id="org.junit.source" version="4.12.0.v201504281640"/>
 		<unit id="org.mockito" version="2.13.0.v20180426-1843"/>
 		<unit id="org.mockito.source" version="2.13.0.v20180426-1843"/>
+		<unit id="org.bouncycastle.bcpg" version="1.59.0.v20180326-2325"/>
+		<unit id="org.bouncycastle.bcpkix" version="1.59.0.v20180326-2325"/>
+		<unit id="org.bouncycastle.bcprov" version="1.59.0.v20180328-2148"/>
 		<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Wie in https://forum.portfolio-performance.info/t/frankfurter-fondsbank-ffb-pdf-import/4751/ erwähnt, die PDF Dokumente der Frankfurter Fondsbank (FFB) wurden mit Sicherheitsmerkmalen versehen. Der einzelne Inhalt kann jedoch gelesen werden, nur die Zusammenstellung der Seiten darf nicht verändert werden.

Anyway, dies bedeutet das die PDF Dateien mit einem leeren Passwort verschlüsselt wurden und vor der Weiterverarbeitung entschlüsselt werden müssen.

Das ist die Wurzel des Übels bei der FFB:

![58bb1e711e28d769b08991cc42cd64418d71fe4a](https://user-images.githubusercontent.com/29358155/64074346-28a63a80-ccaa-11e9-89b5-7c4f1ce7751c.png)

#1216
