### PR TITLE
Broader support for online update of securities

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -51,7 +51,7 @@ public class SecurityTest
                 skipped++;
         }
 
-        assertThat(skipped, equalTo(11));
+        assertThat(skipped, equalTo(12));
 
         Security target = source.deepCopy();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -578,7 +578,7 @@ public class Messages extends NLS
     public static String LabelLayoutRelevant;
     public static String LabelLevelNameNumber;
     public static String LabelLevelNumber;
-    public static String LabelLinkedToPortfolioReport;
+    public static String LabelLinkedTo;
     public static String LabelLinkToPortfolioReportNet;
     public static String LabelNamePlusCopy;
     public static String LabelNet;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -579,7 +579,7 @@ public class Messages extends NLS
     public static String LabelLevelNameNumber;
     public static String LabelLevelNumber;
     public static String LabelLinkedTo;
-    public static String LabelLinkToPortfolioReportNet;
+    public static String LabelLinkTo;
     public static String LabelNamePlusCopy;
     public static String LabelNet;
     public static String LabelNewClassification;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/jobs/SyncOnlineSecuritiesJob.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/jobs/SyncOnlineSecuritiesJob.java
@@ -2,19 +2,16 @@ package name.abuchen.portfolio.ui.jobs;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
-import com.ibm.icu.text.MessageFormat;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
-import name.abuchen.portfolio.online.impl.PortfolioReportNet;
+import name.abuchen.portfolio.online.SecuritySearchProvider;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 
@@ -38,26 +35,14 @@ public final class SyncOnlineSecuritiesJob extends AbstractClientJob
 
         boolean isDirty = false;
 
