### PR TITLE
Increase valid formatting range from 6 to 8

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
@@ -19,7 +19,7 @@ public class FormattingPreferencePage extends FieldEditorPreferencePage
     {
         IntegerFieldEditor sharesPrecisionEditor = new IntegerFieldEditor(
                         Preferences.FORMAT_SHARES_DIGITS, Messages.PrefLabelSharesDigits, getFieldEditorParent(), 1);
-        sharesPrecisionEditor.setValidRange(0, 6);
+        sharesPrecisionEditor.setValidRange(0, 8);
         addField(sharesPrecisionEditor);
     }
 }


### PR DESCRIPTION
Servus, @buchen!

I increased the formatting range in [`FormattingPreferencePage.java`](https://github.com/buchen/portfolio/blob/master/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java) from 6 to 8. This allows Portfolio Performance users to use Bitcoin and other crypto currencies to the max. allowed "Nachkommastelle" / decimal point.

Cheers,
Suriyaa