### PR TITLE
Handle NaN as quote correctly.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.model.LatestSecurityPrice;
 import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
@@ -21,7 +22,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, -1L);
+        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
     }
 
     @Test
@@ -31,7 +32,17 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, -1L);
+        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
+    }
+
+    @Test
+    public void asPriceNaNTest() throws ParseException
+    {
+        String priceFromYahoo = "NaN";
+
+        long result = YahooHelper.asPrice(priceFromYahoo);
+
+        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooHelper.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooHelper.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
+import name.abuchen.portfolio.model.LatestSecurityPrice;
 import name.abuchen.portfolio.money.Values;
 
 /* package */class YahooHelper
@@ -26,8 +27,8 @@ import name.abuchen.portfolio.money.Values;
 
     static long asPrice(String s) throws ParseException
     {
-        if ("N/A".equals(s) || "null".equals(s)) //$NON-NLS-1$ //$NON-NLS-2$
-            return -1;
+        if ("N/A".equals(s) || "null".equals(s) || "NaN".equals(s)) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            return LatestSecurityPrice.NOT_AVAILABLE;
         BigDecimal v = (BigDecimal) FMT_PRICE.get().parse(s);
         return v.multiply(Values.Quote.getBigDecimalFactor()).setScale(0, RoundingMode.HALF_UP).longValue();
     }


### PR DESCRIPTION
Treat NaN in quotes properly as data not available. Before PP crashed with the following ClassCastException:
```
java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.math.BigDecimal (java.lang.Double and java.math.BigDecimal are in module java.base of loader 'bootstrap')
	at name.abuchen.portfolio.online.impl.YahooHelper.asPrice(YahooHelper.java:31)
	at name.abuchen.portfolio.online.impl.GenericJSONQuoteFeed.extractValue(GenericJSONQuoteFeed.java:299)
	at name.abuchen.portfolio.online.impl.GenericJSONQuoteFeed.parse(GenericJSONQuoteFeed.java:253)
	at name.abuchen.portfolio.online.impl.GenericJSONQuoteFeed.getHistoricalQuotes(GenericJSONQuoteFeed.java:155)
	at name.abuchen.portfolio.online.impl.GenericJSONQuoteFeed.getHistoricalQuotes(GenericJSONQuoteFeed.java:77)
	at name.abuchen.portfolio.ui.jobs.UpdateQuotesJob$2.run(UpdateQuotesJob.java:269)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

NaN occurs, for example, in the following quote feed:`https://app2.msci.com/products/service/index/indexmaster/getLevelDataForGraph?currency_symbol=LOC&index_variant=STRD&start_date=19691231&end_date=20210306&data_frequency=DAILY&index_codes=106229`