### PR TITLE
Change "Earnings & Expense" to "Income & Expenses" 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -549,6 +549,10 @@ public class Messages extends NLS
     public static String LabelEarningsPerYear;
     public static String LabelEarningsSelectStartYear;
     public static String LabelEarningsExpenses;
+    public static String LabelEarningsUseConsolidateRetired;
+    public static String LabelEarningsConsolidateRetired;
+    public static String LabelEarningsUseTradeProfitLoss;
+    public static String LabelEarningsTradeProfitLoss;
     public static String LabelExpenses;
     public static String LabelError;
     public static String LabelEurostatRegion;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1114,7 +1114,7 @@ LabelEarningsSelectStartYear = Earnings starting with year:
 
 LabelEarningsUseConsoidateRetired = Consolidation of inactive securities
 
-LabelEarningsConsolidateRetired = Retired securities
+LabelEarningsConsolidateRetired = \u2211 Retired securities
 
 LabelEarningsUseTradeProfitLoss = Take into account profits of trades
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1102,7 +1102,7 @@ LabelEarningsByQuarterAndVehicle = Quarter / Instrument
 
 LabelEarningsByYearAndVehicle = Year / Instrument
 
-LabelEarningsExpenses = Earnings & Expenses
+LabelEarningsExpenses = Income & Expenses
 
 LabelEarningsPerMonth = Month
 
@@ -1111,6 +1111,14 @@ LabelEarningsPerQuarter = Quarter
 LabelEarningsPerYear = Year
 
 LabelEarningsSelectStartYear = Earnings starting with year:
+
+LabelEarningsUseConsoidateRetired = Consolidation of inactive securities
+
+LabelEarningsConsolidateRetired = Retired securities
+
+LabelEarningsUseTradeProfitLoss = Take into account profits of trades
+
+LabelEarningsTradeProfitLoss = [Trades] Profit / Loss
 
 LabelError = Error
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1103,7 +1103,7 @@ LabelEarningsSelectStartYear = Ertr\u00E4ge ab Jahr:
 
 LabelEarningsUseConsolidateRetired = Konsolidierung inaktive Wertpapiere
 
-LabelEarningsConsolidateRetired = Inaktive Wertpapiere
+LabelEarningsConsolidateRetired = \u2211 Inaktive Wertpapiere
 
 LabelEarningsUseTradeProfitLoss = Ber\u00FCcksichtigung Gewinne von Trades
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1095,7 +1095,7 @@ LabelEarningsExpenses = Einnahmen & Ausgaben
 
 LabelEarningsPerMonth = Monat
 
-LabelEarningsPerQuart0er = Quartal
+LabelEarningsPerQuarter = Quartal
 
 LabelEarningsPerYear = Jahr
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1091,15 +1091,23 @@ LabelEarningsByQuarterAndVehicle = Quartal / Anlage
 
 LabelEarningsByYearAndVehicle = Jahr / Anlage
 
-LabelEarningsExpenses = Ertr\u00E4ge & Ausgaben
+LabelEarningsExpenses = Einnahmen & Ausgaben
 
 LabelEarningsPerMonth = Monat
 
-LabelEarningsPerQuarter = Quartal
+LabelEarningsPerQuart0er = Quartal
 
 LabelEarningsPerYear = Jahr
 
 LabelEarningsSelectStartYear = Ertr\u00E4ge ab Jahr:
+
+LabelEarningsUseConsolidateRetired = Konsolidierung inaktive Wertpapiere
+
+LabelEarningsConsolidateRetired = Inaktive Wertpapiere
+
+LabelEarningsUseTradeProfitLoss = Ber\u00FCcksichtigung Gewinne von Trades
+
+LabelEarningsTradeProfitLoss = [Trades] Gewinn / Verlust
 
 LabelError = Fehler
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1033,7 +1033,7 @@ LabelEarningsSelectStartYear = Ganancias a partir del a\u00F1o:
 
 LabelEarningsUseConsolidateRetired = Consolidaci\u00F3n de valores inactivos
 
-LabelEarningsConsolidateRetired = Valores retirados
+LabelEarningsConsolidateRetired = \u2211 Valores retirados
 
 LabelEarningsUseTradeProfitLoss = Tenga en cuenta las ganancias de las operaciones
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1021,7 +1021,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Veh\u00EDculo
 
 LabelEarningsByYearAndVehicle = A\u00F1o / Veh\u00EDculo
 
