### PR TITLE
Modify FlatEx PDF-Importer to support tax and tax refund by sell (#2096 + #2098)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1209,7 +1209,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(16508.16)));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-22T00:00")));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-22T16:14")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(5.90))));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(250)));
@@ -1238,7 +1238,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(10.12)));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-22T00:00")));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-22T19:51")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(5.90))));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
@@ -1267,7 +1267,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(4840.15)));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-07-04T00:00")));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-07-04T14:23")));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(5.90))));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(121)));
@@ -1295,7 +1295,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(tx.size(), is(1));
 
         assertThat(tx, hasItem(allOf( //
-                        hasProperty("dateTime", is(LocalDateTime.parse("2018-01-09T00:00"))), //
+                        hasProperty("dateTime", is(LocalDateTime.parse("2018-01-09T15:00"))), //
                         hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
                         hasProperty("monetaryAmount", is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95)))))));
 
@@ -1381,7 +1381,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(tx.size(), is(1));
 
         assertThat(tx, hasItem(allOf( //
-                        hasProperty("dateTime", is(LocalDateTime.parse("2019-06-20T00:00"))), //
+                        hasProperty("dateTime", is(LocalDateTime.parse("2019-06-20T09:08"))), //
                         hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
                         hasProperty("monetaryAmount",
                                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9529.81)))))));
@@ -1457,7 +1457,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(5681.04)));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-19T00:00")));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-19T09:22")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(425)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
                         is(Money.of("EUR", Values.Amount.factorize(9.90 + 2.51))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1499,8 +1499,6 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(9.90))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX), 
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX), 
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check tax-refund transaction
         item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexVerkauf10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexVerkauf10.txt
