### PR TITLE
Feature 8digits precision for shares and quotes

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractorTest.java
@@ -52,11 +52,12 @@ public class IBFlexStatementExtractorTest
         results.stream().filter(i -> !(i instanceof SecurityItem))
                         .forEach(i -> assertThat(i.getAmount(), notNullValue()));
 
-        List<Item> securityItems = results.stream().filter( i -> i instanceof SecurityItem).collect(Collectors.toList());
-        List<Item> buySellTransactions = results.stream().filter( i -> i instanceof BuySellEntryItem).collect(Collectors.toList());
-        
-        assertThat(securityItems.size(), is(5)); 
-        
+        List<Item> securityItems = results.stream().filter(i -> i instanceof SecurityItem).collect(Collectors.toList());
+        List<Item> buySellTransactions = results.stream().filter(i -> i instanceof BuySellEntryItem)
+                        .collect(Collectors.toList());
+
+        assertThat(securityItems.size(), is(5));
+
         // 14 Trade item and one corporate transaction
         assertThat(buySellTransactions.size(), is(15));
         assertThat(results.size(), is(31));
@@ -67,8 +68,7 @@ public class IBFlexStatementExtractorTest
         assertSecondSecurity(results.stream().filter(i -> i instanceof SecurityItem)
                         .reduce((previous, current) -> current).get());
         assertFourthTransaction(results.stream().filter(i -> i instanceof BuySellEntryItem).skip(3).findFirst());
-        
-        
+
         assertOptionBuyTransaction(buySellTransactions.get(13));
 
         assertInterestCharge(results.stream().filter(i -> i instanceof TransactionItem)
@@ -100,7 +100,7 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getMonetaryAmount(), is(Money.of("USD", 2_07L)));
         assertThat(entry.getDateTime(), is(LocalDateTime.parse("2017-09-15T00:00")));
     }
-    
+
     private void assertFee(Optional<Item> item)
     {
         assertThat(item.isPresent(), is(true));
@@ -111,7 +111,7 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getMonetaryAmount(), is(Money.of("USD", 9_18L)));
         assertThat(entry.getDateTime(), is(LocalDateTime.parse("2017-05-03T00:00")));
     }
-    
+
     private void assertFeeRefund(Optional<Item> item)
     {
         assertThat(item.isPresent(), is(true));
@@ -122,7 +122,7 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getMonetaryAmount(), is(Money.of("USD", 9_18L)));
         assertThat(entry.getDateTime(), is(LocalDateTime.parse("2017-05-03T00:00")));
     }
-    
+
     private void assertInterestCharge(Optional<Item> item)
     {
         assertThat(item.isPresent(), is(true));
@@ -171,13 +171,13 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getPortfolioTransaction().getSecurity().getName(), is("GRAN COLOMBIA GOLD CORP"));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of("CAD", 1356_75L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-04-01T09:34")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(5000_000000L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(5000)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of("CAD", 6_75L)));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
                         is(Quote.of("CAD", Values.Quote.factorize(0.27))));
 
     }
-    
+
     private void assertFourthTransaction(Optional<Item> item)
     {
         assertThat(item.isPresent(), is(true));
@@ -190,10 +190,10 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getPortfolioTransaction().getSecurity().getName(), is("URANIUM ONE INC."));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of("CAD", 232_00L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-01-02T15:12")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(100_000000L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of("CAD", 1_00L)));
     }
-    
+
     private void assertOptionBuyTransaction(Item item)
     {
         assertThat(item.getSubject(), instanceOf(BuySellEntry.class));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractorWithAccountDetailsTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractorWithAccountDetailsTest.java
@@ -154,7 +154,7 @@ public class IBFlexStatementExtractorWithAccountDetailsTest
         assertThat(entry.getPortfolioTransaction().getSecurity().getName(), is("ORACLE CORP"));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of("EUR", 4185_05L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-09-15T16:20")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(100_000000L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of("EUR", 1_67L)));
         // 100 shares at 50 USD minus 2USD transaction cost is 49.98 USD per
         // share times 0.83701 is 41.8338

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -735,7 +735,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(t.getUnitSum(Type.FEE), is(Money.of(CurrencyUnit.EUR, 0L)));
         assertThat(t.getDateTime(), is(LocalDateTime.of(2005, 3, 24, 5, 0, 0)));
         assertThat(t.getShares(), is(Values.Share.factorize(52.77908)));
-        assertThat(t.getGrossPricePerShare(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(13.0982))));
+        assertThat(t.getGrossPricePerShare(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(13.09818208))));
     }
 
     @Test
@@ -766,7 +766,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(t.getUnitSum(Type.FEE), is(Money.of(CurrencyUnit.EUR, 13_21L)));
         assertThat(t.getDateTime(), is(LocalDateTime.of(2008, 5, 16, 5, 0, 0)));
         assertThat(t.getShares(), is(Values.Share.factorize(334)));
-        assertThat(t.getGrossPricePerShare(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(9.9296))));
+        assertThat(t.getGrossPricePerShare(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(9.9295509))));
     }
 
     @Test
@@ -933,7 +933,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.95126)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 61L)));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(25.6397))));
+                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(25.6396779))));
     }
 
     @Test
@@ -1295,7 +1295,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(6.43915)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0_00L)));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(15.53))));
+                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(15.53000008))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -611,7 +611,7 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 399_96L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-05-10T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(66_000000L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(66)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 3_96L)));
     }
 
@@ -773,23 +773,23 @@ public class ConsorsbankPDFExtractorTest
     public void testWertpapierVerkauf6_Teilrechte() throws IOException
     {
         PDFImportAssistant assistant = new PDFImportAssistant(new Client(), new ArrayList<>());
-    
+
         List<Exception> errors = new ArrayList<>();
-    
+
         List<Item> results = assistant.runWithInputFile(
                         PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankVerkauf6_Teilrechte.txt"), errors);
-    
+
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
-    
+
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getWkn(), is("ENER6Y"));
         assertThat(security.getIsin(), is("DE000ENER6Y0"));
         assertThat(security.getName(), is("SIEMENS ENERGY AG NA O.N."));
-    
+
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-    
+
         // check buy sell transaction
         Item item = results.get(0);
         BuySellEntry entry = (BuySellEntry) item.getSubject();
@@ -803,23 +803,23 @@ public class ConsorsbankPDFExtractorTest
     public void testWertpapierVerkauf7() throws IOException
     {
         PDFImportAssistant assistant = new PDFImportAssistant(new Client(), new ArrayList<>());
-    
+
         List<Exception> errors = new ArrayList<>();
-    
+
         List<Item> results = assistant.runWithInputFile(
                         PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankVerkauf7.txt"), errors);
-    
+
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
-    
+
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
         assertThat(security.getWkn(), is("A28890"));
         assertThat(security.getIsin(), is("DE000A288904"));
         assertThat(security.getName(), is("COMPUGROUP MED. NA O.N."));
-    
+
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-    
+
         // check buy sell transaction
         Item item = results.get(0);
         BuySellEntry entry = (BuySellEntry) item.getSubject();
@@ -856,7 +856,7 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 5000_00L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.of(2015, 1, 15, 8, 13, 0)));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(132_802120L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(132.80212)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0L)));
     }
 