-LabelEarningsExpenses = Ganancias & Gastos
+LabelEarningsExpenses = Ingresos & Gastos
 
 LabelEarningsPerMonth = Mes
 
@@ -1030,6 +1030,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = A\u00F1o
 
 LabelEarningsSelectStartYear = Ganancias a partir del a\u00F1o:
+
+LabelEarningsUseConsolidateRetired = Consolidaci\u00F3n de valores inactivos
+
+LabelEarningsConsolidateRetired = Valores retirados
+
+LabelEarningsUseTradeProfitLoss = Tenga en cuenta las ganancias de las operaciones
+
+LabelEarningsTradeProfitLoss = [Operaciones] Ganancias / P\u00E9rdidas 
 
 LabelError = Error
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1072,7 +1072,7 @@ LabelEarningsSelectStartYear = B\u00E9n\u00E9fices \u00E0 partir de l'ann\u00E9e
 
 LabelEarningsUseConsolidateRetired = Consolidation de titres inactifs
 
-LabelEarningsConsolidateRetired = Titres retir\u00E9s
+LabelEarningsConsolidateRetired = \u2211 Titres retir\u00E9s
 
 LabelEarningsUseTradeProfitLoss = Prendre en compte les b\u00E9n\u00E9fices des trades
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1060,7 +1060,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Instrument
 
 LabelEarningsByYearAndVehicle = Ann\u00E9e / Instrument
 
-LabelEarningsExpenses = B\u00E9n\u00E9fices & D\u00E9penses
+LabelEarningsExpenses = Recettes & D\u00E9penses
 
 LabelEarningsPerMonth = Mois
 
@@ -1069,6 +1069,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = Ann\u00E9e
 
 LabelEarningsSelectStartYear = B\u00E9n\u00E9fices \u00E0 partir de l'ann\u00E9e :
+
+LabelEarningsUseConsolidateRetired = Consolidation de titres inactifs
+
+LabelEarningsConsolidateRetired = Titres retir\u00E9s
+
+LabelEarningsUseTradeProfitLoss = Prendre en compte les b\u00E9n\u00E9fices des trades
+
+LabelEarningsTradeProfitLoss = [Trades] Profit / Perte 
 
 LabelError = Erreur
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1079,7 +1079,7 @@ LabelEarningsByQuarterAndVehicle = Kwartaal / Instrument
 
 LabelEarningsByYearAndVehicle = Jaar / Instrument
 
-LabelEarningsExpenses = Inkomsten & Uitgaven
+LabelEarningsExpenses = Inkomen & Uitgaven
 
 LabelEarningsPerMonth = Maand
 
@@ -1088,6 +1088,14 @@ LabelEarningsPerQuarter = Kwartaal
 LabelEarningsPerYear = Jaar
 
 LabelEarningsSelectStartYear = Inkomsten beginnend met jaar:
+
+LabelEarningsUseConsolidateRetired = Consolidatie van inactieve effecten
+
+LabelEarningsConsolidateRetired = Gepensioneerde effecten 
+
+LabelEarningsUseTradeProfitLoss = Houd rekening met de winst van transacties
+
+LabelEarningsTradeProfitLoss = [Transacties] Winst / verlies
 
 LabelError = Fout
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1091,7 +1091,7 @@ LabelEarningsSelectStartYear = Inkomsten beginnend met jaar:
 
 LabelEarningsUseConsolidateRetired = Consolidatie van inactieve effecten
 
-LabelEarningsConsolidateRetired = Gepensioneerde effecten 
+LabelEarningsConsolidateRetired = \u2211 Gepensioneerde effecten 
 
 LabelEarningsUseTradeProfitLoss = Houd rekening met de winst van transacties
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1095,7 +1095,7 @@ LabelEarningsSelectStartYear = Ganhos a partir do ano:
 
 LabelEarningsUseConsolidateRetired = Consolida\u00E7\u00E3o de t\u00EDtulos inativos
 
-LabelEarningsConsolidateRetired = T\u00EDtulos aposentados
+LabelEarningsConsolidateRetired = \u2211 T\u00EDtulos aposentados
 
 LabelEarningsUseTradeProfitLoss = Leve em considera\u00E7\u00E3o os lucros das negocia\u00E7\u00F5es
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1083,7 +1083,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Instrumento
 
 LabelEarningsByYearAndVehicle = Ano / Instrumento
 
