### PR TITLE
Json quote feed enhancement

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -120,7 +121,7 @@ public class GenericJSONQuoteFeedTest
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
-        LocalDate date = feed.extractDate(object);
+        LocalDate date = feed.extractDate(object, Optional.empty());
 
         assertEquals(LocalDate.of(2020, 4, 06), date);
     }
@@ -133,7 +134,7 @@ public class GenericJSONQuoteFeedTest
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
-        LocalDate date = feed.extractDate(object);
+        LocalDate date = feed.extractDate(object, Optional.empty());
 
         assertEquals(LocalDate.of(2020, 4, 06), date);
     }
@@ -146,7 +147,7 @@ public class GenericJSONQuoteFeedTest
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
-        LocalDate date = feed.extractDate(object);
+        LocalDate date = feed.extractDate(object, Optional.empty());
 
         assertEquals(LocalDate.of(2020, 4, 06), date);
     }
@@ -159,10 +160,37 @@ public class GenericJSONQuoteFeedTest
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
-        LocalDate date = feed.extractDate(object);
+        LocalDate date = feed.extractDate(object, Optional.empty());
 
         assertEquals(LocalDate.of(2020, 4, 06), date);
     }
+
+    @Test
+    public void testDateExtractionMSCIFormat()
+    {
+        // Date is in milliseconds (but as double) from epoch
+        String json = "{\"data\":[{\"date\":20210313,\"close\":\"123.00\"}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
+        LocalDate date = feed.extractDate(object, Optional.of("yyyyMMdd"));
+
+        assertEquals(LocalDate.of(2021, 3, 13), date);
+    }
+
+    @Test
+    public void testDateExtractionGermanFormat()
+    {
+        // Date is in milliseconds (but as double) from epoch
+        String json = "{\"data\":[{\"date\":14.03.2021,\"close\":\"123.00\"}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
+        LocalDate date = feed.extractDate(object, Optional.of("dd.MM.yyyy"));
+
+        assertEquals(LocalDate.of(2021, 3, 14), date);
+    }
+
 
     @Test
     public void testDateExtractionInvalid()
@@ -172,7 +200,7 @@ public class GenericJSONQuoteFeedTest
         GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
-        LocalDate date = feed.extractDate(object);
+        LocalDate date = feed.extractDate(object, Optional.empty());
 
         assertEquals(null, date);
     }
@@ -199,6 +227,43 @@ public class GenericJSONQuoteFeedTest
 
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC);
         long result = feed.extractValue(object);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testIntValueExtractionDouble() throws ParseException