@@ -1,0 +1,65 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+flatex Bank AG
+Kundenservice
+Opernring 1 / Top 736
+1010 Wien
+Tel.: +43 - (0)720 518 777
+Mail: info@flatex.at
+flatex Bank AG -  Opernring 1 / Top 736 -  A-1010 Wien
+             Wien, 10.11.2020
+0202282000001712291630
+Herr Auftragsdatum      23.10.2020n
+XXXXXXX XXXXXXX Handelstag         10.11.2020am
+XXXXXXX XXXXXX XXXXXXXXXXX Ausführungszeit    17:55 Uhr
+XXXX XXXXXXXXX Valuta             12.11.2020
+XXXXXXXXXX Auftragsnummer     XXXXXXXXX/1
+Ausf.platz/-art    Tradegate Fonds
+Wertpapierabrechnung Verkauf Fonds/Zertifikate
+Ihre Depotnummer: XXXXXXXXXXX
+Depotinhaber:     XXXXXXXXXXXXXXXXX
+Nr.170997333/1     Verkauf          DWS TOP DIVIDENDE LD (DE0009848119/984811)
+Ausgeführt    :              91 St.     Kurswert      :          10.756,20 EUR
+Kurs          :      118,200000 EUR     Provision     :               9,90 EUR
+Devisenkurs   :        1,000000         Eigene Spesen :               0,00 EUR
+                                       *Fremde Spesen :               0,00 EUR
+Verwahrart    : GS-Verwahrung
+Lagerstelle   : Clearstream Nat.
+Lagerland     : Deutschland             Bemessungs-
+                                        grundlage     :               0,00 EUR
+Gewinn/Verlust:          -68,61 EUR   **Einbeh. KESt  :             -18,87 EUR
+                                        Endbetrag     :          10.765,17 EUR
+*   Enthalten sind folgende Gebühren Courtage         :               0,00 EUR
+                             Tradinggebühr            :               0,00 EUR
+                             Regulierung              :               0,00 EUR
+                             Schlussnoten             :               0,00 EUR
+                             LS-Umlegung              :               0,00 EUR
+                             Finanztransaktionssteuer :               0,00 EUR
+                             Sonstige                 :               0,00 EUR
+**  Einbehaltene Kapitalerstragsteuer. Details dazu finden Sie im Steuerreport
+    unter der Transaktion-Nr.: XXXXXXXXXX.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: XXXXXXXXXXX
+Die Wertpapiere sowie den Gegenwert werden wir entsprechend der Abrechnung mit
+dem  angegebenen  Valutatag  buchen.  Bitte prüfen Sie  diese  Abrechnung  auf
+Richtigkeit und Vollständigkeit.  Etwaige Einwendungen gegen diese  Abrechnung
+müssen unverzüglich  nach Zugang bei der Bank  erhoben werden. Die
+______________________________________________________________________________
+                                                                     Seite 1/2
+flatex Bank AG Niederlassung Österreich | Aktiengesellschaft | Opernring 1 / Top 736 | 1010 Wien | Handelsgericht Wien | FN 334642 x | DVR 4000544 | UID ATU 65140956
+Hauptniederlassung: flatex Bank AG | Rotfeder-Ring 7 | 60327 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 105687
+- Vorsitzender des Aufsichtsrats: Martin Korbmacher | Vorstand: Frank Niehage (Vors.), Jörn Engelmann, Steffen Jentsch -
+2000001712291630 0351202280000102
+Unterlassung rechtzeitiger Einwendung gilt als Genehmigung. Bitte beachten
+Sie mögliche Hinweise des Emittenten  hinsichtlich vorzeitiger Fälligstellung,
+beispielsweise wegen Knock-Out, in den jeweiligen Optionsscheinbedingungen und
+informieren Sie sich rechtzeitig, welche spezielle Fälligkeitsregelung auf die
+von Ihnen gehaltenen Wertpapiere zutreffen. Kapitalerträge sind ESt-pflichtig.
+Diese  Mitteilung  ist  maschinell  erstellt  und  wird  nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+flatex Bank AG Niederlassung Österreich | Aktiengesellschaft | Opernring 1 / Top 736 | 1010 Wien | Handelsgericht Wien | FN 334642 x | DVR 4000544 | UID ATU 65140956
+Hauptniederlassung: flatex Bank AG | Rotfeder-Ring 7 | 60327 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 105687
+- Vorsitzender des Aufsichtsrats: Martin Korbmacher | Vorstand: Frank Niehage (Vors.), Jörn Engelmann, Steffen Jentsch -
+2000001712291630 0351202280000202

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexVerkauf9.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatexVerkauf9.txt
@@ -1,0 +1,65 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+flatex Bank AG
+Kundenservice
+Opernring 1 / Top 736
+1010 Wien
+Tel.: +43 - (0)720 518 777
+Mail: info@flatex.at
+flatex Bank AG -  Opernring 1 / Top 736 -  A-1010 Wien
+             Wien, 19.02.2021
+0202282000001871974800
+Herr Auftragsdatum      19.02.2021n
+XXXXXXXXXXXX Handelstag         19.02.2021am
+XXXXXXXXXXXX Ausführungszeit    09:22 Uhr
+XXXXXXXXXXXX Valuta             23.02.2021
+XXXXXXXXXXXX Auftragsnummer     170997375/1
+Ausf.platz/-art    Tradegate
+Wertpapierabrechnung Verkauf Fonds/Zertifikate
+Ihre Depotnummer: XXXXXXXXXXX
+Depotinhaber:     XXXXXXXXXXXX
+Nr.170997375/1     Verkauf     ISHSV-S+500INF.T.SECT.DLA (IE00B3WJKG14/A142N1)
+Ausgeführt    :             425 St.     Kurswert      :           5.999,30 EUR
+Kurs          :       14,116000 EUR     Provision     :               9,90 EUR
+Devisenkurs   :        1,000000         Eigene Spesen :               0,00 EUR
+                                       *Fremde Spesen :               2,51 EUR
+Verwahrart    : Wertpapierrechnung
+Lagerstelle   : Clearstream Lux.
+Lagerland     : Irland                  Bemessungs-
+                                        grundlage     :               0,00 EUR
+Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :             305,85 EUR
+                                        Endbetrag     :           5.681,04 EUR
+*   Enthalten sind folgende Gebühren Courtage         :               0,00 EUR
+                             Tradinggebühr            :               0,00 EUR
+                             Regulierung              :               2,44 EUR
+                             Schlussnoten             :               0,07 EUR
+                             LS-Umlegung              :               0,00 EUR
+                             Finanztransaktionssteuer :               0,00 EUR
+                             Sonstige                 :               0,00 EUR
+**  Einbehaltene Kapitalerstragsteuer. Details dazu finden Sie im Steuerreport
+    unter der Transaktion-Nr.: XXXXXXXXXXXX.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: XXXXXXXXXXXXX
+Die Wertpapiere sowie den Gegenwert werden wir entsprechend der Abrechnung mit
+dem  angegebenen  Valutatag  buchen.  Bitte prüfen Sie  diese  Abrechnung  auf
+Richtigkeit und Vollständigkeit.  Etwaige Einwendungen gegen diese  Abrechnung
+müssen unverzüglich  nach Zugang bei der Bank  erhoben werden. Die
+______________________________________________________________________________
+                                                                     Seite 1/2
+flatex Bank AG Niederlassung Österreich | Aktiengesellschaft | Opernring 1 / Top 736 | 1010 Wien | Handelsgericht Wien | FN 334642 x | DVR 4000544 | UID ATU 65140956
+Hauptniederlassung: flatex Bank AG | Rotfeder-Ring 7 | 60327 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 105687
+- Vorsitzender des Aufsichtsrats: Martin Korbmacher | Vorstand: Frank Niehage (Vors.), Jörn Engelmann, Steffen Jentsch -
+2000001871974800 0351202280000102
+Unterlassung rechtzeitiger Einwendung gilt als Genehmigung. Bitte beachten
+Sie mögliche Hinweise des Emittenten  hinsichtlich vorzeitiger Fälligstellung,
+beispielsweise wegen Knock-Out, in den jeweiligen Optionsscheinbedingungen und
+informieren Sie sich rechtzeitig, welche spezielle Fälligkeitsregelung auf die
+von Ihnen gehaltenen Wertpapiere zutreffen. Kapitalerträge sind ESt-pflichtig.
+Diese  Mitteilung  ist  maschinell  erstellt  und  wird  nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+flatex Bank AG Niederlassung Österreich | Aktiengesellschaft | Opernring 1 / Top 736 | 1010 Wien | Handelsgericht Wien | FN 334642 x | DVR 4000544 | UID ATU 65140956
+Hauptniederlassung: flatex Bank AG | Rotfeder-Ring 7 | 60327 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 105687
+- Vorsitzender des Aufsichtsrats: Martin Korbmacher | Vorstand: Frank Niehage (Vors.), Jörn Engelmann, Steffen Jentsch -
+2000001871974800 0351202280000202

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -823,7 +823,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                                         asAmount(v.get("fee"))))))
 
                         .section("tax", "currency").optional() //
