### PR TITLE
Fix wrong and inconsistent performance calculation for part of portfolio

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
@@ -1,7 +1,7 @@
 package name.abuchen.portfolio.datatransfer.actions;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -35,7 +35,7 @@ public class DetectDuplicatesActionTest
     {
         DetectDuplicatesAction action = new DetectDuplicatesAction(new Client());
 
-        new PropertyChecker<AccountTransaction>(AccountTransaction.class, "note", "forex", "monetaryAmount").before(
+        new PropertyChecker<AccountTransaction>(AccountTransaction.class, "note", "forex", "monetaryAmount", "crossEntry").before(
                         (name, o, c) -> assertThat(name, action.process(o, account(c)).getCode(), is(Code.WARNING)))
                         .after((name, o, c) -> assertThat(name, action.process(o, account(c)).getCode(), is(Code.OK)))
                         .run();
@@ -49,7 +49,7 @@ public class DetectDuplicatesActionTest
         DetectDuplicatesAction action = new DetectDuplicatesAction(new Client());
 
         new PropertyChecker<PortfolioTransaction>(PortfolioTransaction.class, "fees", "taxes", "note", "forex",
-                        "monetaryAmount") //
+                        "monetaryAmount", "crossEntry") //
                                         .before((name, o, c) -> assertThat(name,
                                                         action.process(o, portfolio(c)).getCode(), is(Code.WARNING)))
                                         .after((name, o, c) -> assertThat(name,
@@ -65,7 +65,7 @@ public class DetectDuplicatesActionTest
         DetectDuplicatesAction action = new DetectDuplicatesAction(new Client());
 
         new PropertyChecker<PortfolioTransaction>(PortfolioTransaction.class, "type", "fees", "taxes", "note", "forex",
-                        "monetaryAmount") //
+                        "monetaryAmount", "crossEntry") //
                                         .before((name, o, c) -> {
                                             o.setType(PortfolioTransaction.Type.BUY);
                                             c.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
@@ -77,7 +77,7 @@ public class DetectDuplicatesActionTest
                                         .run();
 
         new PropertyChecker<PortfolioTransaction>(PortfolioTransaction.class, "type", "fees", "taxes", "note", "forex",
-                        "monetaryAmount") //
+                        "monetaryAmount", "crossEntry") //
                                         .before((name, o, c) -> {
                                             o.setType(PortfolioTransaction.Type.SELL);
                                             c.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -2,7 +2,7 @@ package name.abuchen.portfolio.datatransfer.actions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -122,7 +122,8 @@ public class InsertActionTest
         assertThat(properties, hasItem("dateTime"));
         assertThat(properties, hasItem("type"));
         assertThat(properties, hasItem("note"));
+        assertThat(properties, hasItem("crossEntry"));
 
-        assertThat(properties.size(), is(8));
+        assertThat(properties.size(), is(9));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -234,7 +234,7 @@ public abstract class Transaction implements Annotated, Adaptable
         return crossEntry;
     }
 
-    /* package */void setCrossEntry(CrossEntry crossEntry)
+    public void setCrossEntry(CrossEntry crossEntry)
     {
         this.crossEntry = crossEntry;
     }


### PR DESCRIPTION
Issue: https://github.com/buchen/portfolio/issues/1817

The problem was that transfers (in and out) were not part of the lineitems used to calculate costs and capital gains in `SecurityPerformanceRecord`. Adding them to the list, cross portfolio calculations work correctly.