### PR TITLE
Copy Account attributes to ReadOnlyAccount on instantiation

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ReadOnlyAccount.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ReadOnlyAccount.java
@@ -15,6 +15,7 @@ public class ReadOnlyAccount extends Account
         super(source.getName());
         this.setCurrencyCode(source.getCurrencyCode());
         this.source = Objects.requireNonNull(source);
+        this.setAttributes(source.getAttributes());
     }
 
     public Account unwrap()


### PR DESCRIPTION
This fixes an issue with Logos not showing up for accounts in Statement of Assets view when a filter is applied

@buchen I'm not sure what the purpose of the ReadOnlyAccount wrapper class is, but I don't think it hurts to copy the attributes, does it?

https://forum.portfolio-performance.info/t/logos-fuer-konten-einstellen/10318/12