### PR TITLE
Modify Keytrade Bank PDF-Importer to support sell and dividende

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBankExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBankExtractorTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.KeytradeBankPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.model.AccountTransaction;
@@ -23,6 +25,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -59,7 +62,242 @@ public class KeytradeBankExtractorTest
         assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-15T12:31:50")));
         assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(168)));
         assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(1994.39)));
-        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
-                        is(Money.of("EUR", Values.Amount.factorize(14.95))));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.95))));
+    }
+
+    @Test
+    public void testWertpapierKauf02()
+    {
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Kauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE000A14KEB5"));
+        assertThat(security.getName(), is("HOME24 SE  INH O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry t = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(t.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(t.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-10-19T11:53:02")));
+        assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
+        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(4963.99)));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
+    }
+
+    @Test
+    public void testWertpapierKauf03()
+    {
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Kauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE000A14KEB5"));
+        assertThat(security.getName(), is("HOME24 SE  INH O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry t = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(t.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(t.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-10-19T11:53:03")));
+        assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
+        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(4963.99)));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
+    }
+
+    @Test
+    public void testWertpapierKauf04()
+    {
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Kauf04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE0007165607"));
+        assertThat(security.getName(), is("SARTORIUS AG O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry t = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(t.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(t.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-05-13T09:56:05")));
+        assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(22)));
+        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(6118.95)));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf01()
+    {
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Verkauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE000A0JL9W6"));
+        assertThat(security.getName(), is("VERBIO VER.BIOENERGIE ON"));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-10T15:23:42")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10499.55))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf02()
+    {
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE0007165607"));
+        assertThat(security.getName(), is("SARTORIUS AG O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-07-01T12:34:24")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(22)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5409.05))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
+    }
+
+    @Test
+    public void testDividende01()
+    {
+        Client client = new Client();
+
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Dividende01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("DE0007165607"));
+        assertThat(security.getName(), is("SARTORIUS AG O.N."));
+
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.67))));
+        assertThat(t.getShares(), is(Values.Share.factorize(22)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-06-29T00:00")));
+
+        assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.70))));
+        assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.03))));
+    }
+
+    @Test
+    public void testDividende02()
+    {
+        Client client = new Client();
+
+        KeytradeBankPDFExtractor extractor = new KeytradeBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KeytradeBank_Dividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("DE000A0JL9W6"));
+        assertThat(security.getName(), is("VERBIO VER.BIOENERGIE  ON"));
+
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(45.65))));
+        assertThat(t.getShares(), is(Values.Share.factorize(310)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-02-01T00:00")));
+
+        assertThat(t.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(62.00))));
+        assertThat(t.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.35))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende01.txt
@@ -1,0 +1,19 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Betrag: 5,67 EUR
+Zuteilungsjahr 2020
+Einkommensart: Foreign stocks
+Guthaben Kupons Ex-Kupon 29/06/2020
+22 SARTORIUS AG O.N. NR 200629 0,35 EUR
+Bruttobetrag 7,70 EUR
+Verrechnungssteuer 26,38 % 2,03 EUR
+Steuerliche Bemessungsgrundlage falls zutreffend 5,67 EUR
+Nettoguthaben 5,67 EUR Datum  01/07/2020
+Wertschriftenkonto:4/260745 Wertpapier:79010788/DE0007165607 Belegnr.: CPN / 555091
+DUPLICATE

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende02.txt
@@ -1,0 +1,18 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Montant: 45,65 EUR
+Année d'attribution 2021
+Nature des revenus: Actions etrangères
+CREDIT COUPONS Ex-coupon 01/02/2021
+310 VERBIO VER.BIOENERGIE  ON NR 210201 0,2 EUR
+Montant brut 62,00 EUR
+Impôt à la source 26,38 % 16,35 EUR
+Base taxable si applicable 45,65 EUR
+Net CREDIT 45,65 EUR Date  03/02/2021
+Compte-titres:4/260745 Titre:79137418/DE000A0JL9W6 Nr. Quit.: CPN / 583554

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Dividende03.txt
@@ -1,0 +1,19 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Betrag: 1,01 EUR
+Zuteilungsjahr 2016
+Einkommensart: DVE - Dividend US Company
+Guthaben Kupons Record date 08/12/2016
+25 NEWMONT MINING CORPORATION NR 161208 0,05 USD
+Bruttobetrag 1,25 USD
+Verrechnungssteuer 15,00 % 0,19 USD
+Wechselkurs 1,05 1,01 EUR
+Steuerliche Bemessungsgrundlage falls zutreffend 1,01 EUR
+Nettoguthaben 1,06 USD Datum  29/12/2016
+Wertschriftenkonto:4/260745 Wertpapier:80007171/US6516391066 Belegnr.: CPN / 389876

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf02.txt
@@ -1,0 +1,21 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Compte-titres 260745
+Numéro de Bordereau 1857542
+Achat 310 HOME24 SE  INH O.N. (DE000A14KEB5) à 15,9324 EUR
+Type d' instrument: Actions
+Ordre créé à : 19/10/2020 11:53:02 CET
+Type d' ordre : Limit (16 EUR)
+Validité : GTC
+Date et heure d'exécution : 19/10/2020 11:53:03 CET 
+Lieu d'exécution : Internalized by ctp
+Montant brut 4.939,04 EUR
+Frais de transaction 24,95 EUR
+4.963,99 EUR
+Débit 4.963,99 EUR Date valeur 21/10/2020

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf03.txt
@@ -1,0 +1,22 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Wertschriftenkonto 260745
+Belegnummer 1857542
+Kauf 310 HOME24 SE  INH O.N. (DE000A14KEB5) für 15,9324 EUR
+Instrument: Aktien
+Auftragserstellung : 19/10/2020 11:53:02 CET
+Auftragstyp : Limit (16 EUR)
+Gültigkeit : GTC
+Ausführungsdatum und -zeit : 19/10/2020 11:53:03 CET 
+Ausführungsort : Internalized by ctp
+Bruttobetrag 4.939,04 EUR
+Transaktionskosten 24,95 EUR
+4.963,99 EUR
+Lastschrift 4.963,99 EUR Valutadatum 21/10/2020
+DUPLICATE

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf04.txt
@@ -1,0 +1,22 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Wertschriftenkonto 260745
+Belegnummer 1800539
+Kauf 22 SARTORIUS AG O.N. (DE0007165607) für 277 EUR
+Instrument: Aktien
+Auftragserstellung : 13/05/2020 09:49:13 CET
+Auftragstyp : Limit (277 EUR)
+Gültigkeit : GTC
+Ausführungsdatum und -zeit : 13/05/2020 09:56:05 CET 
+Ausführungsort : XETRA
+Bruttobetrag 6.094,00 EUR
+Transaktionskosten 24,95 EUR
+6.118,95 EUR
+Lastschrift 6.118,95 EUR Valutadatum 15/05/2020
+DUPLICATE

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Kauf05.txt
@@ -1,0 +1,22 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Wertschriftenkonto 260745
+Belegnummer 1481325
+Kauf 25 NEWMONT MINING CORPORATION (US6516391066) für 36,96 USD
+Instrument: Aktien
+Auftragserstellung : 16/06/2016 15:45:18 CET
+Auftragstyp : Limit (37,45 USD)
+Gültigkeit : Day
+Ausführungsdatum und -zeit : 16/06/2016 09:45:18 EST 
+Ausführungsort : OTC/NON SUMO, FINRA
+Bruttobetrag 924,00 USD
+Transaktionskosten 29,95 USD
+953,95 USD
+Wechselkurs EUR/USD 1.123000 849,47 EUR
+Lastschrift 953,95 USD Valutadatum 21/06/2016

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf01.txt
@@ -1,0 +1,21 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Compte-titres 260745
+Numéro de Bordereau 1910356
+Vente 310 VERBIO VER.BIOENERGIE ON (DE000A0JL9W6) à 33,95 EUR
+Type d' instrument: Actions
+Ordre créé à : 10/02/2021 15:23:42 CET
+Type d' ordre : Market
+Validité : GTC
+Date et heure d'exécution : 10/02/2021 15:23:42 CET
+Lieu d'exécution : XETRA
+Montant brut 10.524,50 EUR
+Frais de transaction 24,95 EUR
+10.499,55 EUR
+Crédit 10.499,55 EUR Date valeur 12/02/2021

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf02.txt
@@ -1,0 +1,22 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Wertschriftenkonto 260745
+Belegnummer 1820896
+Verkauf 22 SARTORIUS AG O.N. (DE0007165607) für 247 EUR
+Instrument: Aktien
+Auftragserstellung : 01/07/2020 12:34:24 CET
+Auftragstyp : Market
+Gültigkeit : GTC
+Ausführungsdatum und -zeit : 01/07/2020 12:34:24 CET 
+Ausführungsort : XETRA
+Bruttobetrag 5.434,00 EUR
+Transaktionskosten 24,95 EUR
+5.409,05 EUR
+Gutschrift 5.409,05 EUR Valutadatum 03/07/2020
+DUPLICATE

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBank_Verkauf03.txt
@@ -1,0 +1,23 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Keytrade Bank Luxembourg S.A. T +352 45 04 39
+62, Rue Charles Martel F +352 45 04 49
+L-2134 - Luxembourg info@keytradebank.lu
+Grand Duché de Luxembourg www.keytradebank.lu
+RCS B69935 Skype keytradebank.lu
+Wertschriftenkonto 260745
+Belegnummer 1574460
+Verkauf 25 NEWMONT MINING CORPORATION (US6516391066) für 38,751 USD
+Instrument: Aktien
+Auftragserstellung : 11/09/2017 17:09:34 CET
+Auftragstyp : Limit (38,60 USD)
+Gültigkeit : Day
+Ausführungsdatum und -zeit : 11/09/2017 11:09:35 EST 
+Ausführungsort : OTC/NON SUMO, FINRA
+Bruttobetrag 968,78 USD
+Transaktionskosten 29,95 USD
+938,83 USD
+Wechselkurs EUR/USD 1.201000 781,71 EUR
+Gutschrift 938,83 USD Valutadatum 13/09/2017
+DUPLICATE

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -1,9 +1,11 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -20,6 +22,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("Keytrade Bank"); //$NON-NLS-1$
 
         addBuySellTransaction();