@@ -1071,7 +1071,7 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1917_50L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.of(2001, 9, 18, 5, 0, 0)));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(50_000000L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(50)));
 
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, 1_53L + 5_11L + 4_60L)));
@@ -1110,7 +1110,7 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 76_83L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.of(2005, 10, 17, 5, 0, 0)));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(15_752430L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(15.75243)));
 
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0_00L)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, 0_00L)));
@@ -1148,7 +1148,7 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 75_00L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.of(2008, 1, 15, 5, 0, 0)));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(11_878910L));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(11.87891)));
 
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0_00L)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, 0_00L)));
@@ -1158,16 +1158,16 @@ public class ConsorsbankPDFExtractorTest
     public void testWertpapierKauf10() throws IOException
     {
         PDFImportAssistant assistant = new PDFImportAssistant(new Client(), new ArrayList<>());
-    
+
         List<Exception> errors = new ArrayList<>();
-    
-        List<Item> results = assistant.runWithInputFile(
-                        PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf10.txt"), errors);
-    
+
+        List<Item> results = assistant
+                        .runWithInputFile(PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf10.txt"), errors);
+
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-    
+
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
@@ -1175,14 +1175,14 @@ public class ConsorsbankPDFExtractorTest
         assertThat(security.getWkn(), is("263530"));
         assertThat(security.getName(), is("ISH.STOX.EUROPE 600 U.ETF"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
-    
+
         // check buy sell transaction
         BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
-    
+
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-    
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 7659_37L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-12-07T13:57")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(197)));
@@ -1193,16 +1193,16 @@ public class ConsorsbankPDFExtractorTest
     public void testWertpapierKauf11() throws IOException
     {
         PDFImportAssistant assistant = new PDFImportAssistant(new Client(), new ArrayList<>());
-    
+
         List<Exception> errors = new ArrayList<>();
-    
-        List<Item> results = assistant.runWithInputFile(
-                        PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf11.txt"), errors);
-    
+
+        List<Item> results = assistant
+                        .runWithInputFile(PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf11.txt"), errors);
+
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-    
+
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
@@ -1210,14 +1210,14 @@ public class ConsorsbankPDFExtractorTest
         assertThat(security.getWkn(), is("A0JDRR"));
         assertThat(security.getName(), is("URANIUM ENERGY DL-,001"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
-    
+
         // check buy sell transaction
         BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
-    
+
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-    
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 5441_15L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-12-07T14:09")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4974)));
@@ -1228,16 +1228,16 @@ public class ConsorsbankPDFExtractorTest
     public void testWertpapierKauf12() throws IOException
     {
         PDFImportAssistant assistant = new PDFImportAssistant(new Client(), new ArrayList<>());
-    
+
         List<Exception> errors = new ArrayList<>();
-    
-        List<Item> results = assistant.runWithInputFile(
-                        PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf12.txt"), errors);
-    
+
+        List<Item> results = assistant
+                        .runWithInputFile(PDFInputFile.loadSingleTestCase(getClass(), "ConsorsbankKauf12.txt"), errors);
+
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-    
+
         // check security
         Security security = results.stream().filter(i -> i instanceof SecurityItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
@@ -1245,14 +1245,14 @@ public class ConsorsbankPDFExtractorTest
         assertThat(security.getWkn(), is("840400"));
         assertThat(security.getName(), is("ALLIANZ SE NA O.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
-    
+
         // check buy sell transaction
         BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).findAny()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
-    
+
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-    
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 25_00L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-12-15T09:30")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.12804)));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeedTest.java
@@ -1,7 +1,7 @@
 package name.abuchen.portfolio.online.impl;
 
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 
 import name.abuchen.portfolio.model.LatestSecurityPrice;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class AlphavantageQuoteFeedTest
@@ -51,9 +52,9 @@ public class AlphavantageQuoteFeedTest
         LatestSecurityPrice price = feed1.getLatestQuote(security).orElseThrow(IllegalArgumentException::new);
 
         assertThat(price.getDate(), is(LocalDate.of(2020, 4, 20)));
-        assertThat(price.getHigh(), is(2775300L));
-        assertThat(price.getLow(), is(2768550L));
-        assertThat(price.getValue(), is(2768550L));
+        assertThat(price.getHigh(), is(Values.Quote.factorize(277.53)));
+        assertThat(price.getLow(), is(Values.Quote.factorize(276.855)));
+        assertThat(price.getValue(), is(Values.Quote.factorize(276.855)));
         assertThat(price.getVolume(), is(389622L));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
@@ -22,6 +22,7 @@ import com.jayway.jsonpath.ReadContext;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.model.SecurityProperty;
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.online.QuoteFeedData;
 
 @SuppressWarnings("nls")
@@ -53,16 +54,16 @@ public class GenericJSONQuoteFeedTest
 
         QuoteFeedData data = feed.getHistoricalQuotes(security, false);
 
-        assertTrue(data.getErrors().isEmpty());
+        assertTrue(data.getErrors().isEmpty()); // NOSONAR
         assertTrue(data.getPrices().size() == 2);
 
         SecurityPrice price = data.getPrices().get(0);
         assertEquals(LocalDate.of(2020, 4, 12), price.getDate());
-        assertEquals(1238800, price.getValue());
+        assertEquals(Values.Quote.factorize(123.88), price.getValue());
 
         SecurityPrice price2 = data.getPrices().get(1);
         assertEquals(LocalDate.of(2020, 4, 13), price2.getDate());
-        assertEquals(1241230, price2.getValue());
+        assertEquals(Values.Quote.factorize(124.123), price2.getValue());
     }
 
     @Test
@@ -180,7 +181,7 @@ public class GenericJSONQuoteFeedTest
     public void testValueExtractionInteger() throws ParseException
     {
         String json = "{\"data\":[{\"date\":1586174400,\"close\":123.234}],\"info\":\"Json Feed for APPLE ORD\"}";
-        long expected = 1232340l;
+        long expected = Values.Quote.factorize(123.234);
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedTest.java
@@ -39,9 +39,9 @@ public class HTMLTableQuoteFeedTest
 
         Collections.sort(prices, new SecurityPrice.ByDate());
 
-        assertPrice(prices.get(0), "2020-12-03", 6750000, 6750000, 6658900);
-        assertPrice(prices.get(1), "2020-12-04", 6753700, 6753700, 6674600);
-        assertPrice(prices.get(2), "2020-12-07", 6771300, 6803100, 6771300);
+        assertPrice(prices.get(0), "2020-12-03", 675, 675, 665.89);
+        assertPrice(prices.get(1), "2020-12-04", 675.37, 675.37, 667.46);
+        assertPrice(prices.get(2), "2020-12-07", 677.13, 680.31, 677.13);
     }
 
     @Test
@@ -68,12 +68,12 @@ public class HTMLTableQuoteFeedTest
 
     }
 
-    private void assertPrice(LatestSecurityPrice price, String date, long value, long high, long low)
+    private void assertPrice(LatestSecurityPrice price, String date, double value, double high, double low)
     {
         assertThat(price.getDate(), is(LocalDate.parse(date)));
-        assertThat(price.getValue(), is(value));
-        assertThat(price.getHigh(), is(high));
-        assertThat(price.getLow(), is(low));
+        assertThat(price.getValue(), is(Values.Quote.factorize(value)));
+        assertThat(price.getHigh(), is(Values.Quote.factorize(high)));
+        assertThat(price.getLow(), is(Values.Quote.factorize(low)));
     }
 
     private String read(String resourceName)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeedTest.java
@@ -1,8 +1,8 @@
 package name.abuchen.portfolio.online.impl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -51,9 +51,9 @@ public class YahooFinanceQuoteFeedTest
         LatestSecurityPrice price = feed.getLatestQuote(security).get();
 
         assertThat(price.getDate(), is(LocalDate.of(2020, 4, 20)));
-        assertThat(price.getHigh(), is(2816600L));
-        assertThat(price.getLow(), is(2768500L));
-        assertThat(price.getValue(), is(2769300L));
+        assertThat(price.getHigh(), is(Values.Quote.factorize(281.66)));
+        assertThat(price.getLow(), is(Values.Quote.factorize(276.85)));
+        assertThat(price.getValue(), is(Values.Quote.factorize(276.93)));
         assertThat(price.getVolume(), is(31089201L));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.money.Values;
+
 @SuppressWarnings("nls")
 public class YahooHelperTest
 {
@@ -39,7 +41,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, 2775300L);
+        assertEquals(result, Values.Quote.factorize(277.53));
     }
 
     @Test
@@ -49,7 +51,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, 2770000L);
+        assertEquals(result, Values.Quote.factorize(277));
     }
 
     @Test(expected = ParseException.class)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClassificationIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClassificationIndexTest.java
@@ -49,9 +49,9 @@ public class ClassificationIndexTest
                         .addTo(client);
 
         Security security = new SecurityBuilder() //
-                        .addPrice("2011-12-31", 100 * Values.Quote.factor()) //
-                        .addPrice("2012-01-03", 106 * Values.Quote.factor()) //
-                        .addPrice("2012-01-08", 112 * Values.Quote.factor()) //
+                        .addPrice("2011-12-31", Values.Quote.factorize(100)) //
+                        .addPrice("2012-01-03", Values.Quote.factorize(106)) //
+                        .addPrice("2012-01-08", Values.Quote.factorize(112)) //
                         .assign(taxonomy, "one", weight) //
                         .addTo(client);
 
@@ -74,10 +74,10 @@ public class ClassificationIndexTest
                         .addTo(client);
 
         new PortfolioBuilder(account) //
-                        .buy(security, "2012-01-01", Values.Share.factorize(50), 50 * 101 * Values.Amount.factor()) //
+                        .buy(security, "2012-01-01", Values.Share.factorize(50), Values.Amount.factorize(50 * 101)) //
                         .inbound_delivery(security, "2012-01-01", Values.Share.factorize(100),
-                                        100 * 100 * Values.Amount.factor()) //
-                        .sell(security, "2012-01-05", Values.Share.factorize(50), 50 * 105 * Values.Amount.factor()) //
+                                        Values.Amount.factorize(100 * 100)) //
+                        .sell(security, "2012-01-05", Values.Share.factorize(50), Values.Amount.factorize(50 * 105)) //
                         .addTo(client);
 
         return client;

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClassificationIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClassificationIndexTest.java
@@ -74,10 +74,10 @@ public class ClassificationIndexTest
                         .addTo(client);
 
         new PortfolioBuilder(account) //
-                        .buy(security, "2012-01-01", 50 * Values.Share.factor(), 50 * 101 * Values.Amount.factor()) //
-                        .inbound_delivery(security, "2012-01-01", 100 * Values.Share.factor(),
+                        .buy(security, "2012-01-01", Values.Share.factorize(50), 50 * 101 * Values.Amount.factor()) //
+                        .inbound_delivery(security, "2012-01-01", Values.Share.factorize(100),
                                         100 * 100 * Values.Amount.factor()) //
-                        .sell(security, "2012-01-05", 50 * Values.Share.factor(), 50 * 105 * Values.Amount.factor()) //
+                        .sell(security, "2012-01-05", Values.Share.factorize(50), 50 * 105 * Values.Amount.factor()) //
                         .addTo(client);
 
         return client;
@@ -90,7 +90,7 @@ public class ClassificationIndexTest
 
         Classification classification = client.getTaxonomies().get(0).getClassificationById("one");
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
 
         CurrencyConverter converter = new TestCurrencyConverter();
         PerformanceIndex iClient = PerformanceIndex.forClient(client, converter, period, warnings);
@@ -116,7 +116,7 @@ public class ClassificationIndexTest
         // remove account assignment
         classification.getAssignments().remove(1);
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
 
         CurrencyConverter converter = new TestCurrencyConverter();
         PerformanceIndex iClient = PerformanceIndex.forClient(client, converter, period, warnings);
@@ -138,7 +138,7 @@ public class ClassificationIndexTest
 
         Classification classification = client.getTaxonomies().get(0).getClassificationById("one");
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
 
         CurrencyConverter converter = new TestCurrencyConverter();
         PerformanceIndex iClient = PerformanceIndex.forClient(client, converter, period, warnings);
@@ -148,17 +148,17 @@ public class ClassificationIndexTest
         assertThat(warnings.isEmpty(), is(true));
 
         assertThat(iClient.getDates(), is(iClassification.getDates()));
-        assertThat(iClient.getAccumulatedPercentage(), is(iClassification.getAccumulatedPercentage()));
-        assertThat(iClient.getDeltaPercentage(), is(iClassification.getDeltaPercentage()));
         assertThat(half(iClient.getTotals()), is(iClassification.getTotals()));
         assertThat(half(iClient.getTransferals()), is(iClassification.getTransferals()));
+        assertThat(iClient.getAccumulatedPercentage(), is(iClassification.getAccumulatedPercentage()));
+        assertThat(iClient.getDeltaPercentage(), is(iClassification.getDeltaPercentage()));
     }
 
     private long[] half(long[] transferals)
     {
         long[] answer = new long[transferals.length];
         for (int ii = 0; ii < transferals.length; ii++)
-            answer[ii] = transferals[ii] / 2;
+            answer[ii] = Math.round(transferals[ii] / 2.0);
         return answer;
     }
 
@@ -207,7 +207,7 @@ public class ClassificationIndexTest
         Classification classification = new Classification(null, null);
         classification.addAssignment(new Assignment(security));
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
 
         PerformanceIndex index = PerformanceIndex.forClassification(client, new TestCurrencyConverter(), classification,
                         Interval.of(LocalDate.parse("2015-01-01"), LocalDate.parse("2017-01-01")), warnings);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
@@ -3,8 +3,8 @@ package name.abuchen.portfolio.snapshot;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
@@ -67,7 +67,7 @@ public class ClientIndexTest
         Interval period = Interval.of(LocalDate.of(2011, Month.DECEMBER, 31), //
                         LocalDate.of(2012, Month.JANUARY, 8));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<>());
 
         assertNotNull(index);
 
@@ -155,14 +155,14 @@ public class ClientIndexTest
         Interval period = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
                         LocalDate.of(2012, Month.JANUARY, 9));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<>());
 
         double[] accumulated = index.getAccumulatedPercentage();
         for (int ii = 0; ii < accumulated.length; ii++)
             assertThat(accumulated[ii], IsCloseTo.closeTo(delta[ii], PRECISION));
 
         Client anotherClient = createClient(delta, transferals2);
-        index = PerformanceIndex.forClient(anotherClient, converter, period, new ArrayList<Exception>());
+        index = PerformanceIndex.forClient(anotherClient, converter, period, new ArrayList<>());
 
         accumulated = index.getAccumulatedPercentage();
         for (int ii = 0; ii < accumulated.length; ii++)
@@ -177,7 +177,7 @@ public class ClientIndexTest
         Interval period = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
                         LocalDate.of(2012, Month.JANUARY, 9));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<>());
 
         double[] accumulated = index.getAccumulatedPercentage();
         for (int ii = 0; ii < accumulated.length; ii++)
@@ -195,7 +195,7 @@ public class ClientIndexTest
         Interval period = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
                         LocalDate.of(2012, Month.JANUARY, 9));
 
-        List<Exception> errors = new ArrayList<Exception>();
+        List<Exception> errors = new ArrayList<>();
         CurrencyConverter converter = new TestCurrencyConverter();
         PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, errors);
 
@@ -216,7 +216,7 @@ public class ClientIndexTest
         Interval period = Interval.of(LocalDate.of(2011, Month.DECEMBER, 20), //
                         LocalDate.of(2012, Month.JANUARY, 8));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, new ArrayList<>());
 
         assertThat(index.getFirstDataPoint().get(), is(LocalDate.of(2011, 12, 31)));
         assertThat(index.getFirstDataPoint().get(), not(period.getStart()));
