### PR TITLE
Feature: Limit Preis als Attribut

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
@@ -17,6 +17,8 @@ public final class Colors
     public static final Color DARK_RED = Display.getDefault().getSystemColor(SWT.COLOR_DARK_RED);
     public static final Color DARK_GREEN = Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN);
     public static final Color BLACK = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+    public static final Color RED = Display.getDefault().getSystemColor(SWT.COLOR_RED);
+    public static final Color GREEN = Display.getDefault().getSystemColor(SWT.COLOR_GREEN);
 
     private static final ColorRegistry REGISTRY = new ColorRegistry();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -17,6 +17,7 @@ import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.LimitPrice;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.viewers.AttributeEditingSupport;
@@ -110,6 +111,56 @@ public class AttributeColumn extends Column
             return Optional.ofNullable((Boolean) attributes.get(attribute));
         }
     }
+    
+    private static final class LimitPriceLabelProvider extends ColumnLabelProvider
+    {
+        private final AttributeType attribute;
+
+        private LimitPriceLabelProvider(AttributeType attribute)
+        {
+            this.attribute = attribute;
+        }
+
+        @Override
+        public String getText(Object element)
+        {
+            // TODO: element -> Security.class
+            Attributable attributable = Adaptor.adapt(Attributable.class, element);
+            if (attributable == null)
+                return null;
+
+            Attributes attributes = attributable.getAttributes();
+
+            Object value = attributes.get(attribute);
+            return attribute.getConverter().toString(value);
+        }
+
+        /*@Override
+        public Image getImage(Object element)
+        {
+            return getValue(element).map(b -> Boolean.TRUE.equals(b) ? Images.CHECK.image() : Images.XMARK.image())
+                            .orElse(null);
+        }*/
+
+        private Optional<LimitPrice> getValue(Object element)
+        {
+            // TODO!
+            Attributable attributable = Adaptor.adapt(Attributable.class, element);
+            if (attributable == null)
+                return Optional.empty();
+            Attributes attributes = attributable.getAttributes();
+            return Optional.empty();
+            
+            /*
+            Attributable attributable = Adaptor.adapt(Attributable.class, element);
+            if (attributable == null)
+                return Optional.empty();
+
+            Attributes attributes = attributable.getAttributes();
+            return Optional.ofNullable((Boolean) attributes.get(attribute));
+            */
+        }
+    }
 
     private static final String ID = "attribute$"; //$NON-NLS-1$
 
@@ -126,6 +177,11 @@ public class AttributeColumn extends Column
         {
             setLabelProvider(new BooleanLabelProvider(attribute));
             new BooleanAttributeEditingSupport(attribute).attachTo(this);
+        }
+        else if (attribute.getType() == LimitPrice.class)
+        {
+            setLabelProvider(new LimitPriceLabelProvider(attribute));
+            new AttributeEditingSupport(attribute).attachTo(this);
         }
         else
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 
@@ -129,12 +128,13 @@ public class AttributeColumn extends Column
         @Override
         public String getText(Object element)
         {
-            // TODO: element -> Security.class
-            Attributable attributable = Adaptor.adapt(Attributable.class, element);
-            if (attributable == null)
+            Security security = Adaptor.adapt(Security.class, element);
+            if (security == null)
                 return null;
 
-            Attributes attributes = attributable.getAttributes();
+            Attributes attributes = security.getAttributes();
+            if (attributes == null)
+                return null;
 
             Object value = attributes.get(attribute);
             return attribute.getConverter().toString(value);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -18,9 +18,9 @@ import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.LimitPrice;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.money.LimitPrice;
-import name.abuchen.portfolio.money.LimitPrice.CompareType;
+import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.Colors;
@@ -141,39 +141,34 @@ public class AttributeColumn extends Column
         }
         
         @Override
