### PR TITLE
Leerzeichen vor und nach allen Ausgaben in Tooltips hinzugefügt

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
@@ -63,7 +63,7 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
 
             Label topLeft = new Label(container, SWT.NONE);
             topLeft.setForeground(foregroundColor);
-            topLeft.setText(Messages.ColumnSecurity);
+            topLeft.setText(TextUtil.tooltip(Messages.ColumnSecurity));
 
             for (int year = 0; year < noOfYears; year++)
             {
@@ -72,7 +72,7 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
                 Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[year]).getBarColor();
                 label.setBackground(color);
                 label.setForeground(Colors.getTextColor(color));
-                label.setText(String.valueOf(model.getStartYear() + year));
+                label.setText(TextUtil.tooltip(String.valueOf(model.getStartYear() + year)));
                 GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
             }
 
@@ -85,14 +85,14 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
                 {
                     l = new Label(container, SWT.RIGHT);
                     l.setForeground(foregroundColor);
-                    l.setText(Values.Amount.format(line.getValue(m)));
+                    l.setText(TextUtil.tooltip(Values.Amount.format(line.getValue(m))));
                     GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
                 }
             });
 
             Label l = new Label(container, SWT.NONE);
             l.setForeground(foregroundColor);
-            l.setText(Messages.ColumnSum);
+            l.setText(TextUtil.tooltip(Messages.ColumnSum));
 
             for (int m = month; m < totalNoOfMonths; m += 12)
             {
@@ -100,7 +100,7 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
                 Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[m / 12]).getBarColor();
                 l.setBackground(color);
                 l.setForeground(Colors.getTextColor(color));
-                l.setText(Values.Amount.format(model.getSum().getValue(m)));
+                l.setText(TextUtil.tooltip(Values.Amount.format(model.getSum().getValue(m))));
                 GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(l);
             }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
@@ -65,7 +65,7 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
 
             Label topLeft = new Label(container, SWT.NONE);
             topLeft.setForeground(foregroundColor);
-            topLeft.setText(Messages.ColumnSecurity);
+            topLeft.setText(TextUtil.tooltip(Messages.ColumnSecurity));
 
             for (int year = 0; year < noOfYears; year++)
             {
@@ -74,7 +74,7 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
                 Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[year]).getBarColor();
                 label.setBackground(color);
                 label.setForeground(Colors.getTextColor(color));
-                label.setText(String.valueOf(model.getStartYear() + year));
+                label.setText(TextUtil.tooltip(String.valueOf(model.getStartYear() + year)));
                 GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
             }
 
@@ -91,14 +91,14 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
                         value += line.getValue(mQuarter);
                     l = new Label(container, SWT.RIGHT);
                     l.setForeground(foregroundColor);
-                    l.setText(Values.Amount.format(value));
+                    l.setText(TextUtil.tooltip(Values.Amount.format(value)));
                     GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
                 }
             });
 
             Label l = new Label(container, SWT.NONE);
             l.setForeground(foregroundColor);
-            l.setText(Messages.ColumnSum);
+            l.setText(TextUtil.tooltip(Messages.ColumnSum));
 
             for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
             {
@@ -110,7 +110,7 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
                 Color color = ((IBarSeries) getChart().getSeriesSet().getSeries()[m / 12]).getBarColor();
                 l.setBackground(color);
                 l.setForeground(Colors.getTextColor(color));
-                l.setText(Values.Amount.format(value));
+                l.setText(TextUtil.tooltip(Values.Amount.format(value)));
                 GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(l);
             }
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
@@ -65,12 +65,12 @@ public class EarningsPerYearChartTab extends AbstractChartTab
 
             Label topLeft = new Label(container, SWT.NONE);
             topLeft.setForeground(foregroundColor);
-            topLeft.setText(Messages.ColumnSecurity);
+            topLeft.setText(TextUtil.tooltip(Messages.ColumnSecurity));
 
             Label label = new Label(container, SWT.CENTER);
             label.setBackground(barSeries.getBarColor());
             label.setForeground(Colors.getTextColor(barSeries.getBarColor()));
-            label.setText(String.valueOf(model.getStartYear() + year));
+            label.setText(TextUtil.tooltip(String.valueOf(model.getStartYear() + year)));
             GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(label);
 
             lines.forEach(line -> {
@@ -84,13 +84,13 @@ public class EarningsPerYearChartTab extends AbstractChartTab
 
                 l = new Label(container, SWT.RIGHT);
                 l.setForeground(foregroundColor);
-                l.setText(Values.Amount.format(value));
+                l.setText(TextUtil.tooltip(Values.Amount.format(value)));
                 GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
             });
 
             Label l = new Label(container, SWT.NONE);
             l.setForeground(foregroundColor);
-            l.setText(Messages.ColumnSum);
+            l.setText(TextUtil.tooltip(Messages.ColumnSum));
 
             long value = 0;
             for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)
@@ -99,7 +99,7 @@ public class EarningsPerYearChartTab extends AbstractChartTab
             l = new Label(container, SWT.RIGHT);
             l.setBackground(barSeries.getBarColor());
             l.setForeground(Colors.getTextColor(barSeries.getBarColor()));
-            l.setText(Values.Amount.format(value));
+            l.setText(TextUtil.tooltip(Values.Amount.format(value)));
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
@@ -46,7 +46,8 @@ public final class TextUtil
 
     public static final String tooltip(String text)
     {
-        return text == null ? null : text.replace("&", "&&"); //$NON-NLS-1$ //$NON-NLS-2$
+        String extendedText = " " + text + " "; //$NON-NLS-1$ //$NON-NLS-2$
+        return text == null ? null : extendedText.replace("&", "&&"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     public static final String sanitizeFilename(String label)


### PR DESCRIPTION
String für alle Tooltips um Leerzeichen vor/nach dem Text ergänzt.

vorher:
<img width="258" alt="earnings_tooltips" src="https://user-images.githubusercontent.com/34549632/75921085-ce588300-5e60-11ea-90e0-a4413adbbd21.png">

nachher:
<img width="281" alt="fixed_earnings_tooltips" src="https://user-images.githubusercontent.com/34549632/75921090-d0badd00-5e60-11ea-8c65-d985850835d4.png">