@@ -245,7 +245,8 @@ public class ClientIndexTest
             // additionally has the identical performance on its first day -->
             // use the closing quote of the previous day
 
-            long p = security.getSecurityPrice(date.minusDays(1)).getValue();
+            long p = Math.round(security.getSecurityPrice(date.minusDays(1)).getValue() / Values.Quote.dividerToMoney()
+                            * 100);
             portfolio.inbound_delivery(security, date.atStartOfDay().toString(), Values.Share.factorize(100), p);
             date = date.plusDays(20);
         }
@@ -254,7 +255,7 @@ public class ClientIndexTest
 
         Interval period = Interval.of(startDate, endDate);
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
         CurrencyConverter converter = new TestCurrencyConverter();
         PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, warnings);
         assertTrue(warnings.isEmpty());
@@ -292,7 +293,7 @@ public class ClientIndexTest
 
         Interval period = Interval.of(startDate, endDate);
 
-        List<Exception> warnings = new ArrayList<Exception>();
+        List<Exception> warnings = new ArrayList<>();
         CurrencyConverter converter = new TestCurrencyConverter().with(CurrencyUnit.EUR);
 
         PerformanceIndex index = PerformanceIndex.forClient(client, converter, period, warnings);
@@ -322,8 +323,7 @@ public class ClientIndexTest
             Interval reportInterval = Interval.of( //
                             LocalDate.of(2011, Month.DECEMBER, 31), LocalDate.of(2012, Month.JANUARY, 8));
             CurrencyConverter converter = new TestCurrencyConverter();
