### PR TITLE
Fix to reset the exchange rate after deselecting a security

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -345,7 +345,8 @@ public class AccountTransactionModel extends AbstractModel
         if (sourceTransaction != null)
             return;
 
-        if (getAccountCurrencyCode().equals(getSecurityCurrencyCode()))
+        // set exchange rate to 1, if account and security have the same currency or no security is selected
+        if (getAccountCurrencyCode().equals(getSecurityCurrencyCode()) || getSecurityCurrencyCode().isEmpty())
         {
             setExchangeRate(BigDecimal.ONE);
         }


### PR DESCRIPTION
When a security with a different currency than the account currency was set and then removed, the exchange rate stayed the same, even though it should be reset to 1.

Issue: https://forum.portfolio-performance.info/t/waehrungswechsel-bei-gebuehrenbuchung-ohne-wertpapier/11094