### PR TITLE
Add OTC Buy Transaction to DKB including fees for registered shares

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbKaufOTC.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbKaufOTC.txt
@@ -1,0 +1,27 @@
+﻿10919 Berlin
+Depotnummer 500123451
+Kundennummer 51234561
+Max Mustermann
+Auftragsnummer 718643/69.00
+Herrn Datum 25.01.2016
+Max Mustermann Rechnungsnummer W00883-0000051964/16
+Musterstraße 2 Umsatzsteuer-ID DE137178746
+12345 Musterhausen
+DEUTSCHLAND
+Wertpapier Abrechnung Kauf Direkthandel
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 10 COMSTAGE-MSCI WORLD TRN U.ETF LU0392494562 (ETF110)
+NAMENS-AKTIEN O.N.
+Handels-/Ausführungsplatz Außerbörslich (gemäß Weisung)
+Handelspartner Baader Bank
+Schlusstag/-Zeit 07.11.2019 11:11:56 Auftraggeber Max Mustermann
+Ausführungskurs 114,26 EUR Auftragserteilung/ -ort Online-Banking
+Girosammelverwahrung - Sammel-Urkunden in Namensaktien
+Kurswert 1.142,60- EUR
+Provision 1,00- EUR
+Fremde Abwicklungsgebühr für die Umschreibung von Namensaktien 0,60- EUR
+Ausmachender Betrag 1.144,20- EUR
+Den Gegenwert buchen wir mit Valuta 27.01.2016 zu Lasten des Kontos 12345678 (IBAN DE30 1203 0000 0012 3456 78),
+BLZ 12030000 (BIC BYLADEM1001).
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -684,6 +684,40 @@ public class DkbPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.50))));
     }
+    
+    @Test
+    public void testWertpapierKaufAktienOTC() throws IOException
+    {        
+        DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DkbKaufOTC.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        assertSecurityBuyFonds(results);
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1144.20))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-11-07T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.60))));
+    }
 
     @Test
     public void testWertpapierVerkauf() throws IOException


### PR DESCRIPTION
- Added OTC buy transaction to DKB
- Bought shares from Siemens. Bank took transfer fees for the registered shares. Added these fees for all transactions.
- Removed boilerplate from all the buy transactions by updating the regex. All old Testcases and all my OTC settlements are working fine 