### PR TITLE
Add ATS (Austrian Schilling) as a currency

### DIFF
--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.money.ExchangeRateProvider
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.money.ExchangeRateProvider
@@ -3,4 +3,5 @@ name.abuchen.portfolio.money.impl.ExchangeRateProviderGBX
 name.abuchen.portfolio.money.impl.ExchangeRateProviderILA
 name.abuchen.portfolio.money.impl.ExchangeRateProviderAED
 name.abuchen.portfolio.money.impl.ExchangeRateProviderDEM
+name.abuchen.portfolio.money.impl.ExchangeRateProviderATS
 name.abuchen.portfolio.money.impl.SecurityBasedExchangeRateProvider

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
@@ -13,6 +13,8 @@ AOA = Angolan Kwanza
 
 ARS = Argentine Peso
 
+ATS = Austrian Schilling
+
 AUD = Australian Dollar
 
 AWG = Aruban Florin

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
@@ -13,6 +13,8 @@ AOA = Kwanza
 
 ARS = Argentinischer Peso
 
+ATS = Österreichischer Schilling
+
 AUD = Australischer Dollar
 
 AWG = Aruba-Gulden

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderATS.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderATS.java
@@ -1,0 +1,82 @@
+package name.abuchen.portfolio.money.impl;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.ExchangeRate;
+import name.abuchen.portfolio.money.ExchangeRateProvider;
+import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
+
+public class ExchangeRateProviderATS implements ExchangeRateProvider
+{
+    private static final String ATS = "ATS"; //$NON-NLS-1$
+
+    @Override
+    public String getName()
+    {
+        return CurrencyUnit.getInstance(ATS).getDisplayName();
+    }
+
+    @Override
+    public List<ExchangeRateTimeSeries> getAvailableTimeSeries(Client client)
+    {
+        List<ExchangeRateTimeSeries> answer = new ArrayList<>();
+        answer.add(new EURATS(this));
+        return answer;
+    }
+
+    private static class EURATS implements ExchangeRateTimeSeries
+    {
+        private ExchangeRateProvider provider;
+        private BigDecimal rate = BigDecimal.valueOf(13.7603);
+
+        public EURATS(ExchangeRateProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        @Override
+        public String getBaseCurrency()
+        {
+            return CurrencyUnit.EUR;
+        }
+
+        @Override
+        public String getTermCurrency()
+        {
+            return ATS;
+        }
+
+        @Override
+        public Optional<ExchangeRateProvider> getProvider()
+        {
+            return Optional.of(provider);
+        }
+
+        @Override
+        public List<ExchangeRate> getRates()
+        {
+            List<ExchangeRate> answer = new ArrayList<>();
+            answer.add(new ExchangeRate(LocalDate.now(), rate));
+            return answer;
+        }
+
+        @Override
+        public Optional<ExchangeRate> lookupRate(LocalDate requestedTime)
+        {
+            return Optional.of(new ExchangeRate(requestedTime, rate));
+        }
+
+        @Override
+        public int getWeight()
+        {
+            return 2;
+        }
+    }
+
+}


### PR DESCRIPTION
Uses fixed exchange rate of 13.7603 against the Euro

Analog zu https://github.com/buchen/portfolio/commit/cf0ec436a3b66af4596c9c25c52526c626c73628

.. für die ganz alten Buchungen auch aus dem Alpenland, oder einfach sich seinen Bestand in ATS anzeigen zu lassen damit es nicht ganz so schwer ist sich Millionär nennen zu dürfen ;-)

![image](https://user-images.githubusercontent.com/8252355/76085475-674ae380-5fb2-11ea-852b-f742af434071.png)


Irgendwie wäre es schön wenn man Währungen als Benutzer auch selbst erfassen könnte, gibt sicherlich auch Leute die gerne noch Gulden oder Franc oder Lira oder was auch noch haben möchten und für jede einzelne immer eine ganzen ExchangeRateProvider erstellen....naja.

Oder zumindest eine base class "FixedRateExchangeRateProvider" oder sowas erstellen, zumindest AED/DEM und jetzt ATS könnte dann viel duplizierten Code sparen. Vielleicht könnte man dann darüber nachdenken sämtliche Euro Vorgängerwährungen einmal einzupflegen, aber ich weiss nicht in wie Weit das sinnvoll ist. Wenn daran Interesse besteht könnte ich das gerne mal machen.
