### PR TITLE
Issue1329 autosave

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -417,6 +417,7 @@ public class Messages extends NLS
     public static String InvestmentPlanTxForMultiplePlansCreated;
     public static String InvestmentPlanTypeBuyDelivery;
     public static String InvestmentPlanTypeDeposit;
+    public static String JobLabelAutosave;
     public static String JobLabelSyncSecuritiesOnline;
     public static String JobLabelUpdateCPI;
     public static String JobLabelUpdateQuotes;
@@ -882,6 +883,8 @@ public class Messages extends NLS
     public static String PrefDescriptionProxy;
     public static String PrefDescriptionQuandl;
     public static String PrefFinnhubAPIKey;
+    public static String PrefLabelAutosavePeriod;
+    public static String PrefLabelAutosaveWithDatestamp;
     public static String PrefLabelNote;
     public static String PrefLabelProxyHost;
     public static String PrefLabelProxyPort;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
@@ -106,6 +106,18 @@ public interface UIConstants
         String CREATE_BACKUP_BEFORE_SAVING = "CREATE_BACKUP_BEFORE_SAVING"; //$NON-NLS-1$
 
         /**
+         * Preference key which period the autosave function has
+         * Value is given in minutes.
+         */
+        String AUTOSAVE_WITH_DATESTAMP = "AUTOSAVE_WITH_DATESTAMP"; //$NON-NLS-1$
+
+        /**
+         * Preference key which period the autosave function has
+         * Value is given in minutes.
+         */
+
+        String AUTOSAVE_PERIOD = "AUTOSAVE_PERIOD"; //$NON-NLS-1$
+        /**
          * Preference key to store a comma-separated list of recent files
          */
         String RECENT_FILES = "RECENT_FILES"; //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/jobs/AutosaveJob.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/jobs/AutosaveJob.java
