### PR TITLE
Modify 1822Direct PDF-Importer to support new BuySellSavePlan+BuySell

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Sparplan02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Sparplan02.txt
@@ -1,0 +1,35 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postfach · 60255 Frankfurt am Main
+Depotnummer XXXXXXX
+Kundennummer XXXX
+Niklas Mustermann
+Auftragsnummer XXXX/XXX
+Herrn Datum 02.03.2021
+Niklas Mustermann Ihr Berater 1822direkt
+XXXXX Weg 4 Telefon 069 94170-0
+XXXXXXXXnghausen Rechnungsnummer W02158-0000XXXXXX
+Umsatzsteuer-ID DE114104095
+Wertpapier Abrechnung Ausgabe Investmentfonds
+Auftrag vom 27.02.2021 01:22:40 Uhr
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 0,6646 THREADNEEDLE L-GLOBAL TECHNOL. LU0444971666 (A1CU1W)
+NAMENS-ANTEILE AU USD O.N.
+Handels-/Ausführungsplatz Außerbörslich (gemäß Weisung)
+Schlusstag 01.03.2021 Auftraggeber XXXX, Niklas
+Ausführungskurs 94,6879 USD Auftragserteilung/ -ort sonstige
+Wertpapierrechnung Lagerland Luxemburg
+Devisenkurs (EUR/USD) 1,1987 vom 02.03.2021
+Kurswert 52,50- EUR
+Kundenbonifikation 100 % vom Ausgabeaufschlag 2,50 EUR
+Ausmachender Betrag 50,00- EUR
+Ausgabeaufschlag pro Anteil 5,00 %
+Den Gegenwert buchen wir mit Valuta 04.03.2021 zu Lasten des Kontos XXXXXX
+(IBANXXXXXXXX), BLZ XXXXXX (BIC XXXXX).
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+IHR FONDSSPARPLAN NR. 1
+Für das Geschäft wurde keine Anlageberatung erbracht.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+2158.03022115.0003459OR07

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Verkauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Verkauf01.txt
@@ -1,0 +1,60 @@
+PDF Autor: ''
+PDFBox Version: 1.1.11
+-----------------------------------------
+Postfach · 10111 Frankfurt am Main Seite 1 von 1
+Depotnummer 1111111111
+Kundennummer 1111
+Some Name
+Auftragsnummer 111111111/11.00
+Herrn Some Name Datum 01.01.1011
+c/o Some Name Ihr Berater 1822direkt
+Street 11111 Telefon 111 1111111-0
+1111111 City Rechnungsnummer W11111-1111111111/11
+Umsatzsteuer-ID DE11111111111111
+Wertpapier Abrechnung Verkauf
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 1 EXXON MOBIL CORP. US10111G1011 (111111)
+REGISTERED SHARES O.N.
+Handels-/Ausführungsplatz Frankfurt (gemäß Weisung)
+Börsensegment FRAB
+Limit-Order
+Limit 11,00 EUR
+Schlusstag/-Zeit 01.01.2021 11:11:11 Auftraggeber Some, Name
+Ausführungskurs 11,101 EUR Auftragserteilung/ -ort Online-Banking
+Girosammelverw. mehrere Sammelurkunden - kein Stückeausdruck -
+Kurswert 111,11 EUR
+Provision 1,10- EUR
+Eigene Spesen 1,11- EUR
+Transaktionsentgelt Börse 0,11- EUR
+Übertragungs-/Liefergebühr 0,11- EUR
+Handelsentgelt 1,00- EUR
+Ermittlung steuerrelevante Erträge
+Veräußerungsverlust 110,11- EUR
+Eingebuchte Aktienverluste 110,11 EUR
+Ausmachender Betrag 111,11 EUR
+Den Gegenwert buchen wir mit Valuta 01.01.1011 zu Gunsten des Kontos 11111111111111
+(IBAN DE11 1111 1111 1111 1111 11), BLZ 11111111 (BIC AAAAAAA1111).
+Die Wertpapiere entnehmen wir Ihrem Depotkonto.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+1111111.1111111.1111111AB11
+Seite 1 von 1
+Depotnummer 11111111111
+Kundennummer 11111111
+Auftragsnummer 111/11.11111
+Datum 01.01.1011
+Für das Geschäft wurde keine Anlageberatung erbracht.
+Initiator der Besprechung war der Kunde.
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verlustverrechnungstöpfe 1011 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 1,10 0,00 110,11 0,10 0,00
+Verkauf 110,11 0,00 0,00 0,00 0,00
+Nachher 111,11 0,00 110,11 0,10 0,00
+Berücksichtigte Anschaffungsgeschäfte (alle ermittelten Beträge in EUR)
+Geschäft Auftragsnr. Ausführ.-tag Whr./St. Nennwert/Stück AS-Kosten Erlös ant. Ergebnis
+Kauf 1111111100 11.01.1011 Stück 1,0000 101,11- 111,11 110,11- (D)
+Summe aller Erträge nach Differenzmethode und/oder Ersatzbemessungsgrundlage 110,11-
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+1111.01011111.0001111OR01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
@@ -140,4 +140,37 @@ public class direkt1822bankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-05T00:15:28")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.9619)));
     }
