### PR TITLE
Fix to not deduct Quellensteuer from gross value

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -330,8 +330,8 @@ public class ConsorsbankPDFExtractorTest
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9.34))));
 
         Unit grossValue = t.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValue.getAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.66))));
-        assertThat(grossValue.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(12.75))));
+        assertThat(grossValue.getAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.54))));
+        assertThat(grossValue.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(15.00))));
 
         assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.54))));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -605,18 +605,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                 BigDecimal.valueOf(tax.getAmount()).multiply(exchangeRate)
                                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                                t.addUnit(new Unit(Unit.Type.TAX, txTax));
-
-                                // update gross value if necessary
-                                if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                                {
-                                    Unit grossValue = t.getUnit(Unit.Type.GROSS_VALUE).get();
-
-                                    t.removeUnit(grossValue);
-
-                                    t.addUnit(new Unit(Unit.Type.GROSS_VALUE, grossValue.getAmount().subtract(txTax),
-                                                    grossValue.getForex().subtract(tax), grossValue.getExchangeRate()));
-                                }
+                                t.addUnit(new Unit(Unit.Type.TAX, txTax, tax, exchangeRate));
                             }
                         })
 


### PR DESCRIPTION
The deduction of Quellensteuer from gross value gave a wrong gross value. 

One test case needed to be corrected as well