### PR TITLE
Modify context menu to allow setting multiple securities inactive

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1069,6 +1069,9 @@ public class Messages extends NLS
     public static String HoldingsWarningAssetsWithNegativeValuation;
     public static String HoldingsWarningAssetsWithNegativeValuationDetails;
     public static String YearlyPerformanceHeatmapToolTip;
+    public static String SecurityMenuSetSecurityInactive;
+    public static String SecurityMenuSetMultipleSecurityInactiveConfirm;
+    public static String SecurityMenuSetSingleSecurityInactiveConfirm;
     static
     {
         // initialize resource bundle

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2129,3 +2129,9 @@ WatchlistNewLabel = New Watchlist
 WatchlistRename = Rename Watchlist
 
 YearlyPerformanceHeatmapToolTip = Yearly rate of return displayed as heatmap\n\nTo calculate the yearly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full year - even if the reporting interval ends or starts in the middle of a year.
+
+SecurityMenuSetMultipleSecurityInactiveConfirm = Do you really want to set {0} securities inactive?
+
+SecurityMenuSetSecurityInactive = Set Security inactive
+
+SecurityMenuSetSingleSecurityInactiveConfirm = Do you really want to set the security ''{0}'' inactive?

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2116,3 +2116,9 @@ WatchlistNewLabel = Neue Watchliste
 WatchlistRename = Watchliste umbenennen
 
 YearlyPerformanceHeatmapToolTip = Jahresrenditen in einer Heatmap\n\nZur Berechnung der Jahresrendite wird der True-Time Weighted Rate of Return (TTWROR) herangezogen.\n\nDie Rendite bezieht sich immer auf das gesamte Jahr - selbst wenn der Berichtszeitraum in der Mitte des Jahres beginnt bzw. endet.
+
+SecurityMenuSetMultipleSecurityInactiveConfirm = M\u00F6chten Sie diese {0} Wertpapiere wirklich inaktiv setzen?
+
+SecurityMenuSetSecurityInactive = Wertpapier inaktiv setzen
+
+SecurityMenuSetSingleSecurityInactiveConfirm = M\u00F6chten Sie das Wertpapier ''{0}'' wirklich inaktiv setzen?

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -927,6 +927,13 @@ public final class SecuritiesTable implements ModificationListener
         }
 
         manager.add(new Separator());
+        
+        manager.add(new ConfirmActionWithSelection(Messages.SecurityMenuSetSecurityInactive,
+                            MessageFormat.format(Messages.SecurityMenuSetSingleSecurityInactiveConfirm,
+                                            selection.getFirstElement()),
+                            Messages.SecurityMenuSetMultipleSecurityInactiveConfirm, selection,
+                            (s, a) -> retireSecurity(selection)));
+        
         if (watchlist == null)
         {
             manager.add(new ConfirmActionWithSelection(Messages.SecurityMenuDeleteSecurity,
@@ -1029,7 +1036,17 @@ public final class SecuritiesTable implements ModificationListener
 
         manager.add(new Separator());
     }
-
+    
+    private void retireSecurity(IStructuredSelection selection)
+    {
+        for (Object obj : selection.toArray())
+        {
+            Security security = (Security) obj;
+            security.setRetired(true);
+            securities.refresh();
+        }
+    }
+    
     private void deleteSecurity(IStructuredSelection selection)
     {
         boolean isDirty = false;
@@ -1113,7 +1130,8 @@ public final class SecuritiesTable implements ModificationListener
 
         abstract Dialog createDialog(Security security);
     }
-
+    
+    
     private final class EditSecurityAction extends AbstractDialogAction
     {
         private EditSecurityAction()


### PR DESCRIPTION
allows to set multiple securities inactive through context menu:

![image](https://user-images.githubusercontent.com/34549632/109874710-c13ac380-7c6f-11eb-8260-e81f7926db0d.png)
