### PR TITLE
Added volksbank oberbayern to dzbank pdf importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbank/DZBankWertpapierabrechnung_Kauf3.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbank/DZBankWertpapierabrechnung_Kauf3.txt
@@ -9,10 +9,10 @@ Depotnummer 74721608
 Max Mustermann
  Auftragsnummer 370971/71.00
 Max Mustermann Datum 14.05.2020
-Schulgasse 12 Ihr Berater Armin Mitterer
-83329 Waging a. See Telefon 08651 6006-600
+Schulgasse 12 Ihr Berater Armin Mustermann
+83329 Waging a. See Telefon 08111 6000-123
 Rechnungsnummer W06358-0000004203/20
-Steuernummer 016310680064  
+Steuernummer 016311234567  
 VR Depot Klassik
  
 Wertpapier Abrechnung Kauf 
@@ -23,7 +23,7 @@ Handels-/Ausführungsplatz Stuttgart (gemäß Weisung)
 Börsensegment STUA
 Market-Order
 Limit billigst
-Schlusstag/-Zeit 14.05.2020 15:40:55 Auftraggeber Florian Breitfuß
+Schlusstag/-Zeit 14.05.2020 15:40:55 Auftraggeber Flo B
 Ausführungskurs 26,885 EUR Auftragserteilung/ -ort Online-Banking
 Girosammelverwahrung - Sammel-Urkunden in Namensaktien
 Kurswert 1.344,25- EUR
@@ -31,7 +31,7 @@ Provision 9,95- EUR
 Transaktionsentgelt Börse 2,49- EUR
 Ausmachender Betrag 1.356,69- EUR
  
-Den Gegenwert buchen wir mit Valuta 18.05.2020 zu Lasten des Kontos 4721608 (IBAN DE27 7109 0000 0004 7216 08),
+Den Gegenwert buchen wir mit Valuta 18.05.2020 zu Lasten des Kontos 234567 (IBAN DE27 7109 0000 0004 1234 56),
 BLZ 71090000 (BIC GENODEF1BGL).
 Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
 Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbank/DZBankWertpapierabrechnung_Kauf3.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbank/DZBankWertpapierabrechnung_Kauf3.txt
@@ -1,0 +1,41 @@
+﻿PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+   
+VRB Oberbayern Südost eG · Münchner Allee 2 · 83435 Bad Reichenhall
+Depotnummer 74721608
+ 
+ Kundennummer 472160800
+Max Mustermann
+ Auftragsnummer 370971/71.00
+Max Mustermann Datum 14.05.2020
+Schulgasse 12 Ihr Berater Armin Mitterer
+83329 Waging a. See Telefon 08651 6006-600
+Rechnungsnummer W06358-0000004203/20
+Steuernummer 016310680064  
+VR Depot Klassik
+ 
+Wertpapier Abrechnung Kauf 
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 50 DAIMLER AG                         DE0007100000 (710000)
+NAMENS-AKTIEN O.N.                 
+Handels-/Ausführungsplatz Stuttgart (gemäß Weisung)
+Börsensegment STUA
+Market-Order
+Limit billigst
+Schlusstag/-Zeit 14.05.2020 15:40:55 Auftraggeber Florian Breitfuß
+Ausführungskurs 26,885 EUR Auftragserteilung/ -ort Online-Banking
+Girosammelverwahrung - Sammel-Urkunden in Namensaktien
+Kurswert 1.344,25- EUR
+Provision 9,95- EUR
+Transaktionsentgelt Börse 2,49- EUR
+Ausmachender Betrag 1.356,69- EUR
+ 
+Den Gegenwert buchen wir mit Valuta 18.05.2020 zu Lasten des Kontos 4721608 (IBAN DE27 7109 0000 0004 7216 08),
+BLZ 71090000 (BIC GENODEF1BGL).
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+ 
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+6358.05141812.0000028OR07
+

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankPDFExtractor.java
@@ -18,6 +18,7 @@ public class DZBankPDFExtractor extends AbstractPDFExtractor
         super(client);
 
         addBankIdentifier("Volksbank"); //$NON-NLS-1$
+        addBankIdentifier("VRB Oberbayern"); //$NON-NLS-1$
         addBankIdentifier("NIBC Direct Depotservice"); //$NON-NLS-1$
 
         addBuyTransaction();
@@ -76,6 +77,11 @@ public class DZBankPDFExtractor extends AbstractPDFExtractor
                         
                         .section("fee", "currency").optional()
                         .match("(Provision)[ ]*(?<fee>(\\d)*(\\.)?(\\d)*,(\\d)*).* (?<currency>\\w{3}+).*")
+                        .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE,
+                                        Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee"))))))
+
+                        .section("fee", "currency").optional()
+                        .match("(Transaktionsentgelt Börse)[ ]*(?<fee>(\\d)*(\\.)?(\\d)*,(\\d)*).* (?<currency>\\w{3}+).*")
                         .assign((t, v) -> t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE,
                                         Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee"))))))
 


### PR DESCRIPTION
Extended existing pdf importer to support Volksbank Oberbayern and added Transaktionsentgelt Börse

Issue: https://forum.portfolio-performance.info/t/pdf-import-von-volksbank-dz-bank/7504/35