-            PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval,
-                            new ArrayList<Exception>());
+            PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval, new ArrayList<>());
 
             index = Aggregation.aggregate(index, Aggregation.Period.WEEKLY);
 
@@ -358,8 +358,7 @@ public class ClientIndexTest
         Interval reportInterval = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
                         LocalDate.of(2012, Month.JANUARY, 10));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval,
-                        new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval, new ArrayList<>());
 
         double[] accumulated = index.getAccumulatedPercentage();
         assertThat(accumulated[accumulated.length - 2], IsCloseTo.closeTo(0.1d, PRECISION));
@@ -379,8 +378,7 @@ public class ClientIndexTest
         Interval reportInterval = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
                         LocalDate.of(2012, Month.JANUARY, 10));
         CurrencyConverter converter = new TestCurrencyConverter();
-        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval,
-                        new ArrayList<Exception>());
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval, new ArrayList<>());
 
         double[] accumulated = index.getAccumulatedPercentage();
         assertThat(accumulated[accumulated.length - 1], IsCloseTo.closeTo(0.1d, PRECISION));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class DividendTransactionTest
@@ -79,7 +80,7 @@ public class DividendTransactionTest
 
         long result = t.getDividendPerShare();
 
-        assertEquals(result, 9500000000l);
+        assertEquals(result, Values.Share.factorize(9500));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
@@ -2,13 +2,14 @@ package scenarios;
 
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,8 +63,11 @@ public class SecurityPerformanceTaxRefundTestCase
 
         // no changes in holdings, ttwror must (without taxes and tax refunds):
         double startValue = (double) delivery.getAmount() - delivery.getUnitSum(Unit.Type.TAX).getAmount();
-        double endValue = delivery.getShares() * security.getSecurityPrice(LocalDate.parse("2014-12-06")).getValue()
-                        / Values.Share.divider() / Values.Quote.dividerToMoney();
+        double endValue = BigDecimal.valueOf(delivery.getShares())
+                        .multiply(BigDecimal.valueOf(
+                                        security.getSecurityPrice(LocalDate.parse("2014-12-06")).getValue()), Values.MC)
+                        .divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC).doubleValue();
         double ttwror = (endValue / startValue) - 1;
         assertThat(record.getTrueTimeWeightedRateOfReturn(), closeTo(ttwror, 0.0001));
 

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
@@ -1,11 +1,12 @@
 package scenarios;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import org.junit.Test;
@@ -55,9 +56,14 @@ public class SecurityTestCase
         // actually, in this simple scenario (no cash transfers involved), the
         // ttwror is easy to calculate:
 
-        double endvalue = delivery.getShares() * security.getSecurityPrice(LocalDate.parse("2014-12-04")).getValue()
-                        / Values.Share.divider() / Values.Quote.dividerToMoney();
+        double endvalue = BigDecimal.valueOf(delivery.getShares())
+                        .multiply(BigDecimal.valueOf(
+                                        security.getSecurityPrice(LocalDate.parse("2014-12-04")).getValue()), Values.MC)
+                        .divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                        .divide(BigDecimal.valueOf(delivery.getAmount()), Values.MC).subtract(BigDecimal.ONE)
+                        .doubleValue();
 
-        assertThat(record.getTrueTimeWeightedRateOfReturn(), closeTo((endvalue / delivery.getAmount()) - 1, 0.0001));
+        assertThat(record.getTrueTimeWeightedRateOfReturn(), closeTo(endvalue, 0.0001));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
@@ -17,9 +17,9 @@ public class FormattingPreferencePage extends FieldEditorPreferencePage
     @Override
     protected void createFieldEditors()
     {
-        IntegerFieldEditor sharesPrecisionEditor = new IntegerFieldEditor(
-                        Preferences.FORMAT_SHARES_DIGITS, Messages.PrefLabelSharesDigits, getFieldEditorParent(), 1);
-        sharesPrecisionEditor.setValidRange(0, 6);
+        IntegerFieldEditor sharesPrecisionEditor = new IntegerFieldEditor(Preferences.FORMAT_SHARES_DIGITS,
+                        Messages.PrefLabelSharesDigits, getFieldEditorParent(), 1);
+        sharesPrecisionEditor.setValidRange(0, 8);
         addField(sharesPrecisionEditor);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Classification.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Classification.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.model;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,6 +82,7 @@ public class Classification implements Named
     }
 
     public static final int ONE_HUNDRED_PERCENT = 100 * Values.Weight.factor();