-LabelEarningsExpenses = Ganhos & Despesas
+LabelEarningsExpenses = Receitas & Despesas
 
 LabelEarningsPerMonth = M\u00EAs
 
@@ -1092,6 +1092,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = Ano
 
 LabelEarningsSelectStartYear = Ganhos a partir do ano:
+
+LabelEarningsUseConsolidateRetired = Consolida\u00E7\u00E3o de t\u00EDtulos inativos
+
+LabelEarningsConsolidateRetired = T\u00EDtulos aposentados
+
+LabelEarningsUseTradeProfitLoss = Leve em considera\u00E7\u00E3o os lucros das negocia\u00E7\u00F5es
+
+LabelEarningsTradeProfitLoss = [Trades] Lucro / Perda
 
 LabelError = Erro
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
@@ -78,8 +78,21 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
                 }
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                for (int m = month; m < totalNoOfMonths; m += 12)
+                {
+                    ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                    cl.setText(Values.Amount.format(model.getSumRetired().getValue(m)));
+                    GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+                }
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             for (int m = month; m < totalNoOfMonths; m += 12)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
@@ -198,14 +198,17 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             public String getText(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? vehicle.getName() : Messages.ColumnSum;
+                return vehicle != null ? vehicle.getName()
+                                : (((EarningsViewModel.Line) element).getConsolidatedRetired()
+                                                ? Messages.LabelEarningsConsolidateRetired
+                                                : Messages.ColumnSum);
             }
 
             @Override
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 
@@ -257,7 +260,7 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 
@@ -300,7 +303,7 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             @Override
             public Font getFont(Object element)
             {
-                return boldFont;
+                return ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
@@ -84,8 +84,25 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
                 }
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
+                {
+                    int mLimit = m + 3;
+                    long value = 0;
+                    for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                        value += model.getSumRetired().getValue(mQuarter);
+                    ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                    cl.setText(Values.Amount.format(value));
+                    GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+                }
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
@@ -134,7 +134,7 @@ public class EarningsPerQuarterMatrixTab extends EarningsPerMonthMatrixTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
@@ -87,8 +87,22 @@ public class EarningsPerYearChartTab extends AbstractChartTab
                 GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                long value = 0;
+                for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)
+                    value += model.getSumRetired().getValue(m);
+
+                ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                cl.setText(Values.Amount.format(value));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             long value = 0;
             for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearMatrixTab.java
