### PR TITLE
eye candy - trades equal to earnings view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -649,6 +649,8 @@ public class Messages extends NLS
     public static String LabelTotalSum;
     public static String LabelTotalValuePercent;
     public static String LabelTrades;
+    public static String LabelTradesOpen;
+    public static String LabelTradesClosed;
     public static String LabelTradesBasicStatistics;
     public static String LabelTradesProfitLoss;
     public static String LabelTradingActivityChart;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
@@ -47,7 +47,7 @@ import name.abuchen.portfolio.ui.views.dashboard.DashboardView;
 import name.abuchen.portfolio.ui.views.earnings.EarningsView;
 import name.abuchen.portfolio.ui.views.settings.SettingsView;
 import name.abuchen.portfolio.ui.views.taxonomy.TaxonomyView;
-import name.abuchen.portfolio.ui.views.trades.TradeDetailsView;
+import name.abuchen.portfolio.ui.views.trades.TradeView;
 
 public final class Navigation
 {
@@ -433,10 +433,7 @@ public final class Navigation
         performance.add(new Item(Messages.ClientEditorLabelReturnsVolatility, ReturnsVolatilityChartView.class));
         performance.add(new Item(Messages.LabelSecurities, SecuritiesPerformanceView.class));
         performance.add(new Item(Messages.LabelEarningsExpenses, EarningsView.class));
-
-        Item allTrades = new Item(Messages.LabelTrades, TradeDetailsView.class);
-        allTrades.addTag(Tag.HIDE);
-        performance.add(allTrades);
+        performance.add(new Item(Messages.LabelTrades, TradeView.class));
     }
 
     private void createTaxonomyDataSection(Client client)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1307,6 +1307,10 @@ LabelTotalValuePercent = {0} tv
 
 LabelTrades = Trades
 
+LabelTradesOpen = Trades (open)
+
+LabelTradesClosed = Trades (closed)
+
 LabelTradesBasicStatistics = Number of trades (with profit/with loss)
 
 LabelTradesProfitLoss = Trades Profit/Loss

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1303,6 +1303,10 @@ LabelTotalValuePercent = {0} GW
 
 LabelTrades = Trades
 
+LabelTradesOpen = Trades (offen)
+
+LabelTradesClosed = Trades (geschlossen)
+
 LabelTradesBasicStatistics = Anzahl Trades (mit Gewinn/mit Verlust)
 
 LabelTradesProfitLoss = Trades Gewinn/Verlust

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1295,6 +1295,10 @@ LabelTotalValuePercent = {0} tv
 
 LabelTrades = Transacties
 
