### PR TITLE
Fix Smartbroker PDF import for dividends and reuse Consorsbank PDF import code

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend7.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend7.txt
@@ -1,0 +1,52 @@
+﻿PDF Autor: 'Computershare Communication Services GmbH'
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=
+Erträgnisgutschrift aus Wertpapieren DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=
+ADRESSZEILE2=
+Dividende für ADRESSZEILE3=
+01.06.2020 - 31.05.2021 ADRESSZEILE4=
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+ / 26.08.2020 ADRESSZEILE6=
+BELEGNUMMER=
+SEITENNUMMER=1
+STEUERERSTATTUNG=N
+Depotinhaber
+
+München, 26.08.2020
+Dividendengutschrift
+Gattungsbezeichnung ISIN
+Paychex Inc. Registered Shares DL -,01 US7043261079
+Nominal Ex-Tag Zahltag Dividenden-Betrag pro Stück
+STK 10,000 31.07.2020 27.08.2020 USD 0,620000
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+27.08.2020  USD 4,64
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+ausländische Dividende EUR 5,25
+US-Quellensteuer 15% USD 0,93
+davon anrechenbare US-Quellensteuer 15% EUR 0,79
+Aktienverlusttopf EUR 
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 2,09
+einbehaltene Kapitalertragsteuer EUR 0,52
+einbehaltener Solidaritätszuschlag EUR 0,02
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 0,52
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,02
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer .
+Steuerlicher Stichtag: 27.08.2020
+Devisenkurs: EUR/USD 1,1814
+Jahressteuerbescheinigung folgt
+Verwahrart: Girosammelverwahrung      
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.17/ABREEREIERTR/GDBERTRG/002770/260820/232426

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -557,8 +557,11 @@ public class DABPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.39))));
         
-        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).get().getAmount(),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));        
+        Unit grossValue = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
+        assertThat(grossValue.getAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));
+        assertThat(grossValue.getForex(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.25))));
+
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));
         
         CheckCurrenciesAction c = new CheckCurrenciesAction();
         Account account = new Account();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -17,9 +17,12 @@ import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
 import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.datatransfer.ImportAction.Status;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
+import name.abuchen.portfolio.datatransfer.actions.CheckCurrenciesAction;
 import name.abuchen.portfolio.datatransfer.pdf.DABPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
