### PR TITLE
add URLs found in notes of security to URLs context menu.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
@@ -1,5 +1,10 @@
 package name.abuchen.portfolio.ui.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 
@@ -41,9 +46,42 @@ public class BookmarkMenu extends MenuManager
                                 a -> DesktopAPI.browse(bookmark.constructURL(client, security))));
             }
         }
+        // check for urls in notes of security
+        List<String> urls = getUrlsFromNotes(security);
+        if (!urls.isEmpty())
+        {
+            add(new Separator());
+            for (String url : urls)
+            {
+                add(new SimpleAction(url, a -> DesktopAPI.browse(url)));
+            }
+        }
 
         add(new Separator());
         add(new SimpleAction(Messages.BookmarkMenu_EditBookmarks,
                         a -> editor.activateView(SettingsView.class, Integer.valueOf(0))));
+    }
+    
+    /**
+     * Gets all URLs contained in the notes of the given {@link Security}.
+     * 
+     * @param security
+     *            {@link Security}
+     * @return list of notes
+     */
+    private static List<String> getUrlsFromNotes(Security security)
+    {
+        ArrayList<String> urls = new ArrayList<String>();
+        String notes = security.getNote();
+        if ((notes != null) && (notes.length() > 0))
+        {
+            Pattern urlPattern = Pattern.compile("(https?\\:\\/\\/[^ \\t\\r\\n]+)", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
+            Matcher m = urlPattern.matcher(notes);
+            while (m.find())
+            {
+                urls.add(m.group());
+            }
+        }
+        return urls;
     }
 }


### PR DESCRIPTION
Adds URLs from notes of a security to the context menu.
Provides an easy way to add multiple custom URLs to a security by just writing them in the notes.
Looks like that:
![2019-12-28_12-32-15](https://user-images.githubusercontent.com/670885/71543015-3b85fe80-296e-11ea-9ed3-8fcd543ca89d.png)

for that security notes:
![javaw_2019-12-28_12-32-25](https://user-images.githubusercontent.com/670885/71543018-42ad0c80-296e-11ea-9111-612ddd5735c1.png)
