### PR TITLE
Fix Consorsbank PDF import with multiple account holders

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -499,6 +499,36 @@ public class ConsorsbankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf2() throws IOException
+    {
+        ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ConsorsbankVerkauf2.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getWkn(), is("PX2LEH"));
+        assertThat(security.getName(), is("BNP PAR.EHG MINIS XAU"));
+
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check buy sell transaction
+        Item item = results.get(0);
+        BuySellEntry entry = (BuySellEntry) item.getSubject();
+        PortfolioTransaction t = entry.getPortfolioTransaction();
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1386_96L)));
+        assertThat(t.getUnitSum(Type.TAX), is(Money.of(CurrencyUnit.EUR, 1_04L)));
+        assertThat(t.getDateTime(), is(LocalDateTime.of(2020, 3, 2, 14, 51, 46)));
+        assertThat(t.getShares(), is(Values.Share.factorize(100)));
+        assertThat(t.getGrossPricePerShare(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(13.88))));
+    }
+
+    @Test
     public void testWertpapierKauf1() throws IOException
     {
         ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankVerkauf2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankVerkauf2.txt
@@ -1,0 +1,61 @@
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+1111111111/00
+Vorname1 Nachname1
+Vorname2 Nachname2
+Hogwartsstr. 111 Vermerk der Bank 1000
+12345 Hogsmead 02
+ORDERABRECHNUNG
+VERKAUF AM 02.03.2020  UM 14:51:46 INL.AUSSERBOERSLICH NR. 158026714.001
+Bezeichnung WKN ISIN
+BNP PAR.EHG MINIS XAU PX2LEH DE000PX2LEH3
+Einheit Umsatz
+ST 100,00000
+Kündigungsrecht
+Kündigungsrecht des Emittenten zum 30.08.2019
+Kurs 13,880000 EUR P.ST. NETTO  
+Kurswert EUR 1.388,00
+KAPST anteilig 50,00% 25,00% EUR 0,50
+SOLZ 5,50% EUR 0,02
+KAPST anteilig 50,00% 25,00% EUR 0,50
+SOLZ 5,50% EUR 0,02
+Wert 04.03.2020 EUR 1.386,96
+zugunsten Konto-Nr. 0123456789
+Bestand zulasten Girosammelverwahrung 
+CBF 2126
+JAHRESSTEUERBESCHEINIGUNG FOLGT
+Limitkurs One-Cancels-Other 13,880000 EUR
+Beratungsfreies Geschäft
+Hinweis für Orderabrechnungen und Depotbuchungsanzeigen:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der
+Allgemeinen Geschäftsbedingungen (AGB Banken).
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank oder per Fax oder Mail an die
+unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Seite 2 zu Orderabrechnung Nr. 158026714.001 vom 02.03.2020 Depotnummer 1234567890
+Infos bei Gewinn Aktien/ Wertpapiere ungleich Aktien
+Veräusserungsgewinn nach Differenzmethode EUR 4,00
+Summe ergibt
+KAPST-pflichtige Kapitalerträge EUR 4,00
+Mit Sparerpauschbetrag verrechnet EUR 0,00
+Bemessungsgrundlage für KAPST vor QUST EUR 4,00
+An Kapitalertrag anrechenbare. ausl. QUST 0,00*4 EUR 0,00
+Bemessungsgrundlage für KAPST EUR 4,00
+Bemessungsgrundlage für KAPST anteilig 50,00% EUR 2,00
+Bemessungsgrundlage für KAPST anteilig 50,00% EUR 2,00
+Salden nach dem Geschäft
+Verrechnungstopf Aktien nach dem Geschäft EUR 0,00
+Verrechnungstopf Allg. nach dem Geschäft EUR 0,00
+Verrechnungstopf QUST nach dem Geschäft EUR 0,00
+Sparerpauschbetrag nach dem Geschäft EUR 0,00
+Es wurde keine Kirchensteuer einbehalten.
+ 
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -249,12 +249,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             }
                         })
 
-                        .section("kapst", "currency").optional()
+                        .section("kapst", "currency").optional().multipleTimes()
                         .match("KAPST .*(?<currency>\\w{3}+) *(?<kapst>[\\d.]+,\\d+) *")
                         .assign((t, v) -> t.addUnit(new Unit(Unit.Type.TAX,
                                         Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("kapst"))))))
 
-                        .section("solz", "currency").optional()
+                        .section("solz", "currency").optional().multipleTimes()
                         .match("SOLZ .*(?<currency>\\w{3}+) *(?<solz>[\\d.]+,\\d+) *") //
                         .assign((t, v) -> {
                             String currency = asCurrencyCode(v.get("currency"));
@@ -326,7 +326,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T pdfTransaction)
     {
-        pdfTransaction.section("tax", "currency").optional()
+        pdfTransaction.section("tax", "currency").optional().multipleTimes()
                         .match("KAPST .*(?<currency>\\w{3}+) *(?<tax>[\\d.]+,\\d+) *") //
                         .assign((t, v) -> {
                             if (t instanceof name.abuchen.portfolio.model.Transaction)
@@ -341,8 +341,8 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                                 asAmount(v.get("tax")))));
                             }
                         })
-
-                        .section("solz", "currency").optional()
+                        
+                        .section("solz", "currency").optional().multipleTimes()
                         .match("SOLZ .*(?<currency>\\w{3}+) *(?<solz>[\\d.]+,\\d+) *") //
                         .assign((t, v) -> {
                             if (t instanceof name.abuchen.portfolio.model.Transaction)
@@ -358,7 +358,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             }
                         })
 
-                        .section("kirchenst", "currency").optional()
+                        .section("kirchenst", "currency").optional().multipleTimes()
                         .match("KIST .*(?<currency>\\w{3}+) *(?<kirchenst>[\\d.]+,\\d+) *") //
                         .assign((t, v) -> {
                             if (t instanceof name.abuchen.portfolio.model.Transaction)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -309,7 +309,7 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
             Map<String, String> values = new HashMap<>();
 
             int patternNo = 0;
-            boolean patternFound = false;
+            boolean patternsFound = false;
             for (int ii = lineNo; ii <= lineNoEnd; ii++)
             {
                 Pattern p = pattern.get(patternNo);
@@ -319,8 +319,6 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 
                     // extract attributes
                     extractAttributes(values, p, m);
-
-                    patternFound = true;
 
                     // next pattern?
                     patternNo++;
@@ -342,6 +340,7 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
                         if (isMultipleTimes)
                         {
                             // continue searching with first pattern
+                            patternsFound = true;
                             patternNo = 0;
                         }
                         else
@@ -352,7 +351,7 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
                 }
             }
 
-            if (!patternFound)
+            if (patternNo < pattern.size() && !patternsFound)
             {
                 // if section is optional, ignore if patterns do not match
                 if (isOptional)


### PR DESCRIPTION
When selling a security and taxes are supposed to be payed, taxes are
split when there are multiple account holders. The result was that only
half of taxes was recorded.
Added "multipleTimes" flag and extended sections parsing function.
Added test file and test case.