### PR TITLE
Add Boursorama quotes provider

### DIFF
--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
@@ -1,6 +1,7 @@
 name.abuchen.portfolio.online.impl.ManualQuoteFeed
 name.abuchen.portfolio.online.impl.AlphavantageQuoteFeed
 name.abuchen.portfolio.online.impl.BitfinexQuoteFeed
+name.abuchen.portfolio.online.impl.BoursoramaQuoteFeed
 name.abuchen.portfolio.online.impl.FinnhubQuoteFeed
 name.abuchen.portfolio.online.impl.EurostatHICPQuoteFeed
 name.abuchen.portfolio.online.impl.KrakenQuoteFeed

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -116,6 +116,7 @@ public class Messages extends NLS
     public static String IssueTransactionMissingCurrencyCode;
     public static String IssuePortfolioTransactionWithoutSecurity;
     public static String LabelAssetAllocation;
+    public static String LabelBoursorama;
     public static String LabelCreditSuisseHTMLTable;
     public static String LabelDefaultReferenceAccountName;
     public static String LabelDeposits;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -223,6 +223,8 @@ LabelApplyClientCalendar = (Portfolio Performance :: Standard Calendar)
 
 LabelAssetAllocation = Asset Allocation
 
+LabelBoursorama = Boursorama (FR)
+
 LabelCreditSuisseHTMLTable = VIAC/CS Funds (only for residents of Switzerland)
 
 LabelDefaultReferenceAccountName = Reference Account {0}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BoursoramaQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BoursoramaQuoteFeed.java
@@ -1,0 +1,50 @@
+package name.abuchen.portfolio.online.impl;
+
+import java.util.Optional;
+
+import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.model.Security;
+
+public final class BoursoramaQuoteFeed extends GenericJSONQuoteFeed
+{
+
+    public static final String ID = "BOURSORAMA"; //$NON-NLS-1$
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return Messages.LabelBoursorama;
+    }
+
+    @Override
+    public Optional<String> getHelpURL()
+    {
+        return Optional.empty();
+    }
+
+
+    @Override
+    protected String feedURL(Security security)
+    {
+        return "https://www.boursorama.com/bourse/action/graph/ws/GetTicksEOD?symbol={TICKER}&length=7300&period=0&guid="; //$NON-NLS-1$
+    }
+
+    @Override
+    protected Optional<String> dateProperty(Security security)
+    {
+        return Optional.of("$.d.QuoteTab[*].d"); //$NON-NLS-1$
+    }
+
+    @Override
+    protected Optional<String> closeProperty(Security security)
+    {
+        return Optional.of("$.d.QuoteTab[*].c"); //$NON-NLS-1$
+    }
+
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -33,7 +33,7 @@ import name.abuchen.portfolio.online.impl.variableurl.Factory;
 import name.abuchen.portfolio.online.impl.variableurl.urls.VariableURL;
 import name.abuchen.portfolio.util.WebAccess;
 
-public final class GenericJSONQuoteFeed implements QuoteFeed
+public class GenericJSONQuoteFeed implements QuoteFeed
 {
     public static final String ID = "GENERIC-JSON"; //$NON-NLS-1$
     public static final String DATE_PROPERTY_NAME = "GENERIC-JSON-DATE"; //$NON-NLS-1$
@@ -77,7 +77,7 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
     @Override
     public boolean updateHistoricalQuotes(Security security, List<Exception> errors)
     {
-        List<SecurityPrice> prices = getHistoricalQuotes(security, security.getFeedURL(), errors).stream()
+        List<SecurityPrice> prices = getHistoricalQuotes(security, feedURL(security), errors).stream()
                         .map(p -> new SecurityPrice(p.getDate(), p.getValue())).collect(Collectors.toList());
 
         boolean isUpdated = false;
@@ -95,7 +95,7 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
     @Override
     public List<LatestSecurityPrice> getHistoricalQuotes(Security security, LocalDate start, List<Exception> errors)
     {
-        return getHistoricalQuotes(security, security.getFeedURL(), errors).stream()
+        return getHistoricalQuotes(security, feedURL(security), errors).stream()
                         .map(p -> new LatestSecurityPrice(p.getDate(), p.getValue(), LatestSecurityPrice.NOT_AVAILABLE,
                                         LatestSecurityPrice.NOT_AVAILABLE, LatestSecurityPrice.NOT_AVAILABLE))
                         .collect(Collectors.toList());
@@ -103,8 +103,8 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
 
     public List<SecurityPrice> getHistoricalQuotes(Security security, String feedURL, List<Exception> errors)
     {
-        Optional<String> dateProperty = security.getPropertyValue(SecurityProperty.Type.FEED, DATE_PROPERTY_NAME);
-        Optional<String> closeProperty = security.getPropertyValue(SecurityProperty.Type.FEED, CLOSE_PROPERTY_NAME);
+        Optional<String> dateProperty = dateProperty(security);
+        Optional<String> closeProperty = closeProperty(security);
 
         if (!dateProperty.isPresent() || !closeProperty.isPresent())
         {
@@ -231,5 +231,20 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
     public List<Exchange> getExchanges(Security security, List<Exception> errors)
     {
         return Collections.emptyList();
+    }
+
+    protected String feedURL(Security security)
+    {
+        return security.getFeedURL();
+    }
+
+    protected Optional<String> dateProperty(Security security)
+    {
+        return security.getPropertyValue(SecurityProperty.Type.FEED, DATE_PROPERTY_NAME);
+    }
+
+    protected Optional<String> closeProperty(Security security)
+    {
+        return security.getPropertyValue(SecurityProperty.Type.FEED, CLOSE_PROPERTY_NAME);
     }
 }


### PR DESCRIPTION
Boursorama is a major French news website on the stock market, as well as a bank. They have data on a lot of European mutual funds, that is often absent from Yahoo Finance. 

They expose a JSON endpoint able to gather historical quotes in a simple way.

This PR adds support for this endpoint directly in the UI, by extending `GenericJSONQuoteFeed`. A user then only has to add the proper symbol, and select Boursorama as a provider.

It requires https://github.com/buchen/portfolio/pull/1471 to work properly.

Let me know what you think of this approach!