### PR TITLE
PDF import S-Broker until March 2015 also possible for non-German securities

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -47,7 +47,7 @@ public class SBrokerPDFExtractorTest
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getIsin(), is("DE000A0H0785"));
-        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE"));
+        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE Inhaber-Anteile"));
 
         // check buy sell transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
@@ -62,6 +62,37 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-10-01T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(16)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 377L)));
+    }
+    @Test
+    public void testWertpapierKauf2() throws IOException
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "sBroker_Kauf2.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("US5801351017"));
+        assertThat(security.getName(), is("McDonald's Corp. Registered Shares DL-,01"));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1249_30)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-11-15T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(18)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 1090L)));
     }
 
     @Test
@@ -79,7 +110,7 @@ public class SBrokerPDFExtractorTest
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getIsin(), is("DE000A0H0785"));
-        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE"));
+        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE Inhaber-Anteile"));
 
         // check buy sell transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
@@ -112,7 +143,7 @@ public class SBrokerPDFExtractorTest
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getIsin(), is("DE000A0H0785"));
-        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE"));
+        assertThat(security.getName(), is("iS.EO G.B.C.1.5-10.5y.U.ETF DE Inhaber-Anteile"));
 
         // check buy sell transaction
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -123,5 +154,34 @@ public class SBrokerPDFExtractorTest
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 12_70)));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2014-11-17T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(16)));
+    }
+
+    @Test
+    public void testErtragsgutschrift2() throws IOException
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "sBroker_Ertragsgutschrift2.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("US5801351017"));
+        assertThat(security.getName(), is("McDonald's Corp. Registered Shares DL-,01"));
+
+        // check buy sell transaction
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().get().getSubject();
+
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 52_36)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2014-12-15T00:00")));
+        assertThat(t.getShares(), is(Values.Share.factorize(103)));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/sBroker_Ertragsgutschrift2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/sBroker_Ertragsgutschrift2.txt
@@ -1,0 +1,50 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Erträgnisgutschrift aus Wertpapieren EMAILVERSAND=N
+DEPOTNUMMER=123/4567/890
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=0000
+Dividende für ADRESSZEILE1=Herrn
+01.01.2014 - 31.12.2014 ADRESSZEILE2=John DoeADRESSZEILE3=Schlossallee 1
+Herrn        Depot-Nr. Abrechnungs-Nr. ADRESSZEILE4=99999 Monopoly
+John Doe 123/4567/890 49780306 ADRESSZEILE5=
+Schlossallee 1 ADRESSZEILE6=
+99999 Monopoly BELEGNUMMER=5129
+SEITENNUMMER=1
+Depotinhaber STEUERERSTATTUNG=N
+John Doe
+Dividendengutschrift Wiesbaden, 13.12.2014
+Gattungsbezeichnung ISIN
+McDonald's Corp. Registered Shares DL-,01 US5801351017
+Nominal Ex-Tag Zahltag Dividenden-Betrag pro Stück
+STK 103,000 26.11.2014 15.12.2014 USD 0,850000
+Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten
+15.12.2014 12/3456/789 EUR/USD 1,24495 EUR 52,36
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+ausländische Dividende EUR 70,32
+US-Quellensteuer 15% USD 13,13
+davon anrechenbare US-Quellensteuer 15% USD 13,13
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Freistellungsauftrag (eingereicht: EUR 0,00) EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 28,12
+einbehaltene Kapitalertragsteuer EUR 7,03
+einbehaltener Solidaritätszuschlag EUR 0,38
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 127,77
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 7,02
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Wiesbaden, Steuernummer 402/200/0073.
+Zahlungstag 15.12.2014
+Jahressteuerbescheinigung folgt
+Verwahrart: Girosammelverwahrung     
+Mit freundlichen Grüßen
+S Broker AG & Co. KG
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+           
+3.20/ABREEREIERTR/GDBERTRG/005129/131214/020842
+            

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/sBroker_Kauf2.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/sBroker_Kauf2.txt
@@ -1,0 +1,52 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+ 
+Wertpapierabrechnung DEPOTNUMMER=123/4567/890DEPOTUNTERBEZEICHNUNG=
+ 
+Kauf Limitauftrag VERSANDARTENSCHLUESSEL=0000ADRESSZEILE1=Herrn
+Kommissionsgeschäft ADRESSZEILE2=John Doe
+ADRESSZEILE3=Schlossallee 25
+ADRESSZEILE4=99999 Monopoly
+       ADRESSZEILE5=
+Herrn Depot-Nr. Abrechnungs-Nr. ADRESSZEILE6=
+John Doe  123/4567/890 28116496 BELEGNUMMER=2746
+Schlossallee 25 SEITENNUMMER=1 
+99999 Monopoly STEUERERSTATTUNG=N 
+ 
+Depotinhaber
+John Doe
+ 
+ 
+Wir haben für Sie gekauft Wiesbaden, 11.11.2011
+ 
+ 
+Gattungsbezeichnung ISIN
+McDonald's Corp. Registered Shares DL-,01 US5801351017
+Nominal Kurs
+STK 18,000 EUR 68,8000
+ 
+ 
+Handelstag 11.11.201 1 Kurswert                    EUR 1.238,40-
+Handelszeit 09:02 Orderentgelt                EUR 10,90-
+Börse Xetra/EDE
+Verwahrart Girosammelverwahrung
+ 
+Wert  Konto-Nr. Betrag zu Ihren Lasten  
+15.11.2011 12/3456/789 EUR 1.249,30
+ 
+ 
+ 
+ 
+Wir werden in Ihrem Depot wie angegeben buchen.
+ 
+Mit freundlichen Grüßen
+S Broker AG & Co. KG
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+           
+3.31/ABREABHNHANDKFDI/GAAASAFG/002746/111111/235014
+            

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -46,12 +46,12 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
                         .section("isin", "name") //
                         .find("Gattungsbezeichnung ISIN") //
