### PR TITLE
Fix HTMLTableQuoteFeed with wrong datetime format

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -181,11 +181,13 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                             new DateTimeFormatterBuilder().appendPattern("d.M.")
                                             .appendValueReduced(ChronoField.YEAR, 2, 2, Year.now().getValue() - 80)
                                             .toFormatter(),
+                            new DateTimeFormatterBuilder().appendPattern("M/d/")
+                                            .appendValueReduced(ChronoField.YEAR, 2, 2, Year.now().getValue() - 80)
+                                            .toFormatter(),
                             DateTimeFormatter.ofPattern("d.M.y"), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("d. MMM y"), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("d. MMMM y"), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("d. MMM. y"), //$NON-NLS-1$
-                            DateTimeFormatter.ofPattern("M/d/y", Locale.ENGLISH), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("MMM d, y", Locale.ENGLISH), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("MMM dd, y", Locale.ENGLISH), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("MMM dd y", Locale.ENGLISH), //$NON-NLS-1$


### PR DESCRIPTION
Issue https://forum.portfolio-performance.info/t/quelle-tabelle-auf-einer-webseite/7967/9

Change the format from date 03/01/21 to 2021-03-01.
Das ist ja echt blöd gelaufen… und mir nicht aufgefallen, dass die Jahreszahl von zweistellig auf vierstellig nicht automatisch umformatiert werden. Das könnte auch mit anderen von Webseiten gezogen Daten passieren, was zur Folge hätte, das PP 2000 Jahre bei diversen Berechnungen fehlt.

![grafik](https://user-images.githubusercontent.com/45203494/109816613-3aff8c80-7c31-11eb-8989-249a09048c15.png)
