### PR TITLE
Add justTRADE pdf support

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justTrade/JustTradePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justTrade/JustTradePDFExtractorTest.java
@@ -1,0 +1,93 @@
+package name.abuchen.portfolio.datatransfer.pdf.justTrade;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
+import name.abuchen.portfolio.datatransfer.Extractor.Item;
+import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.JustTradePDFExtractor;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+@SuppressWarnings("nls")
+public class JustTradePDFExtractorTest
+{
+
+    private List<Item> results;
+
+    @Before
+    public void loadPDF()
+    {
+        JustTradePDFExtractor extractor = new JustTradePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "justtrade_kauf_pdf.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+    }
+
+    @Test
+    public void testSecurities() throws IOException
+    {
+        List<Security> securities = results.stream().filter(i -> i instanceof SecurityItem)
+                        .map(item -> item.getSecurity()).collect(Collectors.toList());
+
+        assertThat(securities.size(), is(1));
+
+        assertThat(securities.get(0).getName(), is((String) null));
+        assertThat(securities.get(0).getIsin(), is("IE00B1FZS350"));
+        assertThat(securities.get(0).getWkn(), is("A0LEW8"));
+    }
+
+    @Test
+    public void testBuyTransactions() throws IOException
+    {
+        List<BuySellEntry> entries = getTransactionEntries("BUY");
+
+        assertThat(entries.size(), is(1));
+
+        validateTransaction(entries, 0, 1340_64L, "2020-01-02T00:00", 53);
+    }
+
+    private List<BuySellEntry> getTransactionEntries(String type)
+    {
+        return results.stream().filter(i -> i instanceof BuySellEntryItem).map(i -> (BuySellEntryItem) i)
+                        .map(i -> (BuySellEntry) i.getSubject())
+                        .filter(entry -> entry.getAccountTransaction().getType()
+                                        .equals(AccountTransaction.Type.valueOf(type)))
+                        .filter(entry -> entry.getPortfolioTransaction().getType()
+                                        .equals(PortfolioTransaction.Type.valueOf(type)))
+                        .collect(Collectors.toList());
+
+    }
+
+    private void validateTransaction(List<BuySellEntry> entries, int index, long amount, String dateTime, double shares)
+    {
+        assertThat(entries.get(index).getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, amount)));
+        assertThat(entries.get(index).getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse(dateTime)));
+        assertThat(entries.get(index).getPortfolioTransaction().getShares(), is(Values.Share.factorize(shares)));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justTrade/justtrade_kauf_pdf.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justTrade/justtrade_kauf_pdf.txt
@@ -1,0 +1,30 @@
+SUTOR BANK · Postfach 11 33 37 · 20433 Hamburg
+Depotnummer 123456789
+Kundennummer 123456
+Vorname Mittelname Nachnaame
+Auftragsnummer 123456/12.12
+Herrn Datum 02.01.2020
+Vorname Mittelname Nachname Rechnungsnummer W12345-1234567890/12
+Strasse mit Hausnummer 54 Umsatzsteuer-ID DE123456789
+12345 Berlin
+justTRADE
+Wertpapier Abrechnung Kauf
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 53 ISHSII-DEV.MKTS PROP.YLD U.ETF IE00B1FZS350 (A0LEW8)
+REGISTERED SHS USD (DIST) O.N.
+Handels-/Ausführungsplatz Hamburg (gemäß Weisung)
+Börsensegment HAMB
+Schlusstag/-Zeit 02.01.2020 10:49:34 Auftragserteilung/ -ort sonstige
+Ausführungskurs 25,295 EUR
+Wertpapierrechnung Lagerland Irland
+Kurswert 1.340,64- EUR
+Ausmachender Betrag 1.340,64- EUR
+Verwaltungsvergütung pro Jahr 0,59 %
+Den Gegenwert buchen wir mit Valuta 06.01.2020 zu Lasten des Kontos 123456789, BLZ 12345678.
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+afsdiuh38h4aooohdijhfads
+Für das Geschäft wurde keine Anlageberatung erbracht.
+Initiator der Besprechung war der Kunde.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+1234.12345678.1234567AB12

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -1,0 +1,81 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
+
+public class JustTradePDFExtractor extends AbstractPDFExtractor
+{
+    public JustTradePDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("justTRADE"); //$NON-NLS-1$
+
+        addBuyTransaction();
+    }
+
+    @Override
+    public String getPDFAuthor()
+    {
+        return "Sutor Bank"; //$NON-NLS-1$
+    }
+
+    @SuppressWarnings("nls")
+    private void addBuyTransaction()
+    {
+        DocumentType type = new DocumentType("Wertpapier Abrechnung Kauf");
+        this.addDocumentTyp(type);
+
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        pdfTransaction.subject(() -> {
+            BuySellEntry entry = new BuySellEntry();
+            entry.setType(PortfolioTransaction.Type.BUY);
+            return entry;
+        });
+
+        Block firstRelevantLine = new Block("Stück .*");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+        pdfTransaction
+
+                        .section("info").match("Stück (?<info>.*)").assign((t, v) -> {
+                            String info = v.get("info");
+                            String[] splittedInfo = info.split(" ");
+
+                            String isin = splittedInfo[splittedInfo.length - 2];
+                            String rawWkn = splittedInfo[splittedInfo.length - 1];
+                            String wkn = rawWkn.substring(1, rawWkn.length() - 1);
+                            Map<String, String> values = new HashMap<>();
+                            values.put("isin", isin);
+                            values.put("wkn", wkn);
+                            t.setSecurity(getOrCreateSecurity(values));
+
+                            t.setShares(asShares(splittedInfo[0]));
+                        })
+
+                        .section("date").match("Schlusstag\\/\\-Zeit (?<date>.{10}) .*")
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                        .section("amount", "currency")
+                        .match("Kurswert (?<amount>[0-9.]+(\\,[0-9]{2}))- (?<currency>[A-Z]{3})").assign((t, v) -> {
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
+                        }).wrap(BuySellEntryItem::new);
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Sutor justTRADE"; //$NON-NLS-1$
+    }
+}


### PR DESCRIPTION
The security name takes multiple lines, therefore as a small workaround I only parse ISIN / WKN to identify the security.

The test asserts that the name is null. But when running the app and importing the pdf file, the name of the newly created security is set anyway. How?