-                        .match("(?<name>.*) Inhaber-Anteile (?<isin>.*)")
+                        .match("(?<name>.*)\\W+(?<isin>.+)")
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .section("date", "amount", "currency") //
-                        .find("Wert Konto-Nr. Betrag zu Ihren Lasten")
-                        .match("(?<date>\\d+.\\d+.\\d{4}) \\d{2}/\\d{4}/\\d{3} (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)") //
+                        .find("Wert +Konto-Nr. Betrag zu Ihren Lasten *")
+                        .match("(?<date>\\d+.\\d+.\\d{4}) \\d{2}/\\d{4}/\\d{3} (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)") //
                         .assign((t, v) -> {
                             t.setDate(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -63,7 +63,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("fee", "currency").optional() //
-                        .match(".* Orderentgelt (?<currency>\\w{3}+) (?<fee>[\\d.]+,\\d+)-") //
+                        .match(".* Orderentgelt\\W+(?<currency>\\w{3}+) (?<fee>[\\d.]+,\\d+)-") //
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, //
                                         Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee"))))))
 
@@ -93,7 +93,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
                         .section("isin", "name") //
                         .find("Gattungsbezeichnung ISIN") //
-                        .match("(?<name>.*) Inhaber-Anteile (?<isin>.*)")
+                        .match("(?<name>.*)\\W+(?<isin>.+)")
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .section("date", "amount", "currency") //
@@ -128,7 +128,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Erträgnisgutschrift");
         this.addDocumentTyp(type);
 
-        Block block = new Block("Erträgnisgutschrift.*\\d+.\\d+.\\d{4}");
+        Block block = new Block("Erträgnisgutschrift.*EMAILVERSAND.*");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -140,7 +140,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
                         .section("isin", "name") //
                         .find("Gattungsbezeichnung ISIN") //
-                        .match("(?<name>.*) Inhaber-Anteile (?<isin>.*)") //
+                        .match("(?<name>.*)\\W+(?<isin>.+)")
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .section("shares") //
@@ -148,8 +148,8 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         .section("date", "amount", "currency") //
-                        .find("Wert Konto-Nr. Betrag zu Ihren Gunsten")
-                        .match("(?<date>\\d+.\\d+.\\d{4}) \\d{2}/\\d{4}/\\d{3} (?<currency>\\w{3}+) (?<amount>[\\d.]+,\\d+)") //
+                        .find("Wert Konto-Nr. (Devisenkurs )?Betrag zu Ihren Gunsten")
+                        .match("(?<date>\\d+.\\d+.\\d{4}).*(?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));


### PR DESCRIPTION
Bisher konnten nur Abrechnungen importiert werden, wo der Wertpapiername den Textbestandteil "Inhaber-Anteile" hat. Bei McDonald's funktioniert das nicht. Dafür habe ich die regulären Ausdrucke angepasst. Ich konnte allerdings keinen Verkauf testen.
Die Änderung ist nicht abwärtskompatibel, da jetzt der String "Inhaber-Anteile" mit als Namensbestandteil importiert wird.

Ein weiteres Problem waren Dividenden in US-Dollar - hier habe ich den regulären Ausdruck angepasst.
Ich habe vorhandene Unit-Tests angepasst und zwei neue erstellt.

Für spätere Abrechnungen (spätestens ab Oktober 2015) muss der PDF-Text-Konverter (pdfbox) aktualisiert werden.
