### PR TITLE
Fix Flatex PDF import to not read dividend cancellations

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexErtragsgutschrift.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexErtragsgutschrift.txt
@@ -11,7 +11,7 @@ Herr
 Max Mustermann  Frankfurt,          08.05.2014
 An den Häusern 5 
 08150 Berlin
-Dividendengutschrift für inländische Wertpapiere
+Dividendengutschrift
 Ihre Depotnummer: 1000000000
 Depotinhaber    : Mustermann, Max
 Nr.716759781                   HANN.RUECK SE NA O.N.     (DE0008402215/840221)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -452,7 +452,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
-        DocumentType type1 = new DocumentType("[^ ]Dividendengutschrift für inländische Wertpapiere");
+        DocumentType type1 = new DocumentType("([^ ]Dividendengutschrift für inländische Wertpapiere)|(Dividendengutschrift[^ ])");
         DocumentType type2 = new DocumentType("Ertragsmitteilung");
         DocumentType type3 = new DocumentType("Zinsgutschrift");
         this.addDocumentTyp(type1);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -452,7 +452,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
-        DocumentType type1 = new DocumentType("Dividendengutschrift für inländische Wertpapiere");
+        DocumentType type1 = new DocumentType("[^ ]Dividendengutschrift für inländische Wertpapiere");
         DocumentType type2 = new DocumentType("Ertragsmitteilung");
         DocumentType type3 = new DocumentType("Zinsgutschrift");
         this.addDocumentTyp(type1);
@@ -538,7 +538,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private void addForeignDividendTransaction()
     {
-        DocumentType type = new DocumentType("Dividendengutschrift für ausländische Wertpapiere", (context, lines) -> {
+        DocumentType type = new DocumentType("[^ ](Dividendengutschrift für ausländische Wertpapiere)", (context, lines) -> {
             Pattern pCurrencyFx = Pattern.compile(".* Bruttodividende *: *[.\\d]+,\\d{2} (?<currencyFx>\\w{3})");
             Pattern pExchangeRate = Pattern.compile(".*Devisenkurs *: *(?<exchangeRate>[.\\d]+,\\d+).*");
             // read the current context here


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/pdf-import-von-flatex/1752/79

Dividend cancellations "Storno Dividendengutschrift für ausländische
Wertpapiere" were detected as "Dividendengutschrift für ausländische
Wertpapiere" and dividends booked once again.