@@ -83,7 +83,7 @@ public class EarningsPerYearMatrixTab extends EarningsPerMonthMatrixTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
@@ -255,6 +255,8 @@ public class EarningsViewModel
     {
         List<Line> answer = new ArrayList<>();
         answer.addAll(lines);
+        if (useConsolidateRetired)
+            answer.add(sumRetired);
         answer.add(sum);
         return answer;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
@@ -22,6 +22,9 @@ import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.snapshot.trades.Trade;
+import name.abuchen.portfolio.snapshot.trades.TradeCollector;
+import name.abuchen.portfolio.snapshot.trades.TradeCollectorException;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
 import name.abuchen.portfolio.util.Interval;
@@ -40,6 +43,9 @@ public class EarningsViewModel
         FEES(Messages.ColumnFees, AccountTransaction.Type.DIVIDENDS, AccountTransaction.Type.INTEREST,
                         AccountTransaction.Type.INTEREST_CHARGE, AccountTransaction.Type.FEES,
                         AccountTransaction.Type.FEES_REFUND), //
+        TRADES(Messages.LabelEarningsTradeProfitLoss, AccountTransaction.Type.DIVIDENDS,
+                        AccountTransaction.Type.INTEREST, AccountTransaction.Type.INTEREST_CHARGE,
+                        AccountTransaction.Type.FEES, AccountTransaction.Type.FEES_REFUND), //
         ALL("\u2211", AccountTransaction.Type.DIVIDENDS, AccountTransaction.Type.INTEREST, //$NON-NLS-1$
                         AccountTransaction.Type.INTEREST_CHARGE, AccountTransaction.Type.TAXES,
                         AccountTransaction.Type.TAX_REFUND, AccountTransaction.Type.FEES,
@@ -74,18 +80,25 @@ public class EarningsViewModel
     public static class Line
     {
         private InvestmentVehicle vehicle;
+        private boolean consolidateRetired;
         private long[] values;
         private long sum;
 
-        public Line(InvestmentVehicle vehicle, int length)
+        public Line(InvestmentVehicle vehicle, boolean consolidateRetired, int length)
         {
             this.vehicle = vehicle;
+            this.consolidateRetired = consolidateRetired;
             this.values = new long[length];
         }
 
         public InvestmentVehicle getVehicle()
         {
             return vehicle;
+        }
+
+        public boolean getConsolidatedRetired()
+        {
+            return consolidateRetired;
         }
 
         public long getValue(int index)
@@ -115,10 +128,13 @@ public class EarningsViewModel
     private int noOfmonths;
     private List<Line> lines;
     private Line sum;
+    private Line sumRetired;
     private List<TransactionPair<?>> transactions = new ArrayList<>();
 
     private Mode mode = Mode.ALL;
     private boolean useGrossValue = true;
+    private boolean useTradeValue = false;
+    private boolean useConsolidateRetired = true;
 
     public EarningsViewModel(IPreferenceStore preferences, CurrencyConverter converter, Client client)
     {
@@ -138,11 +154,14 @@ public class EarningsViewModel
                         this.clientFilter.getSelectedItem().getUUIDs()));
     }
 
-    public void configure(int startYear, Mode mode, boolean useGrossValue)
+    public void configure(int startYear, Mode mode, boolean useGrossValue, boolean useTradeValue,
+                    boolean useConsolidateRetired)
     {
         this.startYear = startYear;
         this.mode = mode;
         this.useGrossValue = useGrossValue;
+        this.useTradeValue = useTradeValue;
+        this.useConsolidateRetired = useConsolidateRetired;
 
         recalculate();
     }
@@ -177,6 +196,11 @@ public class EarningsViewModel
         return sum;
     }
 
