### PR TITLE
Fix: Consorsbank PDF Kapitalertragsteuer und Soli bei Dividenden

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankErtragsgutschrift12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankErtragsgutschrift12.txt
@@ -1,0 +1,78 @@
+Consorsbank  90318 Nürnberg
+Depotnummer: 0123456789
+1111111111/00
+Vermerk der Bank: 1000
+2
+Max Mueller
+Maxi Mueller Datum: 29.11.2019
+Hauptstr. 3 Seite: 1 von 3
+10101 Stadt
+Dividendengutschrift
+Wertpapierbezeichnung WKN ISIN
+SAMSUNG ELECTRONICS CO. LTD. R.Shs(NV)Pf(GDR144A)/25 SW 100 881823 US7960502018
+Bestand
+3 Stück
+Dividende pro Stück 7,550421 USD Schlusstag 26.09.2019
+Brutto in USD 22,65 USD
+abzgl. Quellensteuer 22,00 % von 22,65 USD 4,98 USD
+abzgl. Fremde Spesen 0,07 USD
+Zwischensumme in USD 17,60 USD
+Devisenkurs 1,102700 USD / EUR
+Brutto in EUR 20,54 EUR
+Quellensteuer in EUR 4,52 EUR
+Zwischensumme in EUR 15,96 EUR
+abzgl. Kapitalertragsteuer 2,06 EUR
+abzgl. Solidaritätszuschlag 0,10 EUR
+Netto zugunsten IBAN DE11 2222 3333 4444 5555 66 13,80 EUR
+Valuta 27.11.2019 BIC CSDBDE71XXX
+Fremde Spesen enthalten 19,00 % MwSt 0,01 EUR
+Anrechenbare Quellensteuer 15,00 % von 22,65 USD 3,08 EUR
+Bitte beachten Sie die weiteren Informationen auf Seite 2.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+PrØsident du Conseil dAdministration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur GØnØral (Generaldirektor): Jean-Laurent BonnafØ
+Depotnummer: 0123456789
+1111111111/00
+Vermerk der Bank: 1000
+2
+Datum: 29.11.2019
+Seite: 2 von 3
+Details zur Abrechnung
+Steuerpflichtiger Gesamtertrag 20,54 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Mit Quellensteuer verrechnet -12,32 EUR
+somit verrechnete Quellensteuer -3,08 EUR
+Bemessungsgrundlage für Kapitalertragsteuer 8,22 EUR
+Details zu den Verrechnungstöpfen
+Verrechnungstopf "Allgemein" vor der Abrechnung 0,00 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Verrechnungstopf "Allgemein" nach der Abrechnung 0,00 EUR
+Sparerpauschbetrag vor der Abrechnung 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Sparerpauschbetrag nach der Abrechnung 0,00 EUR
+Verrechnungstopf "Quellensteuer" vor der Abrechnung 0,00 EUR
+Änderung Verrechnungstopf "Quellensteuer" 0,00 EUR
+Verrechnungstopf "Quellensteuer" nach der Abrechnung 0,00 EUR
+Depotnummer: 0123456789
+1111111111/00
+Vermerk der Bank: 1000
+2
+Datum: 29.11.2019
+Seite: 3 von 3
+Details zur Steuerberechnung
+Bemessungsgrundlage für Kapitalertragsteuer (Hälftige Aufteilung gem. § 51a Absatz 2c Satz 7 und § 2 Absatz 8 EStG)
+Inhaber 1 4,11 EUR
+Inhaber 2 4,11 EUR
+Bemessungsgrundlage für Kapitalertragsteuer gesamt 8,22 EUR
+Kapitalertragsteuer
+Inhaber 1 25,00 % von 4,11 EUR 1,03 EUR
+Inhaber 2 25,00 % von 4,11 EUR 1,03 EUR
+Kapitalertragsteuer gesamt 2,06 EUR
+Solidaritätszuschlag
+Inhaber 1 5,50 % von 1,03 EUR 0,05 EUR
+Inhaber 2 5,50 % von 1,03 EUR 0,05 EUR
+Solidaritätszuschlag gesamt 0,10 EUR
+Keine Kirchensteuerdaten hinterlegt bzw. keine Kirchensteuerpflicht

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -406,6 +406,35 @@ public class ConsorsbankPDFExtractorTest
     }
 
     @Test
+    public void testErtragsgutschrift12() throws IOException
+    {
+        ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "ConsorsbankErtragsgutschrift12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        AccountTransaction t = results.stream() //
+                        .filter(i -> i instanceof TransactionItem)
+                        .map(i -> (AccountTransaction) ((TransactionItem) i).getSubject()) //
+                        .findAny().get();
+
+        assertThat(t.getSecurity().getName(), is("SAMSUNG ELECTRONICS CO. LTD. R.Shs(NV)Pf(GDR144A)/25 SW 100"));
+        assertThat(t.getSecurity().getIsin(), is("US7960502018"));
+        assertThat(t.getSecurity().getWkn(), is("881823"));
+        assertThat(t.getSecurity().getCurrencyCode(), is(CurrencyUnit.USD));
+
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2019-11-27T00:00")));
+        assertThat(t.getShares(), is(Values.Share.factorize(3)));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(13.80))));
+
+        assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.52 + 2.06 + 0.10))));
+    }
+
+    @Test
     public void testBezug1() throws IOException
     {
         ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -591,14 +591,14 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("tax", "currency").optional() //
-                        .match("abzgl. Kapitalertragsteuer .* (\\w{3}+) (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$")
+                        .match("abzgl. Kapitalertragsteuer.* (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$")
                         .assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                         })
 
                         .section("tax", "currency").optional() //
-                        .match("abzgl. Solidaritätszuschlag .* (\\w{3}+) (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$")
+                        .match("abzgl. Solidaritätszuschlag.* (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$")
                         .assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));


### PR DESCRIPTION
Kapitalertragsteuer und Solidaritätszuschlag wurden nicht mehr gefunden,
weil sich das Format des PDFs geändert hat. Eine neue Testdatei ist eingefügt, der Test entsprechend erweitert und die Testergebnisse positiv.