### PR TITLE
Filter trades

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -184,6 +184,7 @@ public class Messages extends NLS
     public static String ColumnFix;
     public static String ColumnForeignCurrencies;
     public static String ColumnGrossDividend;
+    public static String ColumnGrossProfitLoss;
     public static String ColumnGrossValue;
     public static String ColumnHeight;
     public static String ColumnHoldingPeriod;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -697,6 +697,8 @@ public class Messages extends NLS
     public static String LabelTrades;
     public static String LabelTradesBasicStatistics;
     public static String LabelTradesProfitLoss;
+    public static String LabelTradesWithLoss;
+    public static String LabelTradesWithProfit;
     public static String LabelTradesTurnoverRate;
     public static String LabelTradingActivityChart;
     public static String LabelTransactions;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -523,6 +523,7 @@ public class Messages extends NLS
     public static String LabelClientFilterNew;
     public static String LabelClientFilterNoCustomFilterExisting;
     public static String LabelClose;
+    public static String LabelClosedTradeSelection;
     public static String LabelColorSchema;
     public static String LabelColumns;
     public static String LabelCommon;
@@ -599,6 +600,7 @@ public class Messages extends NLS
     public static String LabelNumberDataSeries;
     public static String LabelOneOfX;
     public static String LabelOpenTrade;
+    public static String LabelOpenTradeSelection;
     public static String LabelOrderByTaxonomy;
     public static String LabelPassword;
     public static String LabelPasswordRepeat;
@@ -1058,6 +1060,7 @@ public class Messages extends NLS
     public static String WatchlistRename;
     public static String BookmarkMenu_EditBookmarks;
     public static String FilterNotRetired;
+    public static String FilterOpenClosedTrades;
     public static String FilterValuationNonZero;
     public static String ForceClearPersistedStateDialogTitle;
     public static String ForceClearPersistedStateMessage;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -764,6 +764,8 @@ ExportWizardVINISApp = VINIS-App
 
 FilterNotRetired = Only active accounts/securities
 
+FilterOpenClosedTrades = Filter for open/closed trades
+
 FilterValuationNonZero = Value not Zero
 
 ForceClearPersistedStateDialogTitle = Reset GUI
@@ -1056,6 +1058,8 @@ LabelClientFilterNoCustomFilterExisting = No existing filter.\nCreate a new filt
 
 LabelClose = Close
 
+LabelClosedTradeSelection = closed
+
 LabelColorSchema = Color scheme
 
 LabelColumns = Columns
@@ -1253,6 +1257,8 @@ LabelNumberDataSeries = {0} data series
 LabelOneOfX = (1 of {0})
 
 LabelOpenTrade = (open)
+
+LabelOpenTradeSelection = open
 
 LabelOrderByTaxonomy = Order by Classification
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1058,7 +1058,7 @@ LabelClientFilterNoCustomFilterExisting = No existing filter.\nCreate a new filt
 
 LabelClose = Close
 
-LabelClosedTradeSelection = closed
+LabelClosedTradeSelection = Closed trades
 
 LabelColorSchema = Color scheme
 
@@ -1258,7 +1258,7 @@ LabelOneOfX = (1 of {0})
 
 LabelOpenTrade = (open)
 
-LabelOpenTradeSelection = open
+LabelOpenTradeSelection = Open trades
 
 LabelOrderByTaxonomy = Order by Classification
 
@@ -1409,6 +1409,10 @@ LabelTrades = Trades
 LabelTradesBasicStatistics = Number of trades (with profit/with loss)
 
 LabelTradesProfitLoss = Trades Profit/Loss
+
+LabelTradesWithLoss = Trades with loss
+
+LabelTradesWithProfit = Trades with profit
 
 LabelTradesTurnoverRate = Portfolio Turnover Rate
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -402,6 +402,8 @@ ColumnForeignCurrencies = Forex
 
 ColumnGrossDividend = Gross dividend
 
+ColumnGrossProfitLoss = Gross Profit / Loss
+
 ColumnGrossValue = Gross Value
 
 ColumnHeight = Height

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -395,6 +395,8 @@ ColumnForeignCurrencies = Devisen
 
 ColumnGrossDividend = Bruttodividende
 
+ColumnGrossProfitLoss = Bruttoprofit / Bruttoverlust
+
 ColumnGrossValue = Bruttowert
 
 ColumnHeight = H\u00F6he

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -757,6 +757,8 @@ ExportWizardVINISApp = VINIS-App
 
 FilterNotRetired = Nur aktive Konten/Wertpapiere
 