+    public static final BigDecimal ONE_HUNDRED_PERCENT_BD = BigDecimal.valueOf(Values.Weight.factorize(100));
 
     public static final String UNASSIGNED_ID = "$unassigned$"; //$NON-NLS-1$
     public static final String VIRTUAL_ROOT = "$virtualroot$"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -24,7 +24,7 @@ public class Client
 {
     /* package */static final int MAJOR_VERSION = 1;
 
-    public static final int CURRENT_VERSION = 48;
+    public static final int CURRENT_VERSION = 49;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
 
     private transient PropertyChangeSupport propertyChangeSupport; // NOSONAR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -591,6 +591,9 @@ public class ClientFactory
                 // added fees to dividend transactions
             case 48:
                 incrementSharesPrecisionFromSixToEightDigitsAfterDecimalSign(client);
+                // add 4 more decimal places to the quote to make it 8
+                addDecimalPlacesToQuotes(client);
+                addDecimalPlacesToQuotes(client);
 
                 client.setVersion(Client.CURRENT_VERSION);
                 break;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -589,6 +589,8 @@ public class ClientFactory
                 addDefaultLogoAttributes(client);
             case 47:
                 // added fees to dividend transactions
+            case 48:
+                incrementSharesPrecisionFromSixToEightDigitsAfterDecimalSign(client);
 
                 client.setVersion(Client.CURRENT_VERSION);
                 break;
@@ -1092,6 +1094,16 @@ public class ClientFactory
         client.getSettings().addAttributeType(factory.apply(Account.class));
         client.getSettings().addAttributeType(factory.apply(Portfolio.class));
         client.getSettings().addAttributeType(factory.apply(InvestmentPlan.class));
+    }
+
+    private static void incrementSharesPrecisionFromSixToEightDigitsAfterDecimalSign(Client client)
+    {
+        for (Portfolio portfolio : client.getPortfolios())
+            for (PortfolioTransaction portfolioTransaction : portfolio.getTransactions())
+                portfolioTransaction.setShares(portfolioTransaction.getShares() * 100);
+        for (Account account : client.getAccounts())
+            for (AccountTransaction accountTransaction : account.getTransactions())
+                accountTransaction.setShares(accountTransaction.getShares() * 100);
     }
 
     @SuppressWarnings("nls")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -188,10 +188,10 @@ public class PortfolioTransaction extends Transaction
             return Quote.of(getCurrencyCode(), 0);
 
         long grossPrice = BigDecimal.valueOf(getGrossValueAmount())
