### PR TITLE
Detect duplicates when transaction date is identical

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesAction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesAction.java
@@ -138,7 +138,7 @@ public class DetectDuplicatesAction implements ImportAction
 
     private boolean isPotentialDuplicate(Transaction subject, Transaction other)
     {
-        if (!other.getDateTime().equals(subject.getDateTime()))
+        if (!other.getDateTime().toLocalDate().equals(subject.getDateTime().toLocalDate()))
             return false;
 
         if (!other.getCurrencyCode().equals(subject.getCurrencyCode()))


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/pdf-import-von-baader-bank-scalable-capital/2057/16

If a transaction with time stamp is already recorded, a transaction
without time stamp wasn't recognized as duplicate.