### PR TITLE
Re-apply width of first column

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/CSVImportDefinitionPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/CSVImportDefinitionPage.java
@@ -545,8 +545,17 @@ public class CSVImportDefinitionPage extends AbstractWizardPage
             tableViewer.setInput(input);
             tableViewer.refresh();
             tableViewer.getTable().pack();
+            int hack = 0;
             for (TableColumn column : tableViewer.getTable().getColumns())
+            {
+                int saveWidth = 0;
+                if (hack > 0)
+                    saveWidth = tableViewer.getTable().getColumns()[0].getWidth();
                 column.pack();
+                if (hack > 0)
+                     tableViewer.getTable().getColumns()[0].setWidth(saveWidth);
+                hack += 1;
+            }
 
             doUpdateErrorMessages();
         }


### PR DESCRIPTION
It seems like the pack() function changes the width of the first element, as soon as a column is "packed" with a non-default width.
This causes the first column to be set to the TableViewerWidth.
I have no good explaination why, but this hack fixed the issue #1723 for me.