### PR TITLE
Add VIAC/Credit Suisse funds quote feed

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
@@ -38,6 +38,7 @@ import name.abuchen.portfolio.model.Exchange;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.QuoteFeed;
 import name.abuchen.portfolio.online.impl.AlphavantageQuoteFeed;
+import name.abuchen.portfolio.online.impl.CSQuoteFeed;
 import name.abuchen.portfolio.online.impl.EurostatHICPQuoteFeed;
 import name.abuchen.portfolio.online.impl.HTMLTableQuoteFeed;
 import name.abuchen.portfolio.ui.Messages;
@@ -129,11 +130,11 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
 
     private Group grpQuoteFeed;
     private Label labelDetailData;
-    
+
     private ComboViewer comboExchange;
     private Text textFeedURL;
     private Text textTicker;
-    
+
     private PropertyChangeListener tickerSymbolPropertyChangeListener = e -> onTickerSymbolChanged();
 
     private final EditSecurityModel model;
@@ -300,7 +301,8 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
     {
         boolean dropDown = feed != null && feed.getId() != null
                         && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID));
-        boolean feedURL = feed != null && feed.getId() != null && feed.getId().equals(HTMLTableQuoteFeed.ID);
+        boolean feedURL = feed != null && feed.getId() != null
+                        && (feed.getId().equals(HTMLTableQuoteFeed.ID) || feed.getId().equals(CSQuoteFeed.ID));
         boolean needsTicker = feed != null && feed.getId() != null && feed.getId().equals(AlphavantageQuoteFeed.ID);
 
         if (textFeedURL != null)
@@ -308,21 +310,21 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             textFeedURL.dispose();
             textFeedURL = null;
         }
-        
+
         if (comboExchange != null)
         {
             comboExchange.getControl().dispose();
             comboExchange = null;
         }
-        
+
         if (textTicker != null)
         {
             textTicker.dispose();
             textTicker = null;
-            
+
             model.removePropertyChangeListener("tickerSymbol", tickerSymbolPropertyChangeListener); //$NON-NLS-1$
         }
-        
+
         if (dropDown)
         {
             labelDetailData.setText(Messages.LabelExchange);
@@ -354,15 +356,15 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         else if (needsTicker)
         {
             labelDetailData.setText(Messages.ColumnTicker);
-            
+
             textTicker = new Text(grpQuoteFeed, SWT.BORDER);
             GridDataFactory.fillDefaults().hint(100, SWT.DEFAULT).applyTo(textTicker);
-            
+
             IObservableValue<?> observeText = WidgetProperties.text(SWT.Modify).observe(textTicker);
             @SuppressWarnings("unchecked")
             IObservableValue<?> observable = BeanProperties.value("tickerSymbol").observe(model); //$NON-NLS-1$
             bindings.getBindingContext().bindValue(observeText, observable);
-            
+
             model.addPropertyChangeListener("tickerSymbol", tickerSymbolPropertyChangeListener); //$NON-NLS-1$
         }
         else
@@ -503,7 +505,7 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             setStatus(null);
         }
     }
-    
+
     private void onTickerSymbolChanged()
     {
         boolean hasTicker = model.getTickerSymbol() != null && !model.getTickerSymbol().isEmpty();

--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
@@ -5,3 +5,4 @@ name.abuchen.portfolio.online.impl.HTMLTableQuoteFeed
 name.abuchen.portfolio.online.impl.AlphavantageQuoteFeed
 name.abuchen.portfolio.online.impl.KrakenQuoteFeed
 name.abuchen.portfolio.online.impl.EurostatHICPQuoteFeed
+name.abuchen.portfolio.online.impl.CSQuoteFeed

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -110,6 +110,7 @@ public class Messages extends NLS
     public static String IssueTransactionMissingCurrencyCode;
     public static String IssuePortfolioTransactionWithoutSecurity;
     public static String LabelAssetAllocation;
+    public static String LabelCreditSuisseHTMLTable;
     public static String LabelDefaultReferenceAccountName;
     public static String LabelDeposits;
     public static String LabelEuropeanCentralBank;
@@ -232,5 +233,6 @@ public class Messages extends NLS
     }
 
     private Messages()
