### PR TITLE
Change "Earnings & Expense" to "Income & Expenses" 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -549,6 +549,10 @@ public class Messages extends NLS
     public static String LabelEarningsPerYear;
     public static String LabelEarningsSelectStartYear;
     public static String LabelEarningsExpenses;
+    public static String LabelEarningsUseConsolidateRetired;
+    public static String LabelEarningsConsolidateRetired;
+    public static String LabelEarningsUseTradeProfitLoss;
+    public static String LabelEarningsTradeProfitLoss;
     public static String LabelExpenses;
     public static String LabelError;
     public static String LabelEurostatRegion;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1102,7 +1102,7 @@ LabelEarningsByQuarterAndVehicle = Quarter / Instrument
 
 LabelEarningsByYearAndVehicle = Year / Instrument
 
-LabelEarningsExpenses = Earnings & Expenses
+LabelEarningsExpenses = Income & Expenses
 
 LabelEarningsPerMonth = Month
 
@@ -1111,6 +1111,14 @@ LabelEarningsPerQuarter = Quarter
 LabelEarningsPerYear = Year
 
 LabelEarningsSelectStartYear = Earnings starting with year:
+
+LabelEarningsUseConsoidateRetired = Consolidation of inactive securities
+
+LabelEarningsConsolidateRetired = \u2211 Retired securities
+
+LabelEarningsUseTradeProfitLoss = Take into account profits of trades
+
+LabelEarningsTradeProfitLoss = [Trades] Profit / Loss
 
 LabelError = Error
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1091,7 +1091,7 @@ LabelEarningsByQuarterAndVehicle = Quartal / Anlage
 
 LabelEarningsByYearAndVehicle = Jahr / Anlage
 
-LabelEarningsExpenses = Ertr\u00E4ge & Ausgaben
+LabelEarningsExpenses = Einnahmen & Ausgaben
 
 LabelEarningsPerMonth = Monat
 
@@ -1100,6 +1100,14 @@ LabelEarningsPerQuarter = Quartal
 LabelEarningsPerYear = Jahr
 
 LabelEarningsSelectStartYear = Ertr\u00E4ge ab Jahr:
+
+LabelEarningsUseConsolidateRetired = Konsolidierung inaktive Wertpapiere
+
+LabelEarningsConsolidateRetired = \u2211 Inaktive Wertpapiere
+
+LabelEarningsUseTradeProfitLoss = Ber\u00FCcksichtigung Gewinne von Trades
+
+LabelEarningsTradeProfitLoss = [Trades] Gewinn / Verlust
 
 LabelError = Fehler
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1021,7 +1021,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Veh\u00EDculo
 
 LabelEarningsByYearAndVehicle = A\u00F1o / Veh\u00EDculo
 
-LabelEarningsExpenses = Ganancias & Gastos
+LabelEarningsExpenses = Ingresos & Gastos
 
 LabelEarningsPerMonth = Mes
 
@@ -1030,6 +1030,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = A\u00F1o
 
 LabelEarningsSelectStartYear = Ganancias a partir del a\u00F1o:
+
+LabelEarningsUseConsolidateRetired = Consolidaci\u00F3n de valores inactivos
+
+LabelEarningsConsolidateRetired = \u2211 Valores retirados
+
+LabelEarningsUseTradeProfitLoss = Tenga en cuenta las ganancias de las operaciones
+
+LabelEarningsTradeProfitLoss = [Operaciones] Ganancias / P\u00E9rdidas 
 
 LabelError = Error
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1060,7 +1060,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Instrument
 
 LabelEarningsByYearAndVehicle = Ann\u00E9e / Instrument
 
-LabelEarningsExpenses = B\u00E9n\u00E9fices & D\u00E9penses
+LabelEarningsExpenses = Recettes & D\u00E9penses
 
 LabelEarningsPerMonth = Mois
 
@@ -1069,6 +1069,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = Ann\u00E9e
 
 LabelEarningsSelectStartYear = B\u00E9n\u00E9fices \u00E0 partir de l'ann\u00E9e :
+
+LabelEarningsUseConsolidateRetired = Consolidation de titres inactifs
+
+LabelEarningsConsolidateRetired = \u2211 Titres retir\u00E9s
+
+LabelEarningsUseTradeProfitLoss = Prendre en compte les b\u00E9n\u00E9fices des trades
+
+LabelEarningsTradeProfitLoss = [Trades] Profit / Perte 
 
 LabelError = Erreur
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1079,7 +1079,7 @@ LabelEarningsByQuarterAndVehicle = Kwartaal / Instrument
 
 LabelEarningsByYearAndVehicle = Jaar / Instrument
 
-LabelEarningsExpenses = Inkomsten & Uitgaven
+LabelEarningsExpenses = Inkomen & Uitgaven
 
 LabelEarningsPerMonth = Maand
 
@@ -1088,6 +1088,14 @@ LabelEarningsPerQuarter = Kwartaal
 LabelEarningsPerYear = Jaar
 
 LabelEarningsSelectStartYear = Inkomsten beginnend met jaar:
