### PR TITLE
Asset statement view - share column margin

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
@@ -73,7 +73,7 @@ public abstract class SharesLabelProvider extends OwnerDrawLabelProvider
             s = s.substring(0, p);
 
         TextLayout textLayout = getSharedTextLayout(event.display);
-        textLayout.setText(s + ",000"); //$NON-NLS-1$
+        textLayout.setText(s + ",000 "); //$NON-NLS-1$
 
         return textLayout.getBounds();
     }


### PR DESCRIPTION
added a space to force the column to have a margin on the right side

<img width="59" alt="margin_share_column" src="https://user-images.githubusercontent.com/34549632/75486488-e6398e00-59ac-11ea-9775-650aa0bf7994.png">
