### PR TITLE
Modify-Trade-Republic-PDF-import-FundsSavingsPlan-with-Fees

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -233,7 +233,17 @@ public class DkbPDFExtractorTest
         assertThat(security.getIsin(), is("LU0635178014"));
         assertThat(security.getWkn(), is("ETF127"));
         assertThat(security.getName(), is("COMSTA.-MSCI EM.MKTS.TRN U.ETF"));
-
+        return security;
+    }
+    
+    private Security assertSecurityBuyFondssparplan02(List<Item> results)
+    {
+        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("LU1737652583"));
+        assertThat(security.getWkn(), is("A2H9Q0"));
+        assertThat(security.getName(), is("AMUNDI IND.SOL.-A.IN.MSCI E.M."));
         return security;
     }
 
@@ -1247,6 +1257,64 @@ public class DkbPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-12-05T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2.3160)));
 
+    }
+    
+    @Test
+    public void testWertpapierKaufFondsSparplanSammelbeleg02() throws IOException
+    {
+        // Fonds, only 3 decimal places for amount of shares
+
+        DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DkbSammelbelegFondssparplan02.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(4));
+
+        assertSecurityBuyFondssparplan02(results);
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-02-20T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3.9136)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of("EUR", Values.Amount.factorize(0.49))));
+
+        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
+                        .get(1).getSubject();
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-04-20T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4.8207)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of("EUR", Values.Amount.factorize(0.49))));
+
+        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
+                        .get(2).getSubject();
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-06-22T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4.4425)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of("EUR", Values.Amount.factorize(0.49))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbSammelbelegFondssparplan02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbSammelbelegFondssparplan02.txt
@@ -1,0 +1,29 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+10919 Berlin
+Depotnummer yy
+Kundennummer xx
+.....
+Halbjahresabrechnung Sparplan
+Wertpapierbezeichnung ISIN (WKN)
+AMUNDI IND.SOL.-A.IN.MSCI E.M. LU1737652583 (A2H9Q0)
+ACT.NOM.UCITS ETF DR D ON
+Im Rahmen Ihres bestehenden Sparplans haben wir vereinbarungsgemäß nachstehende Käufe außerbörslich für Sie
+durchgeführt.
+Die Gegenwerte haben wir Ihnen belastet und die erworbenen Stücke Ihrem Depotkonto gutgeschrieben.
+(Girosammelverw. mehrere Sammelurkunden - kein Stückeausdruck -)
+Umsatzart Sparrate in Ordernummer Preis je Stück Devise Anteilsumsatz Schlusstag Valuta Zwischengewinn Steuerausgleich
+EUR in EUR in Stück in EUR in EUR
+Kauf 200,00 256485/46.00 51,1040 1,0000 3,9136 20.02.2020 24.02.2020 0,00 0,00
++ Provision 0,49 Summe 200,49
+Kauf 200,00 342983/71.00 41,4880 1,0000 4,8207 20.04.2020 22.04.2020 0,00 0,00
++ Provision 0,49 Summe 200,49
+Kauf 200,00 414802/35.00 45,0200 1,0000 4,4425 22.06.2020 24.06.2020 0,00 0,00
++ Provision 0,49 Summe 200,49
+Im Abrechnungszeitraum angelegter Betrag EUR 600,00
+Im Abrechnungszeitraum erworbene Anteile Stück 13,1768
+Durchschnittspreis der erworbenen Anteile EUR 45,53
+Evtl. anfallende Erträge werden Ihnen mit separater Abrechnung vergütet. Für evtl. Bestandsveränderungen aus
+zusätzlichen Käufen oder Verkäufen haben Sie separate Abrechnungen erhalten.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.


### PR DESCRIPTION
Hallo @buchen 

- Fix Issue [Forum](https://forum.portfolio-performance.info/t/pdf-import-von-dkb/4449/32)

Grüße
Padawan Alex

PS.:
Ich habe hier mitbekommen, dass in beinden Sparplänen, der (?<nameContinue>.*) nicht eingelesen wird.
Dieser Importer arbeitet etwas anders, als die, die ich bisher kenne.

Sparplan 1:
>Wertpapierbezeichnung ISIN (WKN)
>COMSTA.-MSCI EM.MKTS.TRN U.ETF LU0635178014 (ETF127)
>INHABER-ANTEILE I O.N.`   <----------- dieser Teil

Sparplan 2 (Neuer mit Fees):
>Wertpapierbezeichnung ISIN (WKN)
>AMUNDI IND.SOL.-A.IN.MSCI E.M. LU1737652583 (A2H9Q0)
>ACT.NOM.UCITS ETF DR D ON  <----------- dieser Teil

Da dieser schon beim Sparplan 1 fehlte, habe ich diesen im Sparplan 2 ebenfalls weg gelassen.