-                        .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<tax>[\\d.-]+,\\d+) *(?<currency>\\w{3}+)")
+                        .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<tax>[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
                         .assign((t, v) -> t.getPortfolioTransaction()
                                         .addUnit(new Unit(Unit.Type.TAX,
                                                         Money.of(asCurrencyCode(v.get("currency")),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -737,13 +737,15 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date").optional() //
-                        .match(".*Schlusstag *(?<date>\\d+.\\d+.\\d{4}).*") //
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
-
-                        .section("date").optional() //
-                        .match(".*Handelstag *(?<date>\\d+.\\d+.\\d{4}).*") //
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+                        .section("date", "time")
+                        .match(".*(Schlusstag|Handelstag) *(?<date>\\d+.\\d+.\\d{4}).*") //
+                        .match(".*Ausführungszeit *(?<time>\\d+:\\d+).*") //
+                        .assign((t, v) -> {
+                            if (v.get("time") != null)
+                                t.setDate(asDate(v.get("date"), v.get("time")));
+                            else
+                                t.setDate(asDate(v.get("date")));
+                        })
 
                         .section("wkn", "isin", "name")
                         .match("Nr.(\\d*)/(\\d*) *Verkauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -822,14 +823,26 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                         Money.of(asCurrencyCode(v.get("currency")),
                                                                         asAmount(v.get("fee"))))))
 
-                        .section("tax", "currency").optional() //
+                        // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :             305,85 EUR
+                        .section("tax", "currency").optional()
                         .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<tax>[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.TAX,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("tax"))))))
