### PR TITLE
Revert mistakenly translated keywords

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_pt.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_pt.properties
@@ -278,17 +278,17 @@ LabelReportingPeriodCurrentMonth = M\u00EAs Corrente
 
 LabelReportingPeriodFromXtoY = De {0} at\u00E9 {1}
 
-LabelReportingPeriodLastXDays = {0,escolha,0#0 dias|1#1 dia|1<{0,n\u00FAmero} dias}
+LabelReportingPeriodLastXDays = {0,choice,0#0 dias|1#1 dia|1<{0,number} dias}
 
-LabelReportingPeriodLastXTradingDays = {0,escolha,0#0 dias de negocia\u00E7\u00E3o|1#1 dia de negocia\u00E7\u00E3o|1<{0,n\u00FAmero} dias de negocia\u00E7\u00E3o}
+LabelReportingPeriodLastXTradingDays = {0,choice,0#0 dias de negocia\u00E7\u00E3o|1#1 dia de negocia\u00E7\u00E3o|1<{0,number} dias de negocia\u00E7\u00E3o}
 
-LabelReportingPeriodMonths = {0,escolha,0#|1#1 m\u00EAs|1<{0,n\u00FAmero} meses}
+LabelReportingPeriodMonths = {0,choice,0#|1#1 m\u00EAs|1<{0,number} meses}
 
 LabelReportingPeriodSince = Desde {0}
 
 LabelReportingPeriodYTD = No Ano (YTD)
 
-LabelReportingPeriodYears = {0,escolha,0#|1#1 ano|1<{0,n\u00FAmero} anos}
+LabelReportingPeriodYears = {0,choice,0#|1#1 ano|1<{0,number} anos}
 
 LabelSearchAll = Tudo
 


### PR DESCRIPTION
The keywords number and choice were mistakenly translated to Portuguese, [causing errors](https://forum.portfolio-performance.info/t/15085) when that translation was used.