### PR TITLE
Modify 1822DirektBank PDF-Importer to support other dividende

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Ausschüttung03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Ausschüttung03.txt
@@ -1,0 +1,52 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postfach · 60255 Frankfurt am Main Seite 1
+Depotnummer 1111111111
+Kundennummer 1111111
+Max Muster
+Abrechnungsnr. 11111111122
+Herrn Max Muster Datum 13.03.2021
+c/o Fam. Muster Ihr Berater 1822direkt
+Meine-Strasse. 42 Telefon 012 34560-0
+12345 Berlin
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 6 EXXON MOBIL CORP. US30231G1022 (852549)
+REGISTERED SHARES O.N.
+Zahlbarkeitstag 10.03.2021 Dividende pro Stück 0,87 USD
+Bestandsstichtag 08.02.2021 Herkunftsland USA
+Ex-Tag 09.02.2021 Art der Dividende Quartalsdividende
+Geschäftsjahr 01.01.2021 - 31.12.2021
+Devisenkurs EUR / USD 1,1913
+Devisenkursdatum 10.03.2021
+Dividendengutschrift 5,22 USD 4,38+ EUR
+Umrechnung in EUR 4,38 EUR
+Einbehaltene Quellensteuer 15 % auf 5,22 USD 0,66- EUR
+Anrechenbare Quellensteuer 15 % auf 4,38 EUR 0,66 EUR
+Kapitalertragsteuerpflichtige Dividende 4,38 EUR
+Verrechneter Sparer-Pauschbetrag 4,38 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Ausmachender Betrag 3,72+ EUR
+Lagerstelle Clearstream Banking FFM (849000 / 40030000)
+Den Betrag buchen wir mit Wertstellung 12.03.2021 zu Gunsten des Kontos 1234567890 (IBAN DE00 1111 2222 3333
+4444 55), BLZ 500 500 01 (BIC HELADEF1822).
+Keine Steuerbescheinigung.
+Bitte ggf. Rückseite beachten.
+4444.77777777.0000111ER01
+
+Seite 2
+Depotnummer 1111111111
+Kundennummer 1111111
+Abrechnungsnr. 11111111122
+Datum 10.03.2021
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2021 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 111,11 0,00 100,00 0,50 0,00
+Ertrag 0,00 0,00 4,38- 0,66 0,00
+Nachher 111,11 0,00 95,62 1,16 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+4444.77777777.0000112ER01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
@@ -96,11 +96,13 @@ public class direkt1822bankPDFExtractorTest
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(68.87))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.87))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(920)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-14T00:00")));
 
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(23.41 + 1.28))));
+        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(93.56))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.41 + 1.28))));
         
         CheckCurrenciesAction c = new CheckCurrenciesAction();
         Account account = new Account();
@@ -134,11 +136,53 @@ public class direkt1822bankPDFExtractorTest
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(7.13))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.13))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(118.901)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-03-10T00:00")));
 
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.13))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.EUR);
+        Status s = c.process(t, account);
+        assertThat(s, is(Status.OK_STATUS));
+    }
+
+    @Test
+    public void testAusschuettung03()
+    {
+        Direkt1822BankPDFExtractor extractor = new Direkt1822BankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ausschüttung03.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        AccountTransaction t = results.stream().filter(i -> i instanceof TransactionItem)
+                        .map(i -> (AccountTransaction) ((TransactionItem) i).getSubject()).findAny()
+                        .orElseThrow(IllegalArgumentException::new);
+        
+        assertThat(t.getSecurity().getIsin(), is("US30231G1022"));
+        assertThat(t.getSecurity().getWkn(), is("852549"));
+        assertThat(t.getSecurity().getName(), is("EXXON MOBIL CORP. REGISTERED SHARES O.N."));
+
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.72))));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(6)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-02-09T00:00")));
+
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.38))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.66))));
         
         CheckCurrenciesAction c = new CheckCurrenciesAction();
         Account account = new Account();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -59,95 +59,58 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
