### PR TITLE
Fix dividend yield per year display when split in multiple transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
@@ -176,7 +176,7 @@ public class DividendTransactionTest
                                                                     // 1800
         t1.setMovingAverageCost(movingAverageCost);
 
-        double result = t1.getPersonalDividendYieldMovingAverage(); // hence
+        double result = t1.getPersonalDividendYieldMovingAverage(true); // hence
                                                                     // 5.5556%
                                                                     // yield
 
@@ -190,7 +190,7 @@ public class DividendTransactionTest
                         LocalDateTime.of(2019, 01, 15, 12, 00));
         // Transaction has no movingAverageCosts
 
-        double result = t1.getPersonalDividendYieldMovingAverage();
+        double result = t1.getPersonalDividendYieldMovingAverage(true);
 
         assertEquals(0.0, result, 0.001d);
     }
@@ -209,7 +209,7 @@ public class DividendTransactionTest
                                                                     // 1800
         t1.setMovingAverageCost(movingAverageCost);
 
-        double result = t1.getPersonalDividendYieldMovingAverage(); // hence
+        double result = t1.getPersonalDividendYieldMovingAverage(true); // hence
                                                                     // 6.66666%
                                                                     // yield
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -1212,7 +1212,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
                 CalculationLineItem item = (CalculationLineItem) e;
                 if (item instanceof CalculationLineItem.DividendPayment)
                     return Values.Percent2.formatNonZero(((CalculationLineItem.DividendPayment) item)
-                                    .getPersonalDividendYieldMovingAverage());
+                                    .getPersonalDividendYieldMovingAverage(true));
                 else
                     return null;
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -126,14 +126,14 @@ public interface CalculationLineItem
             return getGrossValueAmount() / cost;
         }
 
-        public double getPersonalDividendYieldMovingAverage()
+        public double getPersonalDividendYieldMovingAverage(boolean checkPartialPosition)
         {
             if ((movingAverageCost == null) || (movingAverageCost.getAmount() <= 0))
                 return 0;
 
             double cost = movingAverageCost.getAmount();
 
-            if (tx().getShares() > 0)
+            if (checkPartialPosition && tx().getShares() > 0)
                 cost = movingAverageCost.getAmount() * (tx().getShares() / (double) totalShares);
 
             return getGrossValueAmount() / cost;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -61,7 +61,7 @@ import name.abuchen.portfolio.util.Dates;
             if (security != null)
             {
                 // try to get moving average/fifo price
-                rr = t.getPersonalDividendYieldMovingAverage();
+                rr = t.getPersonalDividendYieldMovingAverage(false);
                 // check if it is valid (non 0)
                 if (rr == 0)
                 {


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/dividendenrendite-div-jahr-bei-gleichem-wertpapier-in-mehreren-depots/11911

An example can be found in the thread in the forum.

The calculation logic works fine for line items like in the transaction tab, where the individual number of stocks and their specific cost needs to be taken into consideration.
When calculating the average dividend yield per year, this is done by summing up the individual rates of return and here the calculation needs to relate to the total costs, otherwise multiple percentages are summed up.