### PR TITLE
Add support for more VIAC dividend types

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend03.txt
@@ -1,0 +1,28 @@
+PDF author: 'VIAC'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag Vertragnummer Anrede
+Portfolio Portfolionummer Vorname Nachname
+Strasse Hausnummer
+PLZ Ort
+Basel, 27.02.2020
+Dividendenausschüttung
+Wir haben für Sie folgende Ausschüttung verbucht:
+Dividendenart: Rückerstattung Quellensteuer
+0.353 Ant CSIF Emerging Markets
+ISIN: CH0017844686
+Ausschüttung: CHF 16.25
+Betrag CHF 5.73
+ 
+Gutgeschriebener Betrag: Valuta 27.02.2020 CHF 5.73
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacDividend04.txt
@@ -1,0 +1,25 @@
+PDF author: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+Internet www.viac.ch
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+Vertrag 3.333.333.333 Herr
+Portfolio 3.333.333.333.01
+Basel, 27.02.2020
+Dividendenausschüttung
+Wir haben für Sie folgende Ausschüttung verbucht:
+Dividendenart: Rückerstattung Quellensteuer
+0.154 Ant CSIF Europe ex CH
+ISIN: CH0037606552
+Ausschüttung: CHF 8.84
+Betrag CHF 1.36
+Gutgeschriebener Betrag: Valuta 27.02.2020 CHF 1.36
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/viac/ViacPDFExtractorTest.java
@@ -404,6 +404,70 @@ public class ViacPDFExtractorTest
     }
     
     @Test
+    public void testDividend03()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacDividend03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("CH0017844686"));
+        assertThat(security.getName(), is("CSIF Emerging Markets"));
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(5.73))));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.353)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-02-27T00:00")));
+
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", Values.Amount.factorize(0))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(5.73))));
+    }
+
+    @Test
+    public void testDividend04()
+    {
+        Client client = new Client();
+
+        ViacPDFExtractor extractor = new ViacPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ViacDividend04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("CH0037606552"));
+        assertThat(security.getName(), is("CSIF Europe ex CH"));
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of("CHF", Values.Amount.factorize(1.36))));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.154)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-02-27T00:00")));
+
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", Values.Amount.factorize(0))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(1.36))));
+    }
+
+    @Test
     public void testVerkauf01()
     {
         Client client = new Client();


### PR DESCRIPTION
VIAC PDFs for dividends can have multiple types. With this change VIAC
dividends support:
 - Ordentliche Dividende (type `DIVIDEND`)
 - Rückerstattung Quellensteuer (type `TAX_REFUND`)

Sample PDFs and tests added for this case.

Fixes #1514