+
+LabelEarningsUseConsolidateRetired = Consolidatie van inactieve effecten
+
+LabelEarningsConsolidateRetired = \u2211 Gepensioneerde effecten 
+
+LabelEarningsUseTradeProfitLoss = Houd rekening met de winst van transacties
+
+LabelEarningsTradeProfitLoss = [Transacties] Winst / verlies
 
 LabelError = Fout
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1083,7 +1083,7 @@ LabelEarningsByQuarterAndVehicle = Trimestre / Instrumento
 
 LabelEarningsByYearAndVehicle = Ano / Instrumento
 
-LabelEarningsExpenses = Ganhos & Despesas
+LabelEarningsExpenses = Receitas & Despesas
 
 LabelEarningsPerMonth = M\u00EAs
 
@@ -1092,6 +1092,14 @@ LabelEarningsPerQuarter = Trimestre
 LabelEarningsPerYear = Ano
 
 LabelEarningsSelectStartYear = Ganhos a partir do ano:
+
+LabelEarningsUseConsolidateRetired = Consolida\u00E7\u00E3o de t\u00EDtulos inativos
+
+LabelEarningsConsolidateRetired = \u2211 T\u00EDtulos aposentados
+
+LabelEarningsUseTradeProfitLoss = Leve em considera\u00E7\u00E3o os lucros das negocia\u00E7\u00F5es
+
+LabelEarningsTradeProfitLoss = [Trades] Lucro / Perda
 
 LabelError = Erro
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthChartTab.java
@@ -78,8 +78,21 @@ public class EarningsPerMonthChartTab extends AbstractChartTab
                 }
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                for (int m = month; m < totalNoOfMonths; m += 12)
+                {
+                    ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                    cl.setText(Values.Amount.format(model.getSumRetired().getValue(m)));
+                    GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+                }
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             for (int m = month; m < totalNoOfMonths; m += 12)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerMonthMatrixTab.java
@@ -198,14 +198,17 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             public String getText(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? vehicle.getName() : Messages.ColumnSum;
+                return vehicle != null ? vehicle.getName()
+                                : (((EarningsViewModel.Line) element).getConsolidatedRetired()
+                                                ? Messages.LabelEarningsConsolidateRetired
+                                                : Messages.ColumnSum);
             }
 
             @Override
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 
@@ -257,7 +260,7 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 
@@ -300,7 +303,7 @@ public class EarningsPerMonthMatrixTab implements EarningsTab
             @Override
             public Font getFont(Object element)
             {
-                return boldFont;
+                return ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterChartTab.java
@@ -84,8 +84,25 @@ public class EarningsPerQuarterChartTab extends AbstractChartTab
                 }
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
+                {
+                    int mLimit = m + 3;
+                    long value = 0;
+                    for (int mQuarter = m; mQuarter < mLimit && mQuarter < totalNoOfMonths; mQuarter += 1)
+                        value += model.getSumRetired().getValue(mQuarter);
+                    ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                    cl.setText(Values.Amount.format(value));
+                    GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+                }
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             for (int m = quarter * 3; m < totalNoOfMonths; m += 12)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerQuarterMatrixTab.java
@@ -134,7 +134,7 @@ public class EarningsPerQuarterMatrixTab extends EarningsPerMonthMatrixTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
@@ -87,8 +87,22 @@ public class EarningsPerYearChartTab extends AbstractChartTab
                 GridDataFactory.fillDefaults().align(SWT.END, SWT.FILL).applyTo(l);
             });
 
-            Label l = new Label(container, SWT.NONE);
-            l.setText(Messages.ColumnSum);
+            if (model.usesConsolidateRetired())
+            {
+                Label lSumRetired = new Label(container, SWT.NONE);
+                lSumRetired.setText(Messages.LabelEarningsConsolidateRetired);
+
+                long value = 0;
+                for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)
+                    value += model.getSumRetired().getValue(m);
+
+                ColoredLabel cl = new ColoredLabel(container, SWT.RIGHT);
+                cl.setText(Values.Amount.format(value));
+                GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).applyTo(cl);
+            }
+
+            Label lSum = new Label(container, SWT.NONE);
+            lSum.setText(Messages.ColumnSum);
 
             long value = 0;
             for (int m = year * 12; m < (year + 1) * 12 && m < totalNoOfMonths; m += 1)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearMatrixTab.java
@@ -83,7 +83,7 @@ public class EarningsPerYearMatrixTab extends EarningsPerMonthMatrixTab
             public Font getFont(Object element)
             {
                 InvestmentVehicle vehicle = ((EarningsViewModel.Line) element).getVehicle();
-                return vehicle != null ? null : boldFont;
+                return vehicle != null || ((EarningsViewModel.Line) element).getConsolidatedRetired() ? null : boldFont;
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -172,13 +172,13 @@ public class EarningsView extends AbstractFinanceView
                 Action action = new SimpleAction(Messages.LabelUseGrossValue,
                                 a -> model.setUseGrossValue(!model.usesGrossValue()));
                 action.setChecked(model.usesGrossValue());
-                updateTitle(model.getMode().getLabel());
                 manager.add(action);
             }
 
             Action action = new SimpleAction(Messages.LabelEarningsUseTradeProfitLoss, a -> {
                 model.setUseTradeValue(!model.usesTradeValue());
                 updateIcons();
+                updateTitle(model.getMode().getLabel());
             });
             action.setChecked(model.usesTradeValue());
             manager.add(action);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -172,6 +172,7 @@ public class EarningsView extends AbstractFinanceView
                 Action action = new SimpleAction(Messages.LabelUseGrossValue,
                                 a -> model.setUseGrossValue(!model.usesGrossValue()));
                 action.setChecked(model.usesGrossValue());
