### PR TITLE
Update EarningsViewModel.java

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -137,7 +137,6 @@ public class EarningsView extends AbstractFinanceView
         model.getClientFilterMenu().addListener(f -> dropDown.setImage(
                         model.getClientFilterMenu().hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF));
         toolBar.add(dropDown);
-
         toolBar.add(new DropDown(Messages.MenuExportData, Images.EXPORT, SWT.NONE, manager -> {
             final int itemCount = folder.getItemCount();
             for (int ii = 0; ii < itemCount; ii++)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
@@ -16,7 +16,6 @@ import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.InvestmentVehicle;
-import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
@@ -120,6 +119,7 @@ public class EarningsViewModel
     private Mode mode = Mode.ALL;
     private boolean useGrossValue = true;
 
+    @SuppressWarnings("all") 
     public EarningsViewModel(IPreferenceStore preferences, CurrencyConverter converter, Client client)
     {
         this.converter = converter;
@@ -246,16 +246,67 @@ public class EarningsViewModel
         Client filteredClient = clientFilter.getSelectedFilter().filter(client);
 
         EnumSet<Mode> processPorfolioTx = EnumSet.of(Mode.TAXES, Mode.FEES, Mode.ALL);
-        if (processPorfolioTx.contains(mode))
-        {
-            for (Portfolio portfolio : filteredClient.getPortfolios())
-            {
-                for (PortfolioTransaction t : portfolio.getTransactions())
-                {
-                    if (!checkIsInInterval.test(t))
-                        continue;
 
-                    long value = 0;
+        for (TransactionPair<?> transaction : filteredClient.getAllTransactions())
+        {
+            if (!checkIsInInterval.test(transaction.getTransaction()))
+                continue;
+
+            long value = 0;
+
+            if (transaction.getTransaction() instanceof AccountTransaction)
+            {
+                Transaction t = (AccountTransaction) transaction.getTransaction();
+
+                if (!mode.isAccountTxIncluded((AccountTransaction) t))
+                    continue;
+
+                switch (mode)
+                {
+                    case TAXES:
+                        if (((AccountTransaction) t).getType() == AccountTransaction.Type.TAXES
+                                        || ((AccountTransaction) t).getType() == AccountTransaction.Type.TAX_REFUND)
+                        {
+                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
+                            if (((AccountTransaction) t).getType().isDebit())
+                                value *= -1;
+                        }
+                        else
+                        {
+                            value -= t.getUnitSum(Unit.Type.TAX).with(converter.at(t.getDateTime())).getAmount();
+                        }
+                        break;
+                    case FEES:
+                        if (((AccountTransaction) t).getType() == AccountTransaction.Type.FEES
+                                        || ((AccountTransaction) t).getType() == AccountTransaction.Type.FEES_REFUND)
+                        {
+                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
+                            if (((AccountTransaction) t).getType().isDebit())
+                                value *= -1;
+                        }
+                        else
+                        {
+                            value -= t.getUnitSum(Unit.Type.FEE).with(converter.at(t.getDateTime())).getAmount();
+                        }
+                        break;
+                    case ALL:
+                        value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
+                        if (((AccountTransaction) t).getType().isDebit())
+                            value *= -1;
+                        break;
+                    default:
+                        value = (useGrossValue ? ((AccountTransaction) t).getGrossValue()
+                                        : ((AccountTransaction) t).getMonetaryAmount())
+                                                        .with(converter.at(t.getDateTime())).getAmount();
+                        if (((AccountTransaction) t).getType().isDebit())
+                            value *= -1;
+                }
+            }
+            else
+            {
+                Transaction t = (PortfolioTransaction) transaction.getTransaction();
+                if (processPorfolioTx.contains(mode))
+                {
                     switch (mode)
                     {
                         case TAXES:
@@ -271,91 +322,39 @@ public class EarningsViewModel
 
                         default:
                     }
-
-                    if (value != 0)
-                    {
-                        transactions.add(new TransactionPair<>(portfolio, t));
-
-                        int index = (t.getDateTime().getYear() - startYear) * 12 + t.getDateTime().getMonthValue() - 1;
-
-                        Line line = vehicle2line.computeIfAbsent(t.getSecurity(), s -> new Line(s, noOfmonths));
-                        line.values[index] += value;
-                        line.sum += value;
-
-                        sum.values[index] += value;
-                        sum.sum += value;
-                    }
                 }
             }
-        }
-
-        for (Account account : filteredClient.getAccounts())
-        {
-            for (AccountTransaction t : account.getTransactions()) // NOSONAR
+            if (value != 0)
             {
-                if (!mode.isAccountTxIncluded(t))
-                    continue;
+                transactions.add(transaction);
 
-                if (!checkIsInInterval.test(t))
-                    continue;
+                int index = (transaction.getTransaction().getDateTime().getYear() - startYear) * 12
+                                + transaction.getTransaction().getDateTime().getMonthValue() - 1;
 
-                long value = 0;
-                switch (mode)
+                if (transaction.getTransaction() instanceof AccountTransaction)
                 {
-                    case TAXES:
-                        if (t.getType() == AccountTransaction.Type.TAXES
-                                        || t.getType() == AccountTransaction.Type.TAX_REFUND)
-                        {
-                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                            if (t.getType().isDebit())
-                                value *= -1;
-                        }
-                        else
-                        {
-                            value -= t.getUnitSum(Unit.Type.TAX).with(converter.at(t.getDateTime())).getAmount();
-                        }
-                        break;
-                    case FEES:
-                        if (t.getType() == AccountTransaction.Type.FEES
-                                        || t.getType() == AccountTransaction.Type.FEES_REFUND)
-                        {
-                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                            if (t.getType().isDebit())
-                                value *= -1;
-                        }
-                        else
-                        {
-                            value -= t.getUnitSum(Unit.Type.FEE).with(converter.at(t.getDateTime())).getAmount();
-                        }
-                        break;
-                    case ALL:
-                        value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                        if (t.getType().isDebit())
-                            value *= -1;
-                        break;
-                    default:
-                        value = (useGrossValue ? t.getGrossValue() : t.getMonetaryAmount())
-                                        .with(converter.at(t.getDateTime())).getAmount();
-                        if (t.getType().isDebit())
-                            value *= -1;
-                }
-
-                if (value != 0)
-                {
-                    transactions.add(new TransactionPair<>(account, t));
-
-                    int index = (t.getDateTime().getYear() - startYear) * 12 + t.getDateTime().getMonthValue() - 1;
-
-                    InvestmentVehicle vehicle = t.getSecurity() != null ? t.getSecurity() : account;
+                    InvestmentVehicle vehicle = transaction.getTransaction().getSecurity() != null
+                                    ? transaction.getTransaction().getSecurity()
+                                    : (Account) transaction.getOwner();
                     Line line = vehicle2line.computeIfAbsent(vehicle, s -> new Line(s, noOfmonths));
+
                     line.values[index] += value;
                     line.sum += value;
-
-                    sum.values[index] += value;
-                    sum.sum += value;
                 }
+                else
+                {
+                    Line line = vehicle2line.computeIfAbsent(transaction.getTransaction().getSecurity(),
+                                    s -> new Line(s, noOfmonths));
+
+                    line.values[index] += value;
+                    line.sum += value;
+                }
+
+                sum.values[index] += value;
+                sum.sum += value;
             }
         }
+
         this.lines = new ArrayList<>(vehicle2line.values());
     }
 


### PR DESCRIPTION
Using ``` clientFilter.getSelectedFilter().filter(client).getAllTransactions()``` instead of collecting splitted Account/Portfolio transaction. 

However the filtering problem as of https://forum.portfolio-performance.info/t/dividendendarstellung/2012/12 could still not be solved. Depend on the filter (for example) the buy transaction is shown as delivery in or as buy type. Furthermore if multiple portfolios sharing the same account and combined into one filter, the transactions are duplicated,

![Duplicated Transactions](https://user-images.githubusercontent.com/29358155/71439114-9b736f80-26f8-11ea-81f5-c78fec877cb6.png)

![Changed transaction type](https://user-images.githubusercontent.com/29358155/71439059-59e2c480-26f8-11ea-9ac5-7772a802a05a.png)

P.S. Bei den Buchungen der Einnahmen gibt es einen Bug der sich nicht erklären lässt. In der Eclipse IDE werden alle Spalten der Buchungen dargestellt, via MAVEN gebaute Version verschwinden Spalten 🤔 . Siehe https://forum.portfolio-performance.info/t/dividenden-zinsertraege-runrate-movingavg-12-monate/3824/47