-                    // Is type --> "Verkauf" change from BUY to SELL
-                    .section("type").optional()
-                    .match(".*Abrechnung (?<type>Verkauf?).*")
-                    .assign((t, v) -> {
-                        if (v.get("type").equals("Verkauf"))
-                        {
-                            t.setType(PortfolioTransaction.Type.SELL);
-                        }
-                    })
+                // Is type --> "Verkauf" change from BUY to SELL
+                .section("type").optional()
+                .match(".*Abrechnung (?<type>Verkauf?).*")
+                .assign((t, v) -> {
+                    if (v.get("type").equals("Verkauf"))
+                    {
+                        t.setType(PortfolioTransaction.Type.SELL);
+                    }
+                })
 
-                    // Stück 13 COMSTA.-MSCI EM.MKTS.TRN U.ETF LU0635178014 (ETF127)
-                    // INHABER-ANTEILE I O.N.
-                    .section("isin", "wkn", "name", "shares", "name1")
-                    .match("^(St.ck) (?<shares>[.,\\d]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
-                    .match("(?<name1>.*)")
-                    .assign((t, v) -> {
-                        if (!v.get("name1").startsWith("B.rse"))
-                            v.put("name", v.get("name") + " " + v.get("name1"));
-                        t.setSecurity(getOrCreateSecurity(v));
-                        t.setShares(asShares(v.get("shares")));
-                    })
+                // Stück 13 COMSTA.-MSCI EM.MKTS.TRN U.ETF LU0635178014 (ETF127)
+                // INHABER-ANTEILE I O.N.
+                .section("isin", "wkn", "name", "shares", "name1")
+                .match("^(St.ck) (?<shares>[.,\\d]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
+                .match("(?<name1>.*)")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("B.rse"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+                    t.setSecurity(getOrCreateSecurity(v));
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                    // Auftrag vom 05.12.2017 00:15:28 Uhr
-                    .section("date", "time")
-                    .match("^(Schlusstag/-Zeit) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+).*")
-                    .assign((t, v) -> {
-                        if (v.get("time") != null)
-                            t.setDate(asDate(v.get("date"), v.get("time")));
-                        else
-                            t.setDate(asDate(v.get("date")));
-                    })
+                // Auftrag vom 05.12.2017 00:15:28 Uhr
+                .section("date", "time")
+                .match("^(Schlusstag/-Zeit) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+).*")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                    // Ausmachender Betrag 50,00- EUR
-                    .section("currency", "amount")
-                    .match("^(Ausmachender Betrag) (?<amount>[.,\\d.]+)[?(-|\\+)] (?<currency>[\\w]{3})")
-                    .assign((t, v) -> {
-                        t.setAmount(asAmount(v.get("amount")));
-                        t.setCurrencyCode(v.get("currency"));
-                    })
+                // Ausmachender Betrag 50,00- EUR
+                .section("currency", "amount")
+                .match("^(Ausmachender Betrag) (?<amount>[.,\\d.]+)[?(-|\\+)] (?<currency>[\\w]{3})")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                    // Eingebuchte sonstige negative Kapitalerträge 0,02 EUR
-                    .section("tax", "currency").optional()
-                    .match("^(Eingebuchte.*Kapitalerträge) (?<tax>[.,\\d]+) (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.TAX,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("tax"))))))
+                // Devisenkurs (EUR/USD) 1,1987 vom 02.03.2021
+                .section("exchangeRate").optional()
+                .match("^(Devisenkurs) \\([\\w]{3}\\/[\\w]{3}\\) (?<exchangeRate>[.,\\d]+) .*")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                })
 
-                    // Provision 4,95- EUR
-                    .section("fee", "currency").optional()
-                    .match("^(Provision) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
+                .wrap(BuySellEntryItem::new);
 
-                    // Eigene Spesen 1,95- EUR
-                    .section("fee", "currency").optional()
-                    .match("^(Eigene Spesen) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    // Transaktionsentgelt Börse 0,11- EUR
-                    .section("fee", "currency").optional()
-                    .match("(Transaktionsentgelt B.rse) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    // Übertragungs-/Liefergebühr 0,11- EUR
-                    .section("fee", "currency").optional()
-                    .match("(.bertragungs-\\/Liefergeb.hr) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    // Handelsentgelt 1,00- EUR
-                    .section("fee", "currency").optional()
-                    .match("(Handelsentgelt) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    .wrap(BuySellEntryItem::new);
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
     }
 
     private void addBuySellSavePlanTransaction()
@@ -167,38 +130,47 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
-                    // Stück 13 COMSTA.-MSCI EM.MKTS.TRN U.ETF LU0635178014 (ETF127)
-                    // INHABER-ANTEILE I O.N.
-                    .section("isin", "wkn", "name", "shares", "name1")
-                    .match("^(St.ck) (?<shares>[\\d.,]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
-                    .match("(?<name1>.*)")
-                    .assign((t, v) -> {
-                        if (!v.get("name1").startsWith("B.rse"))
-                            v.put("name", v.get("name") + " " + v.get("name1"));
-                        t.setSecurity(getOrCreateSecurity(v));
-                        t.setShares(asShares(v.get("shares")));
-                    })
+                // Stück 13 COMSTA.-MSCI EM.MKTS.TRN U.ETF LU0635178014 (ETF127)
+                // INHABER-ANTEILE I O.N.
+                .section("isin", "wkn", "name", "shares", "name1")
+                .match("^(St.ck) (?<shares>[\\d.,]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
+                .match("(?<name1>.*)")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("B.rse"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+                    t.setSecurity(getOrCreateSecurity(v));
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                    // Auftrag vom 05.12.2017 00:15:28 Uhr
-                    .section("date", "time")
-                    .match("^(Auftrag vom) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+) Uhr")
-                    .assign((t, v) -> {
-                        if (v.get("time") != null)
-                            t.setDate(asDate(v.get("date"), v.get("time")));
-                        else
-                            t.setDate(asDate(v.get("date")));
-                    })
+                // Auftrag vom 05.12.2017 00:15:28 Uhr
+                .section("date", "time")
+                .match("^(Auftrag vom) (?<date>\\d+.\\d+.\\d{4}) (?<time>\\d+:\\d+:\\d+) Uhr")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                    // Ausmachender Betrag 50,00- EUR
-                    .section("amount", "currency")
-                    .match("^(Ausmachender Betrag) (?<amount>[.,\\d]+)- (?<currency>[\\w]{3})")
-                    .assign((t, v) -> {
-                        t.setAmount(asAmount(v.get("amount")));
-                        t.setCurrencyCode(v.get("currency"));
-                    })
+                // Ausmachender Betrag 50,00- EUR
+                .section("amount", "currency")
+                .match("^(Ausmachender Betrag) (?<amount>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                    .wrap(BuySellEntryItem::new);
+                // Devisenkurs (EUR/USD) 1,1987 vom 02.03.2021
+                .section("exchangeRate").optional()
+                .match("^(Devisenkurs) \\([\\w]{3}\\/[\\w]{3}\\) (?<exchangeRate>[.,\\d]+) .*")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                })
 
+                .wrap(BuySellEntryItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
@@ -217,73 +189,74 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
             });
 
         pdfTransaction
-                    // Stück 920 ISHSIV-FA.AN.HI.YI.CO.BD U.ETF IE00BYM31M36 (A2AFCX)
-                    // REGISTERED SHARES USD O.N.
-                    .section("isin", "wkn", "name", "shares", "name1")
-                    .match("^(Stück) (?<shares>[\\d.,]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
-                    .match("(?<name1>.*)")
-                    .assign((t, v) -> {
-                        if (!v.get("name1").startsWith("Zahlbarkeitstag"))
-                            v.put("name", v.get("name") + " " + v.get("name1"));
-                        t.setSecurity(getOrCreateSecurity(v));
-                        t.setShares(asShares(v.get("shares")));
-                    })
+                // Stück 920 ISHSIV-FA.AN.HI.YI.CO.BD U.ETF IE00BYM31M36 (A2AFCX)
+                // REGISTERED SHARES USD O.N.
+                .section("isin", "wkn", "name", "shares", "name1")
+                .match("^(Stück) (?<shares>[\\d.,]+) (?<name>.*) (?<isin>[\\w]{12}.*) (\\((?<wkn>.*)\\).*)")
+                .match("(?<name1>.*)")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Zahlbarkeitstag"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+                    t.setSecurity(getOrCreateSecurity(v));
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                    // Ausmachender Betrag 68,87+ EUR
-                    .section("currency", "amount")
-                    .match("^(Ausmachender Betrag) (?<amount>[.,\\d]+)\\+ (?<currency>[\\w]{3})")
-                    .assign((t, v) -> {
-                        t.setAmount(asAmount(v.get("amount")));
-                        t.setCurrencyCode(v.get("currency"));
-                    })
+                // Ausmachender Betrag 68,87+ EUR
+                .section("currency", "amount")
+                .match("^(Ausmachender Betrag) (?<amount>[.,\\d]+)\\+ (?<currency>[\\w]{3})")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                    // Ex-Tag 14.12.2017 Herkunftsland Irland
-                    .section("date")
-                    .match("^Ex-Tag (?<date>\\d+.\\d+.\\d{4}).*")
-                    .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                // Ex-Tag 14.12.2017 Herkunftsland Irland
+                .section("date")
+                .match("^Ex-Tag (?<date>\\d+.\\d+.\\d{4}).*")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                    // Devisenkurs EUR / USD 1,2095
-                    // Devisenkursdatum 02.01.2018
-                    // Ausschüttung 113,16 USD 93,56+ EUR
-                    .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
-                    .match("^(Devisenkurs) .* (?<exchangeRate>[.,\\d]+)$")
-                    .match("^(Ausschüttung) (?<fxAmount>[.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<amount>[.,\\d]+)\\+ (?<currency>[\\w]{3})$")                        
-                    .assign((t, v) -> {
-                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                        if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                // Devisenkurs EUR / USD 1,2095
+                // Devisenkursdatum 02.01.2018
+                // Ausschüttung 113,16 USD 93,56+ EUR
+                .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
+                .match("^(Devisenkurs) .* (?<exchangeRate>[.,\\d]+)$")
+                .match("^(Ausschüttung) (?<fxAmount>[.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<amount>[.,\\d]+)\\+ (?<currency>[\\w]{3})$")                        
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    {
+                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    }
+
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+
+                    if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                    {
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                        RoundingMode.HALF_DOWN);
+
+                        // check, if forex currency is transaction
+                        // currency or not and swap amount, if necessary
+                        Unit grossValue;
+                        if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
                         {
-                            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),asAmount(v.get("fxAmount")));
+                            Money amount = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("amount")));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
                         }
-
-                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                        if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                        else
                         {
-                            BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                            RoundingMode.HALF_DOWN);
-
-                            // check, if forex currency is transaction
-                            // currency or not and swap amount, if necessary
-                            Unit grossValue;
-                            if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
-                            {
-                                Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),asAmount(v.get("fxAmount")));
-                                Money amount = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("amount")));
-                                grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
-                            }
-                            else
-                            {
-                                Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
-                                Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
-                                grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
-                            }
-                            t.addUnit(grossValue);
+                            Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
                         }
-                    })
+                        t.addUnit(grossValue);
+                    }
+                })
 
