### PR TITLE
Fix wrong periodicity when multiple bookings

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -120,12 +120,14 @@ import name.abuchen.portfolio.util.Dates;
         }
 
         int years = 0;
+        
         // now walk through individual years
         for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
         {
             years++;
             int countPerYear = 0;
             long sumPerYear = 0;
+            LocalDate lastDate = null;
 
             // first calc sum only for this year
             for (DividendPayment p : payments)
@@ -146,7 +148,7 @@ import name.abuchen.portfolio.util.Dates;
 
             // calc expected amount for this year
             double expectedAmount = sumPerYear / (double) countPerYear;
-
+            
             // then calc significance
             for (DividendPayment p : payments)
             {
@@ -158,8 +160,12 @@ import name.abuchen.portfolio.util.Dates;
                     double significance = p.amount.getAmount() / expectedAmount;
                     if (significance > 0.3)
                     {
-                        significantCount++;
+                        if (lastDate == null || !p.date.equals(lastDate))
+                        {
+                            significantCount++;
+                        }
                     }
+                    lastDate = p.date;
                 }
             }
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -160,6 +160,8 @@ import name.abuchen.portfolio.util.Dates;
                     double significance = p.amount.getAmount() / expectedAmount;
                     if (significance > 0.3)
                     {
+                        // check, if dividends were recorded for multiple
+                        // accounts at the same date
                         if (lastDate == null || !p.date.equals(lastDate))
                         {
                             significantCount++;


### PR DESCRIPTION
When a security exists in multiple accounts and dividends are recorded separately, periodicity might be incorrect