### PR TITLE
Modify JSONPDFExtractor to support nameContinued

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicAusschuettung01.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicAusschuettung01.json
@@ -8,7 +8,7 @@
 			"amount": 4.18,
 			"shares": 10.0,
 			"security": {
-				"name": "iShsV-EM Dividend UCITS ETF",
+				"name": "iShsV-EM Dividend UCITS ETF Registered Shares USD o.N.",
 				"isin": "IE00B652H904",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende01.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende01.json
@@ -8,7 +8,7 @@
 			"amount": 3.1,
 			"shares": 10.0,
 			"security": {
-				"name": "Microsoft Corp.",
+				"name": "Microsoft Corp. Registered Shares DL-,00000625",
 				"isin": "US5949181045",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende02.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende02.json
@@ -8,7 +8,7 @@
 			"amount": 2.2,
 			"shares": 1.0,
 			"security": {
-				"name": "Blackrock Inc.",
+				"name": "Blackrock Inc. Reg. Shares Class A DL -,01",
 				"isin": "US09247X1019",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende03.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende03.json
@@ -8,7 +8,7 @@
 			"amount": 1.63,
 			"shares": 8.0,
 			"security": {
-				"name": "iSh.ST.Gl.Sel.Div.100 U.ETF DE",
+				"name": "iSh.ST.Gl.Sel.Div.100 U.ETF DE Inhaber-Anteile",
 				"isin": "DE000A0F5UH1",
 				"currency": "EUR"
 			}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende04.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende04.json
@@ -8,7 +8,7 @@
 			"amount": 39.21,
 			"shares": 142.0,
 			"security": {
-				"name": "Tanger Fact.Outlet Centrs Inc.",
+				"name": "Tanger Fact.Outlet Centrs Inc. Registered Shares DL -,01",
 				"isin": "US8754651060",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende05.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende05.json
@@ -8,7 +8,7 @@
 			"amount": 50.30,
 			"shares": 500.0,
 			"security": {
-				"name": "Royal Dutch Shell",
+				"name": "Royal Dutch Shell Reg. Shares Class A EO -,07",
 				"isin": "GB00B03MLX29",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende06.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicDividende06.json
@@ -8,7 +8,7 @@
 			"amount": 1.09,
 			"shares": 3.3272,
 			"security": {
-				"name": "Walgreens Boots Alliance Inc.",
+				"name": "Walgreens Boots Alliance Inc. Reg. Shares DL -,01",
 				"isin": "US9314271084",
 				"currency": "USD"
 			},

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan01.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan01.json
@@ -8,7 +8,7 @@
 			"amount": 25.0,
 			"shares": 0.4534,
 			"security": {
-				"name": "iShsIII-Core MSCI World U.ETF",
+				"name": "iShsIII-Core MSCI World U.ETF Registered Shs USD (Acc) o.N.",
 				"isin": "IE00B4L5Y983",
 				"currency": "EUR"
 			}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan02.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan02.json
@@ -8,7 +8,7 @@
 			"amount": 100.0,
 			"shares": 4.9261,
 			"security": {
-				"name": "iSh.DJ Asia Pa.S.D.30 U.ETF DE",
+				"name": "iSh.DJ Asia Pa.S.D.30 U.ETF DE Inhaber-Anteile",
 				"isin": "DE000A0H0744",
 				"currency": "EUR"
 			}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan03.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan03.json
@@ -8,7 +8,7 @@
 			"amount": 150.0,
 			"shares": 5.5520,
 			"security": {
-				"name": "iShs Core S&P 500 UC.ETF USDD",
+				"name": "iShs Core S&P 500 UC.ETF USDD Registered Shares USD (Dist)oN",
 				"isin": "IE0031442068",
 				"currency": "EUR"
 			}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan04.json
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicSparplan04.json
@@ -8,7 +8,7 @@
 			"amount": 1003.0,
 			"shares": 2.0028,
 			"security": {
-				"name": "LVMH Moët Henn. L. Vuitton SE",
+				"name": "LVMH Moët Henn. L. Vuitton SE Actions Port. (C.R.) EO 0,3",
 				"isin": "FR0000121014",
 				"currency": "EUR"
 			},

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JSONPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JSONPDFExtractor.java
@@ -167,7 +167,12 @@ public class JSONPDFExtractor extends AbstractPDFExtractor
     private void setValuesToSecurity(JTransaction t, Map<String, String> v)
     {
         JSecurity security = new JSecurity();
-        security.setName(TextUtil.strip(v.get("name"))); //$NON-NLS-1$
+        
+        if (TextUtil.strip(v.get("nameContinued")) != null) //$NON-NLS-1$
+            security.setName(TextUtil.strip(v.get("name") + " " + TextUtil.strip(v.get("nameContinued")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        else
+            security.setName(TextUtil.strip(v.get("name"))); //$NON-NLS-1$
+
         security.setIsin(v.get("isin")); //$NON-NLS-1$
         security.setTicker(v.get("ticker")); //$NON-NLS-1$
         security.setWkn(v.get("wkn")); //$NON-NLS-1$
@@ -299,7 +304,12 @@ public class JSONPDFExtractor extends AbstractPDFExtractor
     private Security convertToSecurity(JTransaction t)
     {
         Map<String, String> values = new HashMap<>();
-        values.put("name", t.getSecurity().getName()); //$NON-NLS-1$
+        
+        if (values.get("nameContinued") != null) //$NON-NLS-1$
+            values.put("name", t.getSecurity().getName() + " " + values.get("nameContinued")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        else
+            values.put("name", t.getSecurity().getName()); //$NON-NLS-1$
+        
         values.put("isin", t.getSecurity().getIsin()); //$NON-NLS-1$
         values.put("tickerSymbol", t.getSecurity().getTicker()); //$NON-NLS-1$
         values.put("wkn", t.getSecurity().getWkn()); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/trade-republic-dividends.json
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/trade-republic-dividends.json
@@ -15,7 +15,7 @@
 					"pattern": [
 						"POSITION ANZAHL ERTRÄGNIS BETRAG",
 						"(?<name>.*) ([\\d+,.]*) Stk. ([\\d+,.]*) (?<currency>\\w{3}) ([\\d+,.]*) (\\w{3})$",
-						".*",
+						"(?<nameContinued>.*)",
 						"(ISIN: )?(?<isin>.*)"
 					]
 				},

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/trade-republic-investmentplan.json
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/trade-republic-investmentplan.json
@@ -16,7 +16,7 @@
 					"pattern": [
 						"POSITION ANZAHL (KURS|DURCHSCHNITTSKURS) BETRAG",
 						"(?<name>.*) ([\\d+,.]*) Stk. ([\\d+,.]*) (?<currency>\\w{3}+) ([\\d+,.]*) (\\w{3}+)$",
-						".*",
+						"(?<nameContinued>.*)",
 						"(ISIN: )?(?<isin>.*)"
 					]
 				},


### PR DESCRIPTION
Hallo,
ich habe den JSONPDFExtractor.java angepasst, dass dieser auch "nameContinued" analog des PDFExtractors unterstützt und hoffe dass diese Änderungen so in Ordnung sind.
Als Test habe ich zum Anlass des Issue #2110 genommen und es mussten dadurch einige Trade Republic TestCases angepasst werden.

Bitte nochmal prüfen.