### PR TITLE
Ertragsgutschrift und Zinsgutschrift mit NV

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -207,7 +207,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Ertragsgutschrift", isJointAccount);
         this.addDocumentTyp(type);
 
-        Block block = new Block("Ertragsgutschrift");
+        Block block = new Block("Ertragsgutschrift.*");
         type.addBlock(block);
         Transaction<AccountTransaction> transaction = new Transaction<AccountTransaction>()
 
@@ -273,7 +273,7 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Zinsgutschrift", isJointAccount);
         this.addDocumentTyp(type);
 
-        Block block = new Block("Zinsgutschrift");
+        Block block = new Block("Zinsgutschrift.*");
         type.addBlock(block);
         Transaction<AccountTransaction> transaction = new Transaction<AccountTransaction>()
 


### PR DESCRIPTION
Pattern erkennt ansonsten bei  Angabe des NV Bescheids, wie in Issue #1414 beschrieben , das PDF von ING-DiBa nicht
This resolves #1414 