+    {
+        String json = "{\"data\":[{\"date\":1586174400,\"close\":123.234}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC);
+        long result = feed.extractIntValue(object);
+
+        assertEquals(123, result);
+    }
+
+    @Test
+    public void testIntValueExtractionInteger() throws ParseException
+    {
+        String json = "{\"data\":[{\"date\":1586174400,\"close\":123}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC);
+        long result = feed.extractIntValue(object);
+
+        assertEquals(123, result);
+    }
+
+    @Test
+    public void testIntValueExtractionIntegerInvalid() throws ParseException
+    {
+        // Value is an array -> invalid
+        String json = "{\"data\":[{\"date\":1586174400,\"close\":[]}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC);
+        long result = feed.extractIntValue(object);
 
         assertEquals(0, result);
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
@@ -96,6 +96,28 @@ public class GenericJSONQuoteFeedTest
     @Test
     public void testSimpleExtraction() throws IOException, URISyntaxException
     {
+        String jsonResponse = "{\"data\":[{\"date\":\"2020-04-12\",\"close\":123.88},{\"date\":2020-04-13,\"close\":124.123}],\"info\":\"Json Feed for APPLE ORD\"}";
+
+        GenericJSONQuoteFeed feed = Mockito.spy(new GenericJSONQuoteFeed());
+        Mockito.doReturn(jsonResponse).when(feed).getJson(feedUrl);
+
+        QuoteFeedData data = feed.getHistoricalQuotes(security, false);
+
+        assertTrue(data.getErrors().isEmpty()); // NOSONAR
+        assertTrue(data.getPrices().size() == 2);
+
+        SecurityPrice price = data.getPrices().get(0);
+        assertEquals(LocalDate.of(2020, 4, 12), price.getDate());
+        assertEquals(Values.Quote.factorize(123.88), price.getValue());
+
+        SecurityPrice price2 = data.getPrices().get(1);
+        assertEquals(LocalDate.of(2020, 4, 13), price2.getDate());
+        assertEquals(Values.Quote.factorize(124.123), price2.getValue());
+    }
+
+    @Test
+    public void testSimpleExtractionWithStrings() throws IOException, URISyntaxException
+    {
         String jsonResponse = "{\"data\":[{\"date\":\"2020-04-12\",\"close\":\"123.88\"},{\"date\":\"2020-04-13\",\"close\":\"124.123\"}],\"info\":\"Json Feed for APPLE ORD\"}";
 
         GenericJSONQuoteFeed feed = Mockito.spy(new GenericJSONQuoteFeed());
@@ -117,6 +139,28 @@ public class GenericJSONQuoteFeedTest
 
     @Test
     public void testSimpleExtractionDateFormat1() throws IOException, URISyntaxException
+    {
+        String jsonResponse = "{\"data\":[{\"date\":20200412,\"close\":\"123.88\"},{\"date\":\"20200413\",\"close\":\"124.123\"}],\"info\":\"Json Feed for APPLE ORD\"}";
+
+        GenericJSONQuoteFeed feed = Mockito.spy(new GenericJSONQuoteFeed());
+        Mockito.doReturn(jsonResponse).when(feed).getJson(feedUrl);
+
+        QuoteFeedData data = feed.getHistoricalQuotes(securityWithSpecialDateFormat1, false);
+
+        assertTrue(data.getErrors().isEmpty()); // NOSONAR
+        assertTrue(data.getPrices().size() == 2);
+
+        SecurityPrice price = data.getPrices().get(0);
+        assertEquals(LocalDate.of(2020, 4, 12), price.getDate());
+        assertEquals(Values.Quote.factorize(123.88), price.getValue());
+
+        SecurityPrice price2 = data.getPrices().get(1);
+        assertEquals(LocalDate.of(2020, 4, 13), price2.getDate());
+        assertEquals(Values.Quote.factorize(124.123), price2.getValue());
+    }
+
+    @Test
+    public void testSimpleExtractionDateFormat1AsString() throws IOException, URISyntaxException
     {
         String jsonResponse = "{\"data\":[{\"date\":\"20200412\",\"close\":\"123.88\"},{\"date\":\"20200413\",\"close\":\"124.123\"}],\"info\":\"Json Feed for APPLE ORD\"}";
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -667,6 +667,11 @@ public class Messages extends NLS
     public static String LabelJSONPathHint;
     public static String LabelJSONPathToClose;
     public static String LabelJSONPathToDate;
+    public static String LabelJSONDateFormat;
+    public static String LabelJSONDateFormatHint;
+    public static String LabelJSONPathToLow;
+    public static String LabelJSONPathToHigh;
+    public static String LabelJSONPathToVolume;
     public static String LabelKeyIndicators;
     public static String LabelMaxDrawdown;
     public static String LabelMaxDrawdownDuration;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1190,6 +1190,16 @@ LabelJSONPathToClose = Path to Close
 
 LabelJSONPathToDate = Path to Date
 
+LabelJSONDateFormat = Date Format:
+
+LabelJSONDateFormatHint = Date format like dd.MM.yyyy or MM/dd/yyyy.\n\nLeave empty for ISO date format or if the date is represented\nby the number of milliseconds or dayes since 1970-01-01.  
+
+LabelJSONPathToLow = Path to Day's Low
+
+LabelJSONPathToHigh = Path to Day's High
+
+LabelJSONPathToVolume = Path to Volume
+
 LabelKeyIndicators = Key Indicators
 
 LabelLanguage = Language

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1177,6 +1177,16 @@ LabelJSONPathToClose = Pfad zu Kurs
 
 LabelJSONPathToDate = Pfad zu Datum
 
+LabelJSONDateFormat = Datumsformat:
+
+LabelJSONDateFormatHint = Datumsformat wie dd.MM.yyyy oder MM/dd/yyyy.\n\nLeer lassen für das ISO-Datumsformat oder falls das Datum durch die\nAnzahl Millisekunden oder Tage seit dem 01.01.1970 repräsentiert wird.
+
+LabelJSONPathToLow = Pfad zu Tagestief
+
+LabelJSONPathToHigh = Pfad zu Tageshoch
+
+LabelJSONPathToVolume = Pfad zu Volumen  
+
 LabelKeyIndicators = Kennzahlen
 
 LabelLanguage = Sprache

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
@@ -389,7 +389,6 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         // create a temporary security and set all attributes
         Security security = new Security();
         model.setAttributes(security);
-        model.getSecurity().getProperties().forEach(security::addProperty);
         return security;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
@@ -166,6 +166,14 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
     private Text textJsonPathDate;
     private Label labelJsonPathClose;
     private Text textJsonPathClose;
+    private Label labelJsonDateFormat;
+    private Text textJsonDateFormat;
+    private Label labelJsonPathLow;
+    private Text textJsonPathLow;
+    private Label labelJsonPathHigh;
+    private Text textJsonPathHigh;
+    private Label labelJsonPathVolume;
+    private Text textJsonPathVolume;
 
     private PropertyChangeListener tickerSymbolPropertyChangeListener = e -> onTickerSymbolChanged();
 
@@ -198,7 +206,15 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
 
     protected abstract String getJSONDatePropertyName();
 
+    protected abstract String getJSONDateFormatPropertyName();
+
     protected abstract String getJSONClosePropertyName();
+
+    protected abstract String getJSONLowPathPropertyName();
+
+    protected abstract String getJSONHighPathPropertyName();
+
+    protected abstract String getJSONVolumePathPropertyName();
 
     protected abstract void setStatus(String status);
 
@@ -263,6 +279,34 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         {
             String path = model.getFeedProperty(getJSONClosePropertyName());
             textJsonPathClose.setText(path != null ? path : ""); //$NON-NLS-1$
+        }
+
+        if (textJsonDateFormat != null
+                        && !textJsonDateFormat.getText().equals(model.getFeedProperty(getJSONDateFormatPropertyName())))
+        {
+            String dateFormat = model.getFeedProperty(getJSONDateFormatPropertyName());
+            textJsonDateFormat.setText(dateFormat != null ? dateFormat : ""); //$NON-NLS-1$
+        }
+
+        if (textJsonPathLow != null
+                        && !textJsonPathLow.getText().equals(model.getFeedProperty(getJSONLowPathPropertyName())))
+        {
+            String lowPath = model.getFeedProperty(getJSONLowPathPropertyName());
+            textJsonPathLow.setText(lowPath != null ? lowPath : ""); //$NON-NLS-1$
+        }
+
+        if (textJsonPathHigh != null
+                        && !textJsonPathHigh.getText().equals(model.getFeedProperty(getJSONHighPathPropertyName())))
+        {
+            String highPath = model.getFeedProperty(getJSONHighPathPropertyName());
+            textJsonPathHigh.setText(highPath != null ? highPath : ""); //$NON-NLS-1$
+        }
+
+        if (textJsonPathVolume != null
+                        && !textJsonPathVolume.getText().equals(model.getFeedProperty(getJSONVolumePathPropertyName())))
+        {
+            String volumePath = model.getFeedProperty(getJSONVolumePathPropertyName());
+            textJsonPathVolume.setText(volumePath != null ? volumePath : ""); //$NON-NLS-1$
         }
     }
 
@@ -465,6 +509,14 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         textJsonPathDate = disposeIf(textJsonPathDate);
         labelJsonPathClose = disposeIf(labelJsonPathClose);
         textJsonPathClose = disposeIf(textJsonPathClose);
+        labelJsonDateFormat = disposeIf(labelJsonDateFormat);
+        textJsonDateFormat = disposeIf(textJsonDateFormat);
+        labelJsonPathLow = disposeIf(labelJsonPathLow);
+        textJsonPathLow = disposeIf(textJsonPathLow);
+        labelJsonPathHigh = disposeIf(labelJsonPathHigh);
+        textJsonPathHigh = disposeIf(textJsonPathHigh);
+        labelJsonPathVolume = disposeIf(labelJsonPathVolume);
+        textJsonPathVolume = disposeIf(textJsonPathVolume);
 
         if (dropDown)
         {
@@ -537,7 +589,7 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         {
             labelJsonPathDate = new Label(grpQuoteFeed, SWT.NONE);
             labelJsonPathDate.setText(Messages.LabelJSONPathToDate);
-
+            
             textJsonPathDate = new Text(grpQuoteFeed, SWT.BORDER);
             GridDataFactory.fillDefaults().span(2, 1).hint(100, SWT.DEFAULT).applyTo(textJsonPathDate);
             textJsonPathDate.addModifyListener(e -> onJsonPathDateChanged());
@@ -547,7 +599,22 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             deco.setImage(Images.INFO.image());
             deco.setMarginWidth(2);
             deco.show();
+            
+            
+            labelJsonDateFormat = new Label(grpQuoteFeed, SWT.NONE);
+            labelJsonDateFormat.setText(Messages.LabelJSONDateFormat);
 
+            textJsonDateFormat = new Text(grpQuoteFeed, SWT.BORDER);
+            GridDataFactory.fillDefaults().span(2, 1).hint(100, SWT.DEFAULT).applyTo(textJsonDateFormat);
+            textJsonDateFormat.addModifyListener(e -> onJsonDateFormatChanged());
+
+            deco = new ControlDecoration(textJsonDateFormat, SWT.CENTER | SWT.RIGHT);
+            deco.setDescriptionText(Messages.LabelJSONDateFormatHint);
+            deco.setImage(Images.INFO.image());
+            deco.setMarginWidth(2);
+            deco.show();
+            
+            
             labelJsonPathClose = new Label(grpQuoteFeed, SWT.NONE);
             labelJsonPathClose.setText(Messages.LabelJSONPathToClose);
 
@@ -556,6 +623,48 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             textJsonPathClose.addModifyListener(e -> onJsonPathCloseChanged());
 
             deco = new ControlDecoration(textJsonPathClose, SWT.CENTER | SWT.RIGHT);
+            deco.setDescriptionText(Messages.LabelJSONPathHint);
+            deco.setImage(Images.INFO.image());
+            deco.setMarginWidth(2);
+            deco.show();
+            
+
+            labelJsonPathLow = new Label(grpQuoteFeed, SWT.NONE);
+            labelJsonPathLow.setText(Messages.LabelJSONPathToLow);
+
+            textJsonPathLow = new Text(grpQuoteFeed, SWT.BORDER);
+            GridDataFactory.fillDefaults().span(2, 1).hint(100, SWT.DEFAULT).applyTo(textJsonPathLow);
+            textJsonPathLow.addModifyListener(e -> onJsonPathLowChanged());
+
+            deco = new ControlDecoration(textJsonPathLow, SWT.CENTER | SWT.RIGHT);
+            deco.setDescriptionText(Messages.LabelJSONPathHint);
+            deco.setImage(Images.INFO.image());
+            deco.setMarginWidth(2);
+            deco.show();
+            
+
+            labelJsonPathHigh = new Label(grpQuoteFeed, SWT.NONE);
+            labelJsonPathHigh.setText(Messages.LabelJSONPathToHigh);
+
+            textJsonPathHigh = new Text(grpQuoteFeed, SWT.BORDER);
+            GridDataFactory.fillDefaults().span(2, 1).hint(100, SWT.DEFAULT).applyTo(textJsonPathHigh);
+            textJsonPathHigh.addModifyListener(e -> onJsonPathHighChanged());
+
+            deco = new ControlDecoration(textJsonPathHigh, SWT.CENTER | SWT.RIGHT);
+            deco.setDescriptionText(Messages.LabelJSONPathHint);
+            deco.setImage(Images.INFO.image());
+            deco.setMarginWidth(2);
+            deco.show();
+            
+
+            labelJsonPathVolume = new Label(grpQuoteFeed, SWT.NONE);
+            labelJsonPathVolume.setText(Messages.LabelJSONPathToVolume);
+
+            textJsonPathVolume = new Text(grpQuoteFeed, SWT.BORDER);
+            GridDataFactory.fillDefaults().span(2, 1).hint(100, SWT.DEFAULT).applyTo(textJsonPathVolume);
+            textJsonPathVolume.addModifyListener(e -> onJsonPathVolumeChanged());
+
+            deco = new ControlDecoration(textJsonPathVolume, SWT.CENTER | SWT.RIGHT);
             deco.setDescriptionText(Messages.LabelJSONPathHint);
             deco.setImage(Images.INFO.image());
             deco.setMarginWidth(2);
@@ -640,6 +749,22 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             String closePath = model.getFeedProperty(getJSONClosePropertyName());
             if (closePath != null)
                 textJsonPathClose.setText(closePath);
+            
+            String dateFormat = model.getFeedProperty(getJSONDateFormatPropertyName());
+            if (dateFormat != null)
+                textJsonDateFormat.setText(dateFormat);
+            
+            String lowPath = model.getFeedProperty(getJSONLowPathPropertyName());
+            if (lowPath != null)
+                textJsonPathLow.setText(lowPath);
+            
+            String highPath = model.getFeedProperty(getJSONHighPathPropertyName());
+            if (highPath != null)
+                textJsonPathHigh.setText(highPath);
+            
+            String volumePath = model.getFeedProperty(getJSONVolumePathPropertyName());
+            if (volumePath != null)
+                textJsonPathVolume.setText(volumePath);
         }
     }
 
@@ -729,6 +854,22 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
             String closePath = model.getFeedProperty(getJSONClosePropertyName());
             if (closePath != null)
                 textJsonPathClose.setText(closePath);
+
+            String dateFormat = model.getFeedProperty(getJSONDateFormatPropertyName());
+            if (dateFormat != null)
+                textJsonDateFormat.setText(dateFormat);
+
+            String lowPath = model.getFeedProperty(getJSONLowPathPropertyName());
+            if (lowPath != null)
+                textJsonDateFormat.setText(lowPath);
+
+            String highPath = model.getFeedProperty(getJSONHighPathPropertyName());
+            if (highPath != null)
+                textJsonDateFormat.setText(highPath);
+
+            String volumePath = model.getFeedProperty(getJSONVolumePathPropertyName());
+            if (volumePath != null)
+                textJsonDateFormat.setText(volumePath);
         }
 
         if (comboExchange == null && textFeedURL == null && textQuandlCode == null && textJsonPathDate == null)
@@ -846,6 +987,50 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         String closePath = textJsonPathClose.getText();
 
         model.setFeedProperty(getJSONClosePropertyName(), closePath.isEmpty() ? null : closePath);
+
+        QuoteFeed feed = (QuoteFeed) ((IStructuredSelection) comboProvider.getSelection()).getFirstElement();
+        showSampleQuotes(feed, null);
+        setStatus(null);
+    }
+
+    private void onJsonDateFormatChanged()
+    {
+        String dateFormat = textJsonDateFormat.getText();
+
+        model.setFeedProperty(getJSONDateFormatPropertyName(), dateFormat.isEmpty() ? null : dateFormat);
+
+        QuoteFeed feed = (QuoteFeed) ((IStructuredSelection) comboProvider.getSelection()).getFirstElement();
+        showSampleQuotes(feed, null);
+        setStatus(null);
+    }
+
+    private void onJsonPathLowChanged()
+    {
+        String lowPath = textJsonPathLow.getText();
+
+        model.setFeedProperty(getJSONLowPathPropertyName(), lowPath.isEmpty() ? null : lowPath);
+
+        QuoteFeed feed = (QuoteFeed) ((IStructuredSelection) comboProvider.getSelection()).getFirstElement();
+        showSampleQuotes(feed, null);
+        setStatus(null);
+    }
+
+    private void onJsonPathHighChanged()
+    {
+        String highPath = textJsonPathHigh.getText();
+
+        model.setFeedProperty(getJSONHighPathPropertyName(), highPath.isEmpty() ? null : highPath);
+
+        QuoteFeed feed = (QuoteFeed) ((IStructuredSelection) comboProvider.getSelection()).getFirstElement();
+        showSampleQuotes(feed, null);
+        setStatus(null);
+    }
+
+    private void onJsonPathVolumeChanged()
+    {
+        String volumePath = textJsonPathVolume.getText();
+
+        model.setFeedProperty(getJSONVolumePathPropertyName(), volumePath.isEmpty() ? null : volumePath);
 
         QuoteFeed feed = (QuoteFeed) ((IStructuredSelection) comboProvider.getSelection()).getFirstElement();
         showSampleQuotes(feed, null);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
@@ -108,6 +108,30 @@ public class HistoricalQuoteProviderPage extends AbstractQuoteProviderPage
     }
 
     @Override
