### PR TITLE
escaping text search field

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import org.eclipse.jface.action.ControlContribution;
 import org.eclipse.jface.action.Separator;
@@ -117,7 +118,7 @@ public class AllTransactionsView extends AbstractFinanceView
                 search.setSize(300, SWT.DEFAULT);
 
                 search.addModifyListener(e -> {
-                    String filterText = search.getText().trim();
+                    String filterText = Pattern.quote(search.getText().trim());
                     if (filterText.length() == 0)
                     {
                         filter = null;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -410,7 +410,7 @@ public class SecurityListView extends AbstractListView implements ModificationLi
                 search.setSize(300, SWT.DEFAULT);
 
                 search.addModifyListener(e -> {
-                    String filterText = search.getText().trim();
+                    String filterText = Pattern.quote(search.getText().trim());
                     if (filterText.length() == 0)
                     {
                         filterPattern = null;


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/fehler-beim-filtern-von-wertpapieren-mit-wildcards/6302

Bei der Freitext Suche über Wertpapiere werden Regex Metacharakter nicht abgefangen.

![9de86bda047f56c3a268d47b8f28927aaa4c1699](https://user-images.githubusercontent.com/29358155/68699640-d32cba80-0583-11ea-8be8-6c02c986ce94.png)
