### PR TITLE
Modify HTMLTableQuoteFeed to read VolumeColumn in HistoryData

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -170,7 +170,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
             DecimalFormat format = null;
             int potency = 0;
 
-            Pattern patternSingleValue = Pattern.compile("[\\d,.]+(k|m)$"); //$NON-NLS-1$
+            Pattern patternSingleValue = Pattern.compile("[\\d,.]+(k|m|t)$"); //$NON-NLS-1$
             Pattern patternThreeValue = Pattern.compile("[\\d,.]+(mio|mrd|md.)$"); //$NON-NLS-1$
 
             Matcher m = patternSingleValue.matcher(text);
@@ -182,8 +182,13 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                 {
                     case 'k':
                         potency = 3;
+                        break;
+                    case 't':
+                        potency = 3;
+                        break;
                     case 'm':
                         potency = 6;
+                        break;
                     default: 
                         // do nothing
                 }
@@ -210,10 +215,13 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                 {
                     case "mio": //$NON-NLS-1$
                         potency = 6;
+                        break;
                     case "mrd": //$NON-NLS-1$
                         potency = 9;
+                        break;
                     case "md.": //$NON-NLS-1$
                         potency = 9;
+                        break;
                     default: 
                         // do nothing
                 }


### PR DESCRIPTION
Hallo @buchen
ich habe mich mal heran getraut die VolumeColumn bei den "Historischen Kursen" zu erstellen.
Es werden derzeit die Zahlenabkürzungen 
- "k", "t" = tausend
- "m", "mio" = million
- "mrd", "md." = millarden

unterstützt, können jedoch beliebig erweitert werden.
Wie diese Daten dann gespeichert werden, habe ich noch nicht herausgefunden, würde mich aber freuen, wenn du das noch komplettieren könntest. Der Knaller wäre naturlich noch, wenn man das Handelsvolumen grafisch darstellen könnte.

Ergebnis Avira:
[Alibaba History Quotes als Beispiel](https://www.ariva.de/alibaba_group_holding-aktie/historische_kurse)
![avira](https://user-images.githubusercontent.com/45203494/109312553-78d26e80-7847-11eb-981e-364904de30e3.JPG)
![grafik](https://user-images.githubusercontent.com/45203494/109313330-5f7df200-7848-11eb-83f6-387af92a01f8.png)


Ergebnis OnVista:
[History Quotes Xetra Gold als Beispiel](https://www.onvista.de/onvista/times+sales/popup/historische-kurse/?notationId=22703847&dateStart=01.01.2014&interval=Y5&assetName=XETRA-GOLD&exchange=Emittentenkurs)
![onvista](https://user-images.githubusercontent.com/45203494/109312575-7ec84f80-7847-11eb-9dbe-210a28f281db.JPG)
![grafik](https://user-images.githubusercontent.com/45203494/109313401-76bcdf80-7848-11eb-8056-bd01bad094a7.png)
