### PR TITLE
Support standard SALE for ebase PDF documents

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ebase.json
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ebase.json
@@ -313,6 +313,51 @@
 					}
 				}
 			]
+		},
+		{
+			"comment": "Verkauf",
+			"type": "SALE",
+			"startsWith": "^Verkauf [0-9,]* Anteile mit Kursdatum .*",
+			"sections": [
+				{
+					"context": "SECURITY",
+					"pattern": [
+						"^Verkauf [0-9,]* Anteile mit Kursdatum .*",
+						"^(?<name>.*)$",
+						".*",
+						"^ISIN .*",
+						"^(?<isin>[^ ]*).*"
+					]
+				},
+				{
+					"pattern": [
+						"^Verkauf [0-9,]* Anteile mit Kursdatum (?<date>\\d+.\\d+.\\d{4}+) .*"
+					]
+				},
+				{
+					"pattern": [
+						"^ISIN .*",
+						"^.*-(?<shares>[\\d+,.]*).*"
+					]
+				},
+				{
+					"pattern": [
+						"^.* Zahlungsbetrag$",
+						"^.* (?<amount>[\\d.,]+) (?<currency>\\w{3}+)$"
+					]
+				},
+				{
+					"context": "UNIT",
+					"isOptional": true,
+					"pattern": [
+						"^(Kapitalertragsteuer Solidaritätszuschlag Kirchensteuer abzgl. Steuern)$",
+						"^([\\d,.]* \\w{3} ){3}(?<amount>[\\d,.]*) (?<currency>\\w{3})$"
+					],
+					"attributes": {
+						"type": "TAX"
+					}
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
During ebase PDF import I noticed that "Verkauf" documents were not accepted.
I tried to adjust the import definition file to also accept these PDFs.
With the adjustments my few sales PDF documents were imported correctly. But since this is my first attempt to modify the import please review my changes.

Here is an example text dump I used.

```
Verkauf 60,000000 Anteile mit Kursdatum TT.MM.JJJJ aus Depotposition XXXXXXXXXXX.XX
XXXWertpapierXXX
Ref. Nr. XXXXXXXXX/XXXXXXXX, Buchungsdatum TT.MM.JJJJ
ISIN Anteile Abrechnungskurs Betrag
XXXISINXXX -60,000000 103,230000 EUR 6.193,80 EUR
Abwicklung über IBAN Institut Zahlungsbetrag
DE00000000000000000000 XXXXXXXXXXXXXXXXXXXXX 6.193,80 EUR
```
