### PR TITLE
Fix sBroker/Sparkasse PDF-Importer to support missing taxes

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ import name.abuchen.portfolio.money.Values;
 public class SBrokerPDFExtractorTest
 {
     @Test
-    public void testWertpapierKauf1() throws IOException
+    public void testWertpapierKauf1()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -58,14 +57,17 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1930_17)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1930.17))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-10-01T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(16)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 377L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.77))));
     }
 
     @Test
-    public void testWertpapierKauf2() throws IOException
+    public void testWertpapierKauf2()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -90,14 +92,17 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1249_30)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1249.30))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-11-15T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(18)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 1090L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.90))));
     }
 
     @Test
-    public void testWertpapierKauf3() throws IOException
+    public void testWertpapierKauf3()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -135,7 +140,7 @@ public class SBrokerPDFExtractorTest
     }
 
     @Test
-    public void testWertpapierVerkauf1() throws IOException
+    public void testWertpapierVerkauf1()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -160,14 +165,17 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 5648_24)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5648.24))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-06-04T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(47)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 821L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.21))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testErtragsgutschrift1() throws IOException
+    public void testErtragsgutschrift1()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -190,13 +198,17 @@ public class SBrokerPDFExtractorTest
 
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
-        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 12_70)));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.70))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2014-11-17T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(16)));
+        assertThat(t.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(t.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testErtragsgutschrift2() throws IOException
+    public void testErtragsgutschrift2()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
 
@@ -219,8 +231,15 @@ public class SBrokerPDFExtractorTest
 
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
-        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 52_36)));
-        assertThat(t.getDateTime(), is(LocalDateTime.parse("2014-12-15T00:00")));
+        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(70.32))));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2014-11-26T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(103)));
+
+        assertThat(t.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(88.28))));
+        assertThat(t.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.03 + 0.38 + 10.55))));
+        assertThat(t.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -11,7 +10,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -1,5 +1,9 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
+
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -24,6 +28,18 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         addDividendTransaction();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "S Broker AG & Co. KG / Sparkasse"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getPDFAuthor()
+    {
+        return ""; //$NON-NLS-1$
+    }
+
     private void addBuySellTransaction()
     {
         DocumentType type = new DocumentType("(Kauf .*|Verkauf .*|Wertpapier Abrechnung Ausgabe Investmentfonds)");
@@ -43,7 +59,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                     // Is type --> "Verkauf" change from BUY to SELL
                     .section("type").optional()
-                    .match("(?<type>Verkauf?) .*")
+                    .match("(?<type>Verkauf) .*")
                     .assign((t, v) -> {
                         if (v.get("type").equals("Verkauf"))
                         {
@@ -101,47 +117,11 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                         t.setAmount(asAmount(v.get("amount")));
                         t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     })
-                    
-                    // Handelszeit 09:02 Orderentgelt                EUR 10,90-
-                    .section("fee", "currency").optional()
-                    .match(".* Orderentgelt\\W+(?<currency>\\w{3}+) (?<fee>[.,\\d]+)-")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    // Börse Stuttgart Börsengebühr EUR 2,29-
-                    .section("fee", "currency").optional()
-                    .match(".* B.rsengeb.hr (?<currency>\\w{3}+) (?<fee>[.,\\d]+)-")
-                    .assign((t, v) -> t.getPortfolioTransaction()
-                                    .addUnit(new Unit(Unit.Type.FEE,
-                                                    Money.of(asCurrencyCode(v.get("currency")),
-                                                                    asAmount(v.get("fee"))))))
-
-                    // Kurswert 509,71- EUR
-                    // Kundenbonifikation 40 % vom Ausgabeaufschlag 9,71 EUR
-                    // Ausgabeaufschlag pro Anteil 5,00 %
-                    .section("feeFx", "feeFy", "amountFx", "currency").optional()
-                    .match("^Kurswert (?<amountFx>[.,\\d]+)[-]? (?<currency>\\w{3})")
-                    .match("^Kundenbonifikation (?<feeFy>[.,\\d]+) % vom Ausgabeaufschlag [.,\\d]+ \\w{3}")
-                    .match("^Ausgabeaufschlag pro Anteil (?<feeFx>[.,\\d]+) %")
-                    .assign((t, v) -> {
-                        // Fee in percent
-                        double amountFx = Double.parseDouble(v.get("amountFx").replace(',', '.'));
-                        double feeFy = Double.parseDouble(v.get("feeFy").replace(',', '.'));
-                        double feeFx = Double.parseDouble(v.get("feeFx").replace(',', '.'));
-                        feeFy = (amountFx / (1 + feeFx / 100)) * (feeFx / 100) * (feeFy / 100);
-                        String fee =  Double.toString((amountFx / (1 + feeFx / 100)) * (feeFx / 100) - feeFy).replace('.', ',');                        
-                        v.put("fee", fee);
-
-                        t.getPortfolioTransaction()
-                                .addUnit(new Unit(Unit.Type.FEE,
-                                                Money.of(asCurrencyCode(v.get("currency")),
-                                                                asAmount(v.get("fee")))));
-                    })
 
                     .wrap(BuySellEntryItem::new);
 
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
     }
 
     private void addDividendTransaction()
@@ -151,44 +131,141 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("Erträgnisgutschrift.*EMAILVERSAND.*");
         type.addBlock(block);
-        block.set(new Transaction<AccountTransaction>()
-
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
                         .subject(() -> {
-                            AccountTransaction transaction = new AccountTransaction();
-                            transaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return transaction;
-                        })
+                            AccountTransaction entry = new AccountTransaction();
+                            entry.setType(AccountTransaction.Type.DIVIDENDS);
+                            return entry;
+                        });
 
-                        .section("isin", "name")
-                        .find("Gattungsbezeichnung ISIN")
-                        .match("(?<name>.*)\\W+(?<isin>.+)")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+        pdfTransaction
+                    // Gattungsbezeichnung ISIN
+                    // iS.EO G.B.C.1.5-10.5y.U.ETF DE Inhaber-Anteile DE000A0H0785
+                    .section("isin", "name")
+                    .find("Gattungsbezeichnung ISIN")
+                    .match("(?<name>.*)\\W+(?<isin>.+)")
+                    .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
-                        .section("shares")
-                        .match("^STK (?<shares>\\d+,\\d+?) .*")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        .section("date", "amount", "currency")
-                        .find("Wert Konto-Nr. (Devisenkurs )?Betrag zu Ihren Gunsten")
-                        .match("(?<date>\\d+.\\d+.\\d{4}).*(?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)")
-                        .assign((t, v) -> {
+                    // STK 16,000 17.11.2014 17.11.2014 EUR 0,793806
+                    .section("shares", "date")
+                    .match("^STK (?<shares>\\d+,\\d+?) (?<date>\\d+.\\d+.\\d{4}) .*$")
+                    .assign((t, v) -> {
+                        t.setShares(asShares(v.get("shares")));
+                        if (v.get("time") != null)
+                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                        else
                             t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
+                    })
 
-                        .wrap(t -> new TransactionItem(t)));
+                    .section("amount", "currency").optional()
+                    .match("^Zinsanteil \\(Aussch.ttung\\) (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)")
+                    .assign((t, v) -> {
+                        t.setAmount(asAmount(v.get("amount")));
+                        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    })
+
+                    .section("amount", "currency").optional()
+                    .match("^ausländische Dividende (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)")
+                    .assign((t, v) -> {
+                        t.setAmount(asAmount(v.get("amount")));
+                        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    })
+
+                    // // 15.12.2014 12/3456/789 EUR/USD 1,24495 EUR 52,36
+                    .section("exchangeRate").optional()
+                    .match("^.* [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[.,\\d]+) [\\w]{3} [.,\\d]+")
+                    .assign((t, v) -> {
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    })
+
+                    .wrap(t -> new TransactionItem(t));
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
+
+        block.set(pdfTransaction);
     }
 
-    @Override
-    public String getLabel()
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
-        return "S Broker AG & Co. KG / Sparkasse"; //$NON-NLS-1$
+        transaction
+                // einbehaltene Kapitalertragsteuer EUR 7,03
+                .section("tax", "currency").optional()
+                .match("^einbehaltene Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // einbehaltener Solidaritätszuschlag EUR 0,38
+                .section("tax", "currency").optional()
+                .match("^einbehaltener Solidaritätszuschlag (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // US-Quellensteuer 15% USD 13,13
+                .section("tax", "currency").optional()
+                .match("^US-Quellensteuer [.,\\d]+% (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)$")
+                .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
-    @Override
-    public String getPDFAuthor()
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
-        return ""; //$NON-NLS-1$
+        transaction
+                // Handelszeit 09:02 Orderentgelt                EUR 10,90-
+                .section("fee", "currency").optional()
+                .match(".* Orderentgelt\\W+(?<currency>\\w{3}+) (?<fee>[.,\\d]+)-")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Börse Stuttgart Börsengebühr EUR 2,29-
+                .section("fee", "currency").optional()
+                .match(".* B.rsengeb.hr (?<currency>\\w{3}+) (?<fee>[.,\\d]+)-")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Kurswert 509,71- EUR
+                // Kundenbonifikation 40 % vom Ausgabeaufschlag 9,71 EUR
+                // Ausgabeaufschlag pro Anteil 5,00 %
+                .section("feeFx", "feeFy", "amountFx", "currency").optional()
+                .match("^Kurswert (?<amountFx>[.,\\d]+)[-]? (?<currency>\\w{3})")
+                .match("^Kundenbonifikation (?<feeFy>[.,\\d]+) % vom Ausgabeaufschlag [.,\\d]+ \\w{3}")
+                .match("^Ausgabeaufschlag pro Anteil (?<feeFx>[.,\\d]+) %")
+                .assign((t, v) -> {
+                    // Fee in percent
+                    double amountFx = Double.parseDouble(v.get("amountFx").replace(',', '.'));
+                    double feeFy = Double.parseDouble(v.get("feeFy").replace(',', '.'));
+                    double feeFx = Double.parseDouble(v.get("feeFx").replace(',', '.'));
+                    feeFy = (amountFx / (1 + feeFx / 100)) * (feeFx / 100) * (feeFy / 100);
+                    String fee =  Double.toString((amountFx / (1 + feeFx / 100)) * (feeFx / 100) - feeFy).replace('.', ',');
+                    v.put("fee", fee);
+
+                    processFeeEntries(t, v, type);
+                });
+    }
+
+    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
+    }
+
+    private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee, 
+                            (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee,
+                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
     }
 }


### PR DESCRIPTION
Fix dividende transaction - missing taxes
Integration in the PDFExtractorUtils.java (fee's and tax's)

**Hinweis:**
Mit diesem und den anderen Pull-Requests werden die
PDF-Importer im Aufbau, Funktion und Source gleich gemacht.

Folgenden PDF-Importer sind somit fertig überarbeitet:
- Commerzbank
- KeyTrade Bank
- 1822Direkt
- Postbank
- Weberbank
- s.Broker / Sparkasse
- DreiBankenEDV
- Erste Bank
- LGT-Bank
- MPL-Bank
- DZBank
- JustTrade