-        PortfolioReportNet portfolioReport = new PortfolioReportNet();
-
         for (Security security : toBeSynced)
         {
-            monitor.worked(1);
+            SecuritySearchProvider securityUpdater = security.getOnlineProvider();
 
+            monitor.worked(1);
             try
             {
-                Optional<ResultItem> item = portfolioReport.getUpdatedValues(security.getOnlineId());
-
-                if (item.isPresent())
-                {
-                    boolean hasUpdate = PortfolioReportNet.updateWith(security, item.get());
-                    isDirty = isDirty || hasUpdate;
-                }
-                else
-                {
-                    PortfolioPlugin.info(MessageFormat.format("No data found for ''{0}'' with OnlineId {1}", //$NON-NLS-1$
-                                    security.getName(), security.getOnlineId()));
-                }
+                isDirty = isDirty || securityUpdater.update(security);
             }
             catch (IOException e)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1196,9 +1196,9 @@ LabelLevelNameNumber = {0} (Level {1})
 
 LabelLevelNumber = Level {0}
 
-LabelLinkToPortfolioReportNet = Link to Portfolio Report
+LabelLinkedTo = Linked to <a>{0}</a>
 
-LabelLinkedToPortfolioReport = Linked to <a>Portfolio Report</a>
+LabelLinkToPortfolioReportNet = Link to Portfolio Report
 
 LabelMaxDrawdown = Maximum Drawdown
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1922,7 +1922,7 @@ SecurityMenuAddEvent = Event...
 
 SecurityMenuAddNewSecurity = Add new investment instrument
 
-SecurityMenuAddNewSecurityDescription = Search Yahoo Finance by ticker symbol, ISIN, or name\n(using your web browser might find more).
+SecurityMenuAddNewSecurityDescription = Search by ticker symbol, ISIN, or name\n(using your web browser might find more).
 
 SecurityMenuAddPrice = Add
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1198,7 +1198,7 @@ LabelLevelNumber = Level {0}
 
 LabelLinkedTo = Linked to <a>{0}</a>
 
-LabelLinkToPortfolioReportNet = Link to Portfolio Report
+LabelLinkTo = Link to ...
 
 LabelMaxDrawdown = Maximum Drawdown
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1185,7 +1185,7 @@ LabelLevelNumber = Ebene {0}
 
 LabelLinkToPortfolioReportNet = Mit Portfolio Report verkn\u00FCpfen
 
-LabelLinkedToPortfolioReport = Verkn\u00FCpft mit <a>Portfolio Report</a>
+LabelLinkedTo = Verkn\u00FCpft mit <a>{0}</a>
 
 LabelMaxDrawdown = Maximaler Drawdown
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1183,9 +1183,9 @@ LabelLevelNameNumber = {0} (Ebene {1})
 
 LabelLevelNumber = Ebene {0}
 
-LabelLinkToPortfolioReportNet = Mit Portfolio Report verkn\u00FCpfen
-
 LabelLinkedTo = Verkn\u00FCpft mit <a>{0}</a>
+
+LabelLinkTo = Verkn\u00FCpfen mit ...
 
 LabelMaxDrawdown = Maximaler Drawdown
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1909,7 +1909,7 @@ SecurityMenuAddEvent = Ereignis...
 
 SecurityMenuAddNewSecurity = Wertpapier hinzuf\u00FCgen
 
-SecurityMenuAddNewSecurityDescription = Auf Yahoo Finance anhand Ticker Symbol, ISIN, oder Name nach\nWertpapieren suchen (direkt im Browser findet man evtl. mehr).
+SecurityMenuAddNewSecurityDescription = Suche anhand von Ticker Symbol, ISIN, oder Name nach\nWertpapieren (direkt im Browser findet man evtl. mehr).
 
 SecurityMenuAddPrice = Neu
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1705,7 +1705,7 @@ SecurityListFilterOnlySecurities = Solo valores
 
 SecurityMenuAddNewSecurity = A\u00F1adir un nuevo instrumento de inversi\u00F3n
 
-SecurityMenuAddNewSecurityDescription = Buscar Yahoo Finanzas por s\u00EDmbolo, ISIN, o nombre\n(utilizando el navegador web puede encontrar m\u00E1s).
+SecurityMenuAddNewSecurityDescription = Buscar por s\u00EDmbolo, ISIN, o nombre\n(utilizando el navegador web puede encontrar m\u00E1s).
 
 SecurityMenuAddPrice = A\u00F1adir
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1053,7 +1053,7 @@ LabelLevelNameNumber = {0} (Nivel {1})
 
 LabelLevelNumber = Nivel {0}
 
-LabelLinkToPortfolioReportNet = Enlace con Portfolio Report
+LabelLinkTo = Enlace con ...
 
 LabelLinkedTo = Vinculado al <a>{0}</a>
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1055,7 +1055,7 @@ LabelLevelNumber = Nivel {0}
 
 LabelLinkToPortfolioReportNet = Enlace con Portfolio Report
 
-LabelLinkedToPortfolioReport = Vinculado al <a>Portfolio Report</a>
+LabelLinkedTo = Vinculado al <a>{0}</a>
 
 LabelMaxDrawdown = Drawdown m\u00E1ximo
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1870,7 +1870,7 @@ SecurityListFilterOnlySecurities = Seulement titres
 
 SecurityMenuAddNewSecurity = Ajouter nouvel instrument
 
-SecurityMenuAddNewSecurityDescription = Rechercher Yahoo Finance par symbole, ISIN ou nom\n(l'utilisation du navigateur Web peut en trouver plus).
+SecurityMenuAddNewSecurityDescription = Rechercher par symbole, ISIN ou nom\n(l'utilisation du navigateur Web peut en trouver plus).
 
 SecurityMenuAddPrice = Ajouter
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1156,7 +1156,7 @@ LabelLevelNameNumber = {0} (Niveau {1})
 
 LabelLevelNumber = Niveau {0}
 
-LabelLinkToPortfolioReportNet = Lien vers Portfolio Report
+LabelLinkTo = Lien vers ...
 
 LabelLinkedTo = Li\u00E9 \u00E0 <a>{0}</a>
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1158,7 +1158,7 @@ LabelLevelNumber = Niveau {0}
 
 LabelLinkToPortfolioReportNet = Lien vers Portfolio Report
 
-LabelLinkedToPortfolioReport = Li\u00E9 \u00E0 <a>Portfolio Report</a>
+LabelLinkedTo = Li\u00E9 \u00E0 <a>{0}</a>
 
 LabelMaxDrawdown = Maximum Drawdown
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1175,7 +1175,7 @@ LabelLevelNameNumber = {0} (Niveau {1})
 
 LabelLevelNumber = Niveau {0}
 
-LabelLinkToPortfolioReportNet = Link met Portfolio Report
+LabelLinkTo = Link met ...
 
 LabelLinkedTo = Gekoppeld aan <a>{0}</a>
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1891,7 +1891,7 @@ SecurityListFilterOnlySecurities = Alleen effecten
 
 SecurityMenuAddNewSecurity = Nieuw beleggingsinstrument toevoegen
 
-SecurityMenuAddNewSecurityDescription = Zoeken naar Yahoo Finance op tickersymbool, ISIN of naam\n(mogelijk vindt u via uw webbrowser meer).
+SecurityMenuAddNewSecurityDescription = Zoeken op tickersymbool, ISIN of naam\n(mogelijk vindt u via uw webbrowser meer).
 
 SecurityMenuAddPrice = Toevoegen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1177,7 +1177,7 @@ LabelLevelNumber = Niveau {0}
 
 LabelLinkToPortfolioReportNet = Link met Portfolio Report
 
-LabelLinkedToPortfolioReport = Gekoppeld aan <a>Portfolio Report</a>
+LabelLinkedTo = Gekoppeld aan <a>{0}</a>
 
 LabelMaxDrawdown = Maximale daling
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1179,7 +1179,7 @@ LabelLevelNameNumber = {0} (N\u00EDvel {1})
 
 LabelLevelNumber = Level {0}
 
-LabelLinkToPortfolioReportNet = Vincule com o Portfolio Report
+LabelLinkTo = Vincule com o ...
 
 LabelLinkedTo = Vinculado ao <a>{0}</a>
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1897,7 +1897,7 @@ SecurityListFilterOnlySecurities = Apenas a\u00E7\u00F5es
 
 SecurityMenuAddNewSecurity = Adicionar um novo instrumento de investimento
 
-SecurityMenuAddNewSecurityDescription = Pesquise no Yahoo Finance pelo s\u00EDmbolo, ISIN ou nome\n(usando o seu navegador pode encontrar mais).
+SecurityMenuAddNewSecurityDescription = Pesquise pelo s\u00EDmbolo, ISIN ou nome\n(usando o seu navegador pode encontrar mais).
 
 SecurityMenuAddPrice = Adicionar
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1181,7 +1181,7 @@ LabelLevelNumber = Level {0}
 
 LabelLinkToPortfolioReportNet = Vincule com o Portfolio Report
 
-LabelLinkedToPortfolioReport = Vinculado ao <a>Portfolio Report</a>
+LabelLinkedTo = Vinculado ao <a>{0}</a>
 
 LabelMaxDrawdown = Drawdown m\u00E1ximo
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -104,7 +104,7 @@ public final class SecuritiesTable implements ModificationListener
 
         public LinkToPortfolioReport(Security security)
         {
-            super(Messages.LabelLinkToPortfolioReportNet);
+            super(Messages.LabelLinkTo);
             this.security = security;
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizard.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizard.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.wizards.security;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.swt.graphics.Image;
 
+import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
@@ -38,7 +39,12 @@ public class SearchSecurityWizard extends Wizard
         if (item == null)
             return null;
 
-        return item.create();
+        Security newSecurity = item.create();
+
+        for (AttributeType type : newSecurity.getAttributes().getAll().keySet())
+            this.client.getSettings().addAttributeTypeIfNotExists(type);
+
+        return newSecurity;
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
@@ -79,6 +79,10 @@ public class SearchSecurityWizardPage extends WizardPage
         GridDataFactory.fillDefaults().span(3, 1).grab(true, true).applyTo(resultTable.getControl());
 
         TableColumn column = new TableColumn(resultTable.getTable(), SWT.NONE);
+        column.setText(Messages.LabelQuoteFeedProvider);
+        column.setWidth(100);
+
+        column = new TableColumn(resultTable.getTable(), SWT.NONE);
         column.setText(Messages.ColumnName);
         column.setWidth(250);
 
@@ -101,6 +105,10 @@ public class SearchSecurityWizardPage extends WizardPage
         column = new TableColumn(resultTable.getTable(), SWT.NONE);
         column.setText(Messages.ColumnSecurityExchange);
         column.setWidth(80);
+
+        column = new TableColumn(resultTable.getTable(), SWT.NONE);
+        column.setText(Messages.EditWizardAttributesTitle);
+        column.setWidth(250);
 
         resultTable.getTable().setHeaderVisible(true);
         resultTable.getTable().setLinesVisible(true);
@@ -192,7 +200,7 @@ public class SearchSecurityWizardPage extends WizardPage
         @Override
         public Image getColumnImage(Object element, int columnIndex)
         {
-            if (columnIndex != 0)
+            if (columnIndex != 1)
                 return null;
 
             ResultItem item = (ResultItem) element;
@@ -212,17 +220,21 @@ public class SearchSecurityWizardPage extends WizardPage
             switch (columnIndex)
             {
                 case 0:
-                    return item.getName();
+                    return item.getProvider();
                 case 1:
-                    return item.getSymbol();
+                    return item.getName();
                 case 2:
-                    return item.getIsin();
+                    return item.getSymbol();
                 case 3:
-                    return item.getWkn();
+                    return item.getIsin();
                 case 4:
-                    return item.getType();
+                    return item.getWkn();
                 case 5:
+                    return item.getType();
+                case 6:
                     return item.getExchange();
+                case 7:
+                    return item.getExtraAttributeNames();
                 default:
                     throw new IllegalArgumentException(String.valueOf(columnIndex));
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.wizards.security;
 
+import java.text.MessageFormat;
+
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
@@ -47,9 +49,8 @@ public class SecurityMasterDataPage extends AbstractPage
         GridLayoutFactory.fillDefaults().numColumns(2).margins(5, 5).applyTo(container);
 
         boolean isExchangeRate = model.getSecurity().isExchangeRate();
-        boolean isSyncedOnline = model.getOnlineId() != null;
 
-        if (isSyncedOnline)
+        if (model.getSecurity().hasOnlineLink())
         {
             // empty cell
             new Label(container, SWT.NONE).setText(""); //$NON-NLS-1$
@@ -60,9 +61,9 @@ public class SecurityMasterDataPage extends AbstractPage
             area.setLayout(layout);
 
             Link link = new Link(area, SWT.UNDERLINE_LINK);
-            link.setText(Messages.LabelLinkedToPortfolioReport);
+            link.setText(MessageFormat.format(Messages.LabelLinkedTo, model.getSecurity().getOnlineProvider().getName()));
             link.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> DesktopAPI
-                            .browse("https://www.portfolio-report.net/securities/" + model.getOnlineId()))); //$NON-NLS-1$
+                            .browse(model.getSecurity().getOnlineProvider().getLinkFor(model.getSecurity()))));
 
             Button unlink = new Button(area, SWT.PUSH);
             unlink.setText(Messages.EditWizardMasterDataUnlink);
@@ -109,7 +110,7 @@ public class SecurityMasterDataPage extends AbstractPage
         if (!isExchangeRate)
         {
             isin = bindings.bindISINInput(container, Messages.ColumnISIN, "isin"); //$NON-NLS-1$
-            if (isSyncedOnline)
+            if (model.getSecurity().hasOnlineLink())
             {
                 isin.setEditable(false);
                 isin.setBackground(Colors.SIDEBAR_BACKGROUND_SELECTED);
@@ -121,7 +122,7 @@ public class SecurityMasterDataPage extends AbstractPage
         if (!isExchangeRate)
         {
             wkn = bindings.bindStringInput(container, Messages.ColumnWKN, "wkn", SWT.NONE, 12); //$NON-NLS-1$
-            if (isSyncedOnline)
+            if (model.getSecurity().hasOnlineLink())
             {
                 wkn.setEditable(false);
                 wkn.setBackground(Colors.SIDEBAR_BACKGROUND_SELECTED);

--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.SecuritySearchProvider
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.SecuritySearchProvider
@@ -1,2 +1,3 @@
 name.abuchen.portfolio.online.impl.PortfolioReportNetSearchProvider
 name.abuchen.portfolio.online.impl.YahooSearchProvider
+name.abuchen.portfolio.online.impl.ETFDataComSearchProvider

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AttributeType.java
@@ -468,4 +468,26 @@ public class AttributeType
                 return ((Comparable<Object>) o1).compareTo((Comparable<Object>) o2);
         };
     }
+
+    @Override
+    public int hashCode()
+    {
+        return this.id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if(o == null)
+            return false;
+
+        if (o == this)
+            return true;
+
+        if (getClass() != o.getClass())
+            return false;
+
+        AttributeType e = (AttributeType) o;
+        return (this.getId().equals(e.getId()));
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Attributes.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Attributes.java
@@ -6,31 +6,36 @@ import java.util.stream.Stream;
 
 public class Attributes
 {
-    private Map<String, Object> map = new HashMap<>();
+    private Map<AttributeType, Object> map = new HashMap<>();
 
     public Object put(AttributeType attribute, Object value)
     {
-        return map.put(attribute.getId(), value);
+        return map.put(attribute, value);
     }
 
     public Object get(AttributeType attribute)
     {
-        return map.get(attribute.getId());
+        return map.get(attribute);
     }
 
     public Object remove(AttributeType attribute)
     {
-        return map.remove(attribute.getId());
+        return map.remove(attribute);
     }
 
     public boolean exists(AttributeType attribute)
     {
-        return map.containsKey(attribute.getId());
+        return map.containsKey(attribute);
     }
 
     public Stream<Object> getAllValues()
     {
         return map.values().stream();
+    }
+
+    public Map<AttributeType, Object> getAll()
+    {
+        return map;
     }
 
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
@@ -182,6 +182,13 @@ public class ClientSettings
         attributeTypes.add(index, type);
     }
 
+    public void addAttributeTypeIfNotExists(AttributeType type)
+    {
+        if (attributeTypes.contains(type))
+            return;
+        attributeTypes.add(type);
+    }
+
     public int getAttributeTypeIndexOf(AttributeType type)
     {
         return attributeTypes.indexOf(type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -159,6 +159,22 @@ public final class Security implements Attributable, InvestmentVehicle
 
     public void setOnlineId(String onlineId)
     {
+        if (onlineId == null || this.onlineId == null)
+        {
+            this.onlineId = onlineId;
+            return;
+        }
+        if (onlineId.contains(":")) //$NON-NLS-1$
+        {
+            this.onlineId = onlineId;
+            return;
+        }
+        if (this.onlineId.contains(":"))  //$NON-NLS-1$
+        {
+            String providerName = this.onlineId.split(":", 2)[0]; //$NON-NLS-1$
+            this.onlineId = String.format("%s:%s", providerName, onlineId); //$NON-NLS-1$
+            return;
+        }
         this.onlineId = onlineId;
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -135,7 +135,7 @@ public final class Security implements Attributable, InvestmentVehicle
     {
         if (hasOnlineLink() && onlineId.contains(":")) //$NON-NLS-1$
         {
-            return onlineId.split(":", 1)[1]; //$NON-NLS-1$
+            return onlineId.split(":", 2)[1]; //$NON-NLS-1$
         }
         else
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -17,6 +17,9 @@ import java.util.stream.Stream;
 import com.google.common.base.Strings;
 
 import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.online.Factory;
+import name.abuchen.portfolio.online.SecuritySearchProvider;
+import name.abuchen.portfolio.online.impl.PortfolioReportNetSearchProvider;
 import name.abuchen.portfolio.util.Pair;
 
 /**
@@ -123,9 +126,35 @@ public final class Security implements Attributable, InvestmentVehicle
             generateUUID();
     }
 
+    public boolean hasOnlineLink()
+    {
+        return onlineId != null && !onlineId.isEmpty();
+    }
+
     public String getOnlineId()
     {
-        return onlineId;
+        if (hasOnlineLink() && onlineId.contains(":")) //$NON-NLS-1$
+        {
+            return onlineId.split(":", 1)[1]; //$NON-NLS-1$
+        }
+        else
+        {
+            // Legacy case for non-prefixed Portfolio-Report.net
+            return onlineId;
+        }
+    }
+
+    public SecuritySearchProvider getOnlineProvider()
+    {
+        for (SecuritySearchProvider securitySearchProvider : Factory.getSearchProvider())
+        {
+            if (onlineId.startsWith(securitySearchProvider.getName()))
+                return securitySearchProvider;
+        }
+
+        // Fallback to support existing Portfolio-Report.net
+        // onlineId's that have no prefix yet
+        return new PortfolioReportNetSearchProvider();
     }
 
     public void setOnlineId(String onlineId)
@@ -160,7 +189,7 @@ public final class Security implements Attributable, InvestmentVehicle
     /**
      * Gets the target currency for exchange rates (the currency of the exchange
      * rate).
-     * 
+     *
      * @return target currency for exchange rates, else null
      */
     public String getTargetCurrencyCode()
@@ -171,7 +200,7 @@ public final class Security implements Attributable, InvestmentVehicle
     /**
      * Sets the target currency for exchange rates (defines the currency of the
      * exchange rate).
-     * 
+     *
      * @param targetCurrencyCode
      *            target currency for exchange rates, else null
      */

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
@@ -61,4 +61,8 @@ public interface SecuritySearchProvider
     String getName();
 
     List<ResultItem> search(String query, Type type) throws IOException;
+
+    boolean update(Security existingSecurity) throws IOException;
+
+    String getLinkFor(Security existingSecurity);
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
@@ -62,6 +62,8 @@ public interface SecuritySearchProvider
 
     List<ResultItem> search(String query, Type type) throws IOException;
 
+    boolean supportsUpdates();
+
     boolean update(Security existingSecurity) throws IOException;
 
     String getLinkFor(Security existingSecurity);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
@@ -10,6 +10,8 @@ public interface SecuritySearchProvider
 {
     public interface ResultItem
     {
+        String getProvider();
+
         String getName();
 
         String getSymbol();
@@ -22,6 +24,8 @@ public interface SecuritySearchProvider
 
         String getExchange();
 
+        String getExtraAttributeNames();
+
         default String getOnlineId()
         {
             return null;
@@ -33,6 +37,7 @@ public interface SecuritySearchProvider
         }
 
         Security create();
+
     }
 
     public enum Type

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataCom.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataCom.java
@@ -1,0 +1,263 @@
+package name.abuchen.portfolio.online.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.osgi.framework.FrameworkUtil;
+
+import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.model.AttributeType;
+import name.abuchen.portfolio.model.Attributes;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityProperty;
+import name.abuchen.portfolio.model.AttributeType.PercentPlainConverter;
+import name.abuchen.portfolio.model.AttributeType.StringConverter;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
+import name.abuchen.portfolio.util.WebAccess;
+
+public class ETFDataCom
+{
+    /* package */ static class SymbolInfo
+    {
+        private String exchange;
+        private String symbol;
+
+        static List<SymbolInfo> from(JSONArray listings)
+        {
+            if (listings == null)
+                return Collections.emptyList();
+
+            List<SymbolInfo> res = new ArrayList<>();
+            for (Object listingAsObject : listings)
+            {
+                JSONObject listing = (JSONObject) listingAsObject;
+
+                SymbolInfo m = new SymbolInfo();
+                m.exchange = listing.get("exchange").toString().toUpperCase(Locale.US); //$NON-NLS-1$
+                m.symbol = listing.get("ticker").toString().toUpperCase(Locale.US); //$NON-NLS-1$
+                res.add(m);
+            }
+
+            return(res);
+        }
+
+        private SymbolInfo()
+        {
+        }
+
+        public String getExchange()
+        {
+            return exchange;
+        }
+
+        public String getSymbol()
+        {
+            return symbol;
+        }
+    }
+
+
+    /* package */ static class OnlineItem implements ResultItem
+    {
+        private Double ter;
+        private String indexName;
+        private String name;
+        private String type = "ETF"; //$NON-NLS-1$
+        private String isin;
+        private String provider;
+        private String domicile;
+        private String currencyCode;
+        private String assetClass;
+        private String replicationMethod;
+        private String distributionFrequency;
+        private String distributionType;
+
+        private List<SymbolInfo> symbols;
+
+        /* package */ static OnlineItem from(JSONObject jsonObject)
+        {
+            OnlineItem vehicle = new OnlineItem();
+
+            vehicle.ter = (Double)  jsonObject.get("totalFee"); //$NON-NLS-1$
+            vehicle.indexName = (String) jsonObject.get("indexName"); //$NON-NLS-1$
+            vehicle.name = (String) jsonObject.get("name"); //$NON-NLS-1$
+            vehicle.isin = (String) jsonObject.get("isin"); //$NON-NLS-1$
+            vehicle.provider = (String) jsonObject.get("provider"); //$NON-NLS-1$
+            vehicle.domicile = (String) jsonObject.get("domicile"); //$NON-NLS-1$
+            vehicle.currencyCode = (String) jsonObject.get("baseCurrency"); //$NON-NLS-1$
+            vehicle.replicationMethod = (String) jsonObject.get("replicationMethod"); //$NON-NLS-1$
+            vehicle.distributionFrequency = (String) jsonObject.get("distributionFrequency"); //$NON-NLS-1$
+            vehicle.distributionType = (String) jsonObject.get("distributionType"); //$NON-NLS-1$
+
+            vehicle.symbols = SymbolInfo.from((JSONArray) jsonObject.get("listings")); //$NON-NLS-1$
+            return vehicle;
+        }
+
+        private OnlineItem()
+        {
+        }
+
+        @Override
+        public String getOnlineId()
+        {
+            return isin;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public String getIsin()
+        {
+            return isin;
+        }
+
+        @Override
+        public String getWkn()
+        {
+            return ""; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getSymbol()
+        {
+            return symbols.stream().map(SymbolInfo::getSymbol).reduce((r, l) -> r + "," + l).orElse(null); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getType()
+        {
+            return type;
+        }
+
+        @Override
+        public String getExchange()
+        {
+            return symbols.stream().map(SymbolInfo::getExchange).reduce((r, l) -> r + "," + l).orElse(null); //$NON-NLS-1$
+        }
+
+        @Override
+        public boolean hasPrices()
+        {
+            return false;
+        }
+
+        private Map<String, String> attributeMapping()
+        {
+            Map<String, String> attributeMapping = new HashMap<String, String>();
+            attributeMapping.put("indexName", indexName); //$NON-NLS-1$
+            attributeMapping.put("vendor", provider); //$NON-NLS-1$
+            attributeMapping.put("domicile", domicile); //$NON-NLS-1$
+            attributeMapping.put("replicationMethod", replicationMethod); //$NON-NLS-1$
+            attributeMapping.put("distributionFrequency", distributionFrequency); //$NON-NLS-1$
+            attributeMapping.put("distributionType", distributionType); //$NON-NLS-1$
+
+            return attributeMapping;
+        }
+
+        @Override
+        public Security create()
+        {
+            Security security = new Security();
+
+            security.setOnlineId(isin);
+
+            security.setName(name);
+            security.setIsin(isin);
+            security.setTickerSymbol(symbols.stream().map(SymbolInfo::getSymbol).findAny().orElse(null));
+            symbols.forEach(symbolInfo -> security.addProperty(new SecurityProperty(SecurityProperty.Type.MARKET,
+                            symbolInfo.getExchange(), symbolInfo.getSymbol())));
+            security.setCurrencyCode(CurrencyUnit.getInstance(currencyCode).getCurrencyCode());
+
+
+            Attributes attributes = new Attributes();
+
+            AttributeType terType = new AttributeType("ter"); //$NON-NLS-1$
+            terType.setName(Messages.AttributesTERName);
+            terType.setColumnLabel(Messages.AttributesTERColumn);
+            terType.setTarget(Security.class);
+            terType.setType(Double.class);
+            terType.setConverter(PercentPlainConverter.class);
+            attributes.put(terType, ter/100);
+
+            for (Map.Entry<String, String> am : attributeMapping().entrySet())
+            {
+                AttributeType at = new AttributeType(am.getKey());
+                at.setName(am.getKey());
+                at.setColumnLabel(am.getKey());
+                at.setTarget(Security.class);
+                at.setType(String.class);
+                at.setConverter(StringConverter.class);
+                attributes.put(at, am.getValue());
+            }
+
+            security.setAttributes(attributes);
+
+            return security;
+        }
+
+        public boolean update(Security security)
+        {
+          return false;
+        }
+
+        @Override
+        public String getProvider()
+        {
+            return "ETF-Data.com"; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getExtraAttributeNames()
+        {
+            return String.join(", ", attributeMapping().keySet()); //$NON-NLS-1$
+        }
+    }
+
+
+    private static final String HOST = "api.etf-data.com"; //$NON-NLS-1$
+
+    public List<ResultItem> search(String isin) throws IOException
+    {
+        try
+        {
+            WebAccess webAccess = new WebAccess(HOST, "/product/" + isin) //$NON-NLS-1$
+                            .addUserAgent("PortfolioPerformance/" //$NON-NLS-1$
+                                            + FrameworkUtil.getBundle(ETFDataCom.class).getVersion().toString());
+            return readItems(webAccess.get());
+        }
+        catch (IOException e)
+        {
+            return(new ArrayList<ResultItem>());
+        }
+    }
+
+    private List<ResultItem> readItems(String jsonBlob)
+    {
+        List<ResultItem> onlineItems = new ArrayList<>();
+        JSONObject response = (JSONObject) JSONValue.parse(jsonBlob);
+        onlineItems.add(OnlineItem.from(response));
+
+        return onlineItems;
+    }
+
+    public static boolean updateWith(Security security, ResultItem item)
+    {
+        if (!(item instanceof OnlineItem))
+            throw new IllegalArgumentException();
+
+        return ((OnlineItem) item).update(security);
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataCom.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataCom.java
@@ -13,10 +13,12 @@ import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.osgi.framework.FrameworkUtil;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityProperty;
+import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.AttributeType.StringConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
@@ -171,7 +173,12 @@ public class ETFDataCom
                 attributes = new Attributes();
 
             AttributeType terType = new AttributeType("ter"); //$NON-NLS-1$
-            attributes.put(terType, ter);
+            terType.setName(Messages.AttributesTERName);
+            terType.setColumnLabel(Messages.AttributesTERColumn);
+            terType.setTarget(Security.class);
+            terType.setType(Double.class);
+            terType.setConverter(PercentConverter.class);
+            attributes.put(terType, ter/100);
 
             for (Map.Entry<String, String> am : attributeMapping().entrySet())
             {
@@ -189,7 +196,7 @@ public class ETFDataCom
 
         private Security setInfo(Security security)
         {
-            security.setOnlineId(isin);
+            security.setOnlineId(this.getOnlineId());
 
             security.setName(name);
             security.setIsin(isin);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
@@ -40,4 +40,10 @@ public class ETFDataComSearchProvider implements SecuritySearchProvider
     {
         return "https://api.etf-data.com/product/" + existingSecurity.getIsin(); //$NON-NLS-1$
     }
+
+    @Override
+    public boolean supportsUpdates()
+    {
+        return true;
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
@@ -1,10 +1,12 @@
 package name.abuchen.portfolio.online.impl;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider;
+import name.abuchen.portfolio.util.Isin;
 
 public class ETFDataComSearchProvider implements SecuritySearchProvider
 {
@@ -18,6 +20,9 @@ public class ETFDataComSearchProvider implements SecuritySearchProvider
     @Override
     public List<ResultItem> search(String query, Type type) throws IOException
     {
+        if (!Isin.isValid(query))
+            return new ArrayList<>();
+
         return new ETFDataCom().search(query);
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
@@ -1,0 +1,22 @@
+package name.abuchen.portfolio.online.impl;
+
+import java.io.IOException;
+import java.util.List;
+
+import name.abuchen.portfolio.online.SecuritySearchProvider;
+
+public class ETFDataComSearchProvider implements SecuritySearchProvider
+{
+
+    @Override
+    public String getName()
+    {
+        return "ETF Data API Search Provider"; //$NON-NLS-1$
+    }
+
+    @Override
+    public List<ResultItem> search(String query, Type type) throws IOException
+    {
+        return new ETFDataCom().search(query);
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ETFDataComSearchProvider.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.online.impl;
 import java.io.IOException;
 import java.util.List;
 
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider;
 
 public class ETFDataComSearchProvider implements SecuritySearchProvider
@@ -11,12 +12,27 @@ public class ETFDataComSearchProvider implements SecuritySearchProvider
     @Override
     public String getName()
     {
-        return "ETF Data API Search Provider"; //$NON-NLS-1$
+        return ETFDataCom.PROVIDER_NAME;
     }
 
     @Override
     public List<ResultItem> search(String query, Type type) throws IOException
     {
         return new ETFDataCom().search(query);
+    }
+
+    @Override
+    public boolean update(Security existingSecurity) throws IOException
+    {
+        ETFDataCom etfDataCom = new ETFDataCom();
+        ResultItem searchResult = etfDataCom.search(existingSecurity.getOnlineId()).get(0);
+
+        return ETFDataCom.updateWith(existingSecurity, searchResult);
+    }
+
+    @Override
+    public String getLinkFor(Security existingSecurity)
+    {
+        return "https://api.etf-data.com/product/" + existingSecurity.getIsin(); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
@@ -164,7 +164,7 @@ public class PortfolioReportNet
         @Override
         public String getOnlineId()
         {
-            return id;
+            return String.format("%s:%s", PROVIDER_NAME, id); //$NON-NLS-1$
         }
 
         @Override
@@ -290,7 +290,7 @@ public class PortfolioReportNet
         @Override
         public String getProvider()
         {
-            return "Portfolio-Report.com"; //$NON-NLS-1$
+            return PortfolioReportNet.PROVIDER_NAME;
         }
 
         @Override
@@ -303,6 +303,7 @@ public class PortfolioReportNet
     private static final String TYPE_SHARE = "share"; //$NON-NLS-1$
     private static final String TYPE_BOND = "bond"; //$NON-NLS-1$
 
+    public static final String PROVIDER_NAME = "Portfolio-Report.net"; //$NON-NLS-1$
     private static final String HOST = "www.portfolio-report.net"; //$NON-NLS-1$
 
     public List<ResultItem> search(String query, SecuritySearchProvider.Type type) throws IOException

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
@@ -286,6 +286,18 @@ public class PortfolioReportNet
 
             return isDirty || !remote.isEmpty();
         }
+
+        @Override
+        public String getProvider()
+        {
+            return "Portfolio-Report.com"; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getExtraAttributeNames()
+        {
+            return "";  //$NON-NLS-1$
+        }
     }
 
     private static final String TYPE_SHARE = "share"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
@@ -214,7 +214,7 @@ public class PortfolioReportNet
         {
             Security security = new Security();
 
-            security.setOnlineId(id);
+            security.setOnlineId(this.getOnlineId());
 
             security.setName(name);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNetSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNetSearchProvider.java
@@ -47,4 +47,10 @@ public class PortfolioReportNetSearchProvider implements SecuritySearchProvider
     {
         return "https://www.portfolio-report.net/securities/" + existingSecurity.getOnlineId(); //$NON-NLS-1$
     }
+
+    @Override
+    public boolean supportsUpdates()
+    {
+        return true;
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNetSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNetSearchProvider.java
@@ -2,7 +2,9 @@ package name.abuchen.portfolio.online.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider;
 
 public class PortfolioReportNetSearchProvider implements SecuritySearchProvider
@@ -11,12 +13,38 @@ public class PortfolioReportNetSearchProvider implements SecuritySearchProvider
     @Override
     public String getName()
     {
-        return "Portfolio Report Search Provider"; //$NON-NLS-1$
+        return PortfolioReportNet.PROVIDER_NAME;
     }
 
     @Override
     public List<ResultItem> search(String query, Type type) throws IOException
     {
         return new PortfolioReportNet().search(query, type);
+    }
+
+    @Override
+    public boolean update(Security existingSecurity) throws IOException
+    {
+        PortfolioReportNet portfolioReport = new PortfolioReportNet();
+
+        Optional<ResultItem> item = portfolioReport.getUpdatedValues(existingSecurity.getOnlineId());
+
+        if (item.isPresent())
+        {
+            return PortfolioReportNet.updateWith(existingSecurity, item.get());
+        }
+        else
+        {
+//            TODO: Find an alternative to log update info without direct access to Client
+//            PortfolioPlugin.info(MessageFormat.format("No data found for ''{0}'' with OnlineId {1}", //$NON-NLS-1$
+//                            existingSecurity.getName(), existingSecurity.getOnlineId()));
+        }
+        return false;
+    }
+
+    @Override
+    public String getLinkFor(Security existingSecurity)
+    {
+        return "https://www.portfolio-report.net/securities/" + existingSecurity.getOnlineId(); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
@@ -14,6 +14,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
 import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider;
 import name.abuchen.portfolio.util.WebAccess;
 
@@ -100,5 +101,17 @@ public class YahooSearchProvider implements SecuritySearchProvider
                 }
             }
         }
+    }
+
+    @Override
+    public boolean update(Security existingSecurity) throws IOException
+    {
+        return false;
+    }
+
+    @Override
+    public String getLinkFor(Security existingSecurity)
+    {
+        return null;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
@@ -114,4 +114,10 @@ public class YahooSearchProvider implements SecuritySearchProvider
     {
         return null;
     }
+
+    @Override
+    public boolean supportsUpdates()
+    {
+        return false;
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
@@ -89,6 +89,18 @@ import name.abuchen.portfolio.util.WebAccess;
             security.setFeed(YahooFinanceQuoteFeed.ID);
             return security;
         }
+
+        @Override
+        public String getProvider()
+        {
+            return "Yahoo Finance"; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getExtraAttributeNames()
+        {
+            return ""; //$NON-NLS-1$
+        }
     }
 
     public Stream<Result> search(String query) throws IOException


### PR DESCRIPTION
## Broader support for online update of securities
Some types of investment vehicles receive updates to their base information and attributes. Especially funds tend to get re balanced on their constituents (often), change their TER according to market shifts (occasionally) or even switch the index they tracks (rarely).
Currently there is no extendable way to automate the process of updating those information on a security in Portfolio-Performance.

## Use of etf-data.com
While I personally would prefer to get those pieces of information from the funds respective vendors directly, this has been proven difficult. A lack of consistent public APIs from their side forces us to rely on third party aggregation services. Those vary in accuracy and consistency unfortunately. 
The suggested https://etf-data.com/ is such an independent API provider. It offers both free (without any additional authentication or registration) and paid access. I've personally used their service over the last few days without issues on the free plan. Hoping this will stay available for the foreseeable future 🤞. One downside is that it currently focuses on ETFs only.

## Features
1. Search and import from etf-data.com
2. Showing the SearchProvider's name on the search results table
3. Import and register additional attributes
4. Link existing Securities to ETF-Data.com, much like it currently works with Portfolio-Report.net
5. (Automatic) Updates of Security attributes

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/100136/103247124-19023900-4966-11eb-8c3f-6ea84e247e3e.png">

## Design decisions:
0. Focus on extensibility, **always have another potential data provider / API in mind.**
1. Any `Security` can have one of many online updates sources. Currently we only support Portfolio-Report.net.
2.1. The existing `SecuritySearchProvider` should be in the call chain to do update as well, introducing this interface to also abstract away for updates in `SyncOnlineSecuritiesJob`.
2.2. The `onlineId` field should be used to indicate **which** online updater to use, if any.
2. Initial (search) and recurring (update) online searches can set or change core information on a security (such as ISIN or name), as well as set or update its attributes.
2.1 If an attribute that is received via online sources is not currently configured in the `clientSettings` list of Security attributes, it will be added and therefore appear in the security's edit view / wizard. A user may change the display naming of the attribute at any point.


### Future work
Importing/update Taxonomies such as Region and Sector distribution, potentially guarded by if the user has  `Regions (MSCI)` and/or `Industries (GICS)` enabled
