### PR TITLE
Updated libwebkitgtk error dependency

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1521,7 +1521,7 @@ MsgDialogInputRequired = Input required for ''{0}''
 
 MsgDialogNotAValidISIN = Invalid ISIN: {0}
 
-MsgEmbeddedBrowserError = Unable to create embedded browser to display charts\n\n* Are you running the latest version of your browser?\n* On Linux one has to install the packet 'libwebkitgtk-1.0-0'\n\nThe error message\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates that libwebkitgtk has to be installed. On Ubuntu 14.4, run\n  sudo apt-get install libwebkitgtk-1.0-0\n\n\nDetails:\n{0}
+MsgEmbeddedBrowserError = Unable to create embedded browser to display charts\n\n* Are you running the latest version of your browser?\n* On Linux one has to install the packet 'libwebkitgtk-3.0-0'\n\nThe error message\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates that libwebkitgtk has to be installed. On Ubuntu 18.04, run\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
 MsgErrorConvertToBuySellCurrencyMismatch = Transaction with currency {0} cannot be booked on account ''{2}'' with the currency {1}.
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1517,7 +1517,7 @@ MsgDialogInputRequired = Eingabe fehlt f\u00FCr Feld "{0}"
 
 MsgDialogNotAValidISIN = Ung\u00FCltige ISIN: {0}
 
-MsgEmbeddedBrowserError = Fehler beim \u00D6ffnen des Web Browsers zur Darstellung der Grafiken\n\n* Aktuelleste Version des Browsers installiert?\n* Unter Linux muss das Paket 'libwebkitgtk-1.0-0' installiert sein.\n\nDer Fehlertext\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nheisst meistens, dass libwebkitgtk installiert werden muss. Unter Ubuntu 14.4 z.B. mit\n  sudo apt-get install libwebkitgtk-1.0-0\n\n\nDetails:\n{0}
+MsgEmbeddedBrowserError = Fehler beim \u00D6ffnen des Web Browsers zur Darstellung der Grafiken\n\n* Aktuelleste Version des Browsers installiert?\n* Unter Linux muss das Paket 'libwebkitgtk-3.0-0' installiert sein.\n\nDer Fehlertext\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nheisst meistens, dass libwebkitgtk installiert werden muss. Unter Ubuntu 18.04 z.B. mit\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
 MsgErrorConvertToBuySellCurrencyMismatch = Buchung in der W\u00E4hrung {0} kann nicht auf Konto ''{2}'' mit der W\u00E4hrung {1} gebucht werden.
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1339,7 +1339,7 @@ MsgDialogInputRequired = Entrada requerida para ''{0}''
 
 MsgDialogNotAValidISIN = ISIN no v\u00E1lido: {0}
 
-MsgEmbeddedBrowserError = No se puede crear el navegador incorporado para mostrar gr\u00E1ficos\n\n* \u00BFEst\u00E1 ejecutando la \u00FAltima versi\u00F3n de su navegador?\n* Por un Linux tiene que instalar el paquete 'libwebkitgtk-1.0-0'\n\nEl mensaje de error\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates libwebkitgtk que tiene que ser instalado. En Ubuntu 14.4, ejecute\n  sudo apt-get install libwebkitgtk-1.0-0\n\n\nDetails:\n{0}
+MsgEmbeddedBrowserError = No se puede crear el navegador incorporado para mostrar gr\u00E1ficos\n\n* \u00BFEst\u00E1 ejecutando la \u00FAltima versi\u00F3n de su navegador?\n* Por un Linux tiene que instalar el paquete 'libwebkitgtk-3.0-0'\n\nEl mensaje de error\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates libwebkitgtk que tiene que ser instalado. En Ubuntu 18.04, ejecute\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
 MsgErrorConvertedAmount = Error de c\u00E1lculo: la cantidad convertida no puede resultar de la cantidad y el tipo de cambio
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1507,7 +1507,7 @@ MsgDialogInputRequired = Invoer vereist voor ''{0}''
 
 MsgDialogNotAValidISIN = Ongeldige ISIN: {0}
 
-MsgEmbeddedBrowserError = Kan geen ingesloten browser maken om grafieken weer te geven \n\n* Gebruikt u de nieuwste versie van uw browser?\n* Met Linux moet u het pakket 'libwebkitgtk-1.0-0' installeren \n\nHet foutbericht \n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]" \ngeeft aan dat libwebkitgtk moet worden ge\u00EFnstalleerd. Op Ubuntu 14.4, voer \n  sudo apt-get install libwebkitgtk-1.0-0 \n\n \nDetails: \n{0}
+MsgEmbeddedBrowserError = Kan geen ingesloten browser maken om grafieken weer te geven \n\n* Gebruikt u de nieuwste versie van uw browser?\n* Met Linux moet u het pakket 'libwebkitgtk-3.0-0' installeren \n\nHet foutbericht \n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]" \ngeeft aan dat libwebkitgtk moet worden ge\u00EFnstalleerd. Op Ubuntu 18.04, voer \n  sudo apt-get install libwebkitgtk-3.0-0 \n\n \nDetails: \n{0}
 
 MsgErrorConvertToBuySellCurrencyMismatch = Transactie met valuta {0} kan niet worden geboekt op account ''{2}'' met de valuta {1}.
 


### PR DESCRIPTION
Ubuntu 18.04 is the current LTS release and the version of libwebkitgtk is now 3 and no longer 1. Tested and verified under Ubuntu 18.04.