### PR TITLE
Fix wrong performance calculation for a security

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
@@ -11,6 +11,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
@@ -90,8 +91,9 @@ public class ClientSecurityFilter implements ClientFilter
                                 convertToDelivery(pair.getTransaction(), PortfolioTransaction.Type.DELIVERY_OUTBOUND));
                 break;
             case TRANSFER_IN:
+                convertTransfer(getPortfolio, pair);
             case TRANSFER_OUT:
-                // ignore: transfers are internal to the client file
+                // handled via TRANSFER_IN
                 break;
             default:
                 throw new IllegalArgumentException();
@@ -167,5 +169,16 @@ public class ClientSecurityFilter implements ClientFilter
         t.getUnits().filter(u -> u.getType() != Unit.Type.TAX).forEach(pseudo::addUnit);
 
         return pseudo;
+    }
+
+    private void convertTransfer(Function<Portfolio, ReadOnlyPortfolio> getPortfolio,
+                    TransactionPair<PortfolioTransaction> pair)
+    {
+        PortfolioTransferEntry entry = (PortfolioTransferEntry) pair.getTransaction().getCrossEntry();
+
+        ReadOnlyPortfolio source = getPortfolio.apply(entry.getSourcePortfolio());
+        ReadOnlyPortfolio target = getPortfolio.apply(entry.getTargetPortfolio());
+        
+        ClientFilterHelper.recreateTransfer(entry, source, target);
     }
 }


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/einstandskurs-und-preis-in-der-vermoegensaufstellung-bei-einem-wertpapier-in-zwei-depots-nicht-korrekt/12042/4

A similar problem to the one reported in
https://github.com/buchen/portfolio/issues/1817, this time with a single
security