+        addDividendeTransaction();
     }
 
     @Override
@@ -36,7 +39,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("Kauf");
+        DocumentType type = new DocumentType("(Kauf|Achat|Vente|Verkauf)");
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
@@ -46,46 +49,141 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("Kauf .*");
+        Block firstRelevantLine = new Block("(Kauf|Achat|Vente|Verkauf) .*");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
+                // Is type --> "Verkauf" change from BUY to SELL
+                .section("type").optional()
+                .match("(?<type>(Verkauf|Vente)) .*")
+                .assign((t, v) -> {
+                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Vente"))
+                    {
+                        t.setType(PortfolioTransaction.Type.SELL);
+                    }
+                })
 
-                        // Kauf 168 LYXOR CORE WORLD (LU1781541179) für 11,7824 EUR
-                        .section("isin", "name", "shares")
-                        .match("^Kauf (?<shares>[\\d.,]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .*")
-                        .assign((t, v) -> {
-                            t.setSecurity(getOrCreateSecurity(v));
-                            t.setShares(asShares(v.get("shares")));
-                        })
+                // Kauf 168 LYXOR CORE WORLD (LU1781541179) für 11,7824 EUR
+                // Achat 310 HOME24 SE  INH O.N. (DE000A14KEB5) à 15,9324 EUR
+                // Vente 310 VERBIO VER.BIOENERGIE ON (DE000A0JL9W6) à 33,95 EUR
+                // Verkauf 22 SARTORIUS AG O.N. (DE0007165607) für 247 EUR
+                .section("isin", "name", "shares")
+                .match("^(Kauf|Achat|Verkauf|Vente) (?<shares>[\\d.,]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .*$")
+                .assign((t, v) -> {
+                    t.setSecurity(getOrCreateSecurity(v));
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                        // Ausführungsdatum und -zeit : 15/03/2021 12:31:50 CET
-                        .section("date", "time")
-                        .match("^Ausführungsdatum und -zeit : (?<date>\\d+/\\d+/\\d{4}) (?<time>\\d+:\\d+:\\d+) .*")
-                        .assign((t, v) -> {
-                            if (v.get("time") != null)
-                                t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time")));
-                            else
-                                t.setDate(asDate(v.get("date").replaceAll("/", ".")));
-                        })
+                // Ausführungsdatum und -zeit : 15/03/2021 12:31:50 CET
+                // Ordre créé à : 10/02/2021 15:23:42 CET
+                .section("date", "time")
+                .match("^(Ausführungsdatum und -zeit|Ordre créé à) : (?<date>\\d+/\\d+/\\d{4}) (?<time>\\d+:\\d+:\\d+) .*$")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date").replaceAll("/", ".")));
+                })
 
