### PR TITLE
Reset exchange rate when currencies coincide

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -309,15 +309,17 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
 
     protected void updateExchangeRate()
     {
+        if (getTransactionCurrencyCode().equals(getSecurityCurrencyCode()))
+        {
+            setExchangeRate(BigDecimal.ONE);
+            return;
+        }
+
         // do not auto-suggest exchange rate when editing an existing transaction
         if (hasSource())
             return;
 
-        if (getTransactionCurrencyCode().equals(getSecurityCurrencyCode()))
-        {
-            setExchangeRate(BigDecimal.ONE);
-        }
-        else if (!getTransactionCurrencyCode().isEmpty() && !getSecurityCurrencyCode().isEmpty())
+        if (!getTransactionCurrencyCode().isEmpty() && !getSecurityCurrencyCode().isEmpty())
         {
             ExchangeRateTimeSeries series = getExchangeRateProviderFactory() //
                             .getTimeSeries(getSecurityCurrencyCode(), getTransactionCurrencyCode());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -366,17 +366,19 @@ public class AccountTransactionModel extends AbstractModel
 
     private void updateExchangeRate()
     {
+        // set exchange rate to 1, if account and security have the same currency or no security is selected
+        if (getAccountCurrencyCode().equals(getSecurityCurrencyCode()) || getSecurityCurrencyCode().isEmpty())
+        {
+            setExchangeRate(BigDecimal.ONE);
+            return;
+        }
+
         // do not auto-suggest exchange rates when editing an existing
         // transaction
         if (sourceTransaction != null)
             return;
 
-        // set exchange rate to 1, if account and security have the same currency or no security is selected
-        if (getAccountCurrencyCode().equals(getSecurityCurrencyCode()) || getSecurityCurrencyCode().isEmpty())
-        {
-            setExchangeRate(BigDecimal.ONE);
-        }
-        else if (!getSecurityCurrencyCode().isEmpty())
+        if (!getSecurityCurrencyCode().isEmpty())
         {
             ExchangeRateTimeSeries series = getExchangeRateProviderFactory() //
                             .getTimeSeries(getSecurityCurrencyCode(), getAccountCurrencyCode());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
@@ -231,25 +231,24 @@ public class AccountTransferModel extends AbstractModel
 
     private void updateExchangeRate()
     {
+        if (getSourceAccountCurrency().equals(getTargetAccountCurrency()))
+        {
+            setExchangeRate(BigDecimal.ONE);
+            return;
+        }
+
         // do not auto-suggest exchange rate when editing an existing
         // transaction
         if (source != null)
             return;
 
-        if (getSourceAccountCurrency().equals(getTargetAccountCurrency()))
-        {
-            setExchangeRate(BigDecimal.ONE);
-        }
-        else
-        {
-            ExchangeRateTimeSeries series = getExchangeRateProviderFactory() //
-                            .getTimeSeries(getSourceAccountCurrency(), getTargetAccountCurrency());
+        ExchangeRateTimeSeries series = getExchangeRateProviderFactory() //
+                        .getTimeSeries(getSourceAccountCurrency(), getTargetAccountCurrency());
 
-            if (series != null)
-                setExchangeRate(series.lookupRate(date).orElse(new ExchangeRate(date, BigDecimal.ONE)).getValue());
-            else
-                setExchangeRate(BigDecimal.ONE);
-        }
+        if (series != null)
+            setExchangeRate(series.lookupRate(date).orElse(new ExchangeRate(date, BigDecimal.ONE)).getValue());
+        else
+            setExchangeRate(BigDecimal.ONE);
     }
 
     public LocalDate getDate()


### PR DESCRIPTION
When currencies in a transaction coincide, controls relating to currency conversion are automatically hidden. In this case, the exchange rate is necessarily 1. However, when an existing transaction was edited to make the currencies coincide, the (invisible) exchange rate remained and still influenced the transaction. It did work when a new transaction was created. The bug was introduced by commit d0fdc85c14e1b42e66bea4fc333ec35609993730.

To fix this, make sure that the exchange rate is reset to 1 even when editing an existing transaction.

A similar issue, where hiding the forex controls was caused by deselecting an optional security, was described on the forums in https://forum.portfolio-performance.info/t/11094 and already fixed in commit 702212e15998260e3e9f4810eb8f60e9ad4a39b3.