### PR TITLE
Fix Consorsbank PDF Import to support "Steuerfreie Dividende"

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankErtragsgutschrift14.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankErtragsgutschrift14.txt
@@ -1,0 +1,27 @@
+PDF Autor: 'Consorsbank'
+PDFBox Version: 1.8.16
+-----------------------------------------
+Consorsbank  90318 Nürnberg
+Depotnummer: 0123456789
+1116695023/00
+Vermerk der Bank: 1000
+2
+Max Mustermann
+Maxi Mustermann Datum: 28.07.2020
+Straße. 111 Seite: 1 von 1
+12345 Stadt
+Dividendengutschrift
+Wertpapierbezeichnung WKN ISIN
+Vonovia SE Dividende Cash A2888C DE000A2888C9
+Bestand
+125 Stück
+Steuerfreie Dividende pro Stück 1,57 EUR Schlusstag 23.07.2020
+Brutto 196,25 EUR
+Netto zugunsten IBAN DE12 1234 1234 1234 1234 12 196,25 EUR
+Valuta 28.07.2020 BIC CSDBDEXXXXX
+Fuehrt gemaess BMF-Schreiben vom 18.01.2016, Randziffer 92, zur Reduzierung der Anschaffungskosten.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+PrØsident du Conseil dAdministration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur GØnØral (Generaldirektor): Jean-Laurent BonnafØ

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -548,6 +548,33 @@ public class ConsorsbankPDFExtractorTest
     }
 
     @Test
+    public void testErtragsgutschrift14() throws IOException
+    {
+        ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "ConsorsbankErtragsgutschrift14.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        AccountTransaction t = results.stream() //
+                        .filter(i -> i instanceof TransactionItem)
+                        .map(i -> (AccountTransaction) ((TransactionItem) i).getSubject()) //
+                        .findAny().get();
+
+        assertThat(t.getSecurity().getName(), is("Vonovia SE Dividende Cash"));
+        assertThat(t.getSecurity().getIsin(), is("DE000A2888C9"));
+        assertThat(t.getSecurity().getWkn(), is("A2888C"));
+        assertThat(t.getSecurity().getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-07-28T00:00")));
+        assertThat(t.getShares(), is(Values.Share.factorize(125)));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(196.25))));
+    }
+
+    @Test
     public void testBezug1() throws IOException
     {
         ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -510,7 +510,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         .section("name", "wkn", "isin", "currency") //
                         .find("Wertpapierbezeichnung WKN ISIN") //
                         .match("(?<name>.*) (?<wkn>[^ ]*) (?<isin>[^ ]*)$") //
-                        .match(".* (Dividende pro St.ck|Ertragsaussch.ttung je Anteil) ([\\d.]+,\\d+) (?<currency>\\w{3}+).*") //
+                        .match(".*(Dividende pro St.ck|Ertragsaussch.ttung je Anteil) ([\\d.]+,\\d+) (?<currency>\\w{3}+).*") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -30,13 +30,11 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         addPreemptiveBuyTransaction();
         addSellTransaction();
         addDividendTransaction();
-        addIncomeTransaction();
         addTaxAdjustmentTransaction();
         addVorabpauschaleTransaction();
 
         // documents since Q4 2017 look different
-        addQ42017DividendTransaction();
-        addQ42017IncomeTransaction();
+        addNewDividendTransaction();
     }
 
     @Override
@@ -201,30 +199,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
-        DocumentType type = new DocumentType("DIVIDENDENGUTSCHRIFT");
+        DocumentType type = new DocumentType("(DIVIDENDENGUTSCHRIFT|ERTRAGSGUTSCHRIFT)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("DIVIDENDENGUTSCHRIFT.*");
+        Block block = new Block("(DIVIDENDENGUTSCHRIFT|ERTRAGSGUTSCHRIFT).*");
         type.addBlock(block);
-        block.set(newDividendTransaction(type));
-    }
-
-    @SuppressWarnings("nls")
-    private void addIncomeTransaction()
-    {
-        DocumentType type = new DocumentType("ERTRAGSGUTSCHRIFT");
-        this.addDocumentTyp(type);
-
-        Block block = new Block("ERTRAGSGUTSCHRIFT.*");
-        type.addBlock(block);
-        block.set(newDividendTransaction(type));
-
-    }
-
-    @SuppressWarnings("nls")
-    private Transaction<AccountTransaction> newDividendTransaction(DocumentType type)
-    {
-        return new Transaction<AccountTransaction>()
+        block.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
                             AccountTransaction t = new AccountTransaction();
@@ -347,7 +327,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             }
                         })
 
-                        .wrap(t -> t.getAmount() != 0 ? new TransactionItem(t) : null);
+                        .wrap(t -> t.getAmount() != 0 ? new TransactionItem(t) : null));
     }
 
     @SuppressWarnings("nls")
@@ -511,33 +491,15 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     }
 
     @SuppressWarnings("nls")
-    private void addQ42017IncomeTransaction()
+    private void addNewDividendTransaction()
     {
-        DocumentType type = new DocumentType("Ertragsgutschrift");
+        DocumentType type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("Ertragsgutschrift.*");
+        Block block = new Block("(Dividendengutschrift|Ertragsgutschrift).*");
         type.addBlock(block);
 
-        block.set(newQ42017DividendTransaction(type));
-    }
-
-    @SuppressWarnings("nls")
-    private void addQ42017DividendTransaction()
-    {
-        DocumentType type = new DocumentType("Dividendengutschrift");
-        this.addDocumentTyp(type);
-
-        Block block = new Block("Dividendengutschrift.*");
-        type.addBlock(block);
-
-        block.set(newQ42017DividendTransaction(type));
-    }
-
-    @SuppressWarnings("nls")
-    private Transaction<AccountTransaction> newQ42017DividendTransaction(DocumentType type)
-    {
-        return new Transaction<AccountTransaction>()
+        block.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
                             AccountTransaction t = new AccountTransaction();
@@ -548,7 +510,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         .section("name", "wkn", "isin", "currency") //
                         .find("Wertpapierbezeichnung WKN ISIN") //
                         .match("(?<name>.*) (?<wkn>[^ ]*) (?<isin>[^ ]*)$") //
-                        .match("(Dividende pro Stück|Ertragsausschüttung je Anteil) ([\\d.]+,\\d+) (?<currency>\\w{3}+).*") //
+                        .match(".* (Dividende pro St.ck|Ertragsaussch.ttung je Anteil) ([\\d.]+,\\d+) (?<currency>\\w{3}+).*") //
                         .assign((t, v) -> {
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -636,7 +598,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             checkAndSetTax(tax, t, type);
                         })
 
-                        .wrap(t -> t.getAmount() != 0 ? new TransactionItem(t) : null);
+                        .wrap(t -> t.getAmount() != 0 ? new TransactionItem(t) : null));
 
     }
     


### PR DESCRIPTION
The word "Steuerfreie" prevented the regex from working correctly.
In addition I cleaned up a little.