+FilterOpenClosedTrades = Offene/geschlossene Trades anzeigen
+
 FilterValuationNonZero = Wert nicht Null
 
 ForceClearPersistedStateDialogTitle = GUI zur\u00FCcksetzen
@@ -1045,6 +1047,8 @@ LabelClientFilterNoCustomFilterExisting = Kein vorhandener Filter.\nErstellen Si
 
 LabelClose = Schlie\u00DFen
 
+LabelClosedTradeSelection = geschlossen
+
 LabelColorSchema = Farbschema
 
 LabelColumns = Spalten
@@ -1240,6 +1244,8 @@ LabelNumberDataSeries = {0} Datenreihe{0,choice,0#n|1#|1<n}
 LabelOneOfX = (1 von {0})
 
 LabelOpenTrade = (offen)
+
+LabelOpenTradeSelection = offen
 
 LabelOrderByTaxonomy = Nach Klassifizierung sortieren
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1047,7 +1047,7 @@ LabelClientFilterNoCustomFilterExisting = Kein vorhandener Filter.\nErstellen Si
 
 LabelClose = Schlie\u00DFen
 
-LabelClosedTradeSelection = geschlossen
+LabelClosedTradeSelection = Geschlossene Trades
 
 LabelColorSchema = Farbschema
 
@@ -1245,7 +1245,7 @@ LabelOneOfX = (1 von {0})
 
 LabelOpenTrade = (offen)
 
-LabelOpenTradeSelection = offen
+LabelOpenTradeSelection = Offene Trades
 
 LabelOrderByTaxonomy = Nach Klassifizierung sortieren
 
@@ -1396,6 +1396,10 @@ LabelTrades = Trades
 LabelTradesBasicStatistics = Anzahl Trades (mit Gewinn/mit Verlust)
 
 LabelTradesProfitLoss = Trades Gewinn/Verlust
+
+LabelTradesWithLoss = Trades mit Gewinn
+
+LabelTradesWithProfit = Trades with Verlust
 
 LabelTradesTurnoverRate = Portfolio Turnover Rate
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -97,13 +97,13 @@ public class TradesTableViewer
             public String getText(Object e)
             {
                 Trade t = (Trade) e;
-                return t.getEnd().isPresent() ? Values.DateTime.format(t.getEnd().get()) : Messages.LabelOpenTrade; // NOSONAR
+                return t.isClosed() ? Values.DateTime.format(t.getEnd().get()) : Messages.LabelOpenTrade; // NOSONAR
             }
 
             @Override
             public Color getBackground(Object e)
             {
-                return ((Trade) e).getEnd().isPresent() ? null : Colors.theme().warningBackground();
+                return ((Trade) e).isClosed() ? null : Colors.theme().warningBackground();
             }
         });
         column.setSorter(ColumnViewerSorter.create(e -> {
@@ -181,6 +181,12 @@ public class TradesTableViewer
         column.setLabelProvider(
                         new MoneyColorLabelProvider(element -> ((Trade) element).getProfitLoss(), view.getClient()));
         column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getProfitLoss()));
+        support.addColumn(column);
+        
+        column = new Column("gpl", Messages.ColumnGrossProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setLabelProvider(
+                        new MoneyColorLabelProvider(element -> ((Trade) element).getGrossProfitLoss(), view.getClient()));
+        column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getGrossProfitLoss()));
         support.addColumn(column);
 
         column = new Column("holdingperiod", Messages.ColumnHoldingPeriod, SWT.RIGHT, 80); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -156,7 +156,7 @@ public class TradeDetailsView extends AbstractFinanceView
     
     private void addFilterButtonHelper(IMenuManager manager) {
         
-        Action showOpenAction = new Action("Open") {
+        Action showOpenAction = new Action(Messages.LabelOpenTradeSelection) {
             @Override
             public void run()
             {
@@ -167,7 +167,7 @@ public class TradeDetailsView extends AbstractFinanceView
         showOpenAction.setChecked(showOpen);
         
         
-        Action showClosedAction = new Action("Closed") {
+        Action showClosedAction = new Action(Messages.LabelClosedTradeSelection) {
             @Override
             public void run()
             {
@@ -184,7 +184,7 @@ public class TradeDetailsView extends AbstractFinanceView
     private void addFilterButton(ToolBarManager manager)
     {
         
-        DropDown filterDropDowMenu = new DropDown("Offene/Geschlossene Trades",Images.FILTER_OFF, SWT.NONE, this::addFilterButtonHelper );
+        DropDown filterDropDowMenu = new DropDown(Messages.FilterOpenClosedTrades,Images.FILTER_OFF, SWT.NONE, this::addFilterButtonHelper );
 
         manager.add(filterDropDowMenu);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -154,37 +154,62 @@ public class TradeDetailsView extends AbstractFinanceView
     }
 
     
-    private void addFilterButtonHelper(IMenuManager manager) {
-        
-        Action showOpenAction = new Action(Messages.LabelOpenTradeSelection) {
-            @Override
-            public void run()
-            {
-                showOpen = !showOpen;
-                updateFrom(collectAllTrades());
-            }
-        };
-        showOpenAction.setChecked(showOpen);
-        
-        
-        Action showClosedAction = new Action(Messages.LabelClosedTradeSelection) {
-            @Override
-            public void run()
-            {
-                showClosed = !showClosed;
-                updateFrom(collectAllTrades());
-            }
-        };
-        showClosedAction.setChecked(showClosed);
-        
-        manager.add(showOpenAction);
-        manager.add(showClosedAction);
-    }
+
     
     private void addFilterButton(ToolBarManager manager)
     {
         
-        DropDown filterDropDowMenu = new DropDown(Messages.FilterOpenClosedTrades,Images.FILTER_OFF, SWT.NONE, this::addFilterButtonHelper );
+        DropDown filterDropDowMenu = new DropDown(Messages.FilterOpenClosedTrades,Images.FILTER_OFF, SWT.NONE);
+                        
+        filterDropDowMenu.setMenuListener(mgr -> {
+            
+            Action showOpenAction = new Action(Messages.LabelOpenTradeSelection) 
+            {
+                @Override
+                public void run()
+                {
+                    showOpen = !showOpen;
+                    updateFrom(collectAllTrades());
+                    if (!showOpen || !showClosed) 
+                    {
+                        filterDropDowMenu.setImage(Images.FILTER_ON);
+                    }
+                    else 
+                    {
+                        filterDropDowMenu.setImage(Images.FILTER_OFF);
+                    }
+
+                }
+            };
+            showOpenAction.setChecked(showOpen);
+            
+            
+            Action showClosedAction = new Action(Messages.LabelClosedTradeSelection) 
+            {
+                @Override
+                public void run()
+                {
+                    showClosed = !showClosed;
+                    updateFrom(collectAllTrades());
+                    
+                    if (!showClosed || !showClosed) 
+                    {
+                        filterDropDowMenu.setImage(Images.FILTER_ON);
+                    }
+                    else
+                    {
+                        filterDropDowMenu.setImage(Images.FILTER_OFF);
+                    }
+                }
+            };
+            showClosedAction.setChecked(showClosed);
+            
+            
+            mgr.add(showOpenAction);
+            mgr.add(showClosedAction);
+            
+            
+        });
 
         manager.add(filterDropDowMenu);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -155,6 +155,16 @@ public class TradeDetailsView extends AbstractFinanceView
 
     
 
+    private void setFilterButton(DropDown filterDropDown) {
+        if (!showOpen || !showClosed) 
+        {
+            filterDropDown.setImage(Images.FILTER_ON);
+        }
+        else 
+        {
+            filterDropDown.setImage(Images.FILTER_OFF);
+        }
+    }
     
     private void addFilterButton(ToolBarManager manager)
     {
@@ -170,14 +180,7 @@ public class TradeDetailsView extends AbstractFinanceView
                 {
                     showOpen = !showOpen;
                     updateFrom(collectAllTrades());
-                    if (!showOpen || !showClosed) 
-                    {
-                        filterDropDowMenu.setImage(Images.FILTER_ON);
-                    }
-                    else 
-                    {
-                        filterDropDowMenu.setImage(Images.FILTER_OFF);
-                    }
+                    setFilterButton(filterDropDowMenu);
 
                 }
             };
@@ -191,15 +194,7 @@ public class TradeDetailsView extends AbstractFinanceView
                 {
                     showClosed = !showClosed;
                     updateFrom(collectAllTrades());
-                    
-                    if (!showClosed || !showClosed) 
-                    {
-                        filterDropDowMenu.setImage(Images.FILTER_ON);
-                    }
-                    else
-                    {
-                        filterDropDowMenu.setImage(Images.FILTER_OFF);
-                    }
+                    setFilterButton(filterDropDowMenu);
                 }
             };
             showClosedAction.setChecked(showClosed);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -184,7 +184,8 @@ public class TradeDetailsView extends AbstractFinanceView
 
     
 
-    private void setFilterButton(DropDown filterDropDown) {
+    private void setFilterButton(DropDown filterDropDown) 
+    {
         if (!showOpen.getVal() || !showClosed.getVal() || !showEarnings.getVal() || !showLosses.getVal()) 
         {
             filterDropDown.setImage(Images.FILTER_ON);
@@ -208,7 +209,8 @@ public class TradeDetailsView extends AbstractFinanceView
         }
         
         @Override
-        public void run() {
+        public void run() 
+        {
             filterCriterion.invert();
             updateFrom(collectAllTrades());
             setFilterButton(theMenu);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -81,6 +81,9 @@ public class TradeDetailsView extends AbstractFinanceView
     {
         return Messages.LabelTrades;
     }
+    
+    // if true, only closed trades will be displayed
+    private boolean isFiltered = false;
 
     @Inject
     @Optional
@@ -142,6 +145,26 @@ public class TradeDetailsView extends AbstractFinanceView
 
         toolBarManager.add(new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,
                         manager -> table.getShowHideColumnHelper().menuAboutToShow(manager)));
+        
+        addFilterButton(toolBarManager);
+    }
+    
+    private void addFilterButton(ToolBarManager manager)
+    {
+        Action filter = new Action()
+        {
+            @Override
+            public void run()
+            {
+                isFiltered = !isFiltered;
+             //   getPart().getPreferenceStore().setValue(FILTER_INACTIVE_ACCOUNTS, isFiltered);
+                setImageDescriptor(isFiltered ? Images.FILTER_ON.descriptor() : Images.FILTER_OFF.descriptor());
+               // resetInput();
+            }
+        };
+        filter.setImageDescriptor(isFiltered ? Images.FILTER_ON.descriptor() : Images.FILTER_OFF.descriptor());
+        //filter.setToolTipText(Messages.AccountFilterRetiredAccounts);
+        manager.add(filter);
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -210,6 +210,15 @@ public class Trade implements Adaptable
     {
         return (exitValue.getAmount() / (double) entryValue.getAmount()) - 1;
     }
+    
+    /**
+     * @brief Checks if a trade is closed
+     * @return True if the trade has been closed, false otherwise
+     */
+    public boolean isClosed()
+    {
+        return this.getEnd().isPresent();
+    }
 
     @Override
     public <T> T adapt(Class<T> type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -212,12 +212,30 @@ public class Trade implements Adaptable
     }
     
     /**
-     * @brief Checks if a trade is closed
+     * @brief Checks if the trade is closed
      * @return True if the trade has been closed, false otherwise
      */
     public boolean isClosed()
     {
         return this.getEnd().isPresent();
+    }
+    
+    /**
+     * @brief Checks if the trade made a net loss
+     * @return True if the trade resulted in a net loss
+     */
+    public boolean isLoss()
+    {
+        return this.getProfitLoss().isNegative();
+    }
+    
+    /**
+     * @brief Check if the trade man a gross gross 
+     * @return True if the trade result in a gross loss
+     */
+    public boolean isGrossLoss()
+    {
+        return this.getGrossProfitLoss().isNegative();
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -193,7 +193,8 @@ public class Trade implements Adaptable
 
     public Money getGrossProfitLoss()
     {
-        if (exitGrossValue == null) {
+        if (exitGrossValue == null) 
+        {
             return null;
         }
         return exitGrossValue.subtract(entryGrossValue);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -193,6 +193,9 @@ public class Trade implements Adaptable
 
     public Money getGrossProfitLoss()
     {
+        if (exitGrossValue == null) {
+            return null;
+        }
         return exitGrossValue.subtract(entryGrossValue);
     }
 


### PR DESCRIPTION
I added the support to filter the trades for open and closed trades. (This was a big request in [the forum](https://forum.portfolio-performance.info/t/trades-nach-offen-vs-geschlossen-filtern/11208/5))

The introduced changes are quite nonintrusive except for an additional `isClosed()` method to the trade class.

If there are any requirements (e.g. code formatting) that need to be met, please do not hesitate to tell me.