### PR TITLE
Added support for Vorabpauschale to Consorsbank PDF import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -833,6 +833,36 @@ public class ConsorsbankPDFExtractorTest
         assertThat(item.isPresent(), is(true));
     }
 
+    @Test
+    public void testVorabpauschale01() throws IOException
+    {
+        ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "ConsorsbankVorabpauschale01.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction t = (AccountTransaction) item.get().getSubject();
+
+        assertThat(t.getSecurity().getName(), is("L&G-L&G R.Gbl Robot.Autom.UETF Bearer Shares (Dt. Zert.) o.N."));
+        assertThat(t.getSecurity().getIsin(), is("DE000A12GJD2"));
+        assertThat(t.getSecurity().getWkn(), is("A12GJD"));
+
+        assertThat(t.getType(), is(AccountTransaction.Type.TAXES));
+
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.73))));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-01-02T00:00")));
+    }
+
+    
     private void checkCurrency(final String accountCurrency, AccountTransaction transaction)
     {
         Account account = new Account();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankVorabpauschale01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankVorabpauschale01.txt
@@ -1,0 +1,56 @@
+PDF Author: 'Consorsbank'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Consorsbank  90318 Nürnberg
+Depotnummer: 0123456789
+1001234567/00
+Vermerk der Bank: 1000
+2
+Gxxxxx Lxxxxxx
+Pxxxxxxxxx Sxx 11 Datum: 27.01.2020
+20000 Hamburg Seite: 1 von 2
+Vorabpauschale
+Wertpapierbezeichnung WKN ISIN
+L&G-L&G R.Gbl Robot.Autom.UETF Bearer Shares (Dt. Zert.) o.N. A12GJD DE000A12GJD2
+Bestand
+106 Stück
+Vorabpauschale pro Anteil 0,04106074 EUR Schlusstag 01.01.2020
+Kapitalertrag 0,00 EUR
+abzgl. Kapitalertragsteuer 25,00 % von 2,79 EUR 0,70 EUR
+abzgl. Solidaritätszuschlag 5,50 % von 0,70 EUR 0,03 EUR
+Netto zulasten IBAN DE73 7603 0080 0123 4567 89 0,73 EUR
+Valuta 02.01.2020 BIC CSDBDE71XXX
+Bei unterjährigen Anschaffungen im Vorjahr vermindert sich die Vorabpauschale um ein Zwölftel für jeden Monat.
+Bitte beachten Sie die weiteren Informationen auf Seite 2.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+PrØsident du Conseil dAdministration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur GØnØral (Generaldirektor): Jean-Laurent BonnafØ
+Depotnummer: 0123456789
+1001234567/00
+Vermerk der Bank: 1000
+2
+Datum: 27.01.2020
+Seite: 2 von 2
+Details zur Abrechnung
+Informationen zum Investmentsteuergesetz
+Vorabpauschale gem. §18 InvStG 3,98 EUR
+abzgl. Teilfreistellung 30,00 % von 3,98 EUR 1,19 EUR
+Vorabpauschale mit Teilfreistellung 2,79 EUR
+Steuerpflichtiger Gesamtertrag 2,79 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Mit Quellensteuer verrechnet 0,00 EUR
+somit verrechnete Quellensteuer 0,00 EUR
+Bemessungsgrundlage für Kapitalertragsteuer gesamt 2,79 EUR
+Details zu den Verrechnungstöpfen
+Verrechnungstopf "Allgemein" vor der Abrechnung 0,00 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Verrechnungstopf "Allgemein" nach der Abrechnung 0,00 EUR
+Sparerpauschbetrag vor der Abrechnung 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Sparerpauschbetrag nach der Abrechnung 0,00 EUR
+Verrechnungstopf "Quellensteuer" vor der Abrechnung 0,00 EUR
+Änderung Verrechnungstopf "Quellensteuer" 0,00 EUR
+Verrechnungstopf "Quellensteuer" nach der Abrechnung 0,00 EUR


### PR DESCRIPTION
Added support for Vorabpauschale to Consorsbank PDF import and extended test case

Related to issue 1548
https://github.com/buchen/portfolio/issues/1548