-        public Color getBackground(Object element) {
+        public Color getBackground(Object element)
+        {
             Security security = Adaptor.adapt(Security.class, element);
             if(security == null)
                 return null;
             
             Attributes attributes = security.getAttributes();
-
             LimitPrice limit = (LimitPrice) attributes.get(attribute);
             if(limit == null)
                 return null;
             
-            if(limit.getCompareType() == CompareType.GREATER_OR_EQUAL)
-            {
-                if(security.getLatest().getValue() >= limit.getLimitPrice())
-                    return Colors.GREEN;
-            }
-            else if(limit.getCompareType() == CompareType.SMALLER_OR_EQUAL)
-            {
-                if(security.getLatest().getValue() <= limit.getLimitPrice())
-                    return Colors.RED;
-            }
-            else if(limit.getCompareType() == CompareType.GREATER)
-            {
-                if(security.getLatest().getValue() > limit.getLimitPrice())
-                    return Colors.GREEN;
-            }
-            else if(limit.getCompareType() == CompareType.SMALLER)
-            {
-                if(security.getLatest().getValue() < limit.getLimitPrice())
-                    return Colors.RED;
-            }
+            SecurityPrice latestSecurityPrice = security.getSecurityPrice(LocalDate.now());
+            if(latestSecurityPrice == null)
+                return null;
             
-            return null;
+            switch(limit.getCompareType())
+            {
+                case GREATER_OR_EQUAL:
+                    return (latestSecurityPrice.getValue() >= limit.getValue() ? Colors.GREEN : null);
+                case SMALLER_OR_EQUAL:
+                    return (latestSecurityPrice.getValue() >= limit.getValue() ? Colors.RED : null);
+                case GREATER:
+                    return (latestSecurityPrice.getValue() >= limit.getValue() ? Colors.GREEN : null);
+                case SMALLER:
+                    return (latestSecurityPrice.getValue() >= limit.getValue() ? Colors.RED : null);
+                default:
+                    return null;
+            }
         }
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -10,14 +10,19 @@ import java.util.stream.Stream;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Device;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.LimitPrice;
+import name.abuchen.portfolio.money.LimitPrice.CompareType;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.viewers.AttributeEditingSupport;
@@ -134,31 +139,41 @@ public class AttributeColumn extends Column
             Object value = attributes.get(attribute);
             return attribute.getConverter().toString(value);
         }
