### PR TITLE
Support latest quote using JSON feed

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -62,6 +62,15 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
     @Override
     public boolean updateLatestQuotes(Security security, List<Exception> errors)
     {
+        List<LatestSecurityPrice> prices = getHistoricalQuotes(security, LocalDate.now(), errors);
+
+        for (LatestSecurityPrice p : prices)
+        {
+            if (p.getDate().isEqual(LocalDate.now()))
+            {
+                return security.setLatest(p);
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
This PR adds support for getting the latest quote of a security using a JSON feed.

The current JSON feed implementation only considers historical quotes, using `p.getDate().isBefore(LocalDate.now())`. This change takes the first price that has the current date and uses it as the latest quote.

I'm very new to java and this codebase, so let me know if there is anything I can improve!