+                        .assign((t, v) -> {
+                            t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.TAX, 
+                                            Money.of(asCurrencyCode(v.get("currency")),
+                                                            asAmount(v.get("tax"))))); 
+                        })
+
+                        // Tax Refund (negative amount)
+                        // Gewinn/Verlust:          -68,61 EUR   **Einbeh. KESt  :             -18,87 EUR
+                        .section("taxRefund", "currency").optional()
+                        .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<taxRefund>-[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
+                        .assign((t, v) -> {
+                            t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund")));
+                         })
 
                         .wrap(BuySellEntryItem::new));
+        
+        addTaxRefundForSell(type);
     }
 
     // example is from 2016-12-01
@@ -1342,6 +1355,52 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 return new TransactionItem(t);
                             return null;
                         }));
+    }
+
+    @SuppressWarnings("nls")
+    private void addTaxRefundForSell(DocumentType type)
+    {
+        Block block = new Block(".*(Handelstag) *(?<date>\\d+.\\d+.\\d{4}).*");
+        type.addBlock(block);
+        block.set(new Transaction<AccountTransaction>()
+
+            .subject(() -> {
+                AccountTransaction entry = new AccountTransaction();
+                entry.setType(AccountTransaction.Type.TAX_REFUND);
+                return entry;
+            })
+
+            // Nr.170997333/1     Verkauf          DWS TOP DIVIDENDE LD (DE0009848119/984811)
+            .section("wkn", "isin", "name")
+            .match("Nr.(\\d*)/(\\d*) *Verkauf *(?<name>.*) *\\((?<isin>[^/]*)/(?<wkn>[^)]*)\\)")
+            .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+            // XXXXXXX XXXXXXX Handelstag         10.11.2020am
+            // XXXXXXX XXXXXX XXXXXXXXXXX Ausführungszeit    17:55 Uhr
+            .section("date", "time")
+            .match(".*(Schlusstag|Handelstag) *(?<date>\\d+.\\d+.\\d{4}).*")
+            .match(".*Ausführungszeit *(?<time>\\d+:\\d+).*")
+            .assign((t, v) -> {
+                if (v.get("time") != null)
+                    t.setDateTime(asDate(v.get("date"), v.get("time")));
+                else
+                    t.setDateTime(asDate(v.get("date")));
+            })
+
+            // Tax Refund (negative amount)
+            // Gewinn/Verlust:          -68,61 EUR   **Einbeh. KESt  :             -18,87 EUR
+            .section("taxRefund", "currency").optional()
+            .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<taxRefund>-[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
+            .assign((t, v) -> {
+                t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                t.setAmount(asAmount(v.get("taxRefund")));
+            })
+            
+            .wrap(t -> {
+                if (t.getCurrencyCode() != null && t.getAmount() != 0)
+                    return new TransactionItem(t);
+                return null;
+            }));
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -820,6 +820,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                         Money.of(asCurrencyCode(v.get("currency")),
                                                                         asAmount(v.get("fee"))))))
 
+                        .section("tax", "currency").optional() //
+                        .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<tax>[\\d.-]+,\\d+) *(?<currency>\\w{3}+)")
+                        .assign((t, v) -> t.getPortfolioTransaction()
+                                        .addUnit(new Unit(Unit.Type.TAX,
+                                                        Money.of(asCurrencyCode(v.get("currency")),
+                                                                        asAmount(v.get("tax"))))))
+
                         .wrap(BuySellEntryItem::new));
     }
 


### PR DESCRIPTION
Fixed issue #2096

Edit:
- Im RE-PR wurde noch die Zeit für das Datum hinzugefügt, wie vom Autor gewünscht. #2096 
- Einige TestCases wurden dadurch korrigiert.
- Tax und Tax Refund wurden im PDF-Importer integriert. #2098

**Bitte noch das Issue #2098 lesen.**
- Es ist nicht möglich einen "_manuellen Verkauf_" mit einer negativen Steuer (Steuererstattung) einzutragen.

![grafik](https://user-images.githubusercontent.com/45203494/108607702-2fef6580-73c2-11eb-9f4d-25684507f618.png)


