### PR TITLE
Fix Interactive Brokers importing incorrect amount

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
@@ -331,8 +331,8 @@ public class IBFlexStatementExtractor implements Extractor
             // transaction currency
             String currency = asCurrencyUnit(element.getAttribute("currency"));
 
-            // Set the Amount which is "cost"
-            Double amount = Math.abs(Double.parseDouble(element.getAttribute("cost")));
+            // Set the Amount which is "netCash"
+            Double amount = Math.abs(Double.parseDouble(element.getAttribute("netCash")));
             setAmount(element, transaction.getPortfolioTransaction(), amount, currency);
             setAmount(element, transaction.getAccountTransaction(), amount, currency, false);
 


### PR DESCRIPTION
In exported XML's from FlexQueries the `cost` attribute is incorrect for `sell` operations.
There is however another attribute that has the correct value for both `buy` and `sell` operations.

This patch modifies the source of truth for amount using `netCash` instead.