### PR TITLE
Modify currency to support currency rand cent

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
@@ -32,27 +32,27 @@ public class ExchangeRateProviderZACTest
                         comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("17.8953"), 12, RoundingMode.HALF_DOWN)));
 
         // ZAR -> ZAC
-        ExchangeRateTimeSeries zar_zac = factory.getTimeSeries("GBX", "GBP");
+        ExchangeRateTimeSeries zar_zac = factory.getTimeSeries("ZAR", "ZAC");
         assertThat(zar_zac.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
 
         // inverse of default ZAR -> ZAC
         ExchangeRateTimeSeries zac_zar = factory.getTimeSeries("ZAC", "ZAR");
         assertThat(zac_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
 
-        // ZAC -> EUR
+        // ZAC -> USD
         // default value EUR -> ZAR is 17.8953
         // default value EUR -> USD is 1.2104
         double calculatedRate = 0.01d * (1 / 17.8953d) * 1.2104d;
 
-        ExchangeRateTimeSeries zac_eur = factory.getTimeSeries("ZAC", "EUR");
-        assertThat(zac_eur.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        ExchangeRateTimeSeries zac_usd = factory.getTimeSeries("ZAC", "USD");
+        assertThat(zac_usd.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
 
-        // EUR -> ZAC
+        // USD -> ZAC
         calculatedRate = (1 / 1.2104d) * 17.8953 * 100;
 
-        ExchangeRateTimeSeries eur_zac = factory.getTimeSeries("EUR", "ZAC");
-        assertThat(eur_zac.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        ExchangeRateTimeSeries usd_zac = factory.getTimeSeries("USD", "ZAC");
+        assertThat(usd_zac.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
@@ -1,0 +1,58 @@
+package name.abuchen.portfolio.money.impl;
+
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.hamcrest.number.OrderingComparison.comparesEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
+
+@SuppressWarnings("nls")
+public class ExchangeRateProviderZACTest
+{
+    @Test
+    public void testIt()
+    {
+        ExchangeRateProviderFactory factory = new ExchangeRateProviderFactory(new Client());
+
+        // default value EUR -> ZAR is 17.8953       
+        ExchangeRateTimeSeries eur_zar = factory.getTimeSeries("EUR", "ZAR");
+        assertThat(eur_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("17.8953")));
+
+        // inverse of default EUR -> ZAR
+        ExchangeRateTimeSeries zar_eur = factory.getTimeSeries("ZAR", "EUR");
+        assertThat(zar_eur.lookupRate(LocalDate.now()).get().getValue(),
+                        comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("17.8953"), 12, RoundingMode.HALF_DOWN)));
+
+        // ZAR -> ZAC
+        ExchangeRateTimeSeries zar_zac = factory.getTimeSeries("GBX", "GBP");
+        assertThat(zar_zac.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
+
+        // inverse of default ZAR -> ZAC
+        ExchangeRateTimeSeries zac_zar = factory.getTimeSeries("ZAC", "ZAR");
+        assertThat(zac_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
+
+        // ZAC -> EUR
+        // default value EUR -> ZAR is 17.8953
+        // default value EUR -> USD is 1.2104
+        double calculatedRate = 0.01d * (1 / 17.8953d) * 1.2104d;
+
+        ExchangeRateTimeSeries zac_eur = factory.getTimeSeries("ZAC", "EUR");
+        assertThat(zac_eur.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+                        closeTo(calculatedRate, 0.00000001));
+
+        // EUR -> ZAC
+        calculatedRate = (1 / 1.2104d) * 17.8953 * 100;
+
+        ExchangeRateTimeSeries eur_zac = factory.getTimeSeries("EUR", "ZAC");
+        assertThat(eur_zac.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+                        closeTo(calculatedRate, 0.00000001));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
@@ -22,7 +22,7 @@ public class ExchangeRateProviderZACTest
     {
         ExchangeRateProviderFactory factory = new ExchangeRateProviderFactory(new Client());
 
-        // default value EUR -> ZAR is 17.8953       
+        // default value EUR -> ZAR is 17.8953
         ExchangeRateTimeSeries eur_zar = factory.getTimeSeries("EUR", "ZAR");
         assertThat(eur_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("17.8953")));
 
@@ -35,24 +35,25 @@ public class ExchangeRateProviderZACTest
         ExchangeRateTimeSeries zar_zac = factory.getTimeSeries("ZAR", "ZAC");
         assertThat(zar_zac.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
 
-        // inverse of default ZAR -> ZAC
+        // ZAC -> ZAR
         ExchangeRateTimeSeries zac_zar = factory.getTimeSeries("ZAC", "ZAR");
         assertThat(zac_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
 
-        // ZAC -> USD
+        // ZAR -> USD
         // default value EUR -> ZAR is 17.8953
-        // default value EUR -> USD is 1.2104
-        double calculatedRate = 0.01d * (1 / 17.8953d) * 1.2104d;
+        // default value EUR -> USD is 1.0836
+        double calculatedRate = 0.01d * (1 / 17.8953d) * 1.0836d;
 
-        ExchangeRateTimeSeries zac_usd = factory.getTimeSeries("ZAC", "USD");
-        assertThat(zac_usd.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        ExchangeRateTimeSeries zar_usd = factory.getTimeSeries("ZAR", "USD");
+        assertThat(zar_usd.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
 
-        // USD -> ZAC
-        calculatedRate = (1 / 1.2104d) * 17.8953 * 100;
+        // USD -> ZAR
+        calculatedRate = (1 / 1.0836d) * 17.8953d * 100;
 
-        ExchangeRateTimeSeries usd_zac = factory.getTimeSeries("USD", "ZAC");
-        assertThat(usd_zac.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        ExchangeRateTimeSeries usd_zar = factory.getTimeSeries("USD", "ZAR");
+        assertThat(usd_zar.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
+
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
@@ -671,6 +671,10 @@ YER = Yemeni rial
 
 YER.symbol = Y. Rl
 
+ZAC = South African Cents
+
+ZAC.symbol = c
+
 ZAR = South African rand
 
 ZAR.symbol = R

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
@@ -339,6 +339,8 @@ WST = Samoanischer Tala
 
 YER = Jemen-Rial
 
+ZAC = S\u00FCdafrikanische Cents
+
 ZAR = S\u00FCdafrikanischer Rand
 
 ZMW = Sambischer Kwacha

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_es.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_es.properties
@@ -339,6 +339,8 @@ WST = T\u0101l\u0101 (Moneda)
 
 YER = Rial yemen\u00ED
 
+ZAC = C\u00E9ntimos sudafricano
+
 ZAR = Rand sudafricano
 
 ZMW = Kwacha zambiano

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_fr.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_fr.properties
@@ -339,6 +339,8 @@ WST = Tala
 
 YER = Riyal y\u00E9m\u00E9nite
 
+ZAC = Cents sud-africains
+
 ZAR = Rand (Monnaie)
 
 ZMW = Kwacha zambien

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_nl.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_nl.properties
@@ -339,6 +339,8 @@ WST = Samoaanse tala
 
 YER = Jemenitische rial
 
+ZAC = Zuid-Afrikaanse centen
+
 ZAR = Zuid-Afrikaanse rand
 
 ZMW = Zambiaanse kwacha

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_pt.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_pt.properties
@@ -339,6 +339,8 @@ WST = Tala (Moeda)
 
 YER = Rial iemenita
 
+ZAC = C\u00EAntimos sul-africanos
+
 ZAR = Rand
 
 ZMW = Kwacha zambiano

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBExchangeRateProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBExchangeRateProvider.java
@@ -160,7 +160,7 @@ public class ECBExchangeRateProvider implements ExchangeRateProvider
         summary.addSeries(createDefault("LVL", "2013-12-31", BigDecimal.valueOf(0.702804)));
         summary.addSeries(createDefault("MTL", "2007-12-31", BigDecimal.valueOf(0.4293)));
         summary.addSeries(createDefault("LTL", "2014-12-31", BigDecimal.valueOf(3.4528)));
-        summary.addSeries(createDefault("ZAR", date20151218, BigDecimal.valueOf(16.2998)));
+        summary.addSeries(createDefault("ZAR", "2021-02-10", BigDecimal.valueOf(17.8953)));
         summary.addSeries(createDefault("INR", date20151218, BigDecimal.valueOf(71.955)));
         summary.addSeries(createDefault("CNY", date20151218, BigDecimal.valueOf(7.0274)));
         summary.addSeries(createDefault("THB", date20151218, BigDecimal.valueOf(39.175)));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBExchangeRateProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBExchangeRateProvider.java
@@ -160,7 +160,7 @@ public class ECBExchangeRateProvider implements ExchangeRateProvider
         summary.addSeries(createDefault("LVL", "2013-12-31", BigDecimal.valueOf(0.702804)));
         summary.addSeries(createDefault("MTL", "2007-12-31", BigDecimal.valueOf(0.4293)));
         summary.addSeries(createDefault("LTL", "2014-12-31", BigDecimal.valueOf(3.4528)));
-        summary.addSeries(createDefault("ZAR", "2021-02-10", BigDecimal.valueOf(17.8953)));
+        summary.addSeries(createDefault("ZAC", "2021-02-10", BigDecimal.valueOf(1789.53)));
         summary.addSeries(createDefault("INR", date20151218, BigDecimal.valueOf(71.955)));
         summary.addSeries(createDefault("CNY", date20151218, BigDecimal.valueOf(7.0274)));
         summary.addSeries(createDefault("THB", date20151218, BigDecimal.valueOf(39.175)));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
@@ -37,10 +37,10 @@ public class FixedExchangeRateProvider implements ExchangeRateProvider
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(40.3399), CurrencyUnit.EUR, "LUF", date01011999)); //$NON-NLS-1$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(2.20371), CurrencyUnit.EUR, "NLG", date01011999)); //$NON-NLS-1$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(200.482), CurrencyUnit.EUR, "PTE", date01011999)); //$NON-NLS-1$
-        
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(3.6725), CurrencyUnit.USD, "AED", LocalDate.of(1997, 11, 1))); //$NON-NLS-1$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "GBX", "GBP")); //$NON-NLS-1$ //$NON-NLS-2$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ILA", "ILS")); //$NON-NLS-1$ //$NON-NLS-2$
+        series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ZAC", "ZAR")); //$NON-NLS-1$ //$NON-NLS-2$
         
         return series;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
@@ -40,7 +40,7 @@ public class FixedExchangeRateProvider implements ExchangeRateProvider
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(3.6725), CurrencyUnit.USD, "AED", LocalDate.of(1997, 11, 1))); //$NON-NLS-1$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "GBX", "GBP")); //$NON-NLS-1$ //$NON-NLS-2$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ILA", "ILS")); //$NON-NLS-1$ //$NON-NLS-2$
-        series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ZAC", "ZAR")); //$NON-NLS-1$ //$NON-NLS-2$
+        series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ZAR", "ZAC")); //$NON-NLS-1$ //$NON-NLS-2$
         
         return series;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/FixedExchangeRateProvider.java
@@ -40,7 +40,7 @@ public class FixedExchangeRateProvider implements ExchangeRateProvider
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(3.6725), CurrencyUnit.USD, "AED", LocalDate.of(1997, 11, 1))); //$NON-NLS-1$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "GBX", "GBP")); //$NON-NLS-1$ //$NON-NLS-2$
         series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ILA", "ILS")); //$NON-NLS-1$ //$NON-NLS-2$
-        series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ZAR", "ZAC")); //$NON-NLS-1$ //$NON-NLS-2$
+        series.add(new FixedExchangeRateTimeSeries(this, 2, BigDecimal.valueOf(0.01), "ZAC", "ZAR")); //$NON-NLS-1$ //$NON-NLS-2$
         
         return series;
     }


### PR DESCRIPTION
Hallo @buchen 
ich habe die Unterwährung Rand Cent eingefügt, da mit dieser an den Börsen gehandelt
wird. Ich hoffe, das ich diese so korrekt gemacht habe, jedoch sollte das nochmal geprüft werden.
Ein TestCase liegt auch bereit, jedoch schlägt dieser immer wieder fehl.
Auch wenn ich die GBX<->GBP oder AED manuell ausführer, kommen die Fehler bei den TestCases

Im Währungsrechner funktioniert es richtig:
1 € sind 17,8953 Rand sind 1789,53 Rand cents
![grafik](https://user-images.githubusercontent.com/45203494/107502618-2d5a6800-6b99-11eb-813e-ccb9d9912d7a.png)

Issue: https://forum.portfolio-performance.info/t/waehrung-anlegen/10407/8