### PR TITLE
Fix BuySellEntry cannot be cast to class PortfolioTransferEntry

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
@@ -1072,15 +1072,16 @@ public class OnvistaPDFExtractorTest
         assertSecurityWertpapieruebertrag(results);
 
         // check buy sell transaction
-        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+        assertThat(item.get().getSubject(), instanceOf(PortfolioTransaction.class));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.TRANSFER_IN));
+        PortfolioTransaction entry = (PortfolioTransaction) item.get().getSubject();
 
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(is(LocalDateTime.parse("2011-12-02T00:00"))));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(28)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+
+        assertThat(entry.getDateTime(), is(is(LocalDateTime.parse("2011-12-02T00:00"))));
+        assertThat(entry.getShares(), is(Values.Share.factorize(28)));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -594,10 +594,10 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
         Block block = new Block("Wir erhielten zu Gunsten Ihres Depots(.*)");
         type.addBlock(block);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        Transaction<PortfolioTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.TRANSFER_IN);
+            PortfolioTransaction entry = new PortfolioTransaction();
+            entry.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
             return entry;
         });
 
@@ -622,14 +622,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                             {
                                 t.setShares(asShares(v.get("shares")));
                             }
-                            t.setDate(asDate(v.get("date")));
+                            t.setDateTime(asDate(v.get("date")));
                             t.setCurrencyCode(asCurrencyCode(
-                                            t.getPortfolioTransaction().getSecurity().getCurrencyCode()));
+                                            t.getSecurity().getCurrencyCode()));
                         })
 
-                        .wrap(BuySellEntryItem::new);
-
-        addFeesSectionsTransaction(pdfTransaction);
+                        .wrap(TransactionItem::new);
     }
 
     private void addCapitalReductionTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
@@ -178,6 +178,10 @@ public class ClientSecurityFilter implements ClientFilter
     private void convertTransfer(Function<Portfolio, ReadOnlyPortfolio> getPortfolio,
                     TransactionPair<PortfolioTransaction> pair)
     {
+        // in rare cases (wrong imports) the cross entry can be of type BuySellEntry
+        if (!(pair.getTransaction().getCrossEntry() instanceof PortfolioTransferEntry))
+            return;
+        
         PortfolioTransferEntry entry = (PortfolioTransferEntry) pair.getTransaction().getCrossEntry();
 
         ReadOnlyPortfolio source = getPortfolio.apply(entry.getSourcePortfolio());


### PR DESCRIPTION
Issue: https://github.com/buchen/portfolio/issues/1931

and https://forum.portfolio-performance.info/t/fehler-buysellentry-cannot-be-cast-to-class-portfoliotransferentry/12778/9