### PR TITLE
Fix Trades Widget to count by isPositive rather than IRR

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesWidget.java
@@ -22,7 +22,7 @@ public class TradesWidget extends AbstractTradesWidget
         this.title.setText(TextUtil.tooltip(getWidget().getLabel()));
 
         List<Trade> trades = input.getTrades();
-        long positive = trades.stream().filter(t -> t.getIRR() > 0).count();
+        long positive = trades.stream().filter(t -> t.getProfitLoss().isPositive()).count();
         String text = MessageFormat.format("{0} <green>↑{1}</green> <red>↓{2}</red>", //$NON-NLS-1$
                         trades.size(), positive, trades.size() - positive);
 


### PR DESCRIPTION
When having intraday trades, Irr is shown as -infinity or NaN% and should not be used to calculate the number of positive vs negative trades. Using isPositive method should be more appropriate and fixes the intraday issue.

Issue was reported here: https://forum.portfolio-performance.info/t/anzahl-trades-mit-gewinn-verlust-fehlerhaft-bei-haltedauer-unter-einem-tag/8646