### PR TITLE
Modify JustTrade PDF-Importer to support dateformat

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justtrade/Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justtrade/Kauf03.txt
@@ -1,0 +1,37 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+justTRADE
+Ein Service der Sutor Bank
+JT Technologies GmbH
+Kaiserhofstraße 16
+Herr 60313 Frankfurt am Main
+Email: service@justtrade.com
+Web: www.justtrade.com
+Name des Kunden: 
+Kontonummer:
+WERTPAPIERABRECHNUNG
+Sehr geehrter,
+dieses Dokument ist eine Bestätigung der Transaktion, die wir in Ihrem Namen durchgeführt haben.
+Bei Fragen oder im Falle einer fehlerhaften Abrechnung wenden Sie sich bitte an den justTRADE -
+Kundenservice. Sie finden die Kontaktdetails im Briefkopf dieser Abrechnung.
+Der Gegenwert der Transaktion wird per Valutatag gebucht.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+Produktbezeichnung - FROSTA AG
+Wertpapierhändlername: justTRADE
+Internationale Wertpapierkennnummer (ISIN): DE0006069008
+Währung: EUR
+Handels-/Ausführungsplatz: DUSD
+Handelsreferenz: 603d2318e971a90019a6053b
+Orderausführung Datum/Zeit: 1 Mrz 2021 18:23:36
+Valutatag Datum: 3 Mrz 2021
+Transaktionsart: Kauf
+Kurs: €76,4000
+Stück/Nominale: 30,00
+Kurswert: €2.292,00
+Ausmachender Betrag: €2.292,00
+MAX HEINR. SUTOR OHG TELEFON 040-8090685-0 GESCHÄFTSLEITUNG FINANZAMT HAMBURG AMTSGERICHT HAMBURG
+HERMANNSTRASSE 46 TELEFAX 040-8090685-810 ROBERT FREITAG STNR: 2761000074 HRA 25379
+20095 HAMBURG THOMAS MEIER UST-IDNR: DE155617009
+POSTFACH 11 33 37 INFO@SUTORBANK.DE BANKLEITZAHL 202 308 00
+20433 HAMBURG WWW.SUTORBANK.DE BIC CODE: MHSBDEHBXXX

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -118,9 +118,10 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "time") // length of date is 10 or 11, example: "2 Jun 2019" or "21 Jun 2019"
                         .match("Orderausführung Datum\\/Zeit: (?<date>.{11}).*(?<time>.{8}).*").assign((t, v) -> {
-                            // if length of date is 11, we need to strip the trailing blank
+                            // TODO --> Work around DateTimeFormatter in Local.GERMAN looks like "Mär" not "Mrz" and in Local.ENGLISH like "Mar". 
+                            // if length of date is 11, we need to strip the trailing blank                
                             LocalDateTime dateTime = LocalDateTime.parse(
-                                            String.format("%s %s", stripTrailing(v.get("date")), v.get("time")), DATE_TIME_FORMAT);
+                                            String.format("%s %s", stripTrailing(v.get("date").replace("Mrz", "Mär")), v.get("time")), DATE_TIME_FORMAT);
                             t.setDate(dateTime);
                         })
                         


### PR DESCRIPTION
Issue https://forum.portfolio-performance.info/t/pdf-import-von-justtrade/10853/8
Issue #2116  can be closed

Leider ein Work around:
DateTimeFormatter -> Monatsname "Mrz" ≠ Locale.GERMANY "Mär" ≠ Locale.ENGLISH "Mar"
https://bugs.openjdk.java.net/browse/JDK-8075173
http://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/a379fd7e28b9
