### PR TITLE
Fix Targobank PDF import of dividends

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ertragsgutschrift_03_Ertragsgutschrift_(WPX024).txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ertragsgutschrift_03_Ertragsgutschrift_(WPX024).txt
@@ -1,0 +1,38 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+TARGOBANK AG
+Postfach 10 02 30
+47002 Duisburg
+TARGOBANK AG - Postfach 10 02 30 - 47002 Duisburg www.targobank.de
+HERR
+VORNAME NAME
+ADRESSE1
+ADRESSE2
+Depotnummer NUMMER
+........................................................................................................................................................................................................
+Ertragsgutschrift 30.04.2020
+Rechnungsnummer: CPS-2020-0223620168-0001148
+VORNAME NAME
+Wir informieren Sie über die folgende Ausschüttung:
+Wertpapier Xtrackers Harvest CSI300 - Inhaber-Anteile 1D o.N.
+WKN / ISIN DBX0NK / LU0875160326
+Stück 1.700
+Ausschüttung pro Stück 0,1793 USD
+Ex-Tag 22.04.2020
+Zahlbar 27.04.2020
+Ursprungsland Luxemburg
+Geschäftsjahr 2019
+Geschäftsnummer 12120CG000130O00
+Bruttoertrag 304,81 USD
+Devisenkurs zur Handelswährung USD/EUR 1,09
+Bruttoertrag in EUR 279,64 EUR
+Gutschrift auf Ihrem Konto mit Wertstellung zum 27. April 2020
+Konto-Nr. NUMMER 279,64 EUR
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Seite 1
+TARGOBANK AG | Vorstand: Pascal Laugel (Vorsitzender); Berthold Rüsing; Maria Topaler
+Vorsitzender des Aufsichtsrates:  René Dangel | Sitz der Gesellschaft: Düsseldorf
+Handelsregister Amtsgericht Düsseldorf HRB 83351 | USt-ID-Nr.: DE 811 285 485
+USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 811 623 326
+GH.20200501.024528.5014.0014.5661 X 0 R

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ertragsgutschrift_03_Steuerbeilage_(WPX040).txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ertragsgutschrift_03_Steuerbeilage_(WPX040).txt
@@ -1,0 +1,46 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+TARGOBANK AG
+Postfach 10 02 30
+47002 Duisburg
+TARGOBANK AG - Postfach 10 02 30 - 47002 Duisburg www.targobank.de
+HERR
+VORNAME NAME
+ADRESSE1
+ADRESSE2
+Depotnummer NUMMER
+........................................................................................................................................................................................................
+Ertragsgutschrift (Steuerbeilage) 30.04.2020
+VORNAME NAME
+Wertpapier Xtrackers Harvest CSI300 - Inhaber-Anteile 1D o.N.
+WKN / ISIN DBX0NK / LU0875160326
+Stück 1.700
+Ex-Tag 22.04.2020
+Ursprungsland Luxemburg
+Kapitalertragsteuer Solidaritätszuschlag
+25,00 % * 5,50 %
+Transaktionsreferenz INDTBK12120CG000130O00
+Steuerliche Bemessungsgrundlagen - keine Steuerbescheinigung
+Teilfreistellung (§ 20 InvStG) 30,00 % - 83,89 EUR
+Erträge/Verluste 195,75 EUR
+Auf- oder Abbau von steuerlichen Verrechnungsmöglichkeiten
+Verlustverrechnung aus Aktienhandel: 0,00 EUR
+Verlustverrechnung aus sonstigen Geschäften: 0,00 EUR
+Nutzung des Sparerpauschbetrages/Freistellungsauftrages 0,00 EUR
+Anrechnung ausländischer Quellensteuer ** 0,00 EUR
+Bemessungsgrundlage 195,75 EUR
+Kapitalertragsteuer (KESt): 48,94 EUR
+Solidaritätszuschlag auf KESt: 2,69 EUR
+Kirchensteuer auf KESt: 0,00 EUR
+Gesamtsumme Steuern 51,63 EUR
+Belastung Ihres Kontos NUMMER mit Wertstellung zum 27. April 2020.
+* KESt grundsätzlich 25%. Bei Einbehalt von Kirchensteuer ändert sich der KESt-Satz entsprechend Ihres Kirchensteuersatzes.
+** Quellensteuer multipliziert mit 4 als Ertragsäquivalent
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Seite 1
+TARGOBANK AG | Vorstand: Pascal Laugel (Vorsitzender); Berthold Rüsing; Maria Topaler
+Vorsitzender des Aufsichtsrates:  René Dangel | Sitz der Gesellschaft: Düsseldorf
+Handelsregister Amtsgericht Düsseldorf HRB 83351 | USt-ID-Nr.: DE 811 285 485
+USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 811 623 326
+GH.20200504.022134.5012.0007.10900 X 0 R

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -226,7 +226,9 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("amount", "currency") //
-                        .match("Konto-Nr. \\d* (?<amount>[\\d.]+,\\d+) (?<currency>\\w{3}+)$").assign((t, v) -> {
+//                      .match("Konto-Nr. \\d* (?<amount>[\\d.]+,\\d+) (?<currency>\\w{3}+)$").assign((t, v) -> {
+                        .match(regexAmountAndCurrency) //
+                        .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
                         })
@@ -312,6 +314,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                         .match(regexTaxes).assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
+                            t.setAmount(t.getAmount() - asAmount(v.get("tax")));
                         })
 
                         // use document date to having matching dates from


### PR DESCRIPTION
Net amount was wrong, because tax wasn't properly deducted.
Coding was corrected and examples adjusted accordingly.