### PR TITLE
Fix PurchasePrice marker

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -1099,7 +1099,7 @@ public class SecuritiesChart
                         .filter(t -> t.getSecurity().equals(security))
                         .filter(t -> !(t.getType() == PortfolioTransaction.Type.TRANSFER_IN
                                         || t.getType() == PortfolioTransaction.Type.TRANSFER_OUT))
-                        .filter(t -> t.getDateTime().toLocalDate().isBefore(chartInterval.getEnd()))
+                        .filter(t -> !t.getDateTime().toLocalDate().isAfter(chartInterval.getEnd()))
                         .map(t -> chartInterval.contains(t.getDateTime()) ? t.getDateTime().toLocalDate()
                                         : chartInterval.getStart())
                         .distinct() //
@@ -1192,7 +1192,7 @@ public class SecuritiesChart
                         .filter(t -> t.getSecurity().equals(security))
                         .filter(t -> !(t.getType() == PortfolioTransaction.Type.TRANSFER_IN
                                         || t.getType() == PortfolioTransaction.Type.TRANSFER_OUT))
-                        .filter(t -> t.getDateTime().toLocalDate().isBefore(chartInterval.getEnd()))
+                        .filter(t -> !t.getDateTime().toLocalDate().isAfter(chartInterval.getEnd()))
                         .map(t -> chartInterval.contains(t.getDateTime()) ? t.getDateTime().toLocalDate()
                                         : chartInterval.getStart())
                         .distinct() //


### PR DESCRIPTION
```addFIFOPurchasePrice``` und ```addMovingAveragePurchasePrice``` zeichen das letzte Datum nicht, wenn die Position vollständig verkauft wurde.

#1261