+    public Line getSumRetired()
+    {
+        return sumRetired;
+    }
+
     public Mode getMode()
     {
         return mode;
@@ -196,6 +220,31 @@ public class EarningsViewModel
     public void setUseGrossValue(boolean useGrossValue)
     {
         this.useGrossValue = useGrossValue;
+        recalculate();
+    }
+
+    public boolean usesTradeValue()
+    {
+        return useTradeValue;
+    }
+
+    public void setUseTradeValue(boolean useTradeValue)
+    {
+        if (this.useTradeValue && this.mode == Mode.TRADES)
+            setMode(Mode.ALL);
+
+        this.useTradeValue = useTradeValue;
+        recalculate();
+    }
+
+    public boolean usesConsolidateRetired()
+    {
+        return useConsolidateRetired;
+    }
+
+    public void setUseConsolidateRetired(boolean useConsolidateRetired)
+    {
+        this.useConsolidateRetired = useConsolidateRetired;
         recalculate();
     }
 
@@ -240,36 +289,98 @@ public class EarningsViewModel
 
         Interval interval = Interval.of(LocalDate.of(startYear - 1, Month.DECEMBER, 31), now);
         Predicate<Transaction> checkIsInInterval = t -> interval.contains(t.getDateTime());
+        Predicate<Trade> checkIsInIntervalTrade = t -> interval.contains(t.getEnd().get());
 
         Map<InvestmentVehicle, Line> vehicle2line = new HashMap<>();
 
-        this.sum = new Line(null, this.noOfmonths);
+        this.sum = new Line(null, false, this.noOfmonths);
+        this.sumRetired = new Line(null, useConsolidateRetired, this.noOfmonths);
         this.transactions = new ArrayList<>();
 
         Client filteredClient = clientFilter.getSelectedFilter().filter(client);
+
+        if (useTradeValue)
+        {
+            EnumSet<Mode> processGainTx = EnumSet.of(Mode.TRADES, Mode.ALL);
+            if (processGainTx.contains(mode))
+            {
+                List<Trade> trades = null;
+
+                switch (mode)
+                {
+                    case TRADES:
+                        trades = collectTrade(filteredClient);
+                        break;
+                    case ALL:
+                        trades = collectTrade(filteredClient);
+                        break;
+                    default:
+
+                }
+
+                if (trades != null)
+                {
+                    for (Trade trade : trades)
+                    {
+                        if (!trade.getEnd().isPresent())
+                            continue;
+                        if (!checkIsInIntervalTrade.test(trade))
+                            continue;
+
+                        long value = 0;
+                        value = trade.getGrossProfitLoss().getAmount();
+
+                        if (value != 0)
+                        {
+                            int index = (trade.getEnd().get().getYear() - startYear) * 12
+                                            + trade.getEnd().get().getMonthValue() - 1;
+                            InvestmentVehicle vehicle = trade.getSecurity();
+                            if (useConsolidateRetired && vehicle.isRetired())
+                            {
+                                sumRetired.values[index] += value;
+                                sumRetired.sum += value;
+                            }
+                            else
+                            {
+                                Line line = vehicle2line.computeIfAbsent(vehicle, s -> new Line(s, false, noOfmonths));
+                                line.values[index] += value;
+                                line.sum += value;
+                            }
+
+                            sum.values[index] += value;
+                            sum.sum += value;
+                        }
+                    }
+                }
+            }
+        }
 
         EnumSet<Mode> processPorfolioTx = EnumSet.of(Mode.TAXES, Mode.FEES, Mode.ALL);
         if (processPorfolioTx.contains(mode))
         {
             for (Portfolio portfolio : filteredClient.getPortfolios())
             {
-                for (PortfolioTransaction t : portfolio.getTransactions())
+                for (PortfolioTransaction transaction : portfolio.getTransactions())
                 {
-                    if (!checkIsInInterval.test(t))
+                    if (!checkIsInInterval.test(transaction))
                         continue;
 
                     long value = 0;
                     switch (mode)
                     {
                         case TAXES:
-                            value -= t.getUnitSum(Unit.Type.TAX).with(converter.at(t.getDateTime())).getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.TAX).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
                             break;
                         case FEES:
-                            value -= t.getUnitSum(Unit.Type.FEE).with(converter.at(t.getDateTime())).getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.FEE).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
                             break;
                         case ALL:
-                            value -= t.getUnitSum(Unit.Type.TAX).with(converter.at(t.getDateTime())).getAmount();
-                            value -= t.getUnitSum(Unit.Type.FEE).with(converter.at(t.getDateTime())).getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.TAX).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.FEE).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
                             break;
 
                         default:
@@ -277,14 +388,23 @@ public class EarningsViewModel
 
                     if (value != 0)
                     {
-                        transactions.add(new TransactionPair<>(portfolio, t));
+                        transactions.add(new TransactionPair<>(portfolio, transaction));
 
-                        int index = (t.getDateTime().getYear() - startYear) * 12 + t.getDateTime().getMonthValue() - 1;
+                        int index = (transaction.getDateTime().getYear() - startYear) * 12
+                                        + transaction.getDateTime().getMonthValue() - 1;
 
-                        Line line = vehicle2line.computeIfAbsent(t.getSecurity(), s -> new Line(s, noOfmonths));
-                        line.values[index] += value;
-                        line.sum += value;
-
+                        InvestmentVehicle vehicle = transaction.getSecurity();
+                        if (useConsolidateRetired && vehicle.isRetired())
+                        {
+                            sumRetired.values[index] += value;
+                            sumRetired.sum += value;
+                        }
+                        else
+                        {
+                            Line line = vehicle2line.computeIfAbsent(vehicle, s -> new Line(s, false, noOfmonths));
+                            line.values[index] += value;
+                            line.sum += value;
+                        }
                         sum.values[index] += value;
                         sum.sum += value;
                     }
@@ -294,65 +414,81 @@ public class EarningsViewModel
 
         for (Account account : filteredClient.getAccounts())
         {
-            for (AccountTransaction t : account.getTransactions()) // NOSONAR
+            for (AccountTransaction transaction : account.getTransactions()) // NOSONAR
             {
-                if (!mode.isAccountTxIncluded(t))
+                if (!mode.isAccountTxIncluded(transaction))
                     continue;
 
-                if (!checkIsInInterval.test(t))
+                if (!checkIsInInterval.test(transaction))
                     continue;
 
                 long value = 0;
                 switch (mode)
                 {
                     case TAXES:
-                        if (t.getType() == AccountTransaction.Type.TAXES
-                                        || t.getType() == AccountTransaction.Type.TAX_REFUND)
+                        if (transaction.getType() == AccountTransaction.Type.TAXES
+                                        || transaction.getType() == AccountTransaction.Type.TAX_REFUND)
                         {
-                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                            if (t.getType().isDebit())
+                            value = transaction.getMonetaryAmount().with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
+                            if (transaction.getType().isDebit())
                                 value *= -1;
                         }
                         else
                         {
-                            value -= t.getUnitSum(Unit.Type.TAX).with(converter.at(t.getDateTime())).getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.TAX).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
                         }
                         break;
                     case FEES:
-                        if (t.getType() == AccountTransaction.Type.FEES
-                                        || t.getType() == AccountTransaction.Type.FEES_REFUND)
+                        if (transaction.getType() == AccountTransaction.Type.FEES
+                                        || transaction.getType() == AccountTransaction.Type.FEES_REFUND)
                         {
-                            value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                            if (t.getType().isDebit())
-                                value *= -1;
+                            value = transaction.getMonetaryAmount().with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
+                            if (transaction.getType().isDebit())
+                                value *= -100;
                         }
                         else
                         {
-                            value -= t.getUnitSum(Unit.Type.FEE).with(converter.at(t.getDateTime())).getAmount();
+                            value -= transaction.getUnitSum(Unit.Type.FEE).with(converter.at(transaction.getDateTime()))
+                                            .getAmount();
                         }
                         break;
+                    case TRADES:
+                        break;
                     case ALL:
-                        value = t.getMonetaryAmount().with(converter.at(t.getDateTime())).getAmount();
-                        if (t.getType().isDebit())
+                        value = transaction.getMonetaryAmount().with(converter.at(transaction.getDateTime()))
+                                        .getAmount();
+                        if (transaction.getType().isDebit())
                             value *= -1;
                         break;
                     default:
-                        value = (useGrossValue ? t.getGrossValue() : t.getMonetaryAmount())
-                                        .with(converter.at(t.getDateTime())).getAmount();
-                        if (t.getType().isDebit())
+                        value = (useGrossValue ? transaction.getGrossValue() : transaction.getMonetaryAmount())
+                                        .with(converter.at(transaction.getDateTime())).getAmount();
+                        if (transaction.getType().isDebit())
                             value *= -1;
                 }
 
                 if (value != 0)
                 {
-                    transactions.add(new TransactionPair<>(account, t));
+                    transactions.add(new TransactionPair<>(account, transaction));
 
-                    int index = (t.getDateTime().getYear() - startYear) * 12 + t.getDateTime().getMonthValue() - 1;
+                    int index = (transaction.getDateTime().getYear() - startYear) * 12
+                                    + transaction.getDateTime().getMonthValue() - 1;
 
-                    InvestmentVehicle vehicle = t.getSecurity() != null ? t.getSecurity() : account;
-                    Line line = vehicle2line.computeIfAbsent(vehicle, s -> new Line(s, noOfmonths));
-                    line.values[index] += value;
-                    line.sum += value;
+                    InvestmentVehicle vehicle = transaction.getSecurity() != null ? transaction.getSecurity() : account;
+                    if (useConsolidateRetired && vehicle.isRetired())
+                    {
+                        sumRetired.values[index] += value;
+                        sumRetired.sum += value;
+                    }
+                    else
+                    {
+                        Line line = vehicle2line.computeIfAbsent(vehicle, s -> new Line(s, false, noOfmonths));
+                        line.values[index] += value;
+                        line.sum += value;
+                    }
 
                     sum.values[index] += value;
                     sum.sum += value;
@@ -370,5 +506,23 @@ public class EarningsViewModel
     protected void fireUpdateChange()
     {
         this.listeners.stream().forEach(UpdateListener::onUpdate);
+    }
+
+    public List<Trade> collectTrade(Client filteredClient)
+    {
+        TradeCollector collector = new TradeCollector(filteredClient, converter);
+        List<Trade> trades = new ArrayList<>();
+        List<TradeCollectorException> errors = new ArrayList<>();
+        getClient().getSecurities().forEach(s -> {
+            try
+            {
+                trades.addAll(collector.collect(s));
+            }
+            catch (TradeCollectorException e)
+            {
+                errors.add(e);
+            }
+        });
+        return trades;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -310,7 +310,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Thousands = new Values<Double>("0.###k", 0) //$NON-NLS-1$
+    public static final Values<Double> Thousands = new Values<Double>("#,##0.00", 0) //$NON-NLS-1$
     {
         private ThreadLocal<DecimalFormat> numberFormatter = ThreadLocal // NOSONAR
                         .withInitial(() -> new DecimalFormat("#,##0.###")); //$NON-NLS-1$
@@ -318,7 +318,12 @@ public abstract class Values<E>
         @Override
         public String format(Double value)
         {
-            return numberFormatter.get().format(value / 1000) + "k"; //$NON-NLS-1$
+            if (value < 1000)
+                return numberFormatter.get().format(value); // $NON-NLS-1$
+            else if (value < 1000000)
+                return numberFormatter.get().format(value / 1000) + "k"; //$NON-NLS-1$
+            else
+                return numberFormatter.get().format(value / 1000000) + "m"; //$NON-NLS-1$
         }
     };
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -33,7 +33,9 @@ public class Trade implements Adaptable
     private List<TransactionPair<PortfolioTransaction>> transactions = new ArrayList<>();
 
     private Money entryValue;
+    private Money entryGrossValue;
     private Money exitValue;
+    private Money exitGrossValue;
     private long holdingPeriod;
     private double irr;
 
@@ -52,11 +54,23 @@ public class Trade implements Adaptable
                                         .with(converter.at(t.getTransaction().getDateTime())))
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
+        this.entryGrossValue = transactions.stream() //
+                        .filter(t -> t.getTransaction().getType().isPurchase())
+                        .map(t -> t.getTransaction().getGrossValue()
+                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
         if (end != null)
         {
             this.exitValue = transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isLiquidation())
                             .map(t -> t.getTransaction().getMonetaryAmount()
+                                            .with(converter.at(t.getTransaction().getDateTime())))
+                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+            this.exitGrossValue = transactions.stream() //
+                            .filter(t -> t.getTransaction().getType().isLiquidation())
+                            .map(t -> t.getTransaction().getGrossValue()
                                             .with(converter.at(t.getTransaction().getDateTime())))
                             .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
@@ -175,6 +189,11 @@ public class Trade implements Adaptable
     public Money getProfitLoss()
     {
         return exitValue.subtract(entryValue);
+    }
+
+    public Money getGrossProfitLoss()
+    {
+        return exitGrossValue.subtract(entryGrossValue);
     }
 
     public long getHoldingPeriod()


### PR DESCRIPTION
by implementing optionally trades

In memory of PR #1380 and the case that values from trades are based on calculations rather than fixed bookings and recently repitly asked by the community I've recreated my former PR with few options:;
1. User could decide if they would like to use the calculated earnings from the trade view. Depend on the decission, the icon option were enabled or disabled.
![EnabledDisabledTradeIcon](https://user-images.githubusercontent.com/29358155/107278929-b1580700-6a56-11eb-9d04-25fe9db7a7ef.JPG)
![New Flags](https://user-images.githubusercontent.com/29358155/107278931-b1f09d80-6a56-11eb-83b5-4d9328e4f369.JPG)

2. As the user claimed the k-amount scalling for small amounts I've slighly changed the formatting more intuitive
![AdjustedScalling](https://user-images.githubusercontent.com/29358155/107279335-34795d00-6a57-11eb-808d-784418804f09.JPG)

3. Finally (unfortnately I didn*t find the forum thread) there was asked to consolidate the retired securities to get only the active once. This is available as option as well.
![RetiredSecurities](https://user-images.githubusercontent.com/29358155/107279568-7dc9ac80-6a57-11eb-9951-0979d326b2e9.JPG)


Skalierung der Grafik:
https://forum.portfolio-performance.info/t/skalierung-der-y-achse-im-diagramm-vermoegensaufstellung/1892
https://forum.portfolio-performance.info/t/skala-bei-ertraege-akkumuliert-veraendern/8382

Trades unter "Einnahmen & Ausgaben" aka "Erträge & Ausgaben"
https://forum.portfolio-performance.info/t/gewinne-verluste-aus-trades-unter-ertraege-und-ausgaben/6922
https://forum.portfolio-performance.info/t/anzeige-von-veraeusserungsgewinnen/86

Warm regards
Marco

#2063