+LabelTradesOpen = Trades (open)
+
+LabelTradesClosed = Trades (gesloten)
+
 LabelTradesBasicStatistics = Aantal transacties (met winst / verlies)
 
 LabelTradingActivityChart = Handelsactiviteit

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/AbstractChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/AbstractChartTab.java
@@ -1,0 +1,157 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.text.DateFormatSymbols;
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.eclipse.jface.resource.ColorDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.swtchart.Chart;
+import org.swtchart.IAxis;
+import org.swtchart.IAxis.Position;
+import org.swtchart.ICustomPaintListener;
+import org.swtchart.IPlotArea;
+import org.swtchart.ISeries;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
+
+public abstract class AbstractChartTab implements TradeTab
+{
+    private class PaintBehindListener implements ICustomPaintListener
+    {
+        @Override
+        public void paintControl(PaintEvent e)
+        {
+            int y = chart.getAxisSet().getYAxis(0).getPixelCoordinate(0);
+            e.gc.setForeground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
+            e.gc.setLineStyle(SWT.LINE_SOLID);
+            e.gc.drawLine(0, y, e.width, y);
+        }
+
+        @Override
+        public boolean drawBehindSeries()
+        {
+            return true;
+        }
+    }
+
+    private static final int[][] COLORS = new int[][] { //
+                    new int[] { 140, 86, 75 }, //
+                    new int[] { 227, 119, 194 }, //
+                    new int[] { 127, 127, 127 }, //
+                    new int[] { 188, 189, 34 }, //
+                    new int[] { 23, 190, 207 }, //
+                    new int[] { 114, 124, 201 }, //
+                    new int[] { 250, 115, 92 }, //
+                    new int[] { 253, 182, 103 }, //
+                    new int[] { 143, 207, 112 }, //
+                    new int[] { 87, 207, 253 }, //
+                    new int[] { 31, 119, 180 }, //
+                    new int[] { 255, 127, 14 }, //
+                    new int[] { 44, 160, 44 }, //
+                    new int[] { 214, 39, 40 }, //
+                    new int[] { 148, 103, 189 } }; //
+
+    @Inject
+    protected TradeViewModel model;
+
+    private LocalResourceManager resources;
+    private Chart chart;
+
+    protected abstract void createSeries();
+
+    protected Chart getChart()
+    {
+        return chart;
+    }
+
+    protected LocalResourceManager getResources()
+    {
+        return resources;
+    }
+
+    @Override
+    public final Control createControl(Composite parent)
+    {
+        resources = new LocalResourceManager(JFaceResources.getResources(), parent);
+
+        chart = new Chart(parent, SWT.NONE);
+        chart.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        chart.getTitle().setVisible(false);
+        chart.getLegend().setPosition(SWT.BOTTOM);
+        chart.getPlotArea().addPaintListener(new PaintBehindListener());
+
+        IAxis xAxis = chart.getAxisSet().getXAxis(0);
+        xAxis.getTitle().setVisible(false);
+        xAxis.getTick().setForeground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
+        xAxis.getTitle().setText(Messages.ColumnMonth);
+
+        IAxis yAxis = chart.getAxisSet().getYAxis(0);
+        yAxis.getTitle().setVisible(false);
+        yAxis.getTick().setForeground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
+        yAxis.setPosition(Position.Secondary);
+
+        xAxis.enableCategory(true);
+
+        // add paint listeners
+        IPlotArea plotArea = (IPlotArea) chart.getPlotArea();
+        plotArea.addCustomPaintListener(new PaintBehindListener());
+
+        // format symbols returns 13 values as some calendars have 13 months
+        xAxis.setCategorySeries(Arrays.copyOfRange(new DateFormatSymbols().getMonths(), 0, 12));
+
+        createSeries();
+
+        chart.getAxisSet().adjustRange();
+
+        attachTooltipTo(chart);
+
+        model.addUpdateListener(this::updateChart);
+
+        return chart;
+    }
+
+    protected void attachTooltipTo(Chart chart)
+    {
+        TimelineChartToolTip toolTip = new TimelineChartToolTip(chart);
+        toolTip.enableCategory(true);
+    }
+
+    protected Color getColor(int year)
+    {
+        RGB rgb = new RGB(COLORS[year % COLORS.length][0], //
+                        COLORS[year % COLORS.length][1], //
+                        COLORS[year % COLORS.length][2]);
+        return resources.createColor(ColorDescriptor.createFrom(rgb));
+    }
+
+    private void updateChart()
+    {
+        try
+        {
+            chart.suspendUpdate(true);
+            for (ISeries s : chart.getSeriesSet().getSeries())
+                chart.getSeriesSet().deleteSeries(s.getId());
+
+            createSeries();
+
+            chart.getAxisSet().adjustRange();
+        }
+        finally
+        {
+            chart.suspendUpdate(false);
+        }
+        chart.redraw();
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/StartYearSelectionDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/StartYearSelectionDropDown.java
@@ -1,0 +1,87 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuListener;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.dialogs.IInputValidator;
+import org.eclipse.jface.dialogs.InputDialog;
+import org.eclipse.swt.widgets.Display;
+
+import com.ibm.icu.text.MessageFormat;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.DropDown;
+import name.abuchen.portfolio.ui.util.SimpleAction;
+
+/* package */ class StartYearSelectionDropDown extends DropDown implements IMenuListener
+{
+    private TradeViewModel model;
+
+    public StartYearSelectionDropDown(TradeViewModel model)
+    {
+        super(createLabelTextForYear(model.getStartYear()));
+        this.model = model;
+
+        setMenuListener(this);
+    }
+
+    @Override
+    public void menuAboutToShow(IMenuManager manager)
+    {
+        int now = LocalDate.now().getYear();
+
+        for (int ii = 0; ii < 10; ii++)
+        {
+            int year = now - ii;
+
+            Action action = new Action(String.valueOf(year))
+            {
+                @Override
+                public void run()
+                {
+                    model.updateWith(year);
+                    setLabel(createLabelTextForYear(year));
+                }
+            };
+            action.setChecked(year == model.getStartYear());
+            manager.add(action);
+        }
+
+        manager.add(new Separator());
+        manager.add(new SimpleAction(Messages.LabelSelectYear, a -> {
+
+            IInputValidator validator = newText -> {
+                try
+                {
+                    int year = Integer.parseInt(newText);
+                    return year >= 1900 && year <= now ? null
+                                    : MessageFormat.format(Messages.MsgErrorDividendsYearBetween1900AndNow,
+                                                    String.valueOf(now));
+                }
+                catch (NumberFormatException nfe)
+                {
+                    return MessageFormat.format(Messages.MsgErrorDividendsYearBetween1900AndNow, String.valueOf(now));
+                }
+            };
+
+            InputDialog dialog = new InputDialog(Display.getDefault().getActiveShell(), Messages.LabelYear,
+                            Messages.LabelEarningsSelectStartYear, String.valueOf(model.getStartYear()), validator);
+
+            if (dialog.open() == InputDialog.OK)
+            {
+                int year = Integer.parseInt(dialog.getValue());
+                model.updateWith(year);
+                setLabel(createLabelTextForYear(year));
+            }
+
+        }));
+    }
+
+    private static String createLabelTextForYear(int year)
+    {
+        return Messages.LabelSelectYearSince + " " + year; //$NON-NLS-1$
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerMonthChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerMonthChartTab.java
@@ -1,0 +1,142 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.swtchart.Chart;
+import org.swtchart.IBarSeries;
+import org.swtchart.ISeries.SeriesType;
+
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerMonthChartTab extends AbstractChartTab
+{
+    private class DividendPerMonthChartToolTip extends TimelineChartToolTip
+    {
+        private TradeViewModel model;
+
+        public DividendPerMonthChartToolTip(Chart chart, TradeViewModel model)
+        {
+            super(chart);
+
+            this.model = model;
+        }
+
+        @Override
+        protected void createComposite(Composite parent)
+        {
+            int month = (Integer) getFocusedObject();
+            int totalNoOfMonths = model.getNoOfMonths();
+
+            List<Line> lines = model.getLines().stream() //
+                            .filter(line -> {
+                                for (int index = month; index < totalNoOfMonths; index += 12)
+                                    if (line.getValue(index) != 0L)
+                                        return true;
+                                return false;
+                            })
+                            .sorted((l1, l2) -> l1.getVehicle().getName()
+                                            .compareToIgnoreCase(l2.getVehicle().getName()))
+                            .collect(Collectors.toList());
+
+            int noOfYears = (totalNoOfMonths / 12) + (totalNoOfMonths % 12 > month ? 1 : 0);
+
+            final Composite container = new Composite(parent, SWT.NONE);
+            container.setBackgroundMode(SWT.INHERIT_FORCE);
+            GridLayoutFactory.swtDefaults().numColumns(1 + noOfYears).applyTo(container);
+
+            Color foregroundColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+            container.setForeground(foregroundColor);
+            container.setBackground(Colors.INFO_TOOLTIP_BACKGROUND);
+
+            Label topLeft = new Label(container, SWT.NONE);
+            topLeft.setForeground(foregroundColor);
+            topLeft.setText(Messages.ColumnSecurity);
+
+            for (int year = 0; year < noOfYears; year++)
+            {
+                Label label = new Label(container, SWT.CENTER);
+
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[year]).getBarColor();
+                label.setBackground(color);
+                label.setForeground(Colors.getTextColor(color));
+                label.setText(String.valueOf(model.getStartYear() + year));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
+            }
+
+            lines.forEach(line -> {
+                Label l = new Label(container, SWT.NONE);
+                l.setForeground(foregroundColor);
+                l.setText(TextUtil.tooltip(line.getVehicle().getName()));
+
+                for (int m = month; m < totalNoOfMonths; m += 12)
+                {
+                    l = new Label(container, SWT.RIGHT);
+                    l.setForeground(foregroundColor);
+                    l.setText(Values.Amount.format(line.getValue(m)));
+                    GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
+                }
+            });
+
+            Label l = new Label(container, SWT.NONE);
+            l.setForeground(foregroundColor);
+            l.setText(Messages.ColumnSum);
+
+            for (int m = month; m < totalNoOfMonths; m += 12)
+            {
+                l = new Label(container, SWT.RIGHT);
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[m / 12]).getBarColor();
+                l.setBackground(color);
+                l.setForeground(Colors.getTextColor(color));
+                l.setText(Values.Amount.format(model.getSum().getValue(m)));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(l);
+            }
+
+        }
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsPerMonth;
+    }
+
+    @Override
+    protected void attachTooltipTo(Chart chart)
+    {
+        DividendPerMonthChartToolTip toolTip = new DividendPerMonthChartToolTip(chart, model);
+        toolTip.enableCategory(true);
+    }
+
+    @Override
+    protected void createSeries()
+    {
+        for (int index = 0; index < model.getNoOfMonths(); index += 12)
+        {
+            int year = model.getStartYear() + (index / 12);
+
+            IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,
+                            String.valueOf(year));
+
+            double[] series = new double[Math.min(12, model.getNoOfMonths() - index)];
+            for (int ii = 0; ii < series.length; ii++)
+                series[ii] = model.getSum().getValue(index + ii) / Values.Amount.divider();
+            barSeries.setYSeries(series);
+
+            barSeries.setBarColor(getColor(year));
+            barSeries.setBarPadding(25);
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerMonthMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerMonthMatrixTab.java
@@ -1,0 +1,289 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.function.ToLongFunction;
+
+import javax.inject.Inject;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.resource.FontDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnPixelData;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.window.ToolTip;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.TableColumn;
+
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.InvestmentVehicle;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Images;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.selection.SecuritySelection;
+import name.abuchen.portfolio.ui.selection.SelectionService;
+import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
+import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerMonthMatrixTab implements TradeTab
+{
+    @Inject
+    private SelectionService selectionService;
+
+    @Inject
+    protected TradeViewModel model;
+
+    protected Font boldFont;
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM yy"); //$NON-NLS-1$
+
+    private TableColumnLayout tableLayout;
+    private TableViewer tableViewer;
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsByMonthAndVehicle;
+    }
+
+    @Override
+    public void addExportActions(IMenuManager manager)
+    {
+        manager.add(new Action(MessageFormat.format(Messages.LabelExport, getLabel()))
+        {
+            @Override
+            public void run()
+            {
+                new TableViewerCSVExporter(tableViewer).export(getLabel() + ".csv"); //$NON-NLS-1$
+            }
+        });
+    }
+
+    @Override
+    public Control createControl(Composite parent)
+    {
+        LocalResourceManager resources = new LocalResourceManager(JFaceResources.getResources(), parent);
+        boldFont = resources.createFont(FontDescriptor.createFrom(parent.getFont()).setStyle(SWT.BOLD));
+
+        Composite container = new Composite(parent, SWT.NONE);
+
+        tableLayout = new TableColumnLayout();
+        container.setLayout(tableLayout);
+
+        tableViewer = new TableViewer(container, SWT.FULL_SELECTION);
+        ColumnViewerToolTipSupport.enableFor(tableViewer, ToolTip.NO_RECREATE);
+
+        createColumns(tableViewer, tableLayout);
+
+        tableViewer.getTable().setHeaderVisible(true);
+        tableViewer.getTable().setLinesVisible(true);
+
+        tableViewer.setContentProvider(ArrayContentProvider.getInstance());
+
+        tableViewer.addSelectionChangedListener(event -> {
+            IStructuredSelection selection = event.getStructuredSelection();
+            if (!selection.isEmpty())
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) selection.getFirstElement()).getVehicle();
+                if (vehicle instanceof Security)
+                    selectionService.setSelection(new SecuritySelection(model.getClient(), (Security) vehicle));
+            }
+        });
+
+        tableViewer.setInput(model.getAllLines());
+
+        for (TableColumn c : tableViewer.getTable().getColumns())
+            c.pack();
+
+        model.addUpdateListener(() -> updateColumns(tableViewer, tableLayout));
+
+        return container;
+    }
+
+    protected void createColumns(TableViewer records, TableColumnLayout layout)
+    {
+        createVehicleColumn(records, layout, true);
+
+        // create monthly columns
+        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
+
+        int noOfMonths = model.getNoOfMonths();
+
+        for (int index = 0; index < noOfMonths; index++)
+        {
+            createMonthColumn(records, layout, date, index);
+            date = date.plusMonths(1);
+        }
+
+        createSumColumn(records, layout);
+
+        // add security name at the end of the matrix table again because the
+        // first column is most likely not visible anymore
+        createVehicleColumn(records, layout, false);
+    }
+
+    protected void createVehicleColumn(TableViewer records, TableColumnLayout layout, boolean isSorted)
+    {
+        TableViewerColumn column = new TableViewerColumn(records, SWT.NONE);
+        column.getColumn().setText(Messages.ColumnSecurity);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public Image getImage(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                if (vehicle instanceof Account)
+                    return Images.ACCOUNT.image();
+                else if (vehicle instanceof Security)
+                    return Images.SECURITY.image();
+                else
+                    return null;
+            }
+
+            @Override
+            public String getText(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return vehicle != null ? vehicle.getName() : Messages.ColumnSum;
+            }
+
+            @Override
+            public Font getFont(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return vehicle != null ? null : boldFont;
+            }
+        });
+
+        createSorter((l1, l2) -> l1.getVehicle().getName().compareToIgnoreCase(l2.getVehicle().getName()))
+                        .attachTo(records, column, isSorted);
+
+        layout.setColumnData(column.getColumn(), new ColumnPixelData(200));
+    }
+
+    protected ColumnViewerSorter createSorter(Comparator<TradeViewModel.Line> comparator)
+    {
+        return ColumnViewerSorter.create((o1, o2) -> {
+            int direction = ColumnViewerSorter.SortingContext.getSortDirection();
+
+            TradeViewModel.Line line1 = (TradeViewModel.Line) o1;
+            TradeViewModel.Line line2 = (TradeViewModel.Line) o2;
+
+            if (line1.getVehicle() == null)
+                return direction == SWT.DOWN ? 1 : -1;
+            if (line2.getVehicle() == null)
+                return direction == SWT.DOWN ? -1 : 1;
+
+            return comparator.compare(line1, line2);
+        });
+    }
+
+    private void createMonthColumn(TableViewer records, TableColumnLayout layout, LocalDate start, int index)
+    {
+        TableViewerColumn column = new TableViewerColumn(records, SWT.RIGHT);
+        column.getColumn().setText(formatter.format(start));
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Line line = (TradeViewModel.Line) element;
+                return line.getVehicle() != null ? Values.Amount.formatNonZero(line.getValue(index))
+                                : Values.Amount.format(line.getValue(index));
+            }
+
+            @Override
+            public String getToolTipText(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return TextUtil.tooltip(vehicle != null ? vehicle.getName() : null);
+            }
+
+            @Override
+            public Font getFont(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return vehicle != null ? null : boldFont;
+            }
+        });
+
+        createSorter((l1, l2) -> Long.compare(l1.getValue(index), l2.getValue(index))).attachTo(records, column);
+
+        layout.setColumnData(column.getColumn(), new ColumnPixelData(50));
+    }
+
+    protected void createSumColumn(TableViewer records, TableColumnLayout layout)
+    {
+        ToLongFunction<TradeViewModel.Line> valueFunction = line -> {
+            return line.getSum();
+        };
+
+        TableViewerColumn column;
+        column = new TableViewerColumn(records, SWT.RIGHT);
+        column.getColumn().setText(Messages.ColumnSum);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                TradeViewModel.Line line = (TradeViewModel.Line) element;
+                return Values.Amount.formatNonZero(valueFunction.applyAsLong(line));
+            }
+
+            @Override
+            public Font getFont(Object element)
+            {
+                return boldFont;
+            }
+        });
+
+        createSorter((l1, l2) -> Long.compare(valueFunction.applyAsLong(l1), valueFunction.applyAsLong(l2)))
+                        .attachTo(records, column);
+
+        layout.setColumnData(column.getColumn(), new ColumnPixelData(200));
+    }
+
+    private void updateColumns(TableViewer records, TableColumnLayout layout)
+    {
+        try
+        {
+            // first add, then remove columns
+            // (otherwise rendering of first column is broken)
+            records.getTable().setRedraw(false);
+
+            int count = records.getTable().getColumnCount();
+
+            createColumns(records, layout);
+
+            for (int ii = 0; ii < count; ii++)
+                records.getTable().getColumn(0).dispose();
+
+            records.setInput(model.getAllLines());
+
+            for (TableColumn c : records.getTable().getColumns())
+                c.pack();
+        }
+        finally
+        {
+            records.refresh();
+            records.getTable().setRedraw(true);
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerQuarterChartTab.java
@@ -1,0 +1,165 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.swtchart.Chart;
+import org.swtchart.IBarSeries;
+import org.swtchart.ISeries.SeriesType;
+
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerQuarterChartTab extends AbstractChartTab
+{
+    private class DividendPerQuarterChartToolTip extends TimelineChartToolTip
+    {
+        private TradeViewModel model;
+
+        public DividendPerQuarterChartToolTip(Chart chart, TradeViewModel model)
+        {
+            super(chart);
+
+            this.model = model;
+        }
+
+        @Override
+        protected void createComposite(Composite parent)
+        {
+            int quarter = (Integer) getFocusedObject();
+            int totalNoOfMonths = model.getNoOfMonths();
+
+            List<Line> lines = model.getLines().stream() //
+                            .filter(line -> {
+                                for (int index = 0; index < totalNoOfMonths; index += 1)
+                                {
+                                    if ((line.getValue(index) != 0L) && (((index % 12) / 3) == quarter))
+                                        return true;
+                                }
+                                return false;
+                            }).sorted((l1, l2) -> l1.getVehicle().getName() // sort
+                                                                            // alphabetically
+                                            .compareToIgnoreCase(l2.getVehicle().getName()))
+                            .collect(Collectors.toList());
+
+            int noOfYears = (totalNoOfMonths / 12) + (totalNoOfMonths % 12 > quarter * 3 ? 1 : 0);
+
+            final Composite container = new Composite(parent, SWT.NONE);
+            container.setBackgroundMode(SWT.INHERIT_FORCE);
+            GridLayoutFactory.swtDefaults().numColumns(1 + noOfYears).applyTo(container);
+
+            Color foregroundColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+            container.setForeground(foregroundColor);
+            container.setBackground(Colors.INFO_TOOLTIP_BACKGROUND);
+
+            Label topLeft = new Label(container, SWT.NONE);
+            topLeft.setForeground(foregroundColor);
+            topLeft.setText(Messages.ColumnSecurity);
+
+            for (int year = 0; year < noOfYears; year++)
+            {
+                Label label = new Label(container, SWT.CENTER);
+
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[year]).getBarColor();
+                label.setBackground(color);
+                label.setForeground(Colors.getTextColor(color));
+                label.setText(String.valueOf(model.getStartYear() + year));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
+            }
+
+            lines.forEach(line -> {
+                Label l = new Label(container, SWT.NONE);
+                l.setForeground(foregroundColor);
+                l.setText(TextUtil.tooltip(line.getVehicle().getName()));
+
+                for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
+                {
+                    int mLimit = m + 3;
+                    long value = 0;
+                    for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                        value += line.getValue(mQuarter);
+                    l = new Label(container, SWT.RIGHT);
+                    l.setForeground(foregroundColor);
+                    l.setText(Values.Amount.format(value));
+                    GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
+                }
+            });
+
+            Label l = new Label(container, SWT.NONE);
+            l.setForeground(foregroundColor);
+            l.setText(Messages.ColumnSum);
+
+            for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
+            {
+                int mLimit = m + 3;
+                long value = 0;
+                for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                    value += model.getSum().getValue(mQuarter);
+                l = new Label(container, SWT.RIGHT);
+                Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[m / 12]).getBarColor();
+                l.setBackground(color);
+                l.setForeground(Colors.getTextColor(color));
+                l.setText(Values.Amount.format(value));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(l);
+            }
+        }
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsPerQuarter;
+    }
+
+    @Override
+    protected void attachTooltipTo(Chart chart)
+    {
+        DividendPerQuarterChartToolTip toolTip = new DividendPerQuarterChartToolTip(chart, model);
+        toolTip.enableCategory(true);
+    }
+
+    private void updateCategorySeries()
+    {
+        String[] labels = new String[4];
+        for (int ii = 0; ii < 4; ii++)
+        {
+            String label = String.format("Q%d", ii + 1); //$NON-NLS-1$
+            labels[ii] = label;
+        }
+        getChart().getAxisSet().getXAxis(0).setCategorySeries(labels);
+    }
+
+    @Override
+    protected void createSeries()
+    {
+        updateCategorySeries();
+        for (int index = 0; index < model.getNoOfMonths(); index += 12)
+        {
+            int year = model.getStartYear() + (index / 12);
+
+            IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,
+                            String.valueOf(year));
+
+            double[] series = new double[Math.min(12, model.getNoOfMonths() - index)];
+            for (int ii = 0; ii < series.length; ii++)
+            {
+                series[(int) ii / 3] = series[ii / 3] + model.getSum().getValue(index + ii) / Values.Amount.divider();
+            }
+            barSeries.setYSeries(series);
+
+            barSeries.setBarColor(getColor(year));
+            barSeries.setBarPadding(25);
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerQuarterMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerQuarterMatrixTab.java
@@ -1,0 +1,147 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.function.ToLongFunction;
+
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnPixelData;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+
+import name.abuchen.portfolio.model.InvestmentVehicle;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerQuarterMatrixTab extends TradePerMonthMatrixTab
+{
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy"); //$NON-NLS-1$
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsByQuarterAndVehicle;
+    }
+
+    @Override
+    public void addConfigActions(IMenuManager manager)
+    {
+        // do not add config option from divident / month tab
+    }
+
+    @Override
+    protected void createColumns(TableViewer records, TableColumnLayout layout)
+    {
+        createVehicleColumn(records, layout, true);
+
+        createQuarterColumns(records, layout);
+
+        createSumColumn(records, layout);
+    }
+
+    private void createQuarterColumns(TableViewer records, TableColumnLayout layout)
+    {
+        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
+
+        int nMonths = model.getNoOfMonths();
+
+        /*
+         * The number of month in a quarter. While most people will know this, I
+         * prefer named variables over the occurrence of magic numbers in the
+         * code.
+         */
+        int monthInQuarter = 3;
+
+        // How many quarters we are about to display. We show every started
+        // quarter, hence the Math.ceil
+        int nQuarters = (int) Math.ceil((double) nMonths / (double) monthInQuarter);
+
+        int quarterBeginIndex = 0;
+        int quarterEndIndex = Math.min(monthInQuarter, nMonths);
+
+        for (int quarter = 0; quarter < nQuarters; quarter++)
+        {
+            // the fifth total quarter is the first quarter in the corresponding
+            // year
+            int quarterWithinYear = (quarter % 4) + 1;
+
+            // The caption looks like "Q<quarter within the year> <year>"
+            String columnCaption = String.format("Q%d %s", quarterWithinYear, formatter.format(date)); //$NON-NLS-1$
+
+            createQuarterColumn(records, layout, quarterBeginIndex, quarterEndIndex, columnCaption);
+
+            // Starting from here, we make sure to step into the next quarter
+            quarterBeginIndex = Math.min(quarterBeginIndex + monthInQuarter, nMonths);
+            quarterEndIndex = Math.min(quarterEndIndex + monthInQuarter, nMonths);
+
+            // every four quarters we need to switch to the next year
+            if (quarterWithinYear == 4)
+            {
+                date = date.plusYears(1);
+            }
+        }
+
+    }
+
+    /**
+     * @brief Creates a column collecting quarter-wise dividends. The quarter is
+     *        specified by the start and end position within the values array of
+     *        the Line within the DividendsViewModel.
+     * @param quarterBeginIndex
+     *            The start index of the quarter
+     * @param quarterEndIndex
+     *            The end index of the quarter
+     * @param columnCaption
+     *            The caption used for the column
+     */
+    private void createQuarterColumn(TableViewer records, TableColumnLayout layout, int quarterBeginIndex,
+                    int quarterEndIndex, String columnCaption)
+    {
+        ToLongFunction<TradeViewModel.Line> valueFunction = line -> {
+            long value = 0;
+            for (int i = quarterBeginIndex; i < quarterEndIndex; i++)
+                value += line.getValue(i);
+            return value;
+        };
+
+        TableViewerColumn column = new TableViewerColumn(records, SWT.RIGHT);
+        column.getColumn().setText(columnCaption);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Line line = (TradeViewModel.Line) element;
+                long value = valueFunction.applyAsLong(line);
+                return line.getVehicle() != null ? Values.Amount.formatNonZero(value) : Values.Amount.format(value);
+            }
+
+            @Override
+            public String getToolTipText(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return TextUtil.tooltip(vehicle != null ? vehicle.getName() : null);
+            }
+
+            @Override
+            public Font getFont(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return vehicle != null ? null : boldFont;
+            }
+        });
+
+        createSorter((l1, l2) -> Long.compare(valueFunction.applyAsLong(l1), valueFunction.applyAsLong(l2)))
+                        .attachTo(records, column);
+
+        layout.setColumnData(column.getColumn(), new ColumnPixelData(50));
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerYearChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerYearChartTab.java
@@ -1,0 +1,153 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.swtchart.Chart;
+import org.swtchart.IBarSeries;
+import org.swtchart.ISeries.SeriesType;
+
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerYearChartTab extends AbstractChartTab
+{
+    private class DividendPerYearToolTip extends TimelineChartToolTip
+    {
+        private TradeViewModel model;
+
+        public DividendPerYearToolTip(Chart chart, TradeViewModel model)
+        {
+            super(chart);
+
+            this.model = model;
+        }
+
+        @Override
+        protected void createComposite(Composite parent)
+        {
+            final int year = (Integer) getFocusedObject();
+            int totalNoOfMonths = model.getNoOfMonths();
+
+            IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().getSeries()[0];
+
+            List<Line> lines = model.getLines().stream() //
+                            .filter(line -> {
+                                for (int index = year * 12; index < (year + 1) * 12
+                                                && index < totalNoOfMonths; index += 1)
+                                    if (line.getValue(index) != 0L)
+                                        return true;
+                                return false;
+                            })
+                            .sorted((l1, l2) -> l1.getVehicle().getName()
+                                            .compareToIgnoreCase(l2.getVehicle().getName()))
+                            .collect(Collectors.toList());
+
+            final Composite container = new Composite(parent, SWT.NONE);
+            container.setBackgroundMode(SWT.INHERIT_FORCE);
+            GridLayoutFactory.swtDefaults().numColumns(2).applyTo(container);
+
+            Color foregroundColor = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+            container.setForeground(foregroundColor);
+            container.setBackground(Colors.INFO_TOOLTIP_BACKGROUND);
+
+            Label topLeft = new Label(container, SWT.NONE);
+            topLeft.setForeground(foregroundColor);
+            topLeft.setText(Messages.ColumnSecurity);
+
+            Label label = new Label(container, SWT.CENTER);
+            label.setBackground(barSeries.getBarColor());
+            label.setForeground(Colors.getTextColor(barSeries.getBarColor()));
+            label.setText(String.valueOf(model.getStartYear() + year));
+            GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
+
+            lines.forEach(line -> {
+                Label l = new Label(container, SWT.NONE);
+                l.setForeground(foregroundColor);
+                l.setText(TextUtil.tooltip(line.getVehicle().getName()));
+
+                long value = 0;
+                for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)
+                    value += line.getValue(m);
+
+                l = new Label(container, SWT.RIGHT);
+                l.setForeground(foregroundColor);
+                l.setText(Values.Amount.format(value));
+                GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
+            });
+
+            Label l = new Label(container, SWT.NONE);
+            l.setForeground(foregroundColor);
+            l.setText(Messages.ColumnSum);
+
+            long value = 0;
+            for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)
+                value += model.getSum().getValue(m);
+
+            l = new Label(container, SWT.RIGHT);
+            l.setBackground(barSeries.getBarColor());
+            l.setForeground(Colors.getTextColor(barSeries.getBarColor()));
+            l.setText(Values.Amount.format(value));
+        }
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsPerYear;
+    }
+
+    @Override
+    protected void attachTooltipTo(Chart chart)
+    {
+        DividendPerYearToolTip toolTip = new DividendPerYearToolTip(chart, model);
+        toolTip.enableCategory(true);
+    }
+
+    private void updateCategorySeries()
+    {
+        int startYear = model.getStartYear();
+        String[] labels = new String[LocalDate.now().getYear() - startYear + 1];
+        for (int ii = 0; ii < labels.length; ii++)
+            labels[ii] = String.valueOf(startYear + ii);
+        getChart().getAxisSet().getXAxis(0).setCategorySeries(labels);
+    }
+
+    @Override
+    protected void createSeries()
+    {
+        updateCategorySeries();
+
+        int startYear = model.getStartYear();
+        double[] series = new double[LocalDate.now().getYear() - startYear + 1];
+
+        for (int index = 0; index < model.getNoOfMonths(); index += 12)
+        {
+            int year = (index / 12);
+
+            long total = 0;
+
+            int months = Math.min(12, model.getNoOfMonths() - index);
+            for (int ii = 0; ii < months; ii++)
+                total += model.getSum().getValue(index + ii);
+
+            series[year] = total / Values.Amount.divider();
+        }
+
+        IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR, getLabel());
+        barSeries.setYSeries(series);
+        barSeries.setBarColor(Colors.DARK_BLUE);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerYearMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradePerYearMatrixTab.java
@@ -1,0 +1,96 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.function.ToLongFunction;
+
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnPixelData;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
+
+import name.abuchen.portfolio.model.InvestmentVehicle;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.views.trades.TradeViewModel.Line;
+import name.abuchen.portfolio.util.TextUtil;
+
+public class TradePerYearMatrixTab extends TradePerMonthMatrixTab
+{
+    private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy"); //$NON-NLS-1$
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelEarningsByYearAndVehicle;
+    }
+
+    @Override
+    public void addConfigActions(IMenuManager manager)
+    {
+        // do not add configuration option from earnings / month tab
+    }
+
+    @Override
+    protected void createColumns(TableViewer records, TableColumnLayout layout)
+    {
+        createVehicleColumn(records, layout, true);
+
+        LocalDate date = LocalDate.of(model.getStartYear(), Month.JANUARY, 1);
+        for (int index = 0; index < model.getNoOfMonths(); index += 12)
+        {
+            createYearColumn(records, layout, date, index);
+            date = date.plusYears(1);
+        }
+
+        createSumColumn(records, layout);
+    }
+
+    private void createYearColumn(TableViewer records, TableColumnLayout layout, LocalDate start, int index)
+    {
+        ToLongFunction<TradeViewModel.Line> valueFunction = line -> {
+            long value = 0;
+            for (int ii = index; ii < index + 12 && ii < line.getNoOfMonths(); ii++)
+                value += line.getValue(ii);
+            return value;
+        };
+
+        TableViewerColumn column = new TableViewerColumn(records, SWT.RIGHT);
+        column.getColumn().setText(formatter.format(start));
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Line line = (TradeViewModel.Line) element;
+                long value = valueFunction.applyAsLong(line);
+                return line.getVehicle() != null ? Values.Amount.formatNonZero(value) : Values.Amount.format(value);
+            }
+
+            @Override
+            public String getToolTipText(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return TextUtil.tooltip(vehicle != null ? vehicle.getName() : null);
+            }
+
+            @Override
+            public Font getFont(Object element)
+            {
+                InvestmentVehicle vehicle = ((TradeViewModel.Line) element).getVehicle();
+                return vehicle != null ? null : boldFont;
+            }
+        });
+
+        createSorter((l1, l2) -> Long.compare(valueFunction.applyAsLong(l1), valueFunction.applyAsLong(l2)))
+                        .attachTo(records, column);
+
+        layout.setColumnData(column.getColumn(), new ColumnPixelData(50));
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeTab.java
@@ -1,0 +1,22 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+public interface TradeTab
+{
+    String getLabel();
+
+    Control createControl(Composite parent);
+
+    default void addExportActions(IMenuManager manager)
+    {
+        // no export actions added by default
+    }
+
+    default void addConfigActions(IMenuManager manager)
+    {
+        // no config actions added by default
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeView.java
@@ -1,0 +1,134 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.CurrencyConverterImpl;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.ui.Images;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.util.DropDown;
+
+public class TradeView extends AbstractFinanceView
+{
+    private static final String KEY_TAB = TradeView.class.getSimpleName() + "-tab"; //$NON-NLS-1$
+    private static final String KEY_YEAR = TradeView.class.getSimpleName() + "-year"; //$NON-NLS-1$
+
+    @Inject
+    private Client client;
+
+    @Inject
+    private IPreferenceStore preferences;
+
+    @Inject
+    private ExchangeRateProviderFactory factory;
+
+    private TradeViewModel model;
+
+    private CTabFolder folder;
+
+    @PostConstruct
+    public void setupModel()
+    {
+        CurrencyConverterImpl converter = new CurrencyConverterImpl(factory, client.getBaseCurrency());
+        model = new TradeViewModel(preferences, converter, client);
+
+        int year = preferences.getInt(KEY_YEAR);
+        LocalDate now = LocalDate.now();
+        if (year < 1900 || year > now.getYear())
+            year = now.getYear() - 2;
+
+        model.configure(year);
+
+        model.addUpdateListener(() -> {
+            preferences.setValue(KEY_YEAR, model.getStartYear());
+        });
+    }
+
+    @Override
+    public void notifyModelUpdated()
+    {
+        model.recalculate();
+    }
+
+    @Override
+    protected String getDefaultTitle()
+    {
+        return Messages.LabelTrades;
+    }
+
+    @Override
+    protected void addViewButtons(ToolBarManager toolBarManager)
+    {
+    }
+
+    @Override
+    protected void addButtons(ToolBarManager toolBar)
+    {
+        toolBar.add(new StartYearSelectionDropDown(model));
+
+        DropDown dropDown = new DropDown(Messages.MenuChooseClientFilter,
+                        model.getClientFilterMenu().hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF, SWT.NONE,
+                        model.getClientFilterMenu()::menuAboutToShow);
+        model.getClientFilterMenu().addListener(f -> dropDown.setImage(
+                        model.getClientFilterMenu().hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF));
+        toolBar.add(dropDown);
+
+        toolBar.add(new DropDown(Messages.MenuExportData, Images.EXPORT, SWT.NONE, manager -> {
+            final int itemCount = folder.getItemCount();
+            for (int ii = 0; ii < itemCount; ii++)
+            {
+                TradeTab tab = (TradeTab) folder.getItem(ii).getData();
+                if (tab != null)
+                    tab.addExportActions(manager);
+            }
+        }));
+
+    }
+
+    @Override
+    protected Control createBody(Composite parent)
+    {
+        folder = new CTabFolder(parent, SWT.BORDER);
+
+        createTab(folder, Images.VIEW_TABLE, TradePerMonthMatrixTab.class);
+        createTab(folder, Images.VIEW_TABLE, TradePerQuarterMatrixTab.class);
+        createTab(folder, Images.VIEW_TABLE, TradePerYearMatrixTab.class);
+        createTab(folder, Images.VIEW_BARCHART, TradePerMonthChartTab.class);
+        createTab(folder, Images.VIEW_BARCHART, TradePerQuarterChartTab.class);
+        createTab(folder, Images.VIEW_BARCHART, TradePerYearChartTab.class);
+        createTab(folder, Images.VIEW_TABLE, TradesClosedTab.class);
+        createTab(folder, Images.VIEW_TABLE, TradesOpenTab.class);
+
+        int tab = preferences.getInt(KEY_TAB);
+        if (tab < 0 || tab > 7)
+            tab = 0;
+        folder.setSelection(tab);
+        folder.addDisposeListener(e -> preferences.setValue(KEY_TAB, folder.getSelectionIndex()));
+
+        return folder;
+    }
+
+    private void createTab(CTabFolder folder, Images image, Class<? extends TradeTab> tabClass)
+    {
+        TradeTab tab = this.make(tabClass, model);
+        Control control = tab.createControl(folder);
+        CTabItem item = new CTabItem(folder, SWT.NONE);
+        item.setText(tab.getLabel());
+        item.setControl(control);
+        item.setData(tab);
+        item.setImage(image.image());
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeViewModel.java
@@ -1,0 +1,248 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.InvestmentVehicle;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.snapshot.trades.Trade;
+import name.abuchen.portfolio.snapshot.trades.TradeCollector;
+import name.abuchen.portfolio.snapshot.trades.TradeCollectorException;
+import name.abuchen.portfolio.ui.util.ClientFilterMenu;
+import name.abuchen.portfolio.util.Interval;
+
+public class TradeViewModel
+{
+    @FunctionalInterface
+    public interface UpdateListener
+    {
+        void onUpdate();
+    }
+
+    public static class Line
+    {
+        private InvestmentVehicle vehicle;
+        private long[] values;
+        private long sum;
+
+        public Line(InvestmentVehicle vehicle, int length)
+        {
+            this.vehicle = vehicle;
+            this.values = new long[length];
+        }
+
+        public InvestmentVehicle getVehicle()
+        {
+            return vehicle;
+        }
+
+        public long getValue(int index)
+        {
+            return values[index];
+        }
+
+        public long getSum()
+        {
+            return sum;
+        }
+
+        public int getNoOfMonths()
+        {
+            return values.length;
+        }
+    }
+
+    private List<UpdateListener> listeners = new ArrayList<>();
+
+    private final CurrencyConverter converter;
+    private final Client client;
+
+    private final ClientFilterMenu clientFilter;
+
+    private int startYear;
+    private int noOfmonths;
+    private List<Line> lines;
+    private Line sum;
+    private List<Trade> tradesClosed = new ArrayList<>();
+    private List<Trade> tradesOpen = new ArrayList<>();
+
+    public TradeViewModel(IPreferenceStore preferences, CurrencyConverter converter, Client client)
+    {
+        this.converter = converter;
+        this.client = client;
+
+        this.clientFilter = new ClientFilterMenu(client, preferences, filter -> recalculate());
+
+        String selection = preferences
+                        .getString(TradeViewModel.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX);
+        if (selection != null)
+            this.clientFilter.getAllItems().filter(item -> item.getUUIDs().equals(selection)).findAny()
+                            .ifPresent(this.clientFilter::select);
+
+        this.clientFilter.addListener(filter -> preferences.putValue(
+                        TradeViewModel.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX,
+                        this.clientFilter.getSelectedItem().getUUIDs()));
+    }
+
+    public void configure(int startYear)
+    {
+        this.startYear = startYear;
+
+        recalculate();
+    }
+
+    /* package */Client getClient()
+    {
+        return client;
+    }
+
+    public ClientFilterMenu getClientFilterMenu()
+    {
+        return clientFilter;
+    }
+
+    public int getStartYear()
+    {
+        return startYear;
+    }
+
+    public int getNoOfMonths()
+    {
+        return noOfmonths;
+    }
+
+    public List<Line> getLines()
+    {
+        return lines;
+    }
+
+    public Line getSum()
+    {
+        return sum;
+    }
+
+    /**
+     * Returns all lines including the sum line
+     */
+    public List<Line> getAllLines()
+    {
+        List<Line> answer = new ArrayList<>();
+        answer.addAll(lines);
+        answer.add(sum);
+        return answer;
+    }
+
+    public List<Trade> getTradesClosed()
+    {
+        return tradesClosed;
+    }
+
+    public List<Trade> getTradesOpen()
+    {
+        return tradesOpen;
+    }
+
+    public void updateWith(int year)
+    {
+        this.startYear = year;
+        recalculate();
+    }
+
+    public void recalculate()
+    {
+        calculate();
+        fireUpdateChange();
+    }
+
+    private void calculate()
+    {
+        // determine the number of full months within period
+        LocalDate now = LocalDate.now();
+        if (startYear > now.getYear())
+            throw new IllegalArgumentException();
+        this.noOfmonths = (now.getYear() - startYear) * 12 + now.getMonthValue();
+
+        Interval interval = Interval.of(LocalDate.of(startYear - 1, Month.DECEMBER, 31), now);
+        Predicate<Trade> checkIsInInterval = t -> interval.contains(t.getEnd().get());
+
+        Map<InvestmentVehicle, Line> vehicle2line = new HashMap<>();
+
+        this.sum = new Line(null, this.noOfmonths);
+        this.tradesOpen = new ArrayList<>();
+        this.tradesClosed = new ArrayList<>();
+
+        Client filteredClient = clientFilter.getSelectedFilter().filter(client);
+
+        List<Trade> tradesFilteredClient = collectTrade(filteredClient);
+        if (!tradesFilteredClient.isEmpty())
+        {
+            for (Trade trade : tradesFilteredClient)
+            {
+                if (!trade.getEnd().isPresent())
+                {
+                    tradesOpen.add(trade);
+                    continue;
+                }
+                if (!checkIsInInterval.test(trade))
+                    continue;
+
+                long value = 0;
+                value = trade.getProfitLoss().getAmount();
+
+                if (value != 0)
+                {
+
+                    tradesClosed.add(trade);
+                    int index = (trade.getEnd().get().getYear() - startYear) * 12 + trade.getEnd().get().getMonthValue()
+                                    - 1;
+                    Line line = vehicle2line.computeIfAbsent(trade.getSecurity(), s -> new Line(s, noOfmonths));
+
+                    line.values[index] += value;
+                    line.sum += value;
+
+                    sum.values[index] += value;
+                    sum.sum += value;
+                }
+            }
+        }
+
+        this.lines = new ArrayList<>(vehicle2line.values());
+    }
+
+    public void addUpdateListener(UpdateListener listener)
+    {
+        this.listeners.add(listener);
+    }
+
+    protected void fireUpdateChange()
+    {
+        this.listeners.stream().forEach(UpdateListener::onUpdate);
+    }
+
+    public List<Trade> collectTrade(Client filteredClient)
+    {
+        TradeCollector collector = new TradeCollector(filteredClient, converter);
+        List<Trade> trades = new ArrayList<>();
+        List<TradeCollectorException> errors = new ArrayList<>();
+        getClient().getSecurities().forEach(s -> {
+            try
+            {
+                trades.addAll(collector.collect(s));
+            }
+            catch (TradeCollectorException e)
+            {
+                errors.add(e);
+            }
+        });
+        return trades;
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradesClosedTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradesClosedTab.java
@@ -1,0 +1,78 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import name.abuchen.portfolio.snapshot.trades.Trade;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
+import name.abuchen.portfolio.ui.views.TradesTableViewer;
+
+public class TradesClosedTab extends AbstractFinanceView implements TradeTab
+{
+    @Inject
+    private TradeViewModel model;
+
+    private TradesTableViewer table;
+    private TableViewer tableViewer;
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelTradesClosed;
+    }
+
+    @Override
+    public void addExportActions(IMenuManager manager)
+    {
+        manager.add(new Action(MessageFormat.format(Messages.LabelExport, Messages.LabelTradesClosed))
+        {
+            @Override
+            public void run()
+            {
+                new TableViewerCSVExporter(tableViewer).export(Messages.LabelTradesClosed + ".csv"); //$NON-NLS-1$
+            }
+        });
+    }
+
+    @Override
+    public Control createControl(Composite parent)
+    {
+        table = new TradesTableViewer(this);
+        Control control = table.createViewControl(parent, TradesTableViewer.ViewMode.MULTIPLE_SECURITES);
+        table.setInput(model.getTradesClosed());
+        model.addUpdateListener(() -> table.setInput(model.getTradesClosed()));
+        return control;
+    }
+
+    public void setInput(List<Trade> trades)
+    {
+        this.tableViewer.setInput(trades);
+    }
+
+    public TableViewer getTableViewer()
+    {
+        return tableViewer;
+    }
+
+    @Override
+    protected String getDefaultTitle()
+    {
+        return Messages.LabelTradesClosed;
+    }
+
+    @Override
+    protected Control createBody(Composite parent)
+    {
+        return null;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradesOpenTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradesOpenTab.java
@@ -1,0 +1,78 @@
+package name.abuchen.portfolio.ui.views.trades;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import name.abuchen.portfolio.snapshot.trades.Trade;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
+import name.abuchen.portfolio.ui.views.TradesTableViewer;
+
+public class TradesOpenTab extends AbstractFinanceView implements TradeTab
+{
+    @Inject
+    private TradeViewModel model;
+
+    private TradesTableViewer table;
+    private TableViewer tableViewer;
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.LabelTradesOpen;
+    }
+
+    @Override
+    public void addExportActions(IMenuManager manager)
+    {
+        manager.add(new Action(MessageFormat.format(Messages.LabelExport, Messages.LabelTradesOpen))
+        {
+            @Override
+            public void run()
+            {
+                new TableViewerCSVExporter(tableViewer).export(Messages.LabelTradesOpen + ".csv"); //$NON-NLS-1$
+            }
+        });
+    }
+
+    @Override
+    public Control createControl(Composite parent)
+    {
+        table = new TradesTableViewer(this);
+        Control control = table.createViewControl(parent, TradesTableViewer.ViewMode.MULTIPLE_SECURITES);
+        table.setInput(model.getTradesOpen());
+        model.addUpdateListener(() -> table.setInput(model.getTradesOpen()));
+        return control;
+    }
+
+    public void setInput(List<Trade> trades)
+    {
+        this.tableViewer.setInput(trades);
+    }
+
+    public TableViewer getTableViewer()
+    {
+        return tableViewer;
+    }
+
+    @Override
+    protected String getDefaultTitle()
+    {
+        return Messages.LabelTradesOpen;
+    }
+
+    @Override
+    protected Control createBody(Composite parent)
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
In Anlehnung von Earning & Expenses i. V. m. #1380, reine graphische Aufbereitung der Trades.
Die Charts & Details kennt nur abgeschlossene Trades, die einzelnen Posten können dann aber nach offen/geschlossen detailliert dargestellt werden. 

Vorschlag aus dem Forum @ https://forum.portfolio-performance.info/t/gewinne-verluste-aus-trades-unter-ertraege-und-ausgaben/6922

Ich denke das dies ein guter Kompromiss ist. Die Trades können isoliert graphisch betrachtet werden. Ob, was und wie davon dann bei "Earnings & Expenses" einfließt zeigt dann das Forum. 

VG
Marco 