-                        .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
-                        .multiply(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
-                        .divide(BigDecimal.valueOf(getShares()), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
-                        .longValue();
+                        .movePointRight(Values.Quote.precisionDeltaToMoney()) //
+                        .movePointRight(Values.Share.precision()) //
+                        .divide(BigDecimal.valueOf(getShares()), Values.MC) //
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
 
         return Quote.of(getCurrencyCode(), grossPrice);
     }
@@ -214,10 +214,10 @@ public class PortfolioTransaction extends Transaction
         // the gross value (instead of checking the unit type GROSS_VALUE)
 
         long grossPrice = BigDecimal.valueOf(getGrossValue(converter).getAmount())
-                        .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
-                        .multiply(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
-                        .divide(BigDecimal.valueOf(getShares()), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
-                        .longValue();
+                        .movePointRight(Values.Quote.precisionDeltaToMoney()) //
+                        .movePointRight(Values.Share.precision()) //
+                        .divide(BigDecimal.valueOf(getShares()), Values.MC) //
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
         return Quote.of(converter.getTermCurrency(), grossPrice);
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -187,9 +187,13 @@ public class PortfolioTransaction extends Transaction
         if (getShares() == 0)
             return Quote.of(getCurrencyCode(), 0);
 
-        double grossPrice = getGrossValueAmount() * Values.Share.factor() * Values.Quote.factorToMoney()
-                        / (double) getShares();
-        return Quote.of(getCurrencyCode(), Math.round(grossPrice));
+        long grossPrice = BigDecimal.valueOf(getGrossValueAmount())
+                        .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .multiply(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                        .divide(BigDecimal.valueOf(getShares()), Values.MC)
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
+
+        return Quote.of(getCurrencyCode(), grossPrice);
     }
 
     /**

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -190,8 +190,8 @@ public class PortfolioTransaction extends Transaction
         long grossPrice = BigDecimal.valueOf(getGrossValueAmount())
                         .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
                         .multiply(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
-                        .divide(BigDecimal.valueOf(getShares()), Values.MC)
-                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
+                        .divide(BigDecimal.valueOf(getShares()), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
+                        .longValue();
 
         return Quote.of(getCurrencyCode(), grossPrice);
     }
@@ -213,9 +213,12 @@ public class PortfolioTransaction extends Transaction
         // transaction currency and not in security currency) we must convert
         // the gross value (instead of checking the unit type GROSS_VALUE)
 
-        long grossValue = getGrossValue(converter).getAmount();
-        double grossPrice = grossValue * Values.Share.factor() * Values.Quote.factorToMoney() / (double) getShares();
-        return Quote.of(converter.getTermCurrency(), Math.round(grossPrice));
+        long grossPrice = BigDecimal.valueOf(getGrossValue(converter).getAmount())
+                        .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .multiply(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                        .divide(BigDecimal.valueOf(getShares()), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
+                        .longValue();
+        return Quote.of(converter.getTermCurrency(), grossPrice);
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.money;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,6 +13,8 @@ import java.util.Locale;
 
 public abstract class Values<E>
 {
+    public static final MathContext MC = new MathContext(10, RoundingMode.HALF_UP);
+
     public static final class MoneyValues extends Values<Money>
     {
         private MoneyValues()
@@ -58,9 +62,13 @@ public abstract class Values<E>
         private static final ThreadLocal<DecimalFormat> QUOTE_FORMAT = ThreadLocal // NOSONAR
                         .withInitial(() -> new DecimalFormat(QUOTE_PATTERN));
 
+        private final BigDecimal factorToMoney;
+
         private QuoteValues()
         {
             super(QUOTE_PATTERN, 10000D, 10000);
+
+            factorToMoney = BigDecimal.valueOf(factor() / Values.Money.factor());
         }
 
         @Override
@@ -116,6 +124,11 @@ public abstract class Values<E>
         {
             return divider() / Values.Money.divider();
         }
+
+        public BigDecimal getBigDecimalFactorToMoney()
+        {
+            return factorToMoney;
+        }
     }
 
     public static final Values<Long> Amount = new Values<Long>("#,##0.00", 100D, 100) //$NON-NLS-1$
@@ -166,7 +179,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Long> Share = new Values<Long>("#,##0.######", 1000000D, 1000000) //$NON-NLS-1$
+    public static final Values<Long> Share = new Values<Long>("#,##0.######", 100000000D, 100000000) //$NON-NLS-1$
     {
         private final DecimalFormat format = new DecimalFormat(pattern());
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -57,7 +57,7 @@ public abstract class Values<E>
 
     public static final class QuoteValues extends Values<Long>
     {
-        private static final String QUOTE_PATTERN = "#,##0.00##"; //$NON-NLS-1$
+        private static final String QUOTE_PATTERN = "#,##0.00######"; //$NON-NLS-1$
 
         private static final ThreadLocal<DecimalFormat> QUOTE_FORMAT = ThreadLocal // NOSONAR
                         .withInitial(() -> new DecimalFormat(QUOTE_PATTERN));
@@ -66,7 +66,7 @@ public abstract class Values<E>
 
         private QuoteValues()
         {
-            super(QUOTE_PATTERN, 10000D, 10000);
+            super(QUOTE_PATTERN, 100000000D, 100000000);
 
             factorToMoney = BigDecimal.valueOf(factor() / Values.Money.factor());
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -19,7 +19,7 @@ public abstract class Values<E>
     {
         private MoneyValues()
         {
-            super("#,##0.00", 100D, 100); //$NON-NLS-1$
+            super("#,##0.00", 100); //$NON-NLS-1$
         }
 
         @Override
@@ -63,12 +63,14 @@ public abstract class Values<E>
                         .withInitial(() -> new DecimalFormat(QUOTE_PATTERN));
 
         private final BigDecimal factorToMoney;
+        private final int precisionDeltaToMoney;
 
         private QuoteValues()
         {
-            super(QUOTE_PATTERN, 100000000D, 100000000);
+            super(QUOTE_PATTERN, 100000000);
 
             factorToMoney = BigDecimal.valueOf(factor() / Values.Money.factor());
+            precisionDeltaToMoney = precision() - Values.Money.precision();
         }
 
         @Override
@@ -129,9 +131,14 @@ public abstract class Values<E>
         {
             return factorToMoney;
         }
+
+        public int precisionDeltaToMoney()
+        {
+            return precisionDeltaToMoney;
+        }
     }
 
-    public static final Values<Long> Amount = new Values<Long>("#,##0.00", 100D, 100) //$NON-NLS-1$
+    public static final Values<Long> Amount = new Values<Long>("#,##0.00", 100) //$NON-NLS-1$
     {
         @Override
         public String format(Long amount)
@@ -142,7 +149,7 @@ public abstract class Values<E>
 
     public static final MoneyValues Money = new MoneyValues(); // NOSONAR
 
-    public static final Values<Long> AmountFraction = new Values<Long>("#,##0.00###", 100000D, 100000) //$NON-NLS-1$
+    public static final Values<Long> AmountFraction = new Values<Long>("#,##0.00###", 100000) //$NON-NLS-1$
     {
         private final DecimalFormat format = new DecimalFormat(pattern());
 
@@ -157,7 +164,7 @@ public abstract class Values<E>
      * Optionally format values without decimal places. Currently used only for
      * attributes attached to the security.
      */
-    public static final Values<Long> AmountPlain = new Values<Long>("#,##0.##", 100D, 100) //$NON-NLS-1$
+    public static final Values<Long> AmountPlain = new Values<Long>("#,##0.##", 100) //$NON-NLS-1$
     {
         private final DecimalFormat format = new DecimalFormat(pattern());
 
@@ -168,7 +175,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Long> AmountShort = new Values<Long>("#,##0", 100D, 100) //$NON-NLS-1$
+    public static final Values<Long> AmountShort = new Values<Long>("#,##0", 100) //$NON-NLS-1$
     {
         private final DecimalFormat format = new DecimalFormat(pattern());
 
@@ -179,7 +186,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Long> Share = new Values<Long>("#,##0.######", 100000000D, 100000000) //$NON-NLS-1$
+    public static final Values<Long> Share = new Values<Long>("#,##0.######", 100000000) //$NON-NLS-1$
     {
         private final DecimalFormat format = new DecimalFormat(pattern());
 
@@ -192,7 +199,7 @@ public abstract class Values<E>
 
     public static final QuoteValues Quote = new QuoteValues(); // NOSONAR
 
-    public static final Values<BigDecimal> ExchangeRate = new Values<BigDecimal>("#,##0.0000", 1D, 1)//$NON-NLS-1$
+    public static final Values<BigDecimal> ExchangeRate = new Values<BigDecimal>("#,##0.0000", 1)//$NON-NLS-1$
     {
         @Override
         public String format(BigDecimal exchangeRate)
@@ -201,7 +208,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Integer> Index = new Values<Integer>("#,##0.00", 100D, 100) //$NON-NLS-1$
+    public static final Values<Integer> Index = new Values<Integer>("#,##0.00", 100) //$NON-NLS-1$
     {
         @Override
         public String format(Integer index)
@@ -210,7 +217,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<LocalDate> Date = new Values<LocalDate>("yyyy-MM-dd", 1D, 1) //$NON-NLS-1$
+    public static final Values<LocalDate> Date = new Values<LocalDate>("yyyy-MM-dd", 1) //$NON-NLS-1$
     {
         DateTimeFormatter formatter = DateTimeFormatter
                         .ofLocalizedDate(new Locale("pt").getLanguage().equals(Locale.getDefault() //$NON-NLS-1$
@@ -223,7 +230,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<LocalDateTime> DateTime = new Values<LocalDateTime>("yyyy-MM-dd HH:mm", 1D, 1) //$NON-NLS-1$
+    public static final Values<LocalDateTime> DateTime = new Values<LocalDateTime>("yyyy-MM-dd HH:mm", 1) //$NON-NLS-1$
     {
         DateTimeFormatter formatter = DateTimeFormatter
                         .ofLocalizedDateTime(new Locale("pt").getLanguage().equals(Locale.getDefault() //$NON-NLS-1$
@@ -239,7 +246,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Thousands = new Values<Double>("0.###k", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> Thousands = new Values<Double>("0.###k", 1) //$NON-NLS-1$
     {
         private ThreadLocal<DecimalFormat> numberFormatter = ThreadLocal // NOSONAR
                         .withInitial(() -> new DecimalFormat("#,##0.###")); //$NON-NLS-1$
@@ -251,7 +258,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Percent = new Values<Double>("0.00%", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> Percent = new Values<Double>("0.00%", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Double percent)
@@ -260,7 +267,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> PercentShort = new Values<Double>("0.00%", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> PercentShort = new Values<Double>("0.00%", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Double percent)
@@ -269,7 +276,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> PercentPlain = new Values<Double>("0.00", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> PercentPlain = new Values<Double>("0.00", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Double percent)
@@ -278,7 +285,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Integer> Weight = new Values<Integer>("#,##0.00", 100D, 100) //$NON-NLS-1$
+    public static final Values<Integer> Weight = new Values<Integer>("#,##0.00", 100) //$NON-NLS-1$
     {
         @Override
         public String format(Integer weight)
@@ -287,7 +294,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Integer> WeightPercent = new Values<Integer>("#,##0.00", 100D, 100) //$NON-NLS-1$
+    public static final Values<Integer> WeightPercent = new Values<Integer>("#,##0.00", 100) //$NON-NLS-1$
     {
         @Override
         public String format(Integer weight)
@@ -296,7 +303,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Percent2 = new Values<Double>("0.00%", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> Percent2 = new Values<Double>("0.00%", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Double percent)
@@ -305,7 +312,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Percent5 = new Values<Double>("0.00000%", 1D, 1) //$NON-NLS-1$
+    public static final Values<Double> Percent5 = new Values<Double>("0.00000%", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Double percent)
@@ -314,7 +321,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Integer> Id = new Values<Integer>("#,##0", 1D, 1) //$NON-NLS-1$
+    public static final Values<Integer> Id = new Values<Integer>("#,##0", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Integer amount)
@@ -323,7 +330,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Integer> Year = new Values<Integer>("0", 1D, 1) //$NON-NLS-1$
+    public static final Values<Integer> Year = new Values<Integer>("0", 1) //$NON-NLS-1$
     {
         @Override
         public String format(Integer amount)
@@ -333,31 +340,42 @@ public abstract class Values<E>
     };
 
     private final String pattern;
-    private final double divider;
     private final int factor;
+    private final double divider;
+    private final int precision;
     private final BigDecimal bdFactor;
 
-    private Values(String pattern, double divider, int factor)
+    private Values(String pattern, int factor)
     {
         this.pattern = pattern;
-        this.divider = divider;
         this.factor = factor;
+        this.divider = factor;
+        this.precision = (int) Math.log10(divider);
         this.bdFactor = BigDecimal.valueOf(factor);
     }
 
-    public String pattern()
+    public final String pattern()
     {
         return pattern;
     }
 
-    public double divider()
+    public final double divider()
     {
         return divider;
     }
 
-    public int factor()
+    public final int factor()
     {
         return factor;
+    }
+
+    /**
+     * The number of decimal digits, for example the shares are stored in a long
+     * with 8 decimal digits.
+     */
+    public final int precision()
+    {
+        return precision;
     }
 
     /**

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
@@ -97,9 +97,9 @@ public class SecurityPosition
     public Money calculateValue()
     {
         long marketValue = BigDecimal.valueOf(shares) //
-                        .divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .movePointLeft(Values.Share.precision())
                         .multiply(BigDecimal.valueOf(price.getValue()), Values.MC)
-                        .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                        .movePointLeft(Values.Quote.precisionDeltaToMoney()) //
                         .setScale(0, RoundingMode.HALF_DOWN).longValue();
         return Money.of(investment.getCurrencyCode(), marketValue);
     }
@@ -119,12 +119,12 @@ public class SecurityPosition
             t2.setCurrencyCode(t.getCurrencyCode());
 
             t2.setAmount(BigDecimal.valueOf(t.getAmount()) //
-                            .multiply(bdWeight, Values.MC)
+                            .multiply(bdWeight, Values.MC) //
                             .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
                             .setScale(0, RoundingMode.HALF_DOWN).longValue());
 
             t2.setShares(BigDecimal.valueOf(t.getShares()) //
-                            .multiply(bdWeight, Values.MC)
+                            .multiply(bdWeight, Values.MC) //
                             .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
                             .setScale(0, RoundingMode.HALF_DOWN).longValue());
 
@@ -134,8 +134,8 @@ public class SecurityPosition
         }
 
         long newShares = BigDecimal.valueOf(position.shares) //
-                        .multiply(bdWeight, Values.MC)
-                        .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
+                        .multiply(bdWeight, Values.MC) //
+                        .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC) //
                         .setScale(0, RoundingMode.HALF_DOWN).longValue();
 
         return new SecurityPosition(position.investment, position.converter, position.price, newShares,

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.snapshot;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -94,13 +96,19 @@ public class SecurityPosition
 
     public Money calculateValue()
     {
-        double marketValue = shares / Values.Share.divider() * price.getValue() / Values.Quote.dividerToMoney();
-        return Money.of(investment.getCurrencyCode(), Math.round(marketValue));
+        long marketValue = BigDecimal.valueOf(shares) //
+                        .divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                        .multiply(BigDecimal.valueOf(price.getValue()), Values.MC)
+                        .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+        return Money.of(investment.getCurrencyCode(), marketValue);
     }
 
     public static SecurityPosition split(SecurityPosition position, int weight)
     {
         List<PortfolioTransaction> splitTransactions = new ArrayList<>(position.transactions.size());
+
+        BigDecimal bdWeight = BigDecimal.valueOf(weight);
 
         for (PortfolioTransaction t : position.transactions)
         {
@@ -109,16 +117,28 @@ public class SecurityPosition
             t2.setSecurity(t.getSecurity());
             t2.setType(t.getType());
             t2.setCurrencyCode(t.getCurrencyCode());
-            t2.setAmount(Math.round(t.getAmount() * weight / (double) Classification.ONE_HUNDRED_PERCENT));
-            t2.setShares(Math.round(t.getShares() * weight / (double) Classification.ONE_HUNDRED_PERCENT));
+
+            t2.setAmount(BigDecimal.valueOf(t.getAmount()) //
+                            .multiply(bdWeight, Values.MC)
+                            .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
+                            .setScale(0, RoundingMode.HALF_DOWN).longValue());
+
+            t2.setShares(BigDecimal.valueOf(t.getShares()) //
+                            .multiply(bdWeight, Values.MC)
+                            .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
+                            .setScale(0, RoundingMode.HALF_DOWN).longValue());
 
             t.getUnits().forEach(u -> t2.addUnit(u.split(weight / (double) Classification.ONE_HUNDRED_PERCENT)));
 
             splitTransactions.add(t2);
         }
 
-        return new SecurityPosition(position.investment, position.converter, position.price,
-                        Math.round(position.shares * weight / (double) Classification.ONE_HUNDRED_PERCENT),
+        long newShares = BigDecimal.valueOf(position.shares) //
+                        .multiply(bdWeight, Values.MC)
+                        .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
+                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+
+        return new SecurityPosition(position.investment, position.converter, position.price, newShares,
                         splitTransactions);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientFilterHelper.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientFilterHelper.java
@@ -1,10 +1,14 @@
 package name.abuchen.portfolio.snapshot.filter;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransferEntry;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
+import name.abuchen.portfolio.money.Values;
 
 /* protected */ class ClientFilterHelper
 {
@@ -15,11 +19,11 @@ import name.abuchen.portfolio.model.PortfolioTransferEntry;
     /* package */ static void recreateTransfer(PortfolioTransferEntry transferEntry, ReadOnlyPortfolio sourcePortfolio,
                     ReadOnlyPortfolio targetPortfolio)
     {
-        recreateTransfer(transferEntry, sourcePortfolio, targetPortfolio, Classification.ONE_HUNDRED_PERCENT);
+        recreateTransfer(transferEntry, sourcePortfolio, targetPortfolio, Classification.ONE_HUNDRED_PERCENT_BD);
     }
 
     /* package */ static void recreateTransfer(PortfolioTransferEntry transferEntry, ReadOnlyPortfolio sourcePortfolio,
-                    ReadOnlyPortfolio targetPortfolio, int weight)
+                    ReadOnlyPortfolio targetPortfolio, BigDecimal weight)
     {
         PortfolioTransaction t = transferEntry.getSourceTransaction();
 
@@ -57,11 +61,14 @@ import name.abuchen.portfolio.model.PortfolioTransferEntry;
         targetAccount.internalAddTransaction(copy.getTargetTransaction());
     }
 
-    private static long value(long value, int weight)
+    private static long value(long value, BigDecimal weight)
     {
-        if (weight == Classification.ONE_HUNDRED_PERCENT)
+        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
             return value;
         else
-            return Math.round(value * weight / (double) Classification.ONE_HUNDRED_PERCENT);
+            return BigDecimal.valueOf(value) //
+                            .multiply(weight, Values.MC)
+                            .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
+                            .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.snapshot.security;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -153,8 +155,12 @@ public interface CalculationLineItem
             if (shares == 0)
                 return 0;
 
-            return Math.round((amount * (Values.AmountFraction.factor() / (double) Values.Amount.factor())
-                            * Values.Share.divider()) / (double) shares);
+            return BigDecimal.valueOf(amount)
+                            .multiply(Values.AmountFraction.getBigDecimalFactor(), Values.MC)
+                            .divide(Values.Amount.getBigDecimalFactor(), Values.MC)
+                            .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
+                            .divide(BigDecimal.valueOf(shares), Values.MC)
+                            .setScale(0, RoundingMode.HALF_EVEN).longValue();
         }
 
         public long getGrossValueAmount()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -155,11 +155,11 @@ public interface CalculationLineItem
             if (shares == 0)
                 return 0;
 
-            return BigDecimal.valueOf(amount)
-                            .multiply(Values.AmountFraction.getBigDecimalFactor(), Values.MC)
-                            .divide(Values.Amount.getBigDecimalFactor(), Values.MC)
-                            .multiply(Values.Share.getBigDecimalFactor(), Values.MC)
-                            .divide(BigDecimal.valueOf(shares), Values.MC)
+            return BigDecimal.valueOf(amount) //
+                            .movePointLeft(Values.Amount.precision()) //
+                            .movePointRight(Values.AmountFraction.precision()) //
+                            .movePointRight(Values.Share.precision()) //
+                            .divide(BigDecimal.valueOf(shares), Values.MC) //
                             .setScale(0, RoundingMode.HALF_EVEN).longValue();
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
@@ -550,12 +550,13 @@ public final class SecurityPerformanceRecord implements Adaptable, TrailProvider
         this.movingAverageCost = cost.getMovingAverageCost();
 
         Money netFifoCost = cost.getNetFifoCost();
+
         this.fifoCostPerSharesHeld = Quote.of(netFifoCost.getCurrencyCode(), Math.round(netFifoCost.getAmount()
-                        * Values.Share.factor() * Values.Quote.factorToMoney() / (double) sharesHeld));
+                        / (double) sharesHeld * Values.Share.factor() * Values.Quote.factorToMoney()));
         Money netMovingAverageCost = cost.getNetMovingAverageCost();
         this.movingAverageCostPerSharesHeld = Quote.of(netMovingAverageCost.getCurrencyCode(),
-                        Math.round(netMovingAverageCost.getAmount() * Values.Share.factor()
-                                        * Values.Quote.factorToMoney() / (double) sharesHeld));
+                        Math.round(netMovingAverageCost.getAmount() / (double) sharesHeld * Values.Share.factor()
+                                        * Values.Quote.factorToMoney()));
 
         this.fees = cost.getFees();
         this.taxes = cost.getTaxes();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -70,11 +70,10 @@ public class Trade implements Adaptable
         {
             LocalDate now = LocalDate.now();
 
-            long marketValue = BigDecimal.valueOf(shares)
-                            .divide(Values.Share.getBigDecimalFactor(), Values.MC)
-                            .multiply(BigDecimal.valueOf(security.getSecurityPrice(now).getValue()),
-                                            Values.MC)
-                            .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+            long marketValue = BigDecimal.valueOf(shares) //
+                            .movePointLeft(Values.Share.precision()) //
+                            .multiply(BigDecimal.valueOf(security.getSecurityPrice(now).getValue()), Values.MC)
+                            .movePointLeft(Values.Quote.precisionDeltaToMoney()) //
                             .setScale(0, RoundingMode.HALF_UP).longValue();
 
             this.exitValue = converter.at(now).apply(Money.of(security.getCurrencyCode(), marketValue));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.snapshot.trades;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -67,9 +69,15 @@ public class Trade implements Adaptable
         else
         {
             LocalDate now = LocalDate.now();
-            double marketValue = shares / Values.Share.divider() * security.getSecurityPrice(now).getValue()
-                            / Values.Quote.dividerToMoney();
-            this.exitValue = converter.at(now).apply(Money.of(security.getCurrencyCode(), Math.round(marketValue)));
+
+            long marketValue = BigDecimal.valueOf(shares)
+                            .divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                            .multiply(BigDecimal.valueOf(security.getSecurityPrice(now).getValue()),
+                                            Values.MC)
+                            .divide(Values.Quote.getBigDecimalFactorToMoney(), Values.MC)
+                            .setScale(0, RoundingMode.HALF_UP).longValue();
+
+            this.exitValue = converter.at(now).apply(Money.of(security.getCurrencyCode(), marketValue));
 
             this.holdingPeriod = Math.round(transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isPurchase())
@@ -78,13 +86,14 @@ public class Trade implements Adaptable
                             .sum() / (double) shares);
         }
 
-        // let's sort again because the list might not be sorted anymore due to transfers
+        // let's sort again because the list might not be sorted anymore due to
+        // transfers
         Collections.sort(transactions,
                         (p1, p2) -> p1.getTransaction().getDateTime().compareTo(p2.getTransaction().getDateTime()));
-        
+
         // re-set start date from first entry after sorting
         this.setStart(transactions.get(0).getTransaction().getDateTime());
-        
+
         calculateIRR(converter);
     }
 


### PR DESCRIPTION
This pull request increases the precision for shares and quotes to 8 digits.

The relevant change is that while the data is still kept as ```long``` this change is now using ```BigDecimal``` for the calculations, for example in ```SecurityPosition``` to calculate the market value of a position.

I also tested converting the shares to always use ```BigDecimal```. I decided against it, because from my rough performance tests it showed that it slows down the calculation further (the change in this PR adds up to 10% already). There are a lot of additions and subtractions of shares that are apparently faster if done as ```long```. Plus, most of the code is more readable when working with long.

The last commit uses ```BigDecimal#movePointLeft``` instead of dividing the values to get the correct fractional amount. In this case my performance tests are inconclusive: sometimes it is faster, sometimes the overall calculation is slower.

And finally, I tested whether it makes sense to store the quotes as fractional amounts in the XML file. By adding a lot of trailing zeros, the file size increases quite a lot (although only if the file is stored as an uncompressed XML). In my tests, reading the file was slower however if I had to convert the values into long. Therefore I left it as is for now.


To get some idea on the performance impact, I calculated these three snapshots for a 5 year period on a set of 5 XML files with a file size between 10 and 60 MBytes.
```
SecurityPerformanceSnapshot snapshot1 = SecurityPerformanceSnapshot.create(client, converter, interval);
ClientSnapshot snapshot2 = ClientSnapshot.create(client, converter, interval.getStart());
ClientPerformanceSnapshot snapshot3 = new ClientPerformanceSnapshot(client, converter, interval);
```