-                    .wrap(TransactionItem::new);
+                .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
 
         block.set(pdfTransaction);
     }
@@ -291,59 +264,81 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                    // Kapitalertragsteuer 25 % auf 93,63 EUR 23,41- EUR
-                    .section("tax", "currency").optional()
-                    .match("^(Kapitalertragsteuer) [.,\\d]+ % .* (?<tax>[.,\\d]+)- (?<currency>[\\w]{3})$")
-                    .assign((t, v) -> processTaxEntries(t, v, type))
-                    
-                    // Solidaritätszuschlag 5,5 % auf 23,41 EUR 1,28- EUR
-                    .section("tax", "currency").optional()
-                    .match("^(Solidaritätszuschlag) [.,\\d]+ .* (?<tax>[.,\\d]+)- (?<currency>[\\w]{3})$")
-                    .assign((t, v) -> processTaxEntries(t, v, type))
+                // Eingebuchte sonstige negative Kapitalerträge 0,02 EUR
+                .section("tax", "currency").optional()
+                .match("^(Eingebuchte.*Kapitalerträge) (?<tax>[.,\\d]+) (?<currency>[\\w]{3})")
+                .assign((t, v) -> processTaxEntries(t, v, type))
 
-                    // Einbehaltene Quellensteuer 15 % auf 5,22 USD 0,66- EUR
-                    .section("quellensteinbeh", "currency").optional()
-                    .match("^Einbehaltende Quellensteuer [.,\\d]+ .* (?<quellensteinbeh>[.,\\d]+) (?<currency>[\\w]{3})$")
-                    .assign((t, v) ->  {
-                        type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
-                        addTax(type, t, v, "quellensteinbeh");
-                    })
-                    
-                    // Anrechenbare Quellensteuer 15 % auf 4,38 EUR 0,66 EUR
-                    .section("quellenstanr", "currency").optional()
-                    .match("^Anrechenbare Quellensteuer [.,\\d]+ .* (?<quellenstanr>[.,\\d]+) (?<currency>[\\w]{3})$")
-                    .assign((t, v) -> addTax(type, t, v, "quellenstanr"));
+                // Kapitalertragsteuer 25 % auf 93,63 EUR 23,41- EUR
+                .section("tax", "currency").optional()
+                .match("^(Kapitalertragsteuer) [.,\\d]+ % .* (?<tax>[.,\\d]+)- (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // Solidaritätszuschlag 5,5 % auf 23,41 EUR 1,28- EUR
+                .section("tax", "currency").optional()
+                .match("^(Solidaritätszuschlag) [.,\\d]+ .* (?<tax>[.,\\d]+)- (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // Einbehaltene Quellensteuer 15 % auf 5,22 USD 0,66- EUR
+                .section("quellensteinbeh", "currency").optional()
+                .match("^Einbehaltende Quellensteuer [.,\\d]+ .* (?<quellensteinbeh>[.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) ->  {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
+                    addTax(type, t, v, "quellensteinbeh");
+                })
+
+                // Anrechenbare Quellensteuer 15 % auf 4,38 EUR 0,66 EUR
+                .section("quellenstanr", "currency").optional()
+                .match("^Anrechenbare Quellensteuer [.,\\d]+ .* (?<quellenstanr>[.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> addTax(type, t, v, "quellenstanr"));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                    // Devisenkurs (EUR/USD) 1,1987 vom 02.03.2021
-                    .section("exchangeRate").optional()
-                    .match("^(Devisenkurs) \\([\\w]{3}\\/[\\w]{3}\\) (?<exchangeRate>[.,\\d]+) .*")
-                    .assign((t, v) -> {
-                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-                    })
-                    
-                    // Kurswert 52,50- EUR
-                    // Kundenbonifikation 100 % vom Ausgabeaufschlag 2,50 EUR
-                    // Ausgabeaufschlag pro Anteil 5,00 %
-                    .section("feeFx", "feeFy", "amountFx", "currency").optional()
-                    .match("^Kurswert (?<amountFx>[.,\\d]+)[-]? (?<currency>[\\w]{3})")
-                    .match("^Kundenbonifikation (?<feeFy>[.,\\d]+) % vom Ausgabeaufschlag [.,\\d]+ [\\w]{3}")
-                    .match("^Ausgabeaufschlag pro Anteil (?<feeFx>[.,\\d]+) %")
-                    .assign((t, v) -> {
-                        // Fee in percent
-                        double amountFx = Double.parseDouble(v.get("amountFx").replace(',', '.'));
-                        double feeFy = Double.parseDouble(v.get("feeFy").replace(',', '.'));
-                        double feeFx = Double.parseDouble(v.get("feeFx").replace(',', '.'));
-                        feeFy = (amountFx / (1 + feeFx / 100)) * (feeFx / 100) * (feeFy / 100);
-                        String fee =  Double.toString((amountFx / (1 + feeFx / 100)) * (feeFx / 100) - feeFy).replace('.', ',');
-                        v.put("fee", fee);
+                // Provision 4,95- EUR
+                .section("fee", "currency").optional()
+                .match("^(Provision) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processFeeEntries(t, v, type))
 
-                        processFeeEntries(t, v, type);
-                    });
+                // Eigene Spesen 1,95- EUR
+                .section("fee", "currency").optional()
+                .match("^(Eigene Spesen) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Transaktionsentgelt Börse 0,11- EUR
+                .section("fee", "currency").optional()
+                .match("(Transaktionsentgelt B.rse) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Übertragungs-/Liefergebühr 0,11- EUR
+                .section("fee", "currency").optional()
+                .match("(.bertragungs-\\/Liefergeb.hr) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Handelsentgelt 1,00- EUR
+                .section("fee", "currency").optional()
+                .match("(Handelsentgelt) (?<fee>[.,\\d]+)- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Kurswert 52,50- EUR
+                // Kundenbonifikation 100 % vom Ausgabeaufschlag 2,50 EUR
+                // Ausgabeaufschlag pro Anteil 5,00 %
+                .section("feeFx", "feeFy", "amountFx", "currency").optional()
+                .match("^Kurswert (?<amountFx>[.,\\d]+)[-]? (?<currency>[\\w]{3})")
+                .match("^Kundenbonifikation (?<feeFy>[.,\\d]+) % vom Ausgabeaufschlag [.,\\d]+ [\\w]{3}")
+                .match("^Ausgabeaufschlag pro Anteil (?<feeFx>[.,\\d]+) %")
+                .assign((t, v) -> {
+                    // Fee in percent
+                    double amountFx = Double.parseDouble(v.get("amountFx").replace(',', '.'));
+                    double feeFy = Double.parseDouble(v.get("feeFy").replace(',', '.'));
+                    double feeFx = Double.parseDouble(v.get("feeFx").replace(',', '.'));
+                    feeFy = (amountFx / (1 + feeFx / 100)) * (feeFx / 100) * (feeFy / 100);
+                    String fee =  Double.toString((amountFx / (1 + feeFx / 100)) * (feeFx / 100) - feeFy).replace('.', ',');
+                    v.put("fee", fee);
+
+                    processFeeEntries(t, v, type);
+                });
     }
 
     private void addTax(DocumentType type, Object t, Map<String, String> v, String taxtype)


### PR DESCRIPTION
Fixed issue #2178
Check with holding tax
Optimize some regEx's
Optimize some testcase
Integration in the PDFExtractorUtils.java (fee's and tax's)

**Hinweis:**
Mit diesem und den anderen Pull-Requests werden die
PDF-Importer im Aufbau, Funktion und Source gleich gemacht.

Folgenden PDF-Importer sind somit fertig überarbeitet:
- Commerzbank
- KeyTrade Bank
- 1822Direkt
- Postbank
- Weberbank
- s.Broker / Sparkasse
- DreiBankenEDV
- Erste Bank
- LGT-Bank
- MPL-Bank
- DZBank
- JustTrade