### PR TITLE
fixed comdirect postprocessing for tax-docs without taxes

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectMerge1_Dividende.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectMerge1_Dividende.txt
@@ -1,0 +1,46 @@
+PDF Autor: 'HAVI Solutions GmbH & Co. KG, phg'
+PDFBox Version: 1.8.16
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    12345600 
+     123456 789 BLZ:        123 456 78 
+Herrn                              
+                             
+Max Mustermann             
+                             
+                             
+                                   
+Musterstr. 123                                                        
+                             
+12345 Musterstadt                                                    
+14.05.2018
+ G u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Dividendengutschrift                                                               
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+p e r  0 9 . 0  5.  2 0 1 8                         Al l  i an z   S E                              8 4 0 4 00 
+S  T K              1  6 , 00  0               v i  n k . N am  en  s - Ak t  ie  n  o . N .           D E0 0  0 84  04  00 5 
+                                      Emissionsland: DEUTSCHLAND                   
+EUR 8,00       Dividende pro Stück für Geschäftsjahr        01.01.17 bis 31.12.17  
+zahlbar ab 14.05.2018                                                              
+                         Abrechnung Dividendengutschrift                           
+Bruttobetrag:                                              EUR             128,00  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+DE12 3456 7890 1234 5678 00   EUR       14.05.2018         EUR             128,00  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 1234567890).                                                   
+comdirect bank                                                                     
+Aktiengesellschaft                                                                 
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectMerge1_Steuer.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/comdirectMerge1_Steuer.txt
@@ -1,0 +1,115 @@
+PDF Autor: 'HAVI Solutions GmbH & Co. KG, phg'
+PDFBox Version: 1.8.16
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+1234567  Max  Mustermann                                  
+                                                  
+            
+123 456 78 Musterstr. 123                                    12345 Musterstadt                                      
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+c  o  m   d  i r e  c  t   b  a  n  k    A  G               
+               
+2   5  4  5  1   Q  u  i c  k  b  o  r n                   
+0  1   0  9  7828
+                                                  
+T   e  le  f o  n  :             0   4  1  0  6   -  7  0 8 25 00
+                              
+ H  e  r r n                            D  a  t u  m   :                       1   4  . 0  5  .2018
+ M  a x  M  u   s  t  e r m  a n n               D   e  p  o  t  n  u  m   m  er:        1   2  3  4  5  6 7 00  
+ M  u  s t e  r  s  t r .  1  2  3                  
+12345 Musterstadt                  R   e  f e  r e  n  z  - N   u mmer:    1  2 3 4   5  6  7  8   9 ABCDEF                        
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Inländische Dividende vom 14.05.2018                                                                      
+Stk.              16 ALLIANZ SE NA O.N. , WKN / ISIN: 840400  / DE0008404005                                                      
+ Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R             128,0 0   
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e v o r V e r lu s tv e r re c h n u n g                  E  U   R                             1   2  8 , 0 0                          
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+ in A n s p ru c h  g e n o m m e n e r F r ei s te ll un g s a u ft ra g                                         E    U   R                             1   1  0 , 4 1                          
+                                                                                                                                
+ S te u e rb e m  e ss u n g s g r u n d la g e n a c h V e r lu s t ve r r ec h n u n g               E   U  R                                1  7 , 5 9                          
+                                                                                                                                
+                                                                                                                                
+ K ap i ta le r tr a gs t e ue r                                                                        E  U   R                                  0 , 0 0                          
+(angerechnete ausländische Quellensteuer:       EUR               4,40  )                                                       
+ S ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0                          
+ K irc h e n s te u e r                                                                              _E  _U   _R  _  _  _   _  _  _   _  _  _  _   _  _  _   _  0_ ,_ _0 0_                          
+a b g e f ü h rt e S t e u er n                                                                                                                    _E _U R_ _ _ _ _ _ _ _ _ _ _ _  _ __ 0__,_0 _0   
+                                                                                                                                
+Z u  Ih r e n G u n s t e n n a c h S t e u er n :                                                                                                   E U R             128,0 0   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Gutschrift erfolgt mit Valuta 14.05.2018 auf Konto EUR mit der IBAN DE12 3456 7890 1234 5678 90                                                   
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2018 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+                0,00                 0,00
+                0,00                 0,00
+nach Ermittlung
+                0,00 0,00                 0,00                 4,40                
+Verrechnungssalden in EUR (4)
+in 2018 Gewinne / Verluste sonstige anrechenbare verfügbareraus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+                0,00               111,11               -11,11               111,11
+nach Ermittlung
+                0,00               222,22
+              -22,22                 0,00
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+comdirect bank AG                                                                                                                                     
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG


### PR DESCRIPTION
Fix fuer #1489 
Steuerlose Steuerdokument-Transaktionen unterscheiden sich nur anhand der notes, also anhand des beliebigen Dateinamens.
Jetzt wird die 1. Transaktion ohne Steuer geloescht - vorerst imperativ.