### PR TITLE
PP portable

### DIFF
--- a/portfolio-product/name.abuchen.portfolio.distro.product
+++ b/portfolio-product/name.abuchen.portfolio.distro.product
@@ -35,7 +35,6 @@
    <features>
       <feature id="name.abuchen.portfolio.feature"/>
       <feature id="name.abuchen.portfolio.dependencies.feature"/>
-
       <feature id="org.eclipse.e4.rcp"/>
       <feature id="org.eclipse.emf.ecore"/>
       <feature id="org.eclipse.emf.common"/>
@@ -51,7 +50,6 @@
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.nebula.cwt.feature"/>
       <feature id="org.eclipse.nebula.widgets.cdatetime.feature"/>
-      
       <feature id="name.abuchen.zulu.jre.feature"/>
    </features>
 
@@ -62,9 +60,9 @@
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
-      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/PortfolioPerformance/workspace" os="win32" />
-      <property name="osgi.instance.area.default" value="@user.home/Library/Application Support/name.abuchen.portfolio.product/workspace" os="macosx" />
-      <property name="osgi.instance.area.default" value="@user.home/.PortfolioPerformance/workspace" os="linux" />
+      <property name="osgi.instance.area.default" value="./workspace" os="win32" />
+      <property name="osgi.instance.area.default" value="./workspace" os="macosx" />
+      <property name="osgi.instance.area.default" value="./workspace" os="linux" />
    </configurations>
 
 </product>

--- a/portfolio-product/name.abuchen.portfolio.product
+++ b/portfolio-product/name.abuchen.portfolio.product
@@ -59,9 +59,9 @@
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
-      <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/PortfolioPerformance/workspace" os="win32" />
-      <property name="osgi.instance.area.default" value="@user.home/Library/Application Support/name.abuchen.portfolio.product/workspace" os="macosx" />
-      <property name="osgi.instance.area.default" value="@user.home/.PortfolioPerformance/workspace" os="linux" />
+      <property name="osgi.instance.area.default" value="./workspace" os="win32" />
+      <property name="osgi.instance.area.default" value="./workspace" os="macosx" />
+      <property name="osgi.instance.area.default" value="./workspace" os="linux" />
    </configurations>
 
 </product>


### PR DESCRIPTION
Gelegentlich kommt es bei dem einen oder anderen PP Anwender zum Problem das der Eclipse Workspace zurück gesetzt werden muss oder das verschieben der XML Dateien die Einstellungen (temporär) verloren gehen. Daher die Überlegung das Workspace-Verzeichnis in die PP-Verzeichnisse zu verlagern. Damit wäre https://help.portfolio-performance.info/installation/#workspace-verzeichnis mE obsolete.

Die Idee basiert auf https://forum.portfolio-performance.info/t/installation-portabel-bzw-auf-usb-stick/1939/10 unter zur Hilfe nahme von https://stackoverflow.com/questions/39219501/how-to-append-the-osgi-configuration-area-parameter-to-the-generated-config-ini und https://stackoverflow.com/questions/10087367/setting-eclipse-default-workspace-location-on-startup-based-upon-user-name

Vorteil wäre das das Workspace-Verzeichnis wesentlich schneller vom Anwender gefunden werden kann oder bspw. vollständig auf einem USB-Speicher portabel wird ohne Datei-Reste auf den Anwender PC zu hinterlassen.

Der weitere Vorteil scheint zu sein, so zumindest unter Windows, dass mit dieser Änderung die 
Eclipse-Einstellungen aus dem Standard-Systemordner in den neuen Workspace-Ordner verschiebt 😄 . 

Der Test bei der Änderung des Verzeichnisses (ohne GUI Einstellung next du PP-XML) lief wie folgt:
1. Derzeitige Version Kommer Portfolio erstellt
2. Layout ändern des Dashboards
3. Speichern & PP schließen
4. Wechsel auf diesen Commit
5. Öffnen v. PP mit geändertem Workspace
6. Speichern & PP schließen
7. Löschen des alten Workspace-Verzeichnis
8. PP öffnen und überprüfen das Layout-Änderung unverändert