### PR TITLE
feat: add pdf extractor for targobank

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Kauf (WPX007) TARGO 000000kontonummer am 2020-01-04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Kauf (WPX007) TARGO 000000kontonummer am 2020-01-04.txt
@@ -1,0 +1,45 @@
+PDF Author: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+TARGOBANK AG
+Postfach 10 02 30
+47002 Duisburg
+TARGOBANK AG - Postfach 10 02 30 - 47002 Duisburg www.targobank.de
+FRAU
+MAXIME MITTELNAME MUSTERMANN
+MUSTERSTR.1
+12345 MUSTERHAUSEN
+Depotnummer 010175316543
+........................................................................................................................................................................................................
+Effektenabrechnung 04.01.2020
+Rechnungsnummer: BOE-2020-0223620085-0000068
+MAXIME MUSTERMANN
+Transaktionstyp Kauf
+Stück 987,654
+Wertpapier FanCy shaRe. nAmE X0-X0
+WKN / ISIN ABC123 / DE0000ABC123
+Handelsplatz Außerbörs. Limithandel
+Handelspartner MUSTERBÖRSE
+Schlusstag / Handelszeit 02.01.2020 / 13:01:00
+Kurs 12,34 EUR
+Auftragsart Limitauftrag
+Verwahrart Girosammelverwahrung
+Neuer Bestand 5.432,01
+Geschäftsnummer 111222333444
+Referenznummer 555666777888
+Kurswert 1.000,01 EUR
+Provision 8,90 EUR
+Belastung Ihres Kontos mit Wertstellung zum 04. Januar 2020
+Konto-Nr. 0101753165 1.008,91 EUR
+Kommissionsgeschäft
+Finanzdienstleistungen mit Leistungsort in der Europäischen Union sind umsatzsteuerfrei nach § 4 Nr. 8 UStG.
+Finanzdienstleistungen mit Leistungsort in einem Drittland sind nicht umsatzsteuerbar.
+Dieses Produkt ist keine Bankeinlage. Es unterliegt nicht der Einlagensicherung. Die vergangene Performance lässt
+keine Rückschlüsse auf die zukünftige Wertentwicklung zu. Der Wert der Anlage kann schwanken. Ein teilweiser oder
+ganzer Verlust ist möglich. Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Seite 1
+TARGOBANK AG | Vorstand: Pascal Laugel (Vorsitzender); Berthold Rüsing; Maria Topaler
+Vorsitzender des Aufsichtsrates:  René Dangel | Sitz der Gesellschaft: Düsseldorf
+Handelsregister Amtsgericht Düsseldorf HRB 83351 | USt-ID-Nr.: DE 811 285 485
+USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 811 623 326
+GH.20200121.021202.5018.0014.2959 X 0 R

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/TargobankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/TargobankPDFExtractorTest.java
@@ -1,0 +1,122 @@
+package name.abuchen.portfolio.datatransfer.pdf.targobank;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
+import name.abuchen.portfolio.datatransfer.Extractor.Item;
+import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.TargobankPDFExtractor;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+public class TargobankPDFExtractorTest
+{
+    public void runWertpapierOrderTest(
+                    String testCaseFilename,
+                    int numberOfMatchingFiles,
+                    String actualShareName,
+                    String actualWkn,
+                    String actualIsin,
+                    Object actualPortfoioTransactionType,
+                    Object actualAccoutTransactionType,
+                    String actualDateTime,
+                    double actualAmount,
+                    String actualCurrency,
+                    double actualShares
+    ) {
+        TargobankPDFExtractor extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), testCaseFilename), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(numberOfMatchingFiles));
+
+        Optional<Item> securityItem;
+        Optional<Item> entryItem;
+
+        // SecurityItem
+        securityItem = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(securityItem.isPresent(), is(true));
+        Security security = ((SecurityItem) securityItem.get()).getSecurity();
+        assertThat(security.getName(), is(actualShareName));
+        assertThat(security.getWkn(), is(actualWkn));
+        assertThat(security.getIsin(), is(actualIsin));
+
+        // BuySellEntryItem
+        entryItem = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(entryItem.isPresent(), is(true));
+        assertThat(entryItem.get().getSubject(), instanceOf(BuySellEntry.class));
+        
+        // BuySellEntry...
+        BuySellEntry entry = (BuySellEntry) entryItem.get().getSubject();
+        // ... has the correct type
+        assertThat(entry.getPortfolioTransaction().getType(), is(actualPortfoioTransactionType));
+        assertThat(entry.getAccountTransaction().getType(), is(actualAccoutTransactionType));
+        // ... has the correct values
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse(actualDateTime)));
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(actualAmount)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(actualCurrency, Values.Amount.factorize(0.0))));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(actualShares)));
+    }
+
+    @Test
+    public void testWertpapierKauf01()
+    {
+        String testCaseFilename = "Kauf (WPX007) TARGO 000000kontonummer am 2020-01-04.txt";
+        int numberOfMatchingFiles = 2;
+        String actualShareName = "FanCy shaRe. nAmE X0-X0";
+        String actualWkn = "ABC123";
+        String actualIsin = "DE0000ABC123";
+        Object actualPortfolioTransactionType = PortfolioTransaction.Type.BUY;
+        Object actualAccountTransactionType = AccountTransaction.Type.BUY;
+        String actualDateTime = "2020-01-02T13:01:00";
+        double actualAmount = 1008.91;
+        String actualCurrency = "EUR";
+        double actualShares = 987.654;
+        runWertpapierOrderTest(testCaseFilename, numberOfMatchingFiles,
+                        actualShareName, actualWkn, actualIsin, 
+                        actualPortfolioTransactionType, actualAccountTransactionType,
+                        actualDateTime, actualAmount, actualCurrency, actualShares);
+    }
+    
+    @Test
+    public void testWertpapierVerkauf01()
+    {
+        String testCaseFilename = "Verkauf (WPX010) TARGO 000000000101753165 am 2020-01-22.txt";
+        int numberOfMatchingFiles = 2;
+        String actualShareName = "an0tHer vERy FNcY NaMe";
+        String actualWkn = "ZYX987";
+        String actualIsin = "LU0000ZYX987";
+        Object actualPortfolioTransactionType = PortfolioTransaction.Type.SELL;
+        Object actualAccountTransactionType = AccountTransaction.Type.SELL;
+        String actualDateTime = "2020-01-10T00:00:00";
+        double actualAmount = 1239;
+        String actualCurrency = "EUR";
+        double actualShares = 10;
+        runWertpapierOrderTest(testCaseFilename, numberOfMatchingFiles,
+                        actualShareName, actualWkn, actualIsin, 
+                        actualPortfolioTransactionType, actualAccountTransactionType,
+                        actualDateTime, actualAmount, actualCurrency, actualShares);
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Verkauf (WPX010) TARGO 000000000101753165 am 2020-01-22.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Verkauf (WPX010) TARGO 000000000101753165 am 2020-01-22.txt
@@ -1,0 +1,41 @@
+PDF Author: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+TARGOBANK AG
+Postfach 10 02 30
+47002 Duisburg
+TARGOBANK AG - Postfach 10 02 30 - 47002 Duisburg www.targobank.de
+FRAU
+MAXIME MITTELNAME MUSTERMANN
+MUSTERSTR.1
+12345 MUSTERHAUSEN
+Depotnummer 010175316543
+........................................................................................................................................................................................................
+Effektenabrechnung 22.01.2020
+Rechnungsnummer: BGH-2020-0223620085-0000068
+MAXIME MUSTERMANN
+Transaktionstyp Verkauf
+Stück 10,0000
+Wertpapier an0tHer vERy FNcY NaMe
+WKN / ISIN ZYX987 / LU0000ZYX987
+Fondsgesellschaft XXX Fonds 11elf
+Handelsplatz Fondsgesellschaft
+Preis vom 10. Januar 2020 123,90 EUR
+Schlusstag 10.01.2020
+Auftragsart Bestens
+Verwahrart GS Deutschland
+Neuer Bestand 0,0000
+Geschäftsnummer 0298735DH0293422
+Referenznummer 0291235DH0293422
+Kurswert 1.239,00 EUR
+Gutschrift auf Ihrem Konto mit Wertstellung zum 23. Januar 2020
+Konto-Nr. 0101753165 1.239,00 EUR
+Wiederanlage Fonds
+Kommissionsgeschäft
+Dieses Produkt ist keine Bankeinlage. Es unterliegt nicht der Einlagensicherung. Die vergangene Performance lässt
+keine Rückschlüsse auf die zukünftige Wertentwicklung zu. Der Wert der Anlage kann schwanken. Ein teilweiser oder
+ganzer Verlust ist möglich. Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Vorstand: Pascal Laugel (Vorsitzender); Jürgen Lieberknecht; Berthold Rüsing; Maria Topaler
+Vorsitzender des Aufsichtsrates:  René Dangel - Sitz der Gesellschaft: Düsseldorf - Handelsregister Amtsgericht Düsseldorf HRB 83351
+USt-ID-Nr.: DE 811 285 485; USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 811 623 326 
+GH.20190514.021633.5022.0001.8120 X 0 R

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -48,6 +48,7 @@ public class PDFImportAssistant
         extractors.add(new UnicreditPDFExtractor(client));
         extractors.add(new HelloBankPDFExtractor(client));
         extractors.add(new ViacPDFExtractor(client));
+        extractors.add(new TargobankPDFExtractor(client));
         extractors.add(new TradeRepublicPDFExtractor(client));
         extractors.add(new PostfinancePDFExtractor(client));
         extractors.add(new SutorPDFExtractor(client));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -1,0 +1,159 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+
+public class TargobankPDFExtractor extends AbstractPDFExtractor
+{
+    private static final String regexName = "Wertpapier (?<name>.*)"; //$NON-NLS-1$
+    private static final String regexWknAndIsin = "WKN / ISIN (?<wkn>\\S*) / (?<isin>\\S*)"; //$NON-NLS-1$
+    private static final String regexAmountAndCurrency = "Konto-Nr. \\d* (?<amount>(\\d+\\.)?\\d+(,\\d+)?) (?<currency>\\w{3}+)"; //$NON-NLS-1$
+    private static final String regexDate = "Schlusstag( / Handelszeit)? (?<date>\\d{2}.\\d{2}.\\d{4})( / (?<time>\\d{2}:\\d{2}:\\d{2}))?"; //$NON-NLS-1$
+    private static final String regexTime = "(Schlusstag / )?Handelszeit ((?<date>\\d{2}.\\d{2}.\\d{4}) / )?(?<time>\\d{2}:\\d{2}:\\d{2})"; //$NON-NLS-1$
+    private static final String regexShares = "St.ck (?<shares>\\d+(,\\d+)?)"; //$NON-NLS-1$
+    
+    public TargobankPDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("TARGO"); //$NON-NLS-1$
+        addBankIdentifier("Targobank"); //$NON-NLS-1$
+        
+        addBuyTransaction();
+        addSellTransaction();
+    }
+
+    @SuppressWarnings("nls")
+    private void addBuyTransaction()
+    {
+        DocumentType type = new DocumentType("Kauf");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("(Transaktionstyp )?Kauf"); 
+        type.addBlock(block);   
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<BuySellEntry>()
+
+                        .subject(() -> {
+                            BuySellEntry entry = new BuySellEntry();
+                            entry.setType(PortfolioTransaction.Type.BUY);
+                            return entry;
+                        })
+
+                        .section("name", "wkn", "isin").optional()
+                        .match(regexName)
+                        .match(regexWknAndIsin)
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+                        
+                        .section("time").optional()
+                        .match(regexTime)
+                        .assign((t, v) -> {
+                            type.getCurrentContext().put("time", v.get("time"));
+                        })
+                                                
+                        .section("date").optional()
+                        .match(regexDate)
+                        .assign((t, v) -> {
+                            if (type.getCurrentContext().get("time") != null)
+                            {
+                                t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
+                            }
+                            else
+                            {
+                                t.setDate(asDate(v.get("date")));
+                            }
+                        })
+
+                        .section("amount", "currency")
+                        .match(regexAmountAndCurrency)
+                        .assign((t, v) -> {
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        })
+                            
+                        .section("shares").optional()
+                        .match(regexShares)
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        .wrap(t -> {
+                            if (t.getPortfolioTransaction().getShares() == 0)
+                                throw new IllegalArgumentException(Messages.PDFMsgMissingShares);
+                            return new BuySellEntryItem(t);
+                        });
+
+        block.set(pdfTransaction);
+
+    }
+    
+    @SuppressWarnings("nls")
+    private void addSellTransaction()
+    {
+        DocumentType type = new DocumentType("Verkauf");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("(Transaktionstyp )?Verkauf");
+        type.addBlock(block);   
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<BuySellEntry>()
+
+                        .subject(() -> {
+                            BuySellEntry entry = new BuySellEntry();
+                            entry.setType(PortfolioTransaction.Type.SELL);
+                            return entry;
+                        })
+
+                        .section("name", "wkn", "isin")
+                        .match(regexName)
+                        .match(regexWknAndIsin)
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        .section("time").optional()
+                        .match(regexTime)
+                        .assign((t, v) -> {
+                            type.getCurrentContext().put("time", v.get("time"));
+                        })
+                                                
+                        .section("date").optional()
+                        .match(regexDate)
+                        .assign((t, v) -> {
+                            if (type.getCurrentContext().get("time") != null)
+                            {
+                                t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
+                            }
+                            else
+                            {
+                                t.setDate(asDate(v.get("date")));
+                            }
+                        })
+                        
+                        .section("amount", "currency")
+                        .match(regexAmountAndCurrency)
+                        .assign((t, v) -> {
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        })
+                            
+                        .section("shares").optional()
+                        .match(regexShares)
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        .wrap(t -> {
+                            if (t.getPortfolioTransaction().getShares() == 0)
+                                throw new IllegalArgumentException(Messages.PDFMsgMissingShares);
+                            return new BuySellEntryItem(t);
+                        });
+
+        block.set(pdfTransaction);
+
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "TARGO"; //$NON-NLS-1$
+    }
+
+}


### PR DESCRIPTION
PDF Extractor für Effektenabrechnungen der Targobank. 

Funktioniert nur für Wertpapiert Kauf- und Verkauftransaktionen ab ca. 2017. Funktioniert z.B. nicht für einen Wertpapiertkauf im Rahmen einer Wiederanlage der Erträge.  