### PR TITLE
Fix NPE occuring in TradeDetailsView when input is null

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -100,7 +100,7 @@ public class TradeDetailsView extends AbstractFinanceView
         // only update the trades if it is *not* based on a pre-calculated set
         // of trades, for example when the user navigates from the dashboard to
         // the detailed trades
-        if (table.getInput() != input.getTrades())
+        if (input != null && table.getInput().equals(input.getTrades()))
             updateFrom(collectAllTrades());
 
         if (!table.getTableViewer().getTable().isDisposed())


### PR DESCRIPTION
Hi,

unfortunately a NPE occurs in the `TradeDetailsView `in case the input is null.
This PR fixes this, unless the input in the `TradeDetailsView `is supposed to be never null.