### PR TITLE
Enhanced error handling @ HTMLTableQuoteFeed

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -394,7 +394,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                             .get());
             return parse(url, document, errors);
         }
-        catch (URISyntaxException | IOException e)
+        catch (URISyntaxException | IOException | Error e)
         {
             errors.add(new IOException(url + '\n' + e.getMessage(), e));
             return Collections.emptyList();


### PR DESCRIPTION
Related to https://forum.portfolio-performance.info/t/interner-fehler-mark-invalid-bei-kursabruf-von-tabelle-auf-einer-webseite/8081
```
org.jsoup.UncheckedIOException: java.io.IOException: Mark invalid

	at org.jsoup.parser.CharacterReader.rewindToMark(CharacterReader.java:148)

	at org.jsoup.parser.Tokeniser.consumeCharacterReference(Tokeniser.java:192)

	at org.jsoup.parser.TokeniserState.readCharRef(TokeniserState.java:1707)

	at org.jsoup.parser.TokeniserState.access$100(TokeniserState.java:8)

	at org.jsoup.parser.TokeniserState$2.read(TokeniserState.java:36)

	at org.jsoup.parser.Tokeniser.read(Tokeniser.java:59)

	at org.jsoup.parser.TreeBuilder.runParser(TreeBuilder.java:55)

	at org.jsoup.parser.TreeBuilder.parse(TreeBuilder.java:47)

	at org.jsoup.parser.Parser.parse(Parser.java:107)

	at org.jsoup.Jsoup.parse(Jsoup.java:58)

	at name.abuchen.portfolio.online.impl.HTMLTableQuoteFeed.parseFromURL(HTMLTableQuoteFeed.java:392)

	at name.abuchen.portfolio.online.impl.HTMLTableQuoteFeed.internalGetQuotes(HTMLTableQuoteFeed.java:353)

	at name.abuchen.portfolio.online.impl.HTMLTableQuoteFeed.updateLatestQuotes(HTMLTableQuoteFeed.java:294)

	at name.abuchen.portfolio.ui.jobs.UpdateQuotesJob$1.run(UpdateQuotesJob.java:231)

	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)

Caused by: java.io.IOException: Mark invalid
```

Upon https://stackoverflow.com/questions/47898212/java-jsoup-exception-ignores-try-catch 
> JSoup throws an Object that extends Error, not Exception