+
+    @Test
+    public void testWertpapierSparplan02()
+    {
+        Direkt1822BankPDFExtractor extractor = new Direkt1822BankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Sparplan02.txt"), errors);
+        
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).map(Item::getSecurity).findAny()
+                        .orElseThrow(IllegalArgumentException::new);
+
+        assertThat(security.getIsin(), is("LU0444971666"));
+        assertThat(security.getWkn(), is("A1CU1W"));
+        assertThat(security.getName(), is("THREADNEEDLE L-GLOBAL TECHNOL. NAMENS-ANTEILE AU USD O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.6646)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-27T01:22:40")));
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
@@ -172,6 +172,8 @@ public class direkt1822bankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.95))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -80,7 +80,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Auftrag vom 05.12.2017 00:15:28 Uhr
             .section("date", "time")
-            .match("^(Schlusstag/-Zeit) (?<date>\\d+.\\d+.\\d{4}+) (?<time>\\d+:\\d+:\\d+).*")
+            .match("^(Schlusstag/-Zeit) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+).*")
             .assign((t, v) -> {
                 if (v.get("time") != null)
                     t.setDate(asDate(v.get("date"), v.get("time")));
@@ -90,7 +90,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Ausmachender Betrag 50,00- EUR
             .section("currency", "amount")
-            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)[?(-|\\+)] (?<currency>\\w{3}+)")
+            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)[?(-|\\+)] (?<currency>\\w{3})")
             .assign((t, v) -> {
                 t.setAmount(asAmount(v.get("amount")));
                 t.setCurrencyCode(v.get("currency"));
@@ -106,7 +106,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
             
             // Provision 4,95- EUR
             .section("fee", "currency").optional()
-            .match("^(Provision) (?<fee>[\\d.-]+,\\d+)- (?<currency>\\w{3}+)")
+            .match("^(Provision) (?<fee>[\\d.-]+,\\d+)- (?<currency>\\w{3})")
             .assign((t, v) -> t.getPortfolioTransaction()
                             .addUnit(new Unit(Unit.Type.FEE,
                                             Money.of(asCurrencyCode(v.get("currency")),
@@ -114,7 +114,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
             
             // Eigene Spesen 1,95- EUR
             .section("fee", "currency").optional()
-            .match("^(Eigene Spesen) (?<fee>[\\d.-]+,\\d+)- (?<currency>\\w{3}+)")
+            .match("^(Eigene Spesen) (?<fee>[\\d.-]+,\\d+)- (?<currency>\\w{3})")
             .assign((t, v) -> t.getPortfolioTransaction()
                             .addUnit(new Unit(Unit.Type.FEE,
                                             Money.of(asCurrencyCode(v.get("currency")),
@@ -176,7 +176,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Auftrag vom 05.12.2017 00:15:28 Uhr
             .section("date", "time")
-            .match("^(Auftrag vom) (?<date>\\d+.\\d+.\\d{4}+) (?<time>\\d+:\\d+:\\d+) Uhr")
+            .match("^(Auftrag vom) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+) Uhr")
             .assign((t, v) -> {
                 if (v.get("time") != null)
                     t.setDate(asDate(v.get("date"), v.get("time")));
@@ -186,7 +186,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Ausmachender Betrag 50,00- EUR
             .section("currency", "amount")
-            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)- (?<currency>\\w{3}+)")
+            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)- (?<currency>\\w{3})")
             .assign((t, v) -> {
                 t.setAmount(asAmount(v.get("amount")));
                 t.setCurrencyCode(v.get("currency"));
@@ -248,7 +248,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Ausmachender Betrag 68,87+ EUR
             .section("currency", "amount")
-            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)\\+ (?<currency>\\w{3}+)")
+            .match("^(Ausmachender Betrag) (?<amount>[\\d.]+,\\d+)\\+ (?<currency>\\w{3})")
             .assign((t, v) -> {
                 t.setAmount(asAmount(v.get("amount")));
                 t.setCurrencyCode(v.get("currency"));
@@ -256,7 +256,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
             // Ex-Tag 14.12.2017 Herkunftsland Irland
             .section("date")
-            .match("^Ex-Tag (?<date>\\d+.\\d+.\\d{4}+).*")
+            .match("^Ex-Tag (?<date>\\d+.\\d+.\\d{4}).*")
             .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
             // Devisenkurs EUR / USD 1,2095


### PR DESCRIPTION
Issue https://forum.portfolio-performance.info/t/pdf-import-von-1822direkt/984/8
issue #2125 can be closed

**Hinweis/Feature:**
Im Dokument ist zu erkennen, das Wertpapiere im Wert von `52,50€` gekauft wurden, aber bezahlt wurde nur `50,00€`.
Das ist durch einen sogenannten `Kundenbonifikation 100 % vom Ausgabeaufschlag 2,50 EUR` der 1822Direkt.
Ich habe keine Weg gefunden, dass korrekt zu buchen, da diese zueinander abhängig sind.

![grafik](https://user-images.githubusercontent.com/45203494/110072595-52985b80-7d7e-11eb-8cd3-f3bad284d398.png)


