### PR TITLE
Fix change to previous day

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -385,6 +385,15 @@ public final class Security implements Attributable, InvestmentVehicle
             return false;
 
         LocalDate now = LocalDate.now();
+        LocalDate lastStoredDate = null;
+        LocalDate previousStoredDate = null;
+
+        Optional<Pair<SecurityPrice, SecurityPrice>> previous = getLatestTwoSecurityPrices();
+        if (previous.isPresent())
+        {
+            lastStoredDate = previous.get().getLeft().getDate();
+            previousStoredDate = previous.get().getRight().getDate();
+        }
 
         LocalDate last = null;
         if (!prices.isEmpty())
@@ -395,7 +404,8 @@ public final class Security implements Attributable, InvestmentVehicle
         {
             if (!p.getDate().isAfter(now))
             {
-                boolean doOverwrite = p.getDate().equals(last);
+                boolean doOverwrite = (p.getDate().equals(last) || p.getDate().equals(lastStoredDate)
+                                || p.getDate().equals(previousStoredDate));
                 boolean isAdded = addPrice(p, doOverwrite);
                 isUpdated = isUpdated || isAdded;
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -385,27 +385,20 @@ public final class Security implements Attributable, InvestmentVehicle
             return false;
 
         LocalDate now = LocalDate.now();
-        LocalDate lastStoredDate = null;
         LocalDate previousStoredDate = null;
 
         Optional<Pair<SecurityPrice, SecurityPrice>> previous = getLatestTwoSecurityPrices();
         if (previous.isPresent())
         {
-            lastStoredDate = previous.get().getLeft().getDate();
             previousStoredDate = previous.get().getRight().getDate();
         }
-
-        LocalDate last = null;
-        if (!prices.isEmpty())
-            last = prices.get(prices.size() - 1).getDate();
 
         boolean isUpdated = false;
         for (SecurityPrice p : prices)
         {
-            if (!p.getDate().isAfter(now))
+            if (p.getDate().isBefore(now))
             {
-                boolean doOverwrite = (p.getDate().equals(last) || p.getDate().equals(lastStoredDate)
-                                || p.getDate().equals(previousStoredDate));
+                boolean doOverwrite = p.getDate().equals(previousStoredDate);
                 boolean isAdded = addPrice(p, doOverwrite);
                 isUpdated = isUpdated || isAdded;
             }


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/kursaenderung-zum-vortag-ist-falsch/5189/38

The date used so far (`last`) is the last one coming from quote provider rather than the last one stored as historic security price. Now the comparison should be correct.

Open is still the question, whether todays (`latest`) should be added as historic price as well? I changed the if statement back to `isBefore` to not have the latest price stored as historic price. That seems to work in diagrams and tables (e.g. Kursänderung zum Vortag). 