### PR TITLE
Fix calculating grossPrice in Securities Chart

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -128,8 +128,11 @@ public class PortfolioTransaction extends Transaction
     }
 
     /**
-     * Returns the gross value, i.e. the value excluding taxes and fees. See
-     * {@link #getGrossValue()}.
+     * Returns the gross value, i.e. the value before taxes and fees are
+     * applied. In the case of a buy transaction, that are the gross costs, i.e.
+     * before adding additional taxes and fees. In the case of sell
+     * transactions, that are the gross proceeds before the deduction of taxes
+     * and fees. See {@link #getGrossValue()}.
      */
     public long getGrossValueAmount()
     {


### PR DESCRIPTION
use transaction exchange rate instead that day's exchange rate, which
might be different

Problem was reported in the forum:
https://forum.portfolio-performance.info/t/kursdiagramm-zeigt-anderen-einstandspreis-als-kaufbuchung/9168/5