### PR TITLE
Fix error in trail if whole position is transferred (#1951)

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Money.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Money.java
@@ -66,7 +66,7 @@ public final class Money implements Comparable<Money>
     public Money subtract(Money monetaryAmount)
     {
         if (!monetaryAmount.getCurrencyCode().equals(currencyCode))
-            throw new MonetaryException(MessageFormat.format("Illegal substraction: {0} - {1}", //$NON-NLS-1$
+            throw new MonetaryException(MessageFormat.format("Illegal subtraction: {0} - {1}", //$NON-NLS-1$
                             Values.Money.format(this), Values.Money.format(monetaryAmount)));
 
         return Money.of(currencyCode, amount - monetaryAmount.getAmount());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -146,13 +146,13 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                                         .convert(forex, convert2forex.getRate(item.date, termCurrency)) //
                                         .convert(back, converter.getRate(t.getDateTime(),
                                                         t.getSecurity().getCurrencyCode()))
-                                        .substract(startTrail);
+                                        .subtract(startTrail);
                     }
 
                     realizedCapitalGains.addCapitalGains(Money.of(termCurrency, end - start));
                     realizedCapitalGains.addCapitalGainsTrail(txTrail //
                                     .fraction(Money.of(termCurrency, end), soldShares, t.getShares())
-                                    .substract(startTrail));
+                                    .subtract(startTrail));
                     realizedCapitalGains.addForexCaptialGains(Money.of(termCurrency, forexGain));
                     realizedCapitalGains.addForexCapitalGainsTrail(forexGainTrail);
 
@@ -190,30 +190,24 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                         continue;
 
                     long n = Math.min(moved, entry.shares);
+                    
+                    long transferredValue = Math.round(n / (double) entry.shares * entry.value);                    
+                    LineItem transfer = new LineItem(n, t.getDateTime().toLocalDate(), transferredValue,
+                                    entry.trail.fraction(
+                                                    Money.of(getTermCurrency(), transferredValue),
+                                                    n,
+                                                    entry.originalShares
+                                    ).transfer(t.getDateTime().toLocalDate(), entry.source.getOwner(),
+                                                    transactionItem.getOwner()),
+                                    transactionItem);
 
                     if (n == entry.shares)
                     {
-                        LineItem transfer = new LineItem(entry.shares, entry.date, entry.value,
-                                        entry.trail.transfer(t.getDateTime().toLocalDate(), entry.source.getOwner(),
-                                                        transactionItem.getOwner()),
-                                        transactionItem);
-
                         fifo.add(fifo.indexOf(entry) + 1, transfer);
                         fifo.remove(entry);
                     }
                     else
                     {
-                        long transferredValue = Math.round(n / (double) entry.shares * entry.value);
-
-                        LineItem transfer = new LineItem(n, //
-                                        t.getDateTime().toLocalDate(), transferredValue, //
-                                        entry.trail.fraction(Money.of(getTermCurrency(), transferredValue), n,
-                                                        entry.originalShares) //
-                                                        .transfer(t.getDateTime().toLocalDate(),
-                                                                        entry.source.getOwner(),
-                                                                        transactionItem.getOwner()),
-                                        transactionItem);
-
                         entry.value -= transferredValue;
                         entry.shares -= n;
 
@@ -340,15 +334,15 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
             // convert the forex amount back with the
             // exchange rate at the end (=snapshot end) and
-            // substract start value
+            // subtract start value
 
             forexGainTrail = forexGainTrail
                             .convert(back, converter.getRate(valuationAtEndDate, getSecurity().getCurrencyCode()))
-                            .substract(startTrail);
+                            .subtract(startTrail);
         }
 
         unrealizedCapitalGains.addCapitalGains(Money.of(termCurrency, end - start));
-        unrealizedCapitalGains.addCapitalGainsTrail(endTrail.substract(startTrail));
+        unrealizedCapitalGains.addCapitalGainsTrail(endTrail.subtract(startTrail));
         unrealizedCapitalGains.addForexCaptialGains(Money.of(termCurrency, forexGain));
         unrealizedCapitalGains.addForexCapitalGainsTrail(forexGainTrail);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/ArithmeticTrail.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/ArithmeticTrail.java
@@ -15,7 +15,7 @@ import name.abuchen.portfolio.money.MutableMoney;
 {
     public enum Operation
     {
-        ADDITION, SUBSTRACTION
+        ADDITION, SUBTRACTION
     }
 
     private final Operation operation;
@@ -37,12 +37,12 @@ import name.abuchen.portfolio.money.MutableMoney;
                 this.value = this.children.stream().map(TrailRecord::getValue).filter(Objects::nonNull)
                                 .collect(MoneyCollectors.sum(this.children.get(0).getValue().getCurrencyCode()));
             }
-            else if (operation == Operation.SUBSTRACTION)
+            else if (operation == Operation.SUBTRACTION)
             {
-                MutableMoney substraction = MutableMoney.of(this.children.get(0).getValue());
+                MutableMoney subtraction = MutableMoney.of(this.children.get(0).getValue());
                 for (int index = 1; index < inputs.length; index++)
-                    substraction.subtract(children.get(index).getValue());
-                this.value = substraction.toMoney();
+                    subtraction.subtract(children.get(index).getValue());
+                this.value = subtraction.toMoney();
             }
             else
             {
@@ -110,9 +110,9 @@ import name.abuchen.portfolio.money.MutableMoney;
     }
 
     @Override
-    public TrailRecord substract(TrailRecord trail)
+    public TrailRecord subtract(TrailRecord trail)
     {
-        if (this.operation == Operation.SUBSTRACTION && trail instanceof ArithmeticTrail
+        if (this.operation == Operation.SUBTRACTION && trail instanceof ArithmeticTrail
                         && ((ArithmeticTrail) trail).operation.equals(this.operation))
         {
             ArithmeticTrail answer = new ArithmeticTrail(this.operation, label);
@@ -122,7 +122,7 @@ import name.abuchen.portfolio.money.MutableMoney;
         }
         else
         {
-            return TrailRecord.super.substract(trail);
+            return TrailRecord.super.subtract(trail);
         }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/EmptyTrail.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/EmptyTrail.java
@@ -56,7 +56,7 @@ import name.abuchen.portfolio.money.Money;
     }
 
     @Override
-    public TrailRecord substract(TrailRecord trail)
+    public TrailRecord subtract(TrailRecord trail)
     {
         throw new UnsupportedOperationException();
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
@@ -68,11 +68,11 @@ public interface TrailRecord
         return new ArithmeticTrail(ArithmeticTrail.Operation.ADDITION, Messages.LabelSum, this, trail);
     }
 
-    default TrailRecord substract(TrailRecord trail)
+    default TrailRecord subtract(TrailRecord trail)
     {
         if (trail instanceof EmptyTrail)
             return this;
-        return new ArithmeticTrail(ArithmeticTrail.Operation.SUBSTRACTION, Messages.LabelDifference, this, trail);
+        return new ArithmeticTrail(ArithmeticTrail.Operation.SUBTRACTION, Messages.LabelDifference, this, trail);
     }
 
     default TrailRecord fraction(Money value, long numerator, long denominator)


### PR DESCRIPTION
Even if the entire position in one portfolio is removed,
we should create a "fractional" entry in the trail
in order to determine a correct initial valuation.

This commit fixes the error seen in #1951; I'm not entirely
certain whether it actually covers all edge cases.

(Additionally, minor spelling fix in trail calculation.)