### PR TITLE
Avoid NPE in ColoredLabel Canvas

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
@@ -74,7 +74,7 @@ public class ColoredLabel extends Canvas // NOSONAR
         if (text != null)
         {
             e.gc.setFont(getFont());
-            e.gc.setForeground(Colors.getTextColor(color));
+            e.gc.setForeground(color != null ? Colors.getTextColor(color) : Colors.BLACK);
 
             int offset = MARGIN_HORIZONTAL;
             if ((style & SWT.RIGHT) == SWT.RIGHT || (style & SWT.CENTER) == SWT.CENTER)


### PR DESCRIPTION
This PR fixes the following NPE:

```
java.lang.NullPointerException
	at name.abuchen.portfolio.ui.util.Colors.getTextColor(Colors.java:121)
	at name.abuchen.portfolio.ui.util.swt.ColoredLabel.handlePaint(ColoredLabel.java:77)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:89)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5685)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1423)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1449)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1432)
	at org.eclipse.swt.widgets.Control.gtk_draw(Control.java:3861)
	at org.eclipse.swt.widgets.Scrollable.gtk_draw(Scrollable.java:346)
	at org.eclipse.swt.widgets.Composite.gtk_draw(Composite.java:451)
	at org.eclipse.swt.widgets.Canvas.gtk_draw(Canvas.java:181)
	at org.eclipse.swt.widgets.Widget.windowProc(Widget.java:2231)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:6659)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:5919)
	at org.eclipse.swt.internal.gtk.GTK.gtk_main_do_event(Native Method)
	at org.eclipse.swt.widgets.Display.eventProc(Display.java:1486)
	at org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(Native Method)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4444)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1158)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:338)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1047)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:155)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Application.start(E4Application.java:166)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:137)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:107)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:657)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:594)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1447)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1420)
```