### PR TITLE
Israelischer Agora (ILA)

### DIFF
--- a/name.abuchen.portfolio.tests/infinitest.filters
+++ b/name.abuchen.portfolio.tests/infinitest.filters
@@ -1,5 +1,6 @@
-name.abuchen.portfolio.money.impl.GBXExchangeRateProviderTest
 name.abuchen.portfolio.money.impl.ECBExchangeRateProviderTest
-name.abuchen.portfolio.money.impl.AEDExchangeRateProviderTest
+name.abuchen.portfolio.money.impl.ExchangeRateProviderGBXTest
+name.abuchen.portfolio.money.impl.ExchangeRateProviderILATest
+name.abuchen.portfolio.money.impl.ExchangeRateProviderAEDTest
 name.abuchen.portfolio.datatransfer.pdf.consorsbank.ConsorsbankPDFExtractorPDFTest
 name.abuchen.portfolio.datatransfer.pdf.dkb.DkbPDFExtractorPDFTest

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAEDTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAEDTest.java
@@ -15,7 +15,7 @@ import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
 
 @SuppressWarnings("nls")
-public class AEDExchangeRateProviderTest
+public class ExchangeRateProviderAEDTest
 {
     @Test
     public void testIt()

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBXTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBXTest.java
@@ -15,7 +15,7 @@ import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
 
 @SuppressWarnings("nls")
-public class GBXExchangeRateProviderTest
+public class ExchangeRateProviderGBXTest
 {
     @Test
     public void testIt()

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILATest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILATest.java
@@ -1,0 +1,42 @@
+package name.abuchen.portfolio.money.impl;
+
+import static org.hamcrest.number.OrderingComparison.comparesEqualTo;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
+
+@SuppressWarnings("nls")
+public class ExchangeRateProviderILATest
+{
+    @Test
+    public void testIt()
+    {
+        ExchangeRateProviderFactory factory = new ExchangeRateProviderFactory(new Client());
+
+        // default value EUR -> ILS is 422.10
+        ExchangeRateTimeSeries eur_ILA = factory.getTimeSeries("EUR", "ILA");
+        assertThat(eur_ILA.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("422.1")));
+
+        // inverse of default EUR -> ILS
+        ExchangeRateTimeSeries ILA_eur = factory.getTimeSeries("ILA", "EUR");
+        assertThat(ILA_eur.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(
+                        BigDecimal.ONE.divide(new BigDecimal("422.099999949897"), 12, RoundingMode.HALF_DOWN)));
+
+        // ILA -> ILS
+        ExchangeRateTimeSeries ILA_ILS = factory.getTimeSeries("ILA", "ILS");
+        assertThat(ILA_ILS.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
+
+        // ILS -> ILA
+        ExchangeRateTimeSeries ILS_ILA = factory.getTimeSeries("ILS", "ILA");
+        assertThat(ILS_ILA.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
+
+    }
+}

--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.money.ExchangeRateProvider
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.money.ExchangeRateProvider
@@ -1,4 +1,5 @@
 name.abuchen.portfolio.money.impl.ECBExchangeRateProvider
-name.abuchen.portfolio.money.impl.GBXExchangeRateProvider
-name.abuchen.portfolio.money.impl.AEDExchangeRateProvider
+name.abuchen.portfolio.money.impl.ExchangeRateProviderGBX
+name.abuchen.portfolio.money.impl.ExchangeRateProviderILA
+name.abuchen.portfolio.money.impl.ExchangeRateProviderAED
 name.abuchen.portfolio.money.impl.SecurityBasedExchangeRateProvider

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
@@ -125,6 +125,8 @@ HUF = Hungarian Forint
 
 IDR = Indonesian Rupiah
 
+ILA = Israeli agora
+
 ILS = Israeli Shekel
 
 INR = Indian Rupee

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
@@ -121,6 +121,8 @@ HUF = Ungarischer Forint
 
 IDR = Indonesische Rupiah
 
+ILA = Israelischer Agora
+
 ILS = Israelischer Schekel
 
 INR = Indische Rupie

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAED.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAED.java
@@ -1,0 +1,81 @@
+package name.abuchen.portfolio.money.impl;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.ExchangeRate;
+import name.abuchen.portfolio.money.ExchangeRateProvider;
+import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
+
+public class ExchangeRateProviderAED implements ExchangeRateProvider
+{
+    private static final String AED = "AED"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return CurrencyUnit.getInstance(AED).getDisplayName();
+    }
+
+    @Override
+    public List<ExchangeRateTimeSeries> getAvailableTimeSeries(Client client)
+    {
+        List<ExchangeRateTimeSeries> answer = new ArrayList<>();
+        answer.add(new USDAED(this));
+        return answer;
+    }
+
+    private static class USDAED implements ExchangeRateTimeSeries
+    {
+        private ExchangeRateProvider provider;
+        private BigDecimal rate = BigDecimal.valueOf(3.6725);
+
+        public USDAED(ExchangeRateProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        @Override
+        public String getBaseCurrency()
+        {
+            return CurrencyUnit.USD;
+        }
+
+        @Override
+        public String getTermCurrency()
+        {
+            return AED;
+        }
+
+        @Override
+        public Optional<ExchangeRateProvider> getProvider()
+        {
+            return Optional.of(provider);
+        }
+
+        @Override
+        public List<ExchangeRate> getRates()
+        {
+            List<ExchangeRate> answer = new ArrayList<>();
+            answer.add(new ExchangeRate(LocalDate.now(), rate));
+            return answer;
+        }
+
+        @Override
+        public Optional<ExchangeRate> lookupRate(LocalDate requestedTime)
+        {
+            return Optional.of(new ExchangeRate(requestedTime, rate));
+        }
+
+        @Override
+        public int getWeight()
+        {
+            return 2;
+        }
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBX.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBX.java
@@ -12,7 +12,7 @@ import name.abuchen.portfolio.money.ExchangeRate;
 import name.abuchen.portfolio.money.ExchangeRateProvider;
 import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
 
-public class GBXExchangeRateProvider implements ExchangeRateProvider
+public class ExchangeRateProviderGBX implements ExchangeRateProvider
 {
     private static final String GBX = "GBX"; //$NON-NLS-1$
     private static final String GBP = "GBP"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILA.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILA.java
@@ -12,30 +12,31 @@ import name.abuchen.portfolio.money.ExchangeRate;
 import name.abuchen.portfolio.money.ExchangeRateProvider;
 import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
 
-public class AEDExchangeRateProvider implements ExchangeRateProvider
+public class ExchangeRateProviderILA implements ExchangeRateProvider
 {
-    private static final String AED = "AED"; //$NON-NLS-1$
+    private static final String ILA = "ILA"; //$NON-NLS-1$
+    private static final String ILS = "ILS"; //$NON-NLS-1$
 
     @Override
     public String getName()
     {
-        return CurrencyUnit.getInstance(AED).getDisplayName();
+        return CurrencyUnit.getInstance(ILA).getDisplayName();
     }
 
     @Override
     public List<ExchangeRateTimeSeries> getAvailableTimeSeries(Client client)
     {
         List<ExchangeRateTimeSeries> answer = new ArrayList<>();
-        answer.add(new USDAED(this));
+        answer.add(new ILAILS(this));
         return answer;
     }
 
-    private static class USDAED implements ExchangeRateTimeSeries
+    private static class ILAILS implements ExchangeRateTimeSeries
     {
         private ExchangeRateProvider provider;
-        private BigDecimal rate = BigDecimal.valueOf(3.6725);
+        private BigDecimal rate = BigDecimal.valueOf(0.01);
 
-        public USDAED(ExchangeRateProvider provider)
+        public ILAILS(ExchangeRateProvider provider)
         {
             this.provider = provider;
         }
@@ -43,13 +44,13 @@ public class AEDExchangeRateProvider implements ExchangeRateProvider
         @Override
         public String getBaseCurrency()
         {
-            return CurrencyUnit.USD;
+            return ILA;
         }
 
         @Override
         public String getTermCurrency()
         {
-            return AED;
+            return ILS;
         }
 
         @Override
@@ -78,4 +79,5 @@ public class AEDExchangeRateProvider implements ExchangeRateProvider
             return 2;
         }
     }
+
 }


### PR DESCRIPTION
#1229

Kleine Umbenennung der Exchange Provider um die einzelnen Währungen von Datenlieferanten (hier EZB) zu unterscheiden.