@@ -1,0 +1,145 @@
+package name.abuchen.portfolio.ui.jobs;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.ui.editor.ClientInput;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.PortfolioPlugin;
+
+public final class AutosaveJob extends AbstractClientJob
+{
+    private ClientInput clientInput;
+    private Object clazz;
+    private String identifier;
+    private long   heartbeatPeriod;
+
+    public AutosaveJob(ClientInput clientInput)
+    {
+        super(clientInput.getClient(), Messages.JobLabelAutosave);
+        this.clientInput = clientInput;
+    }
+
+    public AutosaveJob setHeartbeat(long milliseconds)
+    {
+        heartbeatPeriod = milliseconds;
+        return this;
+    }
+
+    public AutosaveJob repeatEvery(Object clazz, String identifier)
+    {
+        this.clazz      = clazz;
+        this.identifier = identifier;
+        return this;
+    }
+
+    private long getRepeatPeriod()
+    {
+        Object value;
+        PropertyDescriptor descriptor = null;
+        Object attributable = null;
+        try
+        {
+            descriptor = descriptorFor(clazz.getClass(), identifier);
+            attributable = Adaptor.adapt(clazz.getClass(), clazz);
+            value = descriptor.getReadMethod().invoke(attributable);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(String.format("Descriptor failed with exception <%s>", e)); //$NON-NLS-1$
+        }
+        return (long) value * 1000 * 60; // value is given in minutes
+    }
+
+    private Boolean hasAutosaveDatestamp()
+    {
+        Object value;
+        PropertyDescriptor descriptor = null;
+        Object attributable = null;
+        try
+        {
+            descriptor = descriptorFor(clazz.getClass(), "autosaveDatestamp"); //$NON-NLS-1$
+            attributable = Adaptor.adapt(clazz.getClass(), clazz);
+            value = descriptor.getReadMethod().invoke(attributable);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(String.format("Descriptor failed with exception <%s>", e)); //$NON-NLS-1$
+        }
+        return (Boolean) value;
+    }
+
+    @Override
+    protected IStatus run(IProgressMonitor monitor)
+    {
+        List<Security> toBeSynced = getClient().getSecurities().stream().filter(s -> s.getOnlineId() != null)
+                        .collect(Collectors.toList());
+
+        long   repeatPeriod = getRepeatPeriod();
+        if (repeatPeriod > 0)
+            schedule(repeatPeriod);
+        else
+        {
+            schedule(heartbeatPeriod);
+            return Status.OK_STATUS;
+        }
+
+        if (clientInput.isDirty() && clientInput.getFile() != null)
+        {
+            File file = clientInput.getFile();
+            String filename = file.getName();
+            LocalDate localDate = LocalDate.now();
+            String suffix = "autosave"; //$NON-NLS-1$
+            if (hasAutosaveDatestamp())
+                suffix = suffix + "-" + DateTimeFormatter.ofPattern("yyyyMMdd").format(localDate);  //$NON-NLS-1$  //$NON-NLS-2$
+
+            int l = filename.lastIndexOf('.');
+            String autosaveName = l > 0 ? filename.substring(0, l) + '.' + suffix + filename.substring(l)
+                            : filename + '.' + suffix;
+            Path sourceFile = file.toPath();
+            File autosaveFile = sourceFile.resolveSibling(autosaveName).toFile();
+            try
+            {
+                ClientFactory.save(clientInput.getClient(), autosaveFile, null, null);
+            }
+            catch (IOException e)
+            {
+            	return new Status(IStatus.WARNING, PortfolioPlugin.PLUGIN_ID, e.getMessage(), e);
+            }
+        }
+
+        return Status.OK_STATUS;
+    }
+
+    protected PropertyDescriptor descriptorFor(Class<?> subjectType, String attributeName)
+    {
+        try
+        {
+            PropertyDescriptor[] properties = Introspector.getBeanInfo(subjectType).getPropertyDescriptors();
+            for (PropertyDescriptor p : properties)
+                if (attributeName.equals(p.getName()))
+                    return p;
+            throw new IllegalArgumentException(String.format("%s has no property named %s", subjectType //$NON-NLS-1$
+                            .getName(), attributeName));
+        }
+        catch (IntrospectionException e)
+        {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -833,6 +833,8 @@ InvestmentPlanTypeBuyDelivery = Security purchase / delivery
 
 InvestmentPlanTypeDeposit = Deposit
 
+JobLabelAutosave = Autosaving Portfolio
+
 JobLabelSyncSecuritiesOnline = Sync investment vehicles with https://portfolio-report.net
 
 JobLabelUpdateCPI = Update Consumer Price Indices
@@ -1774,6 +1776,10 @@ PrefDescriptionProxy = The proxy server is used to download quotes, exchange rat
 PrefDescriptionQuandl = Quandl is a platform for financial, economic, and alternative data that serves investment professionals.\n\nTo use Quandl, you need an API key. Authenticated users of free data feeds have a concurrency limit of one; that is, they can make one call at a time and have an additional call in the queue.\n\nPlease follow this link to sign up:
 
 PrefFinnhubAPIKey = Finnhub API Key
+
+PrefLabelAutosavePeriod = Autosave Period in minutes (0 = no Autosave)
+
+PrefLabelAutosaveWithDatestamp= Autosave file contains date
 
 PrefLabelNote = Note
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/GeneralPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/GeneralPreferencePage.java
@@ -21,6 +21,12 @@ public class GeneralPreferencePage extends FieldEditorPreferencePage
         addField(new BooleanFieldEditor(UIConstants.Preferences.CREATE_BACKUP_BEFORE_SAVING, //
                         Messages.PrefCreateBackupBeforeSaving, getFieldEditorParent()));
 
+        addField(new IntegerFieldEditor(UIConstants.Preferences.AUTOSAVE_PERIOD, //
+                        Messages.PrefLabelAutosavePeriod, getFieldEditorParent()));
+
+        addField(new BooleanFieldEditor(UIConstants.Preferences.AUTOSAVE_WITH_DATESTAMP, //
+                        Messages.PrefLabelAutosaveWithDatestamp, getFieldEditorParent()));
+
         addField(new BooleanFieldEditor(UIConstants.Preferences.UPDATE_QUOTES_AFTER_FILE_OPEN, //
                         Messages.PrefUpdateQuotesAfterFileOpen, getFieldEditorParent()));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/GeneralPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/GeneralPreferencePage.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.preferences;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IntegerFieldEditor;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
@@ -26,6 +27,7 @@ public class GeneralPreferencePage extends FieldEditorPreferencePage
 
         addField(new BooleanFieldEditor(UIConstants.Preferences.AUTOSAVE_WITH_DATESTAMP, //
                         Messages.PrefLabelAutosaveWithDatestamp, getFieldEditorParent()));
+
 
         addField(new BooleanFieldEditor(UIConstants.Preferences.UPDATE_QUOTES_AFTER_FILE_OPEN, //
                         Messages.PrefUpdateQuotesAfterFileOpen, getFieldEditorParent()));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
@@ -14,6 +14,8 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer
         IPreferenceStore store = PortfolioPlugin.getDefault().getPreferenceStore();
         store.setDefault(UIConstants.Preferences.AUTO_UPDATE, true);
         store.setDefault(UIConstants.Preferences.UPDATE_SITE, "https://updates.portfolio-performance.info/portfolio"); //$NON-NLS-1$
+        store.setDefault(UIConstants.Preferences.AUTOSAVE_PERIOD, 0);
+        store.setDefault(UIConstants.Preferences.AUTOSAVE_WITH_DATESTAMP, false);
         store.setDefault(UIConstants.Preferences.USE_INDIRECT_QUOTATION, true);
         store.setDefault(UIConstants.Preferences.CREATE_BACKUP_BEFORE_SAVING, true);
         store.setDefault(UIConstants.Preferences.UPDATE_QUOTES_AFTER_FILE_OPEN, true);


### PR DESCRIPTION
As requested the autosave feature as a dedicated PR.
I added the option to have the datestamp in the filename.
Default is no datestamp and no autosave.
Even though in the Autosave it seems overkill to have a bean descriptor to get the period, I would ask to keep it.
I start portfolio performance in a docker environment, so I have no "Preferences" stored at all. Given that I would need the ability to have this configurations to be in the XML while I understand others have different requirements. With this descriptor setup I can reference to the client class, while others to the clientInput class. Thanks for keeping this as common as possible and your review.
