### PR TITLE
Apply precision setting to calculated quotes in charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -73,7 +73,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
         toolTip = new TimelineChartToolTip(this);
         toolTip.enableCategory(true);
         toolTip.reverseLabels(true);
-        toolTip.setValueFormat(new DecimalFormat("#0.0%")); //$NON-NLS-1$
+        toolTip.setDefaultValueFormat(new DecimalFormat("#0.0%")); //$NON-NLS-1$
 
         new ChartContextMenu(this);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
@@ -7,8 +7,10 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -41,7 +43,8 @@ public class TimelineChartToolTip extends AbstractChartToolTip
 
     private Function<Object, String> xAxisFormat;
 
-    private DecimalFormat valueFormat = new DecimalFormat("#,##0.00"); //$NON-NLS-1$
+    private DecimalFormat defaultValueFormat = new DecimalFormat("#,##0.00"); //$NON-NLS-1$
+    private Map<String, DecimalFormat> overrideValueFormat = new HashMap<>();
 
     private boolean categoryEnabled = false;
     private boolean reverseLabels = false;
@@ -78,9 +81,14 @@ public class TimelineChartToolTip extends AbstractChartToolTip
         this.xAxisFormat = format;
     }
 
-    public void setValueFormat(DecimalFormat valueFormat)
+    public void setDefaultValueFormat(DecimalFormat defaultValueFormat)
     {
-        this.valueFormat = valueFormat;
+        this.defaultValueFormat = defaultValueFormat;
+    }
+
+    public void overrideValueFormat(String series, DecimalFormat valueFormat)
+    {
+        this.overrideValueFormat.put(series, valueFormat);
     }
 
     /**
@@ -208,6 +216,7 @@ public class TimelineChartToolTip extends AbstractChartToolTip
             GridDataFactory.fillDefaults().grab(true, false).applyTo(cl);
 
             right = new Label(data, SWT.RIGHT);
+            DecimalFormat valueFormat = overrideValueFormat.getOrDefault(series.getId(), defaultValueFormat);
             right.setText(valueFormat.format(value.getRight()));
             GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(right);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -24,6 +24,7 @@ import org.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.Aggregation;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Images;
@@ -96,7 +97,7 @@ public class PerformanceChartView extends AbstractHistoricView
         chart.getTitle().setText(getTitle());
         chart.getTitle().setVisible(false);
         chart.getAxisSet().getYAxis(0).getTick().setFormat(new DecimalFormat("0.#%")); //$NON-NLS-1$
-        chart.getToolTip().setValueFormat(new DecimalFormat("0.00%")); //$NON-NLS-1$
+        chart.getToolTip().setDefaultValueFormat(new DecimalFormat(Values.Percent2.pattern()));
         chart.getToolTip().reverseLabels(true);
 
         DataSeriesCache cache = make(DataSeriesCache.class);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -73,6 +73,7 @@ import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
+import name.abuchen.portfolio.util.FormatHelper;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.TradeCalendar;
 import name.abuchen.portfolio.util.TradeCalendarManager;
@@ -380,7 +381,7 @@ public class SecuritiesChart
 
         toolTip.showToolTipOnlyForDatesInDataSeries(Messages.ColumnQuote);
 
-        toolTip.setValueFormat(new DecimalFormat(Values.Quote.pattern()));
+        toolTip.setDefaultValueFormat(new DecimalFormat(Values.Quote.pattern()));
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Positive"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Negative"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Zero"); //$NON-NLS-1$
@@ -394,6 +395,28 @@ public class SecuritiesChart
         toolTip.addSeriesExclude(Messages.LabelChartDetailMarkerDividends + "1"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailMarkerDividends + "2"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailIndicatorBollingerBands);
+
+        int precision = FormatHelper.getCalculatedQuoteDisplayPrecision();
+        DecimalFormat calculatedFormat = new DecimalFormat(Values.CalculatedQuote.pattern());
+        calculatedFormat.setMinimumFractionDigits(precision);
+        calculatedFormat.setMaximumFractionDigits(precision);
+        for (String period : new String[] {
+                        Messages.LabelChartDetailMovingAverage_5days,
+                        Messages.LabelChartDetailMovingAverage_20days,
+                        Messages.LabelChartDetailMovingAverage_30days,
+                        Messages.LabelChartDetailMovingAverage_38days,
+                        Messages.LabelChartDetailMovingAverage_50days,
+                        Messages.LabelChartDetailMovingAverage_100days,
+                        Messages.LabelChartDetailMovingAverage_200days,
+        })
+        {
+            toolTip.overrideValueFormat(String.format("%s (%s)", Messages.LabelChartDetailMovingAverageEMA, period), calculatedFormat); //$NON-NLS-1$
+            toolTip.overrideValueFormat(String.format("%s (%s)", Messages.LabelChartDetailMovingAverageSMA, period), calculatedFormat); //$NON-NLS-1$
+        }
+        toolTip.overrideValueFormat(Messages.LabelChartDetailIndicatorBollingerBandsLower, calculatedFormat);
+        toolTip.overrideValueFormat(Messages.LabelChartDetailIndicatorBollingerBandsUpper, calculatedFormat);
+        toolTip.overrideValueFormat(Messages.LabelChartDetailMarkerPurchaseFIFO, calculatedFormat);
+        toolTip.overrideValueFormat(Messages.LabelChartDetailMarkerPurchaseMovingAverage, calculatedFormat);
 
         toolTip.addExtraInfo((composite, focus) -> {
             if (focus instanceof Date)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
@@ -166,7 +166,7 @@ public class ExchangeRatesListTab implements AbstractTabbedView.Tab
     {
         chart = new TimelineChart(parent);
         stylingEngine.style(chart);
-        chart.getToolTip().setValueFormat(new DecimalFormat("0.0000")); //$NON-NLS-1$
+        chart.getToolTip().setDefaultValueFormat(new DecimalFormat(Values.ExchangeRate.pattern()));
         refreshChart(null);
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
@@ -190,7 +190,7 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
         toolTip = new TimelineChartToolTip(chart);
         toolTip.enableCategory(true);
         toolTip.reverseLabels(true);
-        toolTip.setValueFormat(new DecimalFormat("#")); //$NON-NLS-1$
+        toolTip.setDefaultValueFormat(new DecimalFormat("#")); //$NON-NLS-1$
         toolTip.setXAxisFormat(obj -> {
             Integer index = (Integer) obj;
             @SuppressWarnings("unchecked")
@@ -252,7 +252,7 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
 
             ChartType chartType = get(ChartTypeConfig.class).getValue();
 
-            toolTip.setValueFormat(new DecimalFormat(chartType == ChartType.COUNT ? "#" : "#,##0.00")); //$NON-NLS-1$ //$NON-NLS-2$
+            toolTip.setDefaultValueFormat(new DecimalFormat(chartType == ChartType.COUNT ? "#" : "#,##0.00")); //$NON-NLS-1$ //$NON-NLS-2$
 
             IAxis xAxis = chart.getAxisSet().getXAxis(0);
             Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -199,7 +199,7 @@ public class ChartWidget extends WidgetDelegate<Object>
         chart.getTitle().setText(title.getText());
         chart.getAxisSet().getYAxis(0).getTick().setVisible(false);
         if (useCase != DataSeries.UseCase.STATEMENT_OF_ASSETS)
-            chart.getToolTip().setValueFormat(new DecimalFormat("0.##%")); //$NON-NLS-1$
+            chart.getToolTip().setDefaultValueFormat(new DecimalFormat("0.##%")); //$NON-NLS-1$
         chart.getToolTip().reverseLabels(true);
 
         GC gc = new GC(container);


### PR DESCRIPTION
Fixes #2010. The previous tooltip format is now only
a default that can be overriden for specific series IDs.