### PR TITLE
Convert currencyCode combo to a text entry with autocomplete

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/MANIFEST.MF
+++ b/name.abuchen.portfolio.ui/META-INF/MANIFEST.MF
@@ -115,6 +115,7 @@ Require-Bundle: com.ibm.icu,
  org.eclipse.nebula.cwt,
  org.eclipse.ui.forms,
  org.eclipse.e4.ui.css.core,
- org.eclipse.ui.themes
+ org.eclipse.ui.themes,
+ org.eclipse.jface
 Automatic-Module-Name: name.abuchen.portfolio.ui
 Service-Component: OSGI-INF/name.abuchen.portfolio.ui.util.theme.ColorAndFontProviderImpl.xml

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -464,6 +464,7 @@ public class Messages extends NLS
     public static String LabelAccumulatedTaxes;
     public static String LabelAggregation;
     public static String LabelAggregationDaily;
+    public static String LabelAllCurrencies;
     public static String LabelAllFiles;
     public static String LabelAllSecurities;
     public static String LabelAllTrades;
@@ -817,6 +818,7 @@ public class Messages extends NLS
     public static String MsgDeletionNotPossible;
     public static String MsgDeletionNotPossibleDetail;
     public static String MsgDialogInputRequired;
+    public static String MsgDialogNotAValidCurrency;
     public static String MsgDialogNotAValidISIN;
     public static String MsgEmbeddedBrowserError;
     public static String MsgErrorConvertedAmount;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -938,6 +938,8 @@ LabelAggregation = Aggregation
 
 LabelAggregationDaily = daily
 
+LabelAllCurrencies = All Currencies
+
 LabelAllFiles = All Files
 
 LabelAllSecurities = All Securities
@@ -1655,6 +1657,8 @@ MsgDeletionNotPossible = Deletion not possible
 MsgDeletionNotPossibleDetail = Securities with associated transactions cannot be deleted.\nThe securities are needed to calculate the historical performance.\n\nSecurities with transactions: {0}.
 
 MsgDialogInputRequired = Input required for ''{0}''
+
+MsgDialogNotAValidCurrency = Invalid Currency: {0}
 
 MsgDialogNotAValidISIN = Invalid ISIN: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -931,6 +931,8 @@ LabelAggregation = Verdichtung
 
 LabelAggregationDaily = t\u00E4glich
 
+LabelAllCurrencies = Alle W\u00E4hrungen
+
 LabelAllFiles = Alle Dateien
 
 LabelAllSecurities = Alle Wertpapiere
@@ -1642,6 +1644,8 @@ MsgDeletionNotPossible = L\u00F6schung nicht m\u00F6glich
 MsgDeletionNotPossibleDetail = Wertpapiere mit Ums\u00E4tzen k\u00F6nnen nicht gel\u00F6scht werden.\nDie Wertpapiere werden zur Berechnung der historischen Performance ben\u00F6tigt.\n\nWertpapiere mit Ums\u00E4tzen: {0}.
 
 MsgDialogInputRequired = Eingabe fehlt f\u00FCr Feld "{0}"
+
+MsgDialogNotAValidCurrency = Ung\u00FCltige W\u00E4hrung: {0}
 
 MsgDialogNotAValidISIN = Ung\u00FCltige ISIN: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -79,11 +79,11 @@ public class SecurityMasterDataPage extends AbstractPage
             }));
         }
 
-        ComboViewer currencyCode = bindings.bindCurrencyCodeCombo(container, Messages.ColumnCurrency, "currencyCode", //$NON-NLS-1$
+        Text currencyCode = bindings.bindCurrencyCodeCombo(container, Messages.ColumnCurrency, "currencyCode", //$NON-NLS-1$
                         !isExchangeRate);
         if (model.getSecurity().hasTransactions(model.getClient()))
         {
-            currencyCode.getCombo().setEnabled(false);
+            currencyCode.setEnabled(false);
 
             // empty cell
             new Label(container, SWT.NONE).setText(""); //$NON-NLS-1$
@@ -101,9 +101,9 @@ public class SecurityMasterDataPage extends AbstractPage
 
         if (isExchangeRate)
         {
-            ComboViewer targetCurrencyCode = bindings.bindCurrencyCodeCombo(container, Messages.ColumnTargetCurrency,
+            Text targetCurrencyCode = bindings.bindCurrencyCodeCombo(container, Messages.ColumnTargetCurrency,
                             "targetCurrencyCode", false); //$NON-NLS-1$
-            targetCurrencyCode.getCombo().setToolTipText(Messages.ColumnTargetCurrencyToolTip);
+            targetCurrencyCode.setToolTipText(Messages.ColumnTargetCurrencyToolTip);
         }
 
         if (!isExchangeRate)


### PR DESCRIPTION
Feature Request #1876. Text field suggests matching
currencies first, then all available ones.

What I don't like about this solution is that
* the proposals aren't opened on click
* user can enter anything, requires post-validation
* tab to the next field doesn't work while the popup is open

Hence this is not perfect, but maybe a starting point for
further improvements.