### PR TITLE
Fix flatex/fintechgroup pdf import for foreign dividends

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -482,7 +482,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                             // get foreign currency (should be in Fx)
                             String currencyCodeFx = asCurrencyCode(v.get("currencyFx"));
-                            if (!"EUR".equalsIgnoreCase(currencyCodeFx))
+                            // create a Unit only, if security and transaction currency are different
+                            if (!t.getSecurity().getCurrencyCode().equalsIgnoreCase(currencyCodeFx))
                             {
                                 // get exchange rate (in Fx/EUR) and calculate
                                 // inverse exchange rate (in EUR/Fx)
@@ -499,11 +500,6 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 t.addUnit(new Unit(Unit.Type.GROSS_VALUE, mAmountGrossFxInEUR, mAmountGrossFx,
                                                 inverseRate));
                             }
-                            else
-                            {
-                                // but if not in Fx but Euro already...
-                                t.setAmount(asAmount(v.get("amountGrossFx")));
-                            }
                         })
 
                         // Quellenst.-satz : 30,00 % Gez. Quellenst. : 7,88 USD
@@ -516,7 +512,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                             // transaction currency (should be in EUR)
                             String currencyCode = asCurrencyCode(context.get("currency"));
                             String currencyCodeFx = asCurrencyCode(v.get("currencyFx"));
-                            if (!"EUR".equalsIgnoreCase(currencyCodeFx))
+                            if (!currencyCode.equalsIgnoreCase(currencyCodeFx))
                             {
                                 // get exchange rate (in Fx/EUR) and calculate
                                 // inverse exchange rate (in EUR/Fx)


### PR DESCRIPTION
Statt fest auf EUR zu prüfen, sollte besser auf die Währung des Wertpapiers geprüft werden. Ob das beim realen Import mit existierendem Wertpapier in Währung EUR tatsächlich das Problem behebt, ist leider nicht sicher. Aber mal ein Versuch. Die Testcases laufen noch durch. 

Vemutlich ist es sinnvoll, die Tests dahingehend zu erweitern, dass man angeben kann, ob und in welcher Währung das Wertpapier existiert, um alle Fälle zu testen. Aber das ist ein anderes Thema, das ich mal im Hinterkopf behalte.

Issue: https://forum.portfolio-performance.info/t/dividenden-import-wechselkurs-des-nettowertes-fehlt-flatex/1366/26