### PR TITLE
Gracefully handle the case when logo could not be read

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -836,6 +836,8 @@ public class Messages extends NLS
     public static String MsgIncorrectTotal;
     public static String MsgInfoChangingCurrencyNotPossible;
     public static String MsgInfoRetiredSecurities;
+    public static String MsgInvalidImage;
+    public static String MsgInvalidImageDetail;
     public static String MsgJavaVersionTooOldForLetsEncrypt;
     public static String MsgLoadingFile;
     public static String MsgMissingAccount;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1694,6 +1694,10 @@ MsgInfoChangingCurrencyNotPossible = This security has already transactions reco
 
 MsgInfoRetiredSecurities = Inactive securities are hidden in transactions dialogs (e.g. buy and sell dialogs).\nExisting transactions are not touched.\nQuotes are still updated automatically unless the security is configured as "no automatic download".
 
+MsgInvalidImage = Invalid image file
+
+MsgInvalidImageDetail = Provided file ''{0}'' does not appear to be an image or could not be read. 
+
 MsgJavaVersionTooOldForLetsEncrypt = Your Java runtime is too old. The SSL certificate of the update server will not be accepted.\nYou are using {0}. At least 1.8.0_101 is needed.
 
 MsgLoadingFile = Loading {0}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1681,6 +1681,10 @@ MsgInfoChangingCurrencyNotPossible = Es existieren bereits Buchungen zu diesem W
 
 MsgInfoRetiredSecurities = Inaktive Wertpapiere werden in den Buchungsdialogen nicht (mehr) zur Auswahl angezeigt.\nExistierenden Buchungen werden nicht ge\u00E4ndert.\nAktienkurse werden weiterhin aktualisiert es sei denn das Wertpapier ist mit "kein automatischer Download" konfiguriert.
 
+MsgInvalidImage = Bilddatei fehlerhaft
+
+MsgInvalidImageDetail = Die Datei ''{0}'' konnte nicht als Bild gelesen werden. M\u00F6glicherweise wird das Format nicht unterst\u00FCtzt.
+
 MsgJavaVersionTooOldForLetsEncrypt = Die Java Version ist zu alt. Das SSL Zertifikat des Update Servers wird nicht akzeptiert werden.\nPP ben\u00F6tigt mindestens Version 1.8.0_101, l\u00E4uft aber gerade auf {0}.
 
 MsgLoadingFile = Lade {0}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ImageAttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ImageAttributeEditingSupport.java
@@ -11,6 +11,8 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 
+import com.ibm.icu.text.MessageFormat;
+
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
 import name.abuchen.portfolio.ui.Messages;
@@ -62,8 +64,14 @@ public class ImageAttributeEditingSupport extends AttributeEditingSupport
             {
                 try
                 {
-                    return ImageUtil.loadAndPrepare(filename, ImageConverter.MAXIMUM_SIZE_EMBEDDED_IMAGE,
+                    String image = ImageUtil.loadAndPrepare(filename, ImageConverter.MAXIMUM_SIZE_EMBEDDED_IMAGE,
                                     ImageConverter.MAXIMUM_SIZE_EMBEDDED_IMAGE);
+
+                    if (image == null)
+                        MessageDialog.openError(Display.getCurrent().getActiveShell(), Messages.MsgInvalidImage,
+                                        MessageFormat.format(Messages.MsgInvalidImageDetail, filename));
+
+                    return image;
                 }
                 catch (IOException ex)
                 {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -31,6 +32,8 @@ import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Text;
+
+import com.ibm.icu.text.MessageFormat;
 
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
@@ -98,7 +101,7 @@ public class AttributesPage extends AbstractPage implements IMenuListener
         @Override
         public Object convert(String fromObject)
         {
-            return attribute.getType().getConverter().fromString((String) fromObject);
+            return attribute.getType().getConverter().fromString(fromObject);
         }
     }
 
@@ -230,7 +233,11 @@ public class AttributesPage extends AbstractPage implements IMenuListener
                     {
                         String b64 = ImageUtil.loadAndPrepare(filename, ImageConverter.MAXIMUM_SIZE_EMBEDDED_IMAGE,
                                         ImageConverter.MAXIMUM_SIZE_EMBEDDED_IMAGE);
-                        attributeModel.setValue(b64);
+                        if (b64 == null)
+                            MessageDialog.openError(getShell(), Messages.MsgInvalidImage,
+                                            MessageFormat.format(Messages.MsgInvalidImageDetail, filename));
+                        else
+                            attributeModel.setValue(b64);
                     }
                     catch (IOException ex)
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
@@ -114,6 +114,9 @@ public class ImageUtil
     {
         byte[] data = Files.readAllBytes(Paths.get(filename));
         ImageData imgData = ImageUtil.toImageData(data);
+        if (imgData == null)
+            return null;
+
         if (imgData.width > maxWidth || imgData.height > maxHeight)
         {
             imgData = ImageUtil.resize(imgData, maxWidth, maxHeight, true);


### PR DESCRIPTION
Fixes #2019. Instead of throwing a NullPointerException
(on imgData.width) into the user's face, we should show a
message that tries to explain the error.