-
-        /*@Override
-        public Image getImage(Object element)
-        {
-            return getValue(element).map(b -> Boolean.TRUE.equals(b) ? Images.CHECK.image() : Images.XMARK.image())
-                            .orElse(null);
-        }*/
-
-        private Optional<LimitPrice> getValue(Object element)
-        {
-            // TODO!
-            Attributable attributable = Adaptor.adapt(Attributable.class, element);
-            if (attributable == null)
-                return Optional.empty();
-            Attributes attributes = attributable.getAttributes();
-            return Optional.empty();
+        
+        @Override
+        public Color getBackground(Object element) {
+            Security security = Adaptor.adapt(Security.class, element);
+            if(security == null)
+                return null;
             
-            /*
-            Attributable attributable = Adaptor.adapt(Attributable.class, element);
-            if (attributable == null)
-                return Optional.empty();
+            Attributes attributes = security.getAttributes();
 
-            Attributes attributes = attributable.getAttributes();
-            return Optional.ofNullable((Boolean) attributes.get(attribute));
-            */
+            LimitPrice limit = (LimitPrice) attributes.get(attribute);
+            if(limit == null)
+                return null;
+            
+            if(limit.getCompareType() == CompareType.GREATER_OR_EQUAL)
+            {
+                if(security.getLatest().getValue() >= limit.getLimitPrice())
+                    return new Color(Display.getCurrent(), 0, 255, 0);
+            }
+            else if(limit.getCompareType() == CompareType.SMALLER_OR_EQUAL)
+            {
+                if(security.getLatest().getValue() <= limit.getLimitPrice())
+                    return new Color(Display.getCurrent(), 255, 0, 0);
+            }
+            else if(limit.getCompareType() == CompareType.GREATER)
+            {
+                if(security.getLatest().getValue() > limit.getLimitPrice())
+                    return new Color(Display.getCurrent(), 0, 255, 0);
+            }
+            else if(limit.getCompareType() == CompareType.SMALLER)
+            {
+                if(security.getLatest().getValue() < limit.getLimitPrice())
+                    return new Color(Display.getCurrent(), 255, 0, 0);
+            }
+            
+            return null;
         }
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -12,7 +12,6 @@ import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Attributable;
@@ -24,6 +23,7 @@ import name.abuchen.portfolio.money.LimitPrice;
 import name.abuchen.portfolio.money.LimitPrice.CompareType;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.viewers.AttributeEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.BooleanAttributeEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.Column;
@@ -155,22 +155,22 @@ public class AttributeColumn extends Column
             if(limit.getCompareType() == CompareType.GREATER_OR_EQUAL)
             {
                 if(security.getLatest().getValue() >= limit.getLimitPrice())
-                    return new Color(Display.getCurrent(), 0, 255, 0);
+                    return Colors.GREEN;
             }
             else if(limit.getCompareType() == CompareType.SMALLER_OR_EQUAL)
             {
                 if(security.getLatest().getValue() <= limit.getLimitPrice())
-                    return new Color(Display.getCurrent(), 255, 0, 0);
+                    return Colors.RED;
             }
             else if(limit.getCompareType() == CompareType.GREATER)
             {
                 if(security.getLatest().getValue() > limit.getLimitPrice())
-                    return new Color(Display.getCurrent(), 0, 255, 0);
+                    return Colors.GREEN;
             }
             else if(limit.getCompareType() == CompareType.SMALLER)
             {
                 if(security.getLatest().getValue() < limit.getLimitPrice())
-                    return new Color(Display.getCurrent(), 255, 0, 0);
+                    return Colors.RED;
             }
             
             return null;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
@@ -14,6 +14,8 @@ import name.abuchen.portfolio.model.AttributeType.PercentPlainConverter;
 import name.abuchen.portfolio.model.AttributeType.QuoteConverter;
 import name.abuchen.portfolio.model.AttributeType.ShareConverter;
 import name.abuchen.portfolio.model.AttributeType.StringConverter;
+import name.abuchen.portfolio.model.AttributeType.LimitPriceConverter;
+import name.abuchen.portfolio.money.LimitPrice;
 
 public enum AttributeFieldType
 {
@@ -25,7 +27,8 @@ public enum AttributeFieldType
     QUOTE(Long.class, QuoteConverter.class), //
     SHARE(Long.class, ShareConverter.class), //
     DATE(LocalDate.class, DateConverter.class), //
-    BOOLEAN(Boolean.class, BooleanConverter.class);
+    BOOLEAN(Boolean.class, BooleanConverter.class), //
+    LIMIT_PRICE(LimitPrice.class, LimitPriceConverter.class);
 
     private static final ResourceBundle RESOURCES = ResourceBundle
                     .getBundle("name.abuchen.portfolio.ui.views.settings.labels"); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeFieldType.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.ResourceBundle;
 
 import name.abuchen.portfolio.model.AttributeType;
+import name.abuchen.portfolio.model.LimitPrice;
 import name.abuchen.portfolio.model.AttributeType.AmountConverter;
 import name.abuchen.portfolio.model.AttributeType.AmountPlainConverter;
 import name.abuchen.portfolio.model.AttributeType.BooleanConverter;
@@ -15,7 +16,6 @@ import name.abuchen.portfolio.model.AttributeType.QuoteConverter;
 import name.abuchen.portfolio.model.AttributeType.ShareConverter;
 import name.abuchen.portfolio.model.AttributeType.StringConverter;
 import name.abuchen.portfolio.model.AttributeType.LimitPriceConverter;
-import name.abuchen.portfolio.money.LimitPrice;
 
 public enum AttributeFieldType
 {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels.properties
@@ -16,3 +16,5 @@ QUOTE.name = Quote
 SHARE.name = Share
 
 STRING.name = Text
+
+LIMIT_PRICE.name = Limit Price

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/labels_de.properties
@@ -16,3 +16,5 @@ QUOTE.name = Kurs
 SHARE.name = Anteil
 
 STRING.name = Text
+
+LIMIT_PRICE.name = Limit Preis

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -217,6 +217,7 @@ public class Messages extends NLS
     public static String MsgNoQuotesFoundInHTML;
     public static String MsgNoResults;
     public static String MsgNotANumber;
+    public static String MsgNotAComparator;
     public static String MsgNotAPortflioFile;
     public static String MsgPasswordMissing;
     public static String MsgReadingFile;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -423,6 +423,8 @@ MsgNoResults = No results for '%s'
 
 MsgNotANumber = Not a number: {0}
 
+MsgNotAComparator = No valid comparator > >= < or <= found
+
 MsgNotAPortflioFile = Invalid file format: not a Portfolio Performance file
 
 MsgPasswordMissing = Password is missing

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
@@ -415,6 +415,8 @@ MsgNoQuotesFoundInHTML = Keine Kurse gefunden: {0}\n\n{1}
 
 MsgNoResults = Keine Ergebnisse f\u00FCr '%s'
 
+MsgNotAComparator = Kein gültiger Verlgeich > >= < oder <= gefunden
+
 MsgNotANumber = Eingabe ist keine g\u00FCltige Zahl: {0}
 
 MsgNotAPortflioFile = Falsches Format: Datei ist keine Portfolio Performance Datei

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -52,18 +52,8 @@ public class AttributeType
     {
         private final DecimalFormat full;
 
-        private Values<LimitPrice> values;
-
         public LimitPriceConverter()
         {
-            this.full = new DecimalFormat("#,###"); //$NON-NLS-1$
-            this.full.setParseBigDecimal(true);
-        }
-        
-        public LimitPriceConverter(Values<LimitPrice> values)
-        {
-            this.values = values;
-            
             this.full = new DecimalFormat("#,###"); //$NON-NLS-1$
             this.full.setParseBigDecimal(true);
         }
@@ -71,7 +61,6 @@ public class AttributeType
         @Override
         public String toString(Object object)
         {
-            //return object != null ? values.format((LimitPrice) object) : ""; //$NON-NLS-1$
             return object != null ? ((LimitPrice) object).toString() : ""; //$NON-NLS-1$
         }
 
@@ -120,7 +109,9 @@ public class AttributeType
                     
                 BigDecimal v = (BigDecimal) full.parse(input);
                 //long price = v.multiply(BigDecimal.valueOf(values.factor())).longValue();
-                long price = v.longValue();
+                long price = v.multiply(BigDecimal.valueOf(10000)).longValue();
+                
+                //long price = v.longValue();
                 
                 return new LimitPrice(cType, price);
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -68,35 +68,39 @@ public class AttributeType
         public Object fromString(String value)
         {
             try
-            {
+            {                
                 String input = value.trim();
                 input = input.replace(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
-                if (input.length() == 0 || !startsWithValidComparatorString(input))
+                
+                if(input.length() == 0)
+                    return null;
+                
+                if(!startsWithValidComparatorString(input))
                     throw new IllegalArgumentException(Messages.MsgNotAComparator);
 
                 Matcher m = LIMIT_PRICE_PATTERN.matcher(input);
-                if (!m.matches())
+                if(!m.matches())
                     throw new IllegalArgumentException(MessageFormat.format(Messages.MsgNotANumber, input));
 
                 CompareType cType;
-                if(input.startsWith(">=")) //$NON-NLS-1$
+                if(input.startsWith(CompareType.GREATER_OR_EQUAL.getCompareString()))
                 {
-                    input = input.replace(">=", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                    input = input.replace(CompareType.GREATER_OR_EQUAL.getCompareString(), ""); //$NON-NLS-1$
                     cType = CompareType.GREATER_OR_EQUAL;
                 }
-                else if(input.startsWith("<=")) //$NON-NLS-1$
+                else if(input.startsWith(CompareType.SMALLER_OR_EQUAL.getCompareString()))
                 {
-                    input = input.replace("<=", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                    input = input.replace(CompareType.SMALLER_OR_EQUAL.getCompareString(), ""); //$NON-NLS-1$
                     cType = CompareType.SMALLER_OR_EQUAL;
                 }
-                else if(input.startsWith(">")) //$NON-NLS-1$
+                else if(input.startsWith(CompareType.GREATER.getCompareString()))
                 {
-                    input = input.replace(">", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                    input = input.replace(CompareType.GREATER.getCompareString(), ""); //$NON-NLS-1$
                     cType = CompareType.GREATER;
                 }
-                else if(input.startsWith("<")) //$NON-NLS-1$
+                else if(input.startsWith(CompareType.SMALLER.getCompareString()))
                 {
-                    input = input.replace("<", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                    input = input.replace(CompareType.SMALLER.getCompareString(), ""); //$NON-NLS-1$
                     cType = CompareType.SMALLER;
                 }
                 else 
@@ -104,15 +108,12 @@ public class AttributeType
                     throw new IllegalArgumentException(Messages.MsgNotAComparator);
                 }
                 
-                if (input.length() == 0)
+                if(input.length() == 0)
                     throw new IllegalArgumentException(MessageFormat.format(Messages.MsgNotANumber, input));
                     
                 BigDecimal v = (BigDecimal) full.parse(input);
-                //long price = v.multiply(BigDecimal.valueOf(values.factor())).longValue();
-                long price = v.multiply(BigDecimal.valueOf(10000)).longValue();
                 
-                //long price = v.longValue();
-                
+                long price = v.multiply(BigDecimal.valueOf(Values.Quote.factor())).longValue();
                 return new LimitPrice(cType, price);
             }
             catch (ParseException e)
@@ -123,10 +124,10 @@ public class AttributeType
         
         private boolean startsWithValidComparatorString(String str)
         {
-            if(str.startsWith(">=") || //$NON-NLS-1$
-               str.startsWith("<=") || //$NON-NLS-1$
-               str.startsWith(">") || //$NON-NLS-1$
-               str.startsWith("<")) //$NON-NLS-1$
+            if(str.startsWith(CompareType.GREATER_OR_EQUAL.getCompareString()) ||
+               str.startsWith(CompareType.SMALLER_OR_EQUAL.getCompareString()) ||
+               str.startsWith(CompareType.GREATER.getCompareString()) ||
+               str.startsWith(CompareType.SMALLER.getCompareString()))
                 return true;
             return false;
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -21,7 +21,7 @@ import name.abuchen.portfolio.money.Values;
 public class AttributeType
 {
     private static final Pattern PATTERN = Pattern.compile("^([\\d.,-]*)$"); //$NON-NLS-1$
-    private static final Pattern LIMIT_PRICE_PATTERN = Pattern.compile("^(\\s*(<=?|>=?)\\s*\\d*(,?)\\d*)$"); //$NON-NLS-1$
+    private static final Pattern LIMIT_PRICE_PATTERN = Pattern.compile("^\\s*(<=?|>=?)\\s*([0-9,.']+)$"); //$NON-NLS-1$
 
     public interface Converter
     {
@@ -67,68 +67,23 @@ public class AttributeType
         public Object fromString(String value)
         {
             try
-            {                
-                String input = value.trim();
-                input = input.replace(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
-                
-                if(input.length() == 0)
+            {              
+                if(value.length() == 0)
                     return null;
-                
-                if(!startsWithValidComparatorString(input))
-                    throw new IllegalArgumentException(Messages.MsgNotAComparator);
 
-                Matcher m = LIMIT_PRICE_PATTERN.matcher(input);
+                Matcher m = LIMIT_PRICE_PATTERN.matcher(value);
                 if(!m.matches())
-                    throw new IllegalArgumentException(MessageFormat.format(Messages.MsgNotANumber, input));
-
-                CompareType cType;
-                if(input.startsWith(CompareType.GREATER_OR_EQUAL.getCompareString()))
-                {
-                    input = input.replace(CompareType.GREATER_OR_EQUAL.getCompareString(), ""); //$NON-NLS-1$
-                    cType = CompareType.GREATER_OR_EQUAL;
-                }
-                else if(input.startsWith(CompareType.SMALLER_OR_EQUAL.getCompareString()))
-                {
-                    input = input.replace(CompareType.SMALLER_OR_EQUAL.getCompareString(), ""); //$NON-NLS-1$
-                    cType = CompareType.SMALLER_OR_EQUAL;
-                }
-                else if(input.startsWith(CompareType.GREATER.getCompareString()))
-                {
-                    input = input.replace(CompareType.GREATER.getCompareString(), ""); //$NON-NLS-1$
-                    cType = CompareType.GREATER;
-                }
-                else if(input.startsWith(CompareType.SMALLER.getCompareString()))
-                {
-                    input = input.replace(CompareType.SMALLER.getCompareString(), ""); //$NON-NLS-1$
-                    cType = CompareType.SMALLER;
-                }
-                else 
-                {
                     throw new IllegalArgumentException(Messages.MsgNotAComparator);
-                }
-                
-                if(input.length() == 0)
-                    throw new IllegalArgumentException(MessageFormat.format(Messages.MsgNotANumber, input));
-                    
-                BigDecimal v = (BigDecimal) full.parse(input);
-                
-                long price = v.multiply(BigDecimal.valueOf(Values.Quote.factor())).longValue();
-                return new LimitPrice(cType, price);
+
+                String compare = m.group(1);
+                long price = ((BigDecimal) full.parse(m.group(2))).multiply(Values.Quote.getBigDecimalFactor()).longValue();
+
+                return new LimitPrice(CompareType.valueOf(compare), price);
             }
             catch (ParseException e)
             {
                 throw new IllegalArgumentException(e);
             }
-        }
-        
-        private boolean startsWithValidComparatorString(String str)
-        {
-            if(str.startsWith(CompareType.GREATER_OR_EQUAL.getCompareString()) ||
-               str.startsWith(CompareType.SMALLER_OR_EQUAL.getCompareString()) ||
-               str.startsWith(CompareType.GREATER.getCompareString()) ||
-               str.startsWith(CompareType.SMALLER.getCompareString()))
-                return true;
-            return false;
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -15,8 +15,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
-import name.abuchen.portfolio.money.LimitPrice;
-import name.abuchen.portfolio.money.LimitPrice.CompareType;
+import name.abuchen.portfolio.model.LimitPrice.CompareType;
 import name.abuchen.portfolio.money.Values;
 
 public class AttributeType

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -24,7 +24,7 @@ public class Client
 {
     /* package */static final int MAJOR_VERSION = 1;
 
-    public static final int CURRENT_VERSION = 43;
+    public static final int CURRENT_VERSION = 44;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
 
     private transient PropertyChangeSupport propertyChangeSupport; // NOSONAR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -574,7 +574,9 @@ public class ClientFactory
                 // added tax units to interest transaction
             case 42:
                 // added data map to classification and assignemnt
-
+            case 43:
+                // added LimitPrice as attribute type
+                
                 client.setVersion(Client.CURRENT_VERSION);
                 break;
             case Client.CURRENT_VERSION:
@@ -1097,6 +1099,8 @@ public class ClientFactory
             xstream.useAttributeFor(SecurityPrice.class, "value");
             xstream.aliasField("v", SecurityPrice.class, "value");
 
+            xstream.alias("limitPrice", LimitPrice.class);
+            
             xstream.alias("cpi", ConsumerPriceIndex.class);
             xstream.useAttributeFor(ConsumerPriceIndex.class, "year");
             xstream.aliasField("y", ConsumerPriceIndex.class, "year");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
@@ -1,6 +1,8 @@
-package name.abuchen.portfolio.money;
+package name.abuchen.portfolio.model;
 
 import java.util.Objects;
+
+import name.abuchen.portfolio.money.Values;
 
 public class LimitPrice implements Comparable<LimitPrice>
 {
@@ -23,12 +25,12 @@ public class LimitPrice implements Comparable<LimitPrice>
     }
     
     private CompareType compareType = null;
-    private long limitPrice;
+    private long value;
     
-    public LimitPrice(CompareType type, long price)
+    public LimitPrice(CompareType type, long value)
     {
         this.compareType = type;
-        this.limitPrice = price;
+        this.value = value;
     }
     
     public CompareType getCompareType()
@@ -36,15 +38,15 @@ public class LimitPrice implements Comparable<LimitPrice>
         return compareType;
     }
 
-    public long getLimitPrice()
+    public long getValue()
     {
-        return limitPrice;
+        return value;
     }
     
     @Override
     public int hashCode()
     {
-        return Objects.hash(compareType, limitPrice);
+        return Objects.hash(compareType, value);
     }
     
     @Override
@@ -58,7 +60,7 @@ public class LimitPrice implements Comparable<LimitPrice>
             return false;
 
         LimitPrice other = (LimitPrice) obj;
-        if (limitPrice != other.limitPrice)
+        if (value != other.value)
             return false;
         return Objects.equals(compareType.getCompareString(), other.compareType.getCompareString());
     }
@@ -69,12 +71,12 @@ public class LimitPrice implements Comparable<LimitPrice>
         int compare = compareType.getCompareString().compareTo(other.getCompareType().getCompareString());
         if (compare != 0)
             return compare;
-        return (int) (limitPrice - other.getLimitPrice());
+        return (int) (value - other.getValue());
     }
 
     @Override
     public String toString()
     {
-        return (compareType != null ? compareType.getCompareString() + Values.Quote.format(limitPrice) : ""); //$NON-NLS-1$
+        return (compareType != null ? compareType.getCompareString() + Values.Quote.format(value) : ""); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
@@ -1,16 +1,15 @@
 package name.abuchen.portfolio.money;
 
-import java.math.BigDecimal;
 import java.util.Objects;
 
 public class LimitPrice implements Comparable<LimitPrice>
 {
     public enum CompareType
     {
-        GREATER(">"), //$NON-NLS-1$
         GREATER_OR_EQUAL(">="), //$NON-NLS-1$
-        SMALLER("<"), //$NON-NLS-1$
-        SMALLER_OR_EQUAL("<="); //$NON-NLS-1$
+        SMALLER_OR_EQUAL("<="), //$NON-NLS-1$
+        GREATER(">"), //$NON-NLS-1$
+        SMALLER("<"); //$NON-NLS-1$
         
         private String str;
         
@@ -24,14 +23,20 @@ public class LimitPrice implements Comparable<LimitPrice>
     }
     
     private CompareType compareType;
-    private BigDecimal limitPrice;
+    private long limitPrice;
+    
+    public LimitPrice(CompareType type, long price)
+    {
+        this.compareType = type;
+        this.limitPrice = price;
+    }
     
     public CompareType getCompareType()
     {
         return compareType;
     }
 
-    public BigDecimal getLimitPrice()
+    public long getLimitPrice()
     {
         return limitPrice;
     }
@@ -64,12 +69,13 @@ public class LimitPrice implements Comparable<LimitPrice>
         int compare = compareType.getCompareString().compareTo(other.getCompareType().getCompareString());
         if (compare != 0)
             return compare;
-        return limitPrice.compareTo(other.getLimitPrice());
+        return (int) (limitPrice - other.getLimitPrice());
     }
 
     @Override
     public String toString()
     {
-        return compareType.getCompareString() + limitPrice.toString();
+        String str = compareType.getCompareString() + limitPrice;
+        return str;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
@@ -1,6 +1,5 @@
 package name.abuchen.portfolio.money;
 
-import java.math.BigDecimal;
 import java.util.Objects;
 
 public class LimitPrice implements Comparable<LimitPrice>
@@ -23,7 +22,7 @@ public class LimitPrice implements Comparable<LimitPrice>
         }
     }
     
-    private CompareType compareType;
+    private CompareType compareType = null;
     private long limitPrice;
     
     public LimitPrice(CompareType type, long price)
@@ -76,7 +75,6 @@ public class LimitPrice implements Comparable<LimitPrice>
     @Override
     public String toString()
     {
-        String str = compareType.getCompareString() + BigDecimal.valueOf(limitPrice).divide(BigDecimal.valueOf(10000)).toString();
-        return str;
+        return (compareType != null ? compareType.getCompareString() + Values.Quote.format(limitPrice) : ""); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.money;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 public class LimitPrice implements Comparable<LimitPrice>
@@ -75,7 +76,7 @@ public class LimitPrice implements Comparable<LimitPrice>
     @Override
     public String toString()
     {
-        String str = compareType.getCompareString() + limitPrice;
+        String str = compareType.getCompareString() + BigDecimal.valueOf(limitPrice).divide(BigDecimal.valueOf(10000)).toString();
         return str;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/LimitPrice.java
@@ -1,0 +1,75 @@
+package name.abuchen.portfolio.money;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class LimitPrice implements Comparable<LimitPrice>
+{
+    public enum CompareType
+    {
+        GREATER(">"), //$NON-NLS-1$
+        GREATER_OR_EQUAL(">="), //$NON-NLS-1$
+        SMALLER("<"), //$NON-NLS-1$
+        SMALLER_OR_EQUAL("<="); //$NON-NLS-1$
+        
+        private String str;
+        
+        CompareType(String compareString) {
+            this.str = compareString;
+        }
+     
+        public String getCompareString() {
+            return str;
+        }
+    }
+    
+    private CompareType compareType;
+    private BigDecimal limitPrice;
+    
+    public CompareType getCompareType()
+    {
+        return compareType;
+    }
+
+    public BigDecimal getLimitPrice()
+    {
+        return limitPrice;
+    }
+    
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(compareType, limitPrice);
+    }
+    
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        LimitPrice other = (LimitPrice) obj;
+        if (limitPrice != other.limitPrice)
+            return false;
+        return Objects.equals(compareType.getCompareString(), other.compareType.getCompareString());
+    }
+
+    @Override
+    public int compareTo(LimitPrice other)
+    {
+        int compare = compareType.getCompareString().compareTo(other.getCompareType().getCompareString());
+        if (compare != 0)
+            return compare;
+        return limitPrice.compareTo(other.getLimitPrice());
+    }
+
+    @Override
+    public String toString()
+    {
+        return compareType.getCompareString() + limitPrice.toString();
+    }
+}


### PR DESCRIPTION
Nach der etwas angestaubten Unterhaltung hier https://github.com/buchen/portfolio/issues/143, möchte ich meine Lösung präsentieren:
![limit-preis-implementierung](https://user-images.githubusercontent.com/4254744/71778353-24b65c00-2fad-11ea-8b5f-2277c4a4570b.png)

Ein neuer AttributeType "LimitPrice" wurde eingeführt. Dieser akzeptiert die Vergleichs-Operatoren >=, <=, > und < gefolgt von einem Preis.
Unterschreitungen werden rot, Überschreitungen grün dargestellt.