### PR TITLE
Fix typo in a label string name

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1126,7 +1126,7 @@ LabelEarningsSelectStartYear = Earnings starting with year:
 
 LabelEarningsTradeProfitLoss = Closed trades
 
-LabelEarningsUseConsoidateRetired = Consolidation of inactive securities
+LabelEarningsUseConsolidateRetired = Consolidation of inactive securities
 
 LabelEarningsUseTradeProfitLoss = Take into account profits of trades
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1117,8 +1117,6 @@ LabelEarningsSelectStartYear = Ganhos a partir do ano:
 
 LabelEarningsTradeProfitLoss = Negocia\u00E7\u00F5es fechadas
 
-LabelEarningsUseConsoidateRetired = Consolida\u00E7\u00E3o de t\u00EDtulos inativos
-
 LabelEarningsUseConsolidateRetired = Consolida\u00E7\u00E3o de t\u00EDtulos inativos
 
 LabelEarningsUseTradeProfitLoss = Leve em considera\u00E7\u00E3o os lucros das negocia\u00E7\u00F5es


### PR DESCRIPTION
Add the *l* in *Consolidate* that was missing in some instances of `LabelEarningsUseConsolidateRetired`.