@@ -520,6 +523,49 @@ public class DABPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(198.79))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-05-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+    }
+    
+    @Test
+    public void testDividend7withUSDAccount() throws IOException
+    {
+        Client client = new Client();
+        DABPDFExtractor extractor = new DABPDFExtractor(client);
+
+        Security existingSecurity = new Security("Paychex Inc. Registered Shares DL -,01",
+                        CurrencyUnit.EUR);
+        existingSecurity.setIsin("US7043261079");
+        client.addSecurity(existingSecurity);
+
+        List<Exception> errors = new ArrayList<Exception>();
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DABDividend7.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.USD);
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4.64))));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-08-27T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(10)));
+        
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.39))));
+        
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).get().getAmount(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));        
+        
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.USD);
+        Status s = c.process(transaction, account);
+        assertThat(s, is(Status.OK_STATUS));
+
     }
     
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -555,7 +555,7 @@ public class DABPDFExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(10)));
         
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.39))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.56))));
         
         Unit grossValue = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
         assertThat(grossValue.getAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -401,8 +401,8 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(DocumentType documentType, T pdfTransaction)
     {
-        pdfTransaction.section("exchangeRate").optional() //
-                        .match("Devisenkurs: (?<localCurrency>\\w{3}+)/(?<forexCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)")
+        pdfTransaction.section("exchangeRate", "fxCurrency").optional() //
+                        .match("Devisenkurs: (\\w{3}+)/(?<fxCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)")
                         .assign((t, v) -> {
 
                             BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -2,7 +2,7 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Map;
+import java.util.Optional;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -225,7 +225,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Dividende");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^Dividendengutschrift .*$");
+        Block block = new Block("^Dividendengutschrift.*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
@@ -294,6 +294,46 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                             if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                                 t.addUnit(unit);
                         })
+                        
+                        // if gross dividend is given in document, we need to fix the unit, if security currency and transaction currency differ
+                        .section("fxCurrency", "fxAmount", "currency", "exchangeRate") //
+                        .optional() //
+                        // this line seems to give the gross dividend always in EUR
+                        .match("ausl.ndische Dividende \\w{3} (?<fxAmount>[\\d.]+,\\d+)")
+                        .match("Devisenkurs: (?<fxCurrency>\\w{3}+)/(?<currency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)")
+                        .assign((t, v) -> {
+
+                            if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                            {
+                                BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+
+                                // check, if forex currency is transaction currency or not and swap amount, if necessary
+                                Unit grossValue;
+                                if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
+                                {
+                                    Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),
+                                                    asAmount(v.get("fxAmount")));
+                                    long localAmount = exchangeRate.multiply(BigDecimal.valueOf(fxAmount.getAmount())).longValue();
+                                    Money amount = Money.of(asCurrencyCode(v.get("currency")), localAmount);
+                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
+                                } 
+                                else 
+                                {
+                                    Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")),
+                                                    asAmount(v.get("fxAmount")));
+                                    long forexAmount = exchangeRate.multiply(BigDecimal.valueOf(amount.getAmount())).longValue();
+                                    Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), forexAmount);
+                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
+                                }
+                                // remove existing unit to replace with new one
+                                Optional<Unit> grossUnit = t.getUnit(Unit.Type.GROSS_VALUE);
+                                if (grossUnit.isPresent()) 
+                                {
+                                    t.removeUnit(grossUnit.get());
+                                }
+                                t.addUnit(grossValue);
+                            }
+                        })
 
                         .wrap(t -> {
                             if (t.getAmount() == 0)
@@ -361,35 +401,47 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(DocumentType documentType, T pdfTransaction)
     {
-        pdfTransaction.section("tax", "currency", "label").optional()
+        pdfTransaction.section("exchangeRate").optional() //
+                        .match("Devisenkurs: (?<localCurrency>\\w{3}+)/(?<forexCurrency>\\w{3}+) (?<exchangeRate>[\\d.]+,\\d+)")
+                        .assign((t, v) -> {
+
+                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                            if (getTransaction(t).getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                            {
+                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                            }
+                            documentType.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                        })
+
+                        .section("tax", "currency", "label").optional()
+                        .match("^(?<label>.*)US-Quellensteuer.* (?<currency>\\w{3}+) (?<tax>[\\d.]+,\\d+)-?$")
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
+                        })
+
+                        .section("tax", "currency", "label").optional()
                         .match("^(?<label>.*)Kapitalertragsteuer (?<currency>\\w{3}+) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> addTax(documentType, t, v))
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
+                        })
 
                         .section("tax", "currency", "label").optional()
                         .match("^(?<label>.*)Solidaritätszuschlag (?<currency>\\w{3}+) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> addTax(documentType, t, v))
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
+                        })
 
                         .section("tax", "currency", "label").optional()
                         .match("^(?<label>.*)Kirchensteuer (?<currency>\\w{3}+) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> addTax(documentType, t, v));
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
+                        });
     }
-
-    @SuppressWarnings("nls")
-    private void addTax(DocumentType documentType, Object t, Map<String, String> v)
-    {
-        if (v.get("label").contains("im laufenden Jahr einbehaltene"))
-            return;
-
-        name.abuchen.portfolio.model.Transaction tx = getTransaction(t);
-
-        String currency = asCurrencyCode(v.get("currency"));
-        long amount = asAmount(v.get("tax"));
-
-        // FIXME forex fees must update gross value
-        if (currency.equals(tx.getCurrencyCode()))
-            tx.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, amount)));
-    }
-
+    
     private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
     {
         if (t instanceof name.abuchen.portfolio.model.Transaction)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -1,0 +1,41 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
+
+class PDFExtractorUtils
+{
+    @SuppressWarnings("nls")
+    public static void checkAndSetTax(Money tax, name.abuchen.portfolio.model.Transaction t, DocumentType type) 
+    {
+        if (tax.getCurrencyCode().equals(t.getCurrencyCode()))
+        {
+            t.addUnit(new Unit(Unit.Type.TAX, tax));
+        }
+        else if (type.getCurrentContext().containsKey("exchangeRate"))
+        {
+            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+            BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+            Money txTax = Money.of(t.getCurrencyCode(),
+                            BigDecimal.valueOf(tax.getAmount()).multiply(inverseRate)
+                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+
+            // store tax value in both currencies, if security's currency
+            // is different to transaction currency
+            if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+            {
+                t.addUnit(new Unit(Unit.Type.TAX, txTax));
+            }
+            else
+            {
+                t.addUnit(new Unit(Unit.Type.TAX, txTax, tax, inverseRate));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Enhance PDF import to support documents where dividends are booked in a currency different to the security currency.

Issue: https://forum.portfolio-performance.info/t/pdf-import-smartbroker/7684/16