+    protected String getJSONDateFormatPropertyName()
+    {
+        return GenericJSONQuoteFeed.DATE_FORMAT_PROPERTY_NAME_HISTORIC;
+    }
+
+    @Override
+    protected String getJSONLowPathPropertyName()
+    {
+        return GenericJSONQuoteFeed.LOW_PROPERTY_NAME_HISTORIC;
+    }
+
+    @Override
+    protected String getJSONHighPathPropertyName()
+    {
+        return GenericJSONQuoteFeed.HIGH_PROPERTY_NAME_HISTORIC;
+    }
+
+    @Override
+    protected String getJSONVolumePathPropertyName()
+    {
+        return GenericJSONQuoteFeed.VOLUME_PROPERTY_NAME_HISTORIC;
+    }
+
+    @Override
     protected void setStatus(String status)
     {
         getModel().setStatusHistoricalQuotesProvider(status);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
@@ -216,7 +216,15 @@ public class HistoricalQuoteProviderPage extends AbstractQuoteProviderPage
                             + String.valueOf(getModel()
                                             .getFeedProperty(GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC))
                             + String.valueOf(getModel()
-                                            .getFeedProperty(GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC));
+                                            .getFeedProperty(GenericJSONQuoteFeed.CLOSE_PROPERTY_NAME_HISTORIC))
+                            + String.valueOf(getModel()
+                                            .getFeedProperty(GenericJSONQuoteFeed.DATE_FORMAT_PROPERTY_NAME_HISTORIC))
+                            + String.valueOf(getModel()
+                                            .getFeedProperty(GenericJSONQuoteFeed.LOW_PROPERTY_NAME_HISTORIC))
+                            + String.valueOf(getModel()
+                                            .getFeedProperty(GenericJSONQuoteFeed.HIGH_PROPERTY_NAME_HISTORIC))
+                            + String.valueOf(getModel()
+                                            .getFeedProperty(GenericJSONQuoteFeed.VOLUME_PROPERTY_NAME_HISTORIC));
         else
             return getFeed() + getModel().getFeedURL();
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/LatestQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/LatestQuoteProviderPage.java
@@ -196,6 +196,30 @@ public class LatestQuoteProviderPage extends AbstractQuoteProviderPage
     }
 
     @Override