-                        // Lastschrift 1.994,39 EUR Valutadatum 17/03/2021
-                        .section("currency", "amount")
-                        .match("^Lastschrift (?<amount>[.,\\d]+ (?<currency>\\w{3})) .*")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(v.get("currency"));
-                        })
+                // Lastschrift 1.994,39 EUR Valutadatum 17/03/2021
+                // Gutschrift 5.409,05 EUR Valutadatum 03/07/2020
+                // Crédit 10.499,55 EUR Date valeur 12/02/2021
+                // Débit 4.963,99 EUR Date valeur 21/10/2020
+                .section("amount", "currency")
+                .match("^(Gutschrift|Crédit|Lastschrift|Débit) (?<amount>[.,\\d]+) (?<currency>[\\w]{3}) .*$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                        // Transaktionskosten 14,95 EUR
-                        .section("fee", "currency").optional()
-                        .match("^(Transaktionskosten) (?<fee>[.,\\d]+) (?<currency>\\w{3})")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
+                // Auftragstyp : Limit (16 EUR)
+                .section("note").optional()
+                .match("^(Auftragstyp|Type d' ordre) : (?<note>.*)$")
+                .assign((t, v) -> t.setNote(v.get("note")))
 
-                        .wrap(BuySellEntryItem::new);
+                // Transaktionskosten 14,95 EUR
+                .section("fee", "currency").optional()
+                .match("^(Transaktionskosten|Frais de transaction) (?<fee>[.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> t.getPortfolioTransaction()
+                                .addUnit(new Unit(Unit.Type.FEE,
+                                                Money.of(asCurrencyCode(v.get("currency")),
+                                                                asAmount(v.get("fee"))))))
+
+                .wrap(BuySellEntryItem::new);
+    }
+
+    private void addDividendeTransaction()
+    {
+        DocumentType type = new DocumentType("(Einkommensart|Nature des revenus)");
+        this.addDocumentTyp(type);
+
+        Block block = new Block("(Einkommensart|Nature des revenus): .*");
+        type.addBlock(block);
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
+            .subject(() -> {
+                AccountTransaction entry = new AccountTransaction();
+                entry.setType(AccountTransaction.Type.DIVIDENDS);
+                return entry;
+            });
+
+        pdfTransaction
+
+                // 22 SARTORIUS AG O.N. NR 200629 0,35 EUR
+
+                // Wertschriftenkonto:4/260745 Wertpapier:79010788/DE0007165607 Belegnr.: CPN / 555091
+                // Compte-titres:4/260745 Titre:79137418/DE000A0JL9W6 Nr. Quit.: CPN / 583554
+                .section("shares", "name", "isin")
+                .match("^(?<shares>[.,\\d]+) (?<name>.*) NR .*$")
+                .match("^(Wertschriftenkonto|Compte-titres):.* (Wertpapier|Titre):[\\d]+\\/(?<isin>[\\w]{12}) .*$")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
+
+                // Guthaben Kupons Ex-Kupon 29/06/2020
+                // CREDIT COUPONS Ex-coupon 01/02/2021
+                .section("date")
+                .match("^.* (Ex-Kupon|Ex-coupon) (?<date>\\d+/\\d+/\\d{4})$")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("/", "."))))
+
+                // Nettoguthaben 5,67 EUR Datum  01/07/2020
+                .section("amount", "currency")
+                .match("^(Nettoguthaben|Net CREDIT) (?<amount>[.,\\d]+) (?<currency>[\\w]{3}) .*$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
+
+                .wrap(TransactionItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+
+        block.set(pdfTransaction);
+    }
+
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction
+
+            // Verrechnungssteuer 26,38 % 2,03 EUR
+            // Impôt à la source 26,38 % 16,35 EUR
+            .section("tax", "currency").optional()
+            .match("^(Verrechnungssteuer|Impôt à la source) [.,\\d]+ % (?<tax>[.,\\d]+) (?<currency>\\w{3})$")
+            .assign((t, v) -> processTaxEntries(t, v, type));
+    }
+
+    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -122,9 +122,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
             });
 
         pdfTransaction
