### PR TITLE
Fix handling of fx dividends for OnVista imports

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
@@ -486,7 +486,7 @@ public class OnvistaPDFExtractorTest
         Unit grossValue = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
         assertThat(grossValue.getAmount(),
                         is(Money.of(CurrencyUnit.EUR, transaction.getAmount() + taxes.getAmount())));
-        assertThat(grossValue.getForex(), is(Money.of("DKK", Values.Amount.factorize(3.02 * 7.483 + 8.34))));
+        assertThat(grossValue.getForex(), is(Money.of("DKK", Values.Amount.factorize(6 * 5.15)))); // Rundungsfehler in alter Berechnung: 3.02 * 7.483 + 8.34))));
     }
 
     @Test
@@ -762,7 +762,7 @@ public class OnvistaPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.53))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(500)));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.16 + 0.18 + 4.74))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.62 - 23.53)))); // alternativ: 3.16 + 0.18 + 5.63/1.1859 = 8.09
     }
 
     @Test


### PR DESCRIPTION
Hallo zusammen,

ich führe die Wertpapiere von US-Unternehmen in USD, das Referenzkonto notiert in EUR. Seit einer der letzten Versionen werden nun die Steuern beim Import von OnVista Ertragsgutschriften/Dividenden theoretisch korrekt berechnet, allerdings war die Dividende pro Stück immer noch falsch. Das jeweils händisch zu korrigieren ist etwas nervig. Daher musste ich das jetzt einfach mal fixen ;-) Die Steuer wird nun entsprechend in der Ursprungswährung getracked - neu ist, dass die tatsächliche Dividendensumme der Transaktion nun auch stimmt.

Die Lösung ist immernoch etwas "hintenrum" und könnte im Extremfall zu Abweichungen von 1ct durch Rundungsungenauigkeit führen. Der ganz korrekte Weg wäre, zusätzlich die Dividende pro Stück aus dem PDF auszulesen. Die dafür notwändigen Änderungen beim Dividendenimport wären aber etwas umfangreicher.

Verwandtes Issue: https://forum.portfolio-performance.info/t/onvista-import-dividenden-in-waehrung-dkk-fehler-bei-tax/7341

Mir sind bei dieser Gelegenheit gleich auch noch zwei Rundungsfehler in den entsprechenden Tests aufgefallen, die ich entsprechend korrigiert habe:
- testErtragsgutschriftDividende4, forex gross value: 6 * 5.15 = 30.90 != 30.94 = 3.02*7.483+8.34
- testErtragsgutschriftErtraegnisgutschrift6, total tax: should be total dividend - amount received (8.08 != 8.09)

Frage am Rande: zumindest bei den OnVista-Imports wird bei Umrechungen immer RoundingMode.HALF_DOWN verwendet, gibt es da einen Grund von mathematischer Rundung abzuweichen?

Viele Grüße
Christian