+    protected String getJSONDateFormatPropertyName()
+    {
+        return GenericJSONQuoteFeed.DATE_FORMAT_PROPERTY_NAME_LATEST;
+    }
+
+    @Override
+    protected String getJSONLowPathPropertyName()
+    {
+        return GenericJSONQuoteFeed.LOW_PROPERTY_NAME_LATEST;
+    }
+
+    @Override
+    protected String getJSONHighPathPropertyName()
+    {
+        return GenericJSONQuoteFeed.HIGH_PROPERTY_NAME_LATEST;
+    }
+
+    @Override
+    protected String getJSONVolumePathPropertyName()
+    {
+        return GenericJSONQuoteFeed.VOLUME_PROPERTY_NAME_LATEST;
+    }
+
+    @Override
     protected List<QuoteFeed> getAvailableFeeds()
     {
         List<QuoteFeed> feeds = new ArrayList<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -7,6 +7,7 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,9 +39,17 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 {
     public static final String ID = "GENERIC-JSON"; //$NON-NLS-1$
     public static final String DATE_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-DATE"; //$NON-NLS-1$
+    public static final String DATE_FORMAT_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-DATE-FORMAT"; //$NON-NLS-1$
     public static final String CLOSE_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-CLOSE"; //$NON-NLS-1$
+    public static final String HIGH_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-HIGH"; //$NON-NLS-1$
+    public static final String LOW_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-LOW"; //$NON-NLS-1$
+    public static final String VOLUME_PROPERTY_NAME_HISTORIC = "GENERIC-JSON-VOLUME"; //$NON-NLS-1$
     public static final String DATE_PROPERTY_NAME_LATEST = "GENERIC-JSON-DATE-LATEST"; //$NON-NLS-1$
+    public static final String DATE_FORMAT_PROPERTY_NAME_LATEST = "GENERIC-JSON-DATE-FORMAT-LATEST"; //$NON-NLS-1$
     public static final String CLOSE_PROPERTY_NAME_LATEST = "GENERIC-JSON-CLOSE-LATEST"; //$NON-NLS-1$
+    public static final String HIGH_PROPERTY_NAME_LATEST = "GENERIC-JSON-HIGH-LATEST"; //$NON-NLS-1$
+    public static final String LOW_PROPERTY_NAME_LATEST = "GENERIC-JSON-LOW-LATEST"; //$NON-NLS-1$
+    public static final String VOLUME_PROPERTY_NAME_LATEST = "GENERIC-JSON-VOLUME-LATEST"; //$NON-NLS-1$
 
     private final PageCache<String> cache = new PageCache<>();
 
@@ -84,8 +93,16 @@ public class GenericJSONQuoteFeed implements QuoteFeed
     {
         Optional<String> dateProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
                         isLatest ? DATE_PROPERTY_NAME_LATEST : DATE_PROPERTY_NAME_HISTORIC);
+        Optional<String> dateFormatProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
+                        isLatest ? DATE_FORMAT_PROPERTY_NAME_LATEST : DATE_FORMAT_PROPERTY_NAME_HISTORIC);
         Optional<String> closeProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
                         isLatest ? CLOSE_PROPERTY_NAME_LATEST : CLOSE_PROPERTY_NAME_HISTORIC);