+                updateTitle(model.getMode().getLabel());
                 manager.add(action);
             }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -310,7 +310,7 @@ public abstract class Values<E>
         }
     };
 
-    public static final Values<Double> Thousands = new Values<Double>("0.###k", 0) //$NON-NLS-1$
+    public static final Values<Double> Thousands = new Values<Double>("#,##0.00", 0) //$NON-NLS-1$
     {
         private ThreadLocal<DecimalFormat> numberFormatter = ThreadLocal // NOSONAR
                         .withInitial(() -> new DecimalFormat("#,##0.###")); //$NON-NLS-1$
@@ -318,7 +318,12 @@ public abstract class Values<E>
         @Override
         public String format(Double value)
         {
-            return numberFormatter.get().format(value / 1000) + "k"; //$NON-NLS-1$
+            if (value < 1000)
+                return numberFormatter.get().format(value); // $NON-NLS-1$
+            else if (value < 1000000)
+                return numberFormatter.get().format(value / 1000) + "k"; //$NON-NLS-1$
+            else
+                return numberFormatter.get().format(value / 1000000) + "m"; //$NON-NLS-1$
         }
     };
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -33,7 +33,9 @@ public class Trade implements Adaptable
     private List<TransactionPair<PortfolioTransaction>> transactions = new ArrayList<>();
 
     private Money entryValue;
+    private Money entryGrossValue;
     private Money exitValue;
+    private Money exitGrossValue;
     private long holdingPeriod;
     private double irr;
 
@@ -52,11 +54,23 @@ public class Trade implements Adaptable
                                         .with(converter.at(t.getTransaction().getDateTime())))
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
+        this.entryGrossValue = transactions.stream() //
+                        .filter(t -> t.getTransaction().getType().isPurchase())
+                        .map(t -> t.getTransaction().getGrossValue()
+                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
         if (end != null)
         {
             this.exitValue = transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isLiquidation())
                             .map(t -> t.getTransaction().getMonetaryAmount()
+                                            .with(converter.at(t.getTransaction().getDateTime())))
+                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+            this.exitGrossValue = transactions.stream() //
+                            .filter(t -> t.getTransaction().getType().isLiquidation())
+                            .map(t -> t.getTransaction().getGrossValue()
                                             .with(converter.at(t.getTransaction().getDateTime())))
                             .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
@@ -175,6 +189,11 @@ public class Trade implements Adaptable
     public Money getProfitLoss()
     {
         return exitValue.subtract(entryValue);
+    }
+
+    public Money getGrossProfitLoss()
+    {
+        return exitGrossValue.subtract(entryGrossValue);
     }
 
     public long getHoldingPeriod()


### PR DESCRIPTION
by implementing optionally trades

In memory of PR #1380 and the case that values from trades are based on calculations rather than fixed bookings and recently repitly asked by the community I've recreated my former PR with few options:;
1. User could decide if they would like to use the calculated earnings from the trade view. Depend on the decission, the icon option were enabled or disabled.
![EnabledDisabledTradeIcon](https://user-images.githubusercontent.com/29358155/107278929-b1580700-6a56-11eb-9d04-25fe9db7a7ef.JPG)
![New Flags](https://user-images.githubusercontent.com/29358155/107278931-b1f09d80-6a56-11eb-83b5-4d9328e4f369.JPG)

2. As the user claimed the k-amount scalling for small amounts I've slighly changed the formatting more intuitive
![AdjustedScalling](https://user-images.githubusercontent.com/29358155/107279335-34795d00-6a57-11eb-808d-784418804f09.JPG)

3. Finally (unfortnately I didn*t find the forum thread) there was asked to consolidate the retired securities to get only the active once. This is available as option as well.
![RetiredSecurities1](https://user-images.githubusercontent.com/29358155/107861763-2ad16a00-6e48-11eb-900d-25e18be8387b.JPG)
![RetiredSecurities](https://user-images.githubusercontent.com/29358155/107861764-2b6a0080-6e48-11eb-9ea1-d574582abc43.JPG)


Skalierung der Grafik:
https://forum.portfolio-performance.info/t/skalierung-der-y-achse-im-diagramm-vermoegensaufstellung/1892
https://forum.portfolio-performance.info/t/skala-bei-ertraege-akkumuliert-veraendern/8382

Trades unter "Einnahmen & Ausgaben" aka "Erträge & Ausgaben"
https://forum.portfolio-performance.info/t/gewinne-verluste-aus-trades-unter-ertraege-und-ausgaben/6922
https://forum.portfolio-performance.info/t/anzeige-von-veraeusserungsgewinnen/86

Warm regards
Marco

#2063