-    {}
+    {
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -211,6 +211,8 @@ LabelApplyClientCalendar = (Portfolio Performance :: Standard Calendar)
 
 LabelAssetAllocation = Asset Allocation
 
+LabelCreditSuisseHTMLTable = VIAC/CS Funds (only for residents of Switzerland)
+
 LabelDefaultReferenceAccountName = Reference Account {0}
 
 LabelDeposits = Deposits

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
@@ -211,6 +211,8 @@ LabelApplyClientCalendar = (Portfolio Performance :: Standard Kalender)
 
 LabelAssetAllocation = Asset Allocation
 
+LabelCreditSuisseHTMLTable = VIAC/CS Fonds (nur für Personen mit Wohnsitz Schweiz)
+
 LabelDefaultReferenceAccountName = Referenzkonto {0}
 
 LabelDeposits = Einlagen / Einlieferungen

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CSQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CSQuoteFeed.java
@@ -1,0 +1,97 @@
+/**
+ * 
+ */
+package name.abuchen.portfolio.online.impl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import name.abuchen.portfolio.Messages;
+
+/**
+ * This class provides a feed for Credit Suisse Quotes. Probably all quotes
+ * provided by Credit Suisse can be downloaded but it is only tested with Credit
+ * Suisse institutional funds which are normally not offered to the general
+ * public except in special scenarios like via the Swiss third pillar provider
+ * VIAC (third pillar = "Säule 3a", a tax-exempt retirement saving scheme). The
+ * challenge of downloading these quotes are: 1) there is a HTML page where the
+ * user has to state his/her country of residence plus investor status (private,
+ * professional). This page can be avoided by using "curl" as user agent. -
+ * there are header titles that are specific to Credit Suisse and 2) Credit
+ * Suisse returns the quotes with Excel mime-type which are in fact HTML tables
+ * but would be converted upon opening Excel. This is a little bit of a hack on
+ * CS' part.
+ */
+public class CSQuoteFeed extends HTMLTableQuoteFeed
+{
+    public static final String ID = "CREDITSUISSE_HTML_TABLE"; //$NON-NLS-1$
+    public static final String USERAGENT = "curl/7.58.0"; //$NON-NLS-1$
+
+    protected static class CSDateColumn extends DateColumn
+    {
+        public CSDateColumn()
+        {
+            super(new String[] { "NAV Date" }); //$NON-NLS-1$
+        }
+    }
+
+    protected static class CSCloseColumn extends CloseColumn
+    {
+        public CSCloseColumn()
+        {
+            super(new String[] { "NAV" }); //$NON-NLS-1$
+        }
+    }
+
+    private static final Column[] COLUMNS = new Column[] { new CSDateColumn(), new CSCloseColumn() };
+
+    public CSQuoteFeed()
+    {
+        // EMPTY
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return Messages.LabelCreditSuisseHTMLTable;
+    }
+
+    @Override
+    protected Column[] getColumns()
+    {
+        return COLUMNS;
+    }
+
+    @Override
+    protected String getUserAgent()
+    {
+        return USERAGENT;
+    }
+
+    @Override
+    protected boolean isIgnoreContentType()
+    {
+        return true;
+    }
+
+    /**
+     * Test method to parse HTML tables
+     * 
+     * @param args
+     *            list of URLs and/or local files
+     */
+    public static void main(String[] args) throws IOException
+    {
+        PrintWriter writer = new PrintWriter(System.out); // NOSONAR
+        for (String arg : args)
+            if (arg.charAt(0) != '#')
+                new CSQuoteFeed().doLoad(arg, writer);
+        writer.flush();
+    }
+}


### PR DESCRIPTION
Even though a user wrote in the forum that the quotes of the Credit Suisse institutional funds can also be obtained from the ARD website I think this quote feed still makes sense as it gets the quotes from more than 10 years back whereas ARD only has them for the past month.