+        Optional<String> highProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
+                        isLatest ? HIGH_PROPERTY_NAME_LATEST : HIGH_PROPERTY_NAME_HISTORIC);
+        Optional<String> lowProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
+                        isLatest ? LOW_PROPERTY_NAME_LATEST : LOW_PROPERTY_NAME_HISTORIC);
+        Optional<String> volumeProperty = security.getPropertyValue(SecurityProperty.Type.FEED,
+                        isLatest ? VOLUME_PROPERTY_NAME_LATEST : VOLUME_PROPERTY_NAME_HISTORIC);
 
         if (!dateProperty.isPresent() || !closeProperty.isPresent())
         {
@@ -135,7 +152,8 @@ public class GenericJSONQuoteFeed implements QuoteFeed
             int sizeBefore = newPricesByDate.size();
 
             if (json != null)
-                newPricesByDate.addAll(parse(url, json, dateProperty.get(), closeProperty.get(), data));
+                newPricesByDate.addAll(parse(url, json, dateProperty.get(), closeProperty.get(), data,
+                                dateFormatProperty, lowProperty, highProperty, volumeProperty));
 
             if (newPricesByDate.size() > sizeBefore)
                 failedAttempts = 0;
@@ -176,7 +194,8 @@ public class GenericJSONQuoteFeed implements QuoteFeed
     }
 
     protected List<LatestSecurityPrice> parse(String url, String json, String datePath, String closePath,
-                    QuoteFeedData data)
+                    QuoteFeedData data, Optional<String> dateFormat, Optional<String> lowPath,
+                    Optional<String> highPath, Optional<String> volumePath)
     {
         try
         {
@@ -190,6 +209,22 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
             List<Object> dates = ctx.read(dateP);
             List<Object> close = ctx.read(closeP);
+
+            Optional<List<Object>> high = Optional.empty();
+            Optional<List<Object>> low = Optional.empty();
+            Optional<List<Object>> volume = Optional.empty();
+            if(highPath.isPresent()) {
+                JsonPath highP = JsonPath.compile(highPath.get());
+                high = Optional.of(ctx.read(highP));
+            }
+            if(lowPath.isPresent()) {
+                JsonPath lowP = JsonPath.compile(lowPath.get());
+                low = Optional.of(ctx.read(lowP));
+            }
+            if(volumePath.isPresent()) {
+                JsonPath volumeP = JsonPath.compile(volumePath.get());
+                volume = Optional.of(ctx.read(volumeP));
+            }
 
             if (dates.size() != close.size())
             {
@@ -208,7 +243,7 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
                 // date
                 Object object = dates.get(index);
-                price.setDate(this.extractDate(object));
+                price.setDate(this.extractDate(object, dateFormat));
 
                 // close
                 object = close.get(index);
@@ -216,9 +251,21 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
                 if (price.getDate() != null && price.getValue() > 0)
                 {
-                    price.setHigh(LatestSecurityPrice.NOT_AVAILABLE);
-                    price.setLow(LatestSecurityPrice.NOT_AVAILABLE);
-                    price.setVolume(LatestSecurityPrice.NOT_AVAILABLE);
+                    if(high.isPresent()) {
+                        price.setHigh(this.extractValue(high.get().get(index)));
+                    } else {
+                        price.setHigh(LatestSecurityPrice.NOT_AVAILABLE);
+                    }
+                    if(low.isPresent()) {
+                        price.setLow(this.extractValue(low.get().get(index)));
+                    } else {
+                        price.setLow(LatestSecurityPrice.NOT_AVAILABLE);
+                    }
+                    if(volume.isPresent()) {
+                        price.setVolume(this.extractIntValue(volume.get().get(index)));
+                    } else {
+                        price.setVolume(LatestSecurityPrice.NOT_AVAILABLE);
+                    }
                     prices.add(price);
                 }
             }
@@ -241,8 +288,19 @@ public class GenericJSONQuoteFeed implements QuoteFeed
         return 0;
     }
 
-    /* testing */ LocalDate extractDate(Object object)
+    /* testing */ long extractIntValue(Object object) throws ParseException
     {
+        if (object instanceof Number)
+            return Math.round(((Number) object).doubleValue());
+        return 0;
+    }
+
+    /* testing */ LocalDate extractDate(Object object, Optional<String> dateFormat)
+    {
+        if(dateFormat.isPresent()) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat.get());
+            return LocalDate.parse(object.toString(), formatter);
+        }
         if (object instanceof String)
             return YahooHelper.fromISODate((String) object);
         else if (object instanceof Long)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -262,7 +262,7 @@ public class GenericJSONQuoteFeed implements QuoteFeed
                         price.setLow(LatestSecurityPrice.NOT_AVAILABLE);
                     }
                     if(volume.isPresent()) {
-                        price.setVolume(this.extractIntValue(volume.get().get(index)));
+                        price.setVolume(this.extractIntegerValue(volume.get().get(index)));
                     } else {
                         price.setVolume(LatestSecurityPrice.NOT_AVAILABLE);
                     }
