### PR TITLE
Make HTMLTableQuoteFeed work for latest security price

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedHistoricalSample.html
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedHistoricalSample.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>Druckansicht - Titel</title>
+        <meta name="description" content="">
+
+    </head>
+    <body>
+    <div class="container">
+    <header>
+        <h1>Historische Kurse zu DNB Fund - Technology - A EUR ACC (LU0302296495)</h1>
+    </header>
+    <main role="main">
+        <table>
+            <thead>
+            <tr>
+                                    <th class="text-left" width="64px">Datum</th>
+                                    <th >Eröffnung</th>
+                                    <th >Hoch</th>
+                                    <th >Tief</th>
+                                    <th >Schluss</th>
+                                    <th >Volumen</th>
+                            </tr>
+            </thead>
+            <tfoot>
+            <tr>
+                                    <th class="text-left" width="64px">Datum</th>
+                                    <th >Eröffnung</th>
+                                    <th >Hoch</th>
+                                    <th >Tief</th>
+                                    <th >Schluss</th>
+                                    <th >Volumen</th>
+                            </tr>
+            </tfoot>
+            <tbody>
+                            <tr>
+                                    <td class="text-left" width="64px">03.12.2020</td>                                                                                                <td>665,89</td>                                                                            <td>675,00</td>                                                                            <td>665,89</td>                                                                            <td>675,00</td>                                                                                                <td>0</td>                                </tr>
+                            <tr>
+                                    <td class="text-left" width="64px">04.12.2020</td>                                                                                                <td>675,00</td>                                                                            <td>675,37</td>                                                                            <td>667,46</td>                                                                            <td>675,37</td>                                                                                                <td>3</td>                                </tr>
+                            <tr>
+                                    <td class="text-left" width="64px">07.12.2020</td>                                                                                                <td>678,24</td>                                                                            <td>680,31</td>                                                                            <td>677,13</td>                                                                            <td>677,13</td>                                                                                                <td>8</td>                                </tr>
+                        </tbody>
+        </table>
+    </main>
+</div>
+    </body>
+</html>
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedNonHistoricalSample.html
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedNonHistoricalSample.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>Druckansicht - Titel</title>
+        <meta name="description" content="">
+
+    </head>
+    <body>
+    <div class="container">
+    <header>
+        <h1>Times &amp; Sales zu DNB Fund - Technology - A EUR ACC (LU0302296495)</h1>
+    </header>
+    <main role="main">
+        <table>
+            <thead>
+                <tr>
+                                        <th class="text-left" width="64px">Zeit</th>
+                                        <th >Kurs</th>
+                                        <th >Stück</th>
+                                        <th >Kumuliert</th>
+                                    </tr>
+            </thead>
+            <tfoot>
+                <tr>
+                                            <th class="text-left" width="64px">Zeit</th>
+                                            <th >Kurs</th>
+                                            <th >Stück</th>
+                                            <th >Kumuliert</th>
+                                    </tr>
+            </tfoot>
+            <tbody>
+                            <tr>
+                                    <td class="text-left" width="64px">14:30:23</td>                                                                                                <td>671,40</td>                                                                                                <td>0</td>                                                                            <td>19</td>                                </tr>
+                            <tr>
+                                    <td class="text-left" width="64px">11:15:19</td>                                                                                                <td>671,75</td>                                                                                                <td>0</td>                                                                            <td>15</td>                                </tr>
+                            <tr>
+                                    <td class="text-left" width="64px">08:01:58</td>                                                                                                <td>669,00</td>                                                                                                <td>0</td>                                                                            <td>0</td>                                </tr>
+                        </tbody>
+        </table>
+    </main>
+</div>
+    </body>
+</html>
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedTest.java
@@ -1,0 +1,80 @@
+package name.abuchen.portfolio.online.impl;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.online.QuoteFeedData;
+
+public class HTMLTableQuoteFeedTest
+{
+
+    @Test public void testHistorical()
+    {
+        HTMLTableQuoteFeed feed = new HTMLTableQuoteFeed();
+
+        String html = read("HTMLTableQuoteFeedHistoricalSample.html");
+
+        QuoteFeedData data = feed.getHistoricalQuotes(html);
+
+        List<LatestSecurityPrice> prices = data.getLatestPrices();
+
+        assertPrice(prices.get(0), "2020-12-03", 6750000, 6750000, 6658900);
+        assertPrice(prices.get(1), "2020-12-04", 6753700, 6753700, 6674600);
+        assertPrice(prices.get(2), "2020-12-07", 6771300, 6803100, 6771300);
+    }
+
+    @Test
+    public void testGetLatestQuote()
+    {
+        HTMLTableQuoteFeed feed = new HTMLTableQuoteFeed() {
+            @Override String getHtml(String url) throws IOException, URISyntaxException
+            {
+                return read("HTMLTableQuoteFeedNonHistoricalSample.html");
+            }
+
+            @Override void logErrors(QuoteFeedData data)
+            {
+                // do nothing
+            }
+        };
+        Security security = new Security("foo", "EUR");
+        security.setLatestFeed("Tabelle");
+        security.setLatestFeedURL("http://www.example.com/foo");
+
+        Optional<LatestSecurityPrice> quote = feed.getLatestQuote(security);
+
+        assertThat(quote.isPresent(), is(true));
+
+        System.out.println("quote = " + quote);
+        LatestSecurityPrice price = quote.get();
+        assertThat(price.getValue(), is(6714000L));
+
+    }
+
+    private void assertPrice(LatestSecurityPrice price, String date, long value, long high, long low)
+    {
+        assertThat(price.getDate(), is(LocalDate.parse(date)));
+        assertThat(price.getValue(), is(value));
+        assertThat(price.getHigh(), is(high));
+        assertThat(price.getLow(), is(low));
+    }
+
+    private String read(String resourceName)
+    {
+        try (Scanner scanner = new Scanner(getClass().getResourceAsStream(resourceName), "UTF-8"))
+        {
+            return scanner.useDelimiter("\\A").next();
+        }
+    }
+
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPrice.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.model;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 
 import name.abuchen.portfolio.money.Values;
@@ -15,11 +16,12 @@ public class SecurityPrice implements Comparable<SecurityPrice>
         @Override
         public int compare(SecurityPrice p1, SecurityPrice p2)
         {
-            return p1.date.compareTo(p2.date);
+            return p1.getDateTime().compareTo(p2.getDateTime());
         }
     }
 
     private LocalDate date;
+    private LocalDateTime dateTime;
     private long value;
 
     public SecurityPrice()
@@ -42,6 +44,16 @@ public class SecurityPrice implements Comparable<SecurityPrice>
         this.date = date;
     }
 
+    public LocalDateTime getDateTime()
+    {
+        return dateTime != null ? dateTime : date == null ? null : date.atStartOfDay();
+    }
+
+    public void setDateTime(LocalDateTime dateTime)
+    {
+        this.dateTime = dateTime;
+    }
+    
     public long getValue()
     {
         return value;


### PR DESCRIPTION
I found out that getting the latest quote from "Tabelle auf einer Webseite" doesn't work, because the website usually only contains the time and not the date.
I fixed it and added a unit test for historical and latest quote.