### PR TITLE
Perform short pre-optimisation for IRR

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/IRRTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/IRRTest.java
@@ -48,4 +48,18 @@ public class IRRTest
         assertThat(result, IsCloseTo.closeTo(excel, 0.0001d));
     }
 
+    // issue #1904
+    @Test
+    public void testSmallConvergenceInterval()
+    {
+        double result = IRR.calculate(Arrays.asList(
+                        LocalDate.of(2019, Month.MAY, 24),
+                        LocalDate.of(2020, Month.JANUARY, 13),
+                        LocalDate.of(2020, Month.JUNE, 29)),
+                        Arrays.asList(-1560.94, -1160d, 42.80));
+
+        double excel = -0.999251643;
+
+        assertThat(result, IsCloseTo.closeTo(excel, 0.0001d));
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/IRR.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/IRR.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.math;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import name.abuchen.portfolio.math.NewtonGoalSeek.Function;
 
@@ -11,10 +12,39 @@ public final class IRR
     {
     }
 
+    @SuppressWarnings("nls")
+    private static double halving(Function f, double left, double right, double fLeft, double fRight)
+    {
+        if (fLeft * fRight >= 0)
+            throw new UnsupportedOperationException("Endpoints of interval must have different sign in f");
+
+        double center = (left + right) / 2;
+
+        if (right - left < 0.001d)
+            return center;
+
+        double fCenter = f.compute(center);
+        if (fCenter == 0)
+            return center;
+        else if (fCenter * fLeft < 0)
+            return halving(f, left, center, fLeft, fCenter);
+        else
+            return halving(f, center, right, fCenter, fRight);
+    }
+
     public static double calculate(List<LocalDate> dates, List<Double> values)
     {
         Function npv = new NPVFunction(dates, values);
         Function derivative = new PseudoDerivativeFunction(npv);
-        return NewtonGoalSeek.seek(npv, derivative, 0.05d) - 1;
+
+        // find a crude initial guess in interval (0,1)
+        // npv(0) is undefined, but diverges with sign given by last term
+        double fLeft = Double.POSITIVE_INFINITY * values.get(values.size() - 1);
+        // npv(1) is the sum of undiscounted flows
+        double fRight = values.stream().collect(Collectors.summingDouble(f -> f));
+        // if they have the same sign, we hopefully don't have a very extreme case, so just guess 5%
+        double guess = fLeft * fRight < 0 ? halving(npv, 0, 1, fLeft, fRight) : 1.05;
+
+        return NewtonGoalSeek.seek(npv, derivative, guess) - 1;
     }
 }


### PR DESCRIPTION
When computing IRR, the NPV curve may be very degenerate (such as in #1904):
![curve](https://user-images.githubusercontent.com/5236894/104120111-99487700-5334-11eb-854e-1f57b17545c9.png)
In this example, the Newton iteration only converges if the initial guess x0 is to the left of the extreme point (which is at approx. x = -0.9975), but currently, the initial guess is -0.95. (Note that the code actually computes "IRR+1", hence the initial guess x0 = 0.05.)

This commit attempts to find an initial guess in the interval (-1,0) first, via interval halving. 