### PR TITLE
Timeline Chart - add grouping separator

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.util.chart;
 
+import java.text.DecimalFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
@@ -21,6 +22,7 @@ import org.eclipse.swt.widgets.Display;
 import org.swtchart.Chart;
 import org.swtchart.IAxis;
 import org.swtchart.IAxis.Position;
+import org.swtchart.IAxisTick;
 import org.swtchart.IBarSeries;
 import org.swtchart.ICustomPaintListener;
 import org.swtchart.ILineSeries;
@@ -95,7 +97,10 @@ public class TimelineChart extends Chart // NOSONAR
         yAxis.getTitle().setVisible(false);
         yAxis.getTick().setForeground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
         yAxis.setPosition(Position.Secondary);
-
+        
+        IAxisTick yTick = getAxisSet().getYAxis(0).getTick();
+        yTick.setFormat(new DecimalFormat("#,###")); //$NON-NLS-1$
+        
         // 2nd y axis
         int axisId = getAxisSet().createYAxis();
         IAxis y2Axis = getAxisSet().getYAxis(axisId);


### PR DESCRIPTION
Im Timeline Chart werden Zahlen ohne Tausender Trennzeichen dargestellt. Das wurde hier korrigiert.

Vorher:
<img width="204" alt="vorher" src="https://user-images.githubusercontent.com/34549632/75480245-33176780-59a1-11ea-8c49-aed077d98725.png">

Nachher
<img width="184" alt="nachher" src="https://user-images.githubusercontent.com/34549632/75480256-37438500-59a1-11ea-8815-299a97948968.png">

PS: mein erster pull request. 
Wenn ich den Commit in Eclipse ausführe funktioniert es. Wenn ich jedoch mit Maven eine exe baue werden garkeine Zahlen angezeigt. Was mache ich da beim build falsch?

VG
Martin