-
                 // 22 SARTORIUS AG O.N. NR 200629 0,35 EUR
-
                 // Wertschriftenkonto:4/260745 Wertpapier:79010788/DE0007165607 Belegnr.: CPN / 555091
                 // Compte-titres:4/260745 Titre:79137418/DE000A0JL9W6 Nr. Quit.: CPN / 583554
                 .section("shares", "name", "isin")
@@ -163,7 +161,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Verrechnungssteuer 26,38 % 2,03 EUR
                 // Impôt à la source 26,38 % 16,35 EUR
                 .section("tax", "currency").optional()
-                .match("^(Verrechnungssteuer|Impôt à la source) [.,\\d]+ % (?<tax>[.,\\d]+) (?<currency>\\w{3})$")
+                .match("^(Verrechnungssteuer|Impôt à la source) [.,\\d]+ % (?<tax>[.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-keytrade-bank/15416/5
https://forum.portfolio-performance.info/t/pdf-import-keytrade-bank/15416/9
https://forum.portfolio-performance.info/t/pdf-import-keytrade-bank/15416/15
https://forum.portfolio-performance.info/t/pdf-import-keytrade-bank/15416/17
Add sell transaction
Add french language support
Integration in the PDFExtractorUtils.java (fee's and tax's)

**Hinweis:**
Mit diesem und den anderen Pull-Requests werden die
PDF-Importer im Aufbau, Funktion und Source gleich gemacht.

Folgenden PDF-Importer sind somit fertig überarbeitet:
- Commerzbank
- KeyTrade Bank
- 1822Direkt
- Postbank
- Weberbank
- s.Broker / Sparkasse
- DreiBankenEDV
- Erste Bank
- LGT-Bank
- MPL-Bank
- DZBank
- JustTrade