### PR TITLE
Fix date off-by-one in performance heatmap widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -93,7 +93,7 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
                  month.getYear() == year.getValue();
                  month = month.plusMonths(1))
             {
-                if (actualInterval.intersects(Interval.of(month.atDay(1), month.atEndOfMonth())))
+                if (actualInterval.intersects(Interval.of(month.atDay(1).minusDays(1), month.atEndOfMonth())))
                     row.addData(calculatePerformance.applyAsDouble(month));
                 else
                     row.addData(null);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.ui.views.dashboard.heatmap;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.YearMonth;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.ToDoubleFunction;
@@ -41,15 +43,15 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
         Interval calcInterval = Interval.of(
                         interval.getStart().getDayOfMonth() == interval.getStart().lengthOfMonth() ? interval.getStart()
                                         : interval.getStart().withDayOfMonth(1).minusDays(1),
-                        interval.getEnd().withDayOfMonth(interval.getEnd().lengthOfMonth()));
+                        interval.getEnd().with(TemporalAdjusters.lastDayOfMonth()));
 
         DataSeries dataSeries = get(DataSeriesConfig.class).getDataSeries();
         PerformanceIndex performanceIndex = getDashboardData().calculate(dataSeries, calcInterval);
 
         // build functions to calculate performance and sum values
 
-        ToDoubleFunction<LocalDate> calculatePerformance = month -> getPerformanceFor(performanceIndex, month);
-        ToDoubleFunction<LocalDate> calculateSum = year -> getSumPerformance(performanceIndex, year);
+        ToDoubleFunction<YearMonth> calculatePerformance = month -> getPerformanceFor(performanceIndex, month);
+        ToDoubleFunction<Year> calculateSum = year -> getSumPerformance(performanceIndex, year);
 
         DataSeries benchmark = get(ExcessReturnDataSeriesConfig.class).getDataSeries();
         if (benchmark != null)
@@ -87,10 +89,11 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
             HeatmapModel.Row<Double> row = new HeatmapModel.Row<>(label);
 
             // monthly data
-            for (LocalDate month = LocalDate.of(year.getValue(), 1, 1); month.getYear() == year
-                            .getValue(); month = month.plusMonths(1))
+            for (YearMonth month = YearMonth.of(year.getValue(), 1);
+                 month.getYear() == year.getValue();
+                 month = month.plusMonths(1))
             {
-                if (actualInterval.intersects(Interval.of(month, month.plusMonths(1).minusDays(1))))
+                if (actualInterval.intersects(Interval.of(month.atDay(1), month.atEndOfMonth())))
                     row.addData(calculatePerformance.applyAsDouble(month));
                 else
                     row.addData(null);
@@ -98,7 +101,7 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
 
             // sum
             if (showSum)
-                row.addData(calculateSum.applyAsDouble(LocalDate.of(year.getValue(), 1, 1)));
+                row.addData(calculateSum.applyAsDouble(year));
 
             if (showStandardDeviation)
                 row.addData(standardDeviation(row.getDataSubList(0, 12)));
@@ -119,14 +122,14 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
         return model;
     }
 
-    private double getPerformanceFor(PerformanceIndex index, LocalDate month)
+    private double getPerformanceFor(PerformanceIndex index, YearMonth month)
     {
-        int start = Arrays.binarySearch(index.getDates(), month.minusDays(1));
+        int start = Arrays.binarySearch(index.getDates(), month.atDay(1).minusDays(1));
         // should not happen, but let's be defensive this time
         if (start < 0)
             start = 0;
 
-        int end = Arrays.binarySearch(index.getDates(), month.withDayOfMonth(month.lengthOfMonth()));
+        int end = Arrays.binarySearch(index.getDates(), month.atEndOfMonth());
         // make sure there is an end index if the binary search returns a
         // negative value (i.e. if the current month is not finished)
         if (end < 0)
@@ -138,13 +141,13 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
         return ((index.getAccumulatedPercentage()[end] + 1) / (index.getAccumulatedPercentage()[start] + 1)) - 1;
     }
 
-    private double getSumPerformance(PerformanceIndex index, LocalDate year)
+    private double getSumPerformance(PerformanceIndex index, Year year)
     {
-        int start = Arrays.binarySearch(index.getDates(), year.minusDays(1));
+        int start = Arrays.binarySearch(index.getDates(), year.atDay(1).minusDays(1));
         if (start < 0)
             start = 0;
 
-        int end = Arrays.binarySearch(index.getDates(), year.withDayOfYear(year.lengthOfYear()));
+        int end = Arrays.binarySearch(index.getDates(), year.atDay(1).with(TemporalAdjusters.lastDayOfYear()));
         if (end < 0)
             end = index.getDates().length - 1;
 


### PR DESCRIPTION
As I had [mentioned on the forums](https://forum.portfolio-performance.info/t/januar-fehlt-in-monatlichen-heatmaps/14219/12), March was missing from the performance heatmap on March 1st (but reappered the next day). This was due to an off-by-one bug, where the data interval was compared to monthly intervals of the form (2021-03-01, 2021-03-31) which did not actually include March 1st, because of the half-open nature of `Interval`s.

In addition to the (trivial) fix, I refactored the representation of months and years in the heatmap widget to use `YearMonth`s and `Year`s, instead of abusing `LocalDate`s such as 2021-01-01 to stand for the year 2021 or the month 2021-01, depending on context.