@@ -288,10 +288,17 @@ public class GenericJSONQuoteFeed implements QuoteFeed
         return 0;
     }
 
-    /* testing */ long extractIntValue(Object object) throws ParseException
+    /* testing */ long extractIntegerValue(Object object) throws ParseException
     {
+        if (object instanceof String)
+            try {
+                return Long.parseLong((String) object);
+            } catch(NumberFormatException e) {
+                // try again as Double
+                return Math.round(Double.parseDouble((String) object));
+            }
         if (object instanceof Number)
-            return Math.round(((Number) object).doubleValue());
+            return((Number) object).longValue();
         return 0;
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -213,15 +213,18 @@ public class GenericJSONQuoteFeed implements QuoteFeed
             Optional<List<Object>> high = Optional.empty();
             Optional<List<Object>> low = Optional.empty();
             Optional<List<Object>> volume = Optional.empty();
-            if(highPath.isPresent()) {
+            if(highPath.isPresent())
+            {
                 JsonPath highP = JsonPath.compile(highPath.get());
                 high = Optional.of(ctx.read(highP));
             }
-            if(lowPath.isPresent()) {
+            if(lowPath.isPresent())
+            {
                 JsonPath lowP = JsonPath.compile(lowPath.get());
                 low = Optional.of(ctx.read(lowP));
             }
-            if(volumePath.isPresent()) {
+            if(volumePath.isPresent())
+            {
                 JsonPath volumeP = JsonPath.compile(volumePath.get());
                 volume = Optional.of(ctx.read(volumeP));
             }
@@ -251,19 +254,28 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
                 if (price.getDate() != null && price.getValue() > 0)
                 {
-                    if(high.isPresent()) {
+                    if(high.isPresent())
+                    {
                         price.setHigh(this.extractValue(high.get().get(index)));
-                    } else {
+                    }
+                    else
+                    {
                         price.setHigh(LatestSecurityPrice.NOT_AVAILABLE);
                     }
-                    if(low.isPresent()) {
+                    if(low.isPresent())
+                    {
                         price.setLow(this.extractValue(low.get().get(index)));
-                    } else {
+                    }
+                    else
+                    {
                         price.setLow(LatestSecurityPrice.NOT_AVAILABLE);
                     }
-                    if(volume.isPresent()) {
+                    if(volume.isPresent())
+                    {
                         price.setVolume(this.extractIntegerValue(volume.get().get(index)));
-                    } else {
+                    }
+                    else
+                    {
                         price.setVolume(LatestSecurityPrice.NOT_AVAILABLE);
                     }
                     prices.add(price);
@@ -291,9 +303,12 @@ public class GenericJSONQuoteFeed implements QuoteFeed
     /* testing */ long extractIntegerValue(Object object) throws ParseException
     {
         if (object instanceof String)
-            try {
+            try
+            {
                 return Long.parseLong((String) object);
-            } catch(NumberFormatException e) {
+            }
+            catch(NumberFormatException e)
+            {
                 // try again as Double
                 return Math.round(Double.parseDouble((String) object));
             }
@@ -304,7 +319,8 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
     /* testing */ LocalDate extractDate(Object object, Optional<String> dateFormat)
     {
-        if(dateFormat.isPresent()) {
+        if(dateFormat.isPresent())
+        {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat.get());
             return LocalDate.parse(object.toString(), formatter);
         }

--- a/portfolio-app/eclipse/Portfolio Performance Java11.launch
+++ b/portfolio-app/eclipse/Portfolio Performance Java11.launch
@@ -16,6 +16,7 @@
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-name.abuchen.portfolio.product"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl de -consoleLog"/>
@@ -89,7 +90,6 @@
         <setEntry value="org.eclipse.e4.ui.services@default:default"/>
         <setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
-        <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt.cocoa@default:false"/>
         <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
@@ -112,7 +112,6 @@
         <setEntry value="org.eclipse.equinox.event@default:default"/>
         <setEntry value="org.eclipse.equinox.frameworkadmin.equinox@default:default"/>
         <setEntry value="org.eclipse.equinox.frameworkadmin@default:default"/>
-        <setEntry value="org.eclipse.equinox.launcher.cocoa.macosx.x86_64@default:false"/>
         <setEntry value="org.eclipse.equinox.launcher@default:default"/>
         <setEntry value="org.eclipse.equinox.p2.artifact.repository@default:default"/>
         <setEntry value="org.eclipse.equinox.p2.console@default:default"/>
@@ -130,7 +129,6 @@
         <setEntry value="org.eclipse.equinox.p2.transport.ecf@default:default"/>
         <setEntry value="org.eclipse.equinox.preferences@default:default"/>
         <setEntry value="org.eclipse.equinox.registry@default:default"/>
-        <setEntry value="org.eclipse.equinox.security.macosx@default:false"/>
         <setEntry value="org.eclipse.equinox.security@default:default"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator.manipulator@default:default"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator@1:true"/>
@@ -143,7 +141,6 @@
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
         <setEntry value="org.eclipse.osgi@-1:true"/>
-        <setEntry value="org.eclipse.swt.cocoa.macosx.x86_64@default:false"/>
         <setEntry value="org.eclipse.swt@default:default"/>
         <setEntry value="org.eclipse.ui.forms@default:default"/>
         <setEntry value="org.eclipse.ui.themes@default:default"/>

--- a/portfolio-app/eclipse/name.abuchen.portfolio.ui.tests.launch
+++ b/portfolio-app/eclipse/name.abuchen.portfolio.ui.tests.launch
@@ -28,6 +28,7 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
@@ -86,7 +87,6 @@
         <setEntry value="org.eclipse.core.databinding.property@default:default"/>
         <setEntry value="org.eclipse.core.databinding@default:default"/>
         <setEntry value="org.eclipse.core.expressions@default:default"/>
-        <setEntry value="org.eclipse.core.filesystem.macosx@default:false"/>
         <setEntry value="org.eclipse.core.filesystem@default:default"/>
         <setEntry value="org.eclipse.core.jobs@default:default"/>
         <setEntry value="org.eclipse.core.net@default:default"/>
@@ -111,7 +111,6 @@
         <setEntry value="org.eclipse.e4.ui.services@default:default"/>
         <setEntry value="org.eclipse.e4.ui.widgets@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.addons.swt@default:default"/>
-        <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt.cocoa@default:false"/>
         <setEntry value="org.eclipse.e4.ui.workbench.renderers.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench.swt@default:default"/>
         <setEntry value="org.eclipse.e4.ui.workbench3@default:default"/>
@@ -133,7 +132,6 @@
         <setEntry value="org.eclipse.equinox.p2.repository@default:default"/>
         <setEntry value="org.eclipse.equinox.preferences@default:default"/>
         <setEntry value="org.eclipse.equinox.registry@default:default"/>
-        <setEntry value="org.eclipse.equinox.security.macosx@default:false"/>
         <setEntry value="org.eclipse.equinox.security@default:default"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator@1:true"/>
         <setEntry value="org.eclipse.help@default:default"/>
@@ -146,10 +144,8 @@
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
         <setEntry value="org.eclipse.osgi@-1:true"/>
-        <setEntry value="org.eclipse.swt.cocoa.macosx.x86_64@default:false"/>
         <setEntry value="org.eclipse.swt@default:default"/>
         <setEntry value="org.eclipse.team.core@default:default"/>
-        <setEntry value="org.eclipse.ui.cocoa@default:false"/>
         <setEntry value="org.eclipse.ui.forms@default:default"/>
         <setEntry value="org.eclipse.ui.themes@default:default"/>
         <setEntry value="org.eclipse.ui.workbench@default:default"/>


### PR DESCRIPTION
Hi,
I added new properties to the JSON Quote provider:
- Date format can be specified. This solves https://forum.portfolio-performance.info/t/datumsformat-von-msci-com/15089 (and a lot of other forum entries) without having to work around with JSON proxy server.
- Path to low/high/volume can be specified. (Useful for example with the onvista API, e.g. https://api.onvista.de/api/v1/instruments/FUND/25096683/eod_history?idNotation=108344843&range=M1&startDate=2021-02-12)