### PR TITLE
Modify ErsteBank PDF-Importer to integrade PDFExtractorUtils

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -61,93 +61,80 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
-                        // Is type --> "Verkauf" change from BUY to SELL
-                        .section("type").optional()
-                        .match(".*(?<type>VERKAUF)")
-                        .assign((t, v) -> {
-                            if (v.get("type").equals("VERKAUF"))
-                            {
-                                t.setType(PortfolioTransaction.Type.SELL);
-                            }
-                        })
+                // Is type --> "Verkauf" change from BUY to SELL
+                .section("type").optional()
+                .match(".*(?<type>VERKAUF)")
+                .assign((t, v) -> {
+                    if (v.get("type").equals("VERKAUF"))
+                    {
+                        t.setType(PortfolioTransaction.Type.SELL);
+                    }
+                })
 
-                        // Wertpapier: VOESTALPINE AG AKT. Tradinggebühren: EUR 9,99
-                        // O.N.
-                        // Gesamtbetrag: EUR 3.217,22
-                        // WP-Kenn-Nr.: AT0000937503
-                        .section("name", "name1", "isin").optional()
-                        .match("^Wertpapier: (?<name>.*) (Tradinggebühren|WP-Kommission): [\\w]{3} [.,\\d]+[-]?")
-                        .match("(?<name1>.*)")
-                        .match("^WP-Kenn-Nr.* (?<isin>[\\w]{12})")
-                        .assign((t, v) -> {
-                            if (!v.get("name1").startsWith("Gesamtbetrag"))
-                                v.put("name", v.get("name") + " " + v.get("name1"));
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
+                // Wertpapier: VOESTALPINE AG AKT. Tradinggebühren: EUR 9,99
+                // O.N.
+                // Gesamtbetrag: EUR 3.217,22
+                // WP-Kenn-Nr.: AT0000937503
+                .section("name", "name1", "isin").optional()
+                .match("^Wertpapier: (?<name>.*) (Tradinggebühren|WP-Kommission): [\\w]{3} [.,\\d]+[-]?")
+                .match("(?<name1>.*)")
+                .match("^WP-Kenn-Nr.* (?<isin>[\\w]{12})")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Gesamtbetrag"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        // Wertpapier: DWS TOP 50 WELT
-                        // WP-Kenn-Nr. : DE0009769794
-                        .section("name", "isin").optional()
-                        .match("^Wertpapier: (?<name>.*)")
-                        .match("^WP-Kenn-Nr.* (?<isin>[\\w]{12})")
-                        .assign((t, v) -> {
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
+                // Wertpapier: DWS TOP 50 WELT
+                // WP-Kenn-Nr. : DE0009769794
+                .section("name", "isin").optional()
+                .match("^Wertpapier: (?<name>.*)")
+                .match("^WP-Kenn-Nr.* (?<isin>[\\w]{12})")
+                .assign((t, v) -> {
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        // Stück: 105,00
-                        .section("shares")
-                        .match("^St.ck: (?<shares>[.,\\d]+)")
-                        .assign((t, v) -> {
-                            t.setShares(asShares(v.get("shares")));
-                        })
+                // Stück: 105,00
+                .section("shares")
+                .match("^St.ck: (?<shares>[.,\\d]+)")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                        // Ausführungsdatum: 23.09.2015 Ausführungszeit: 09:02:20
-                        .section("date", "time").optional()
-                        .match("^Ausführungsdatum: (?<date>\\d+.\\d+.\\d{4}) Ausführungszeit: (?<time>\\d+:\\d+:\\d+)$")
-                        .assign((t, v) -> {
-                            if (v.get("time") != null)
-                                t.setDate(asDate(v.get("date"), v.get("time")));
-                            else
-                                t.setDate(asDate(v.get("date")));
-                        })
+                // Ausführungsdatum: 23.09.2015 Ausführungszeit: 09:02:20
+                .section("date", "time").optional()
+                .match("^Ausführungsdatum: (?<date>\\d+.\\d+.\\d{4}) Ausführungszeit: (?<time>\\d+:\\d+:\\d+)$")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                        // Ausführungsdatum: 05. Oktober 2009 Ausführungszeit: 12:39:27
-                        .section("date", "time").optional()
-                        .match("^Ausführungsdatum: (?<date>\\d+\\. .* \\d{4}) Ausführungszeit: (?<time>\\d+:\\d+:\\d+)$")
-                        .assign((t, v) -> {
-                            // Formate the date from 05. Oktober 2009 to 05.10.2009
-                            v.put("date", DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDate.parse(v.get("date"), DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY))));
-                            if (v.get("time") != null)
-                                t.setDate(asDate(v.get("date"), v.get("time")));
-                            else
-                                t.setDate(asDate(v.get("date")));
-                        })
+                // Ausführungsdatum: 05. Oktober 2009 Ausführungszeit: 12:39:27
+                .section("date", "time").optional()
+                .match("^Ausführungsdatum: (?<date>\\d+\\. .* \\d{4}) Ausführungszeit: (?<time>\\d+:\\d+:\\d+)$")
+                .assign((t, v) -> {
+                    // Formate the date from 05. Oktober 2009 to 05.10.2009
+                    v.put("date", DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDate.parse(v.get("date"), DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY))));
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                        // Gesamtbetrag: EUR 3.217,22
-                        .section("currency", "amount")
-                        .match("^Gesamtbetrag: (?<currency>[\\w]{3}) (?<amount>[\\d.-]+,\\d+)")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(v.get("currency"));
-                        })
+                // Gesamtbetrag: EUR 3.217,22
+                .section("currency", "amount")
+                .match("^Gesamtbetrag: (?<currency>[\\w]{3}) (?<amount>[\\d.-]+,\\d+)")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                        // Wertpapier: VOESTALPINE AG AKT. Tradinggebühren: EUR 9,99
-                        .section("fee", "currency").optional()
-                        .match(".* Tradinggebühren: (?<currency>[\\w]{3}) (?<fee>[\\d.-]+,\\d+)[-]?")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
+                .wrap(BuySellEntryItem::new);
 
-                        // Wertpapier: BAY.MOTOREN WERKE AG WP-Kommission: EUR 9,99
-                        .section("fee", "currency").optional()
-                        .match(".* WP-Kommission: (?<currency>[\\w]{3}) (?<fee>[\\d.-]+,\\d+)[-]?")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
-
-                        .wrap(BuySellEntryItem::new);
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
     }
 
     private void addDividendeTransaction()
@@ -166,113 +153,113 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                         });
 
         pdfTransaction
-                        // ISIN : CA0679011084
-                        // Wertpapierbezeichnung : BARRICK GOLD CORP.
-                        .section("isin", "name").optional()
-                        .match("^ISIN : (?<isin>[\\w]{12})")
-                        .match("^Wertpapierbezeichnung : (?<name>.*)")
-                        .assign((t, v) -> {
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
+                // ISIN : CA0679011084
+                // Wertpapierbezeichnung : BARRICK GOLD CORP.
+                .section("isin", "name").optional()
+                .match("^ISIN : (?<isin>[\\w]{12})")
+                .match("^Wertpapierbezeichnung : (?<name>.*)")
+                .assign((t, v) -> {
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        // Wertpapier : MUENCH.RUECKVERS.VNA O.N. Dividende Brutto : EUR 201,25
-                        // WP-Kenn-Nr. : DE0008430026 Fremde Steuer : EUR 53,08
-                        .section("isin", "name").optional()
-                        .match("^Wertpapier : (?<name>.*) Dividende Brutto : [\\w]{3} [.,\\d]+")
-                        .match("^WP-Kenn-Nr.* : (?<isin>[\\w]{12}) Fremde Steuer : [\\w]{3} [.,\\d]+")
-                        .assign((t, v) -> {
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
+                // Wertpapier : MUENCH.RUECKVERS.VNA O.N. Dividende Brutto : EUR 201,25
+                // WP-Kenn-Nr. : DE0008430026 Fremde Steuer : EUR 53,08
+                .section("isin", "name").optional()
+                .match("^Wertpapier : (?<name>.*) Dividende Brutto : [\\w]{3} [.,\\d]+")
+                .match("^WP-Kenn-Nr.* : (?<isin>[\\w]{12}) Fremde Steuer : [\\w]{3} [.,\\d]+")
+                .assign((t, v) -> {
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        // Anspruchsberechtigter : 35
-                        .section("shares").optional()
-                        .match("^Anspruchsberechtigter : (?<shares>[.,\\d]+)")
-                        .assign((t, v) -> {
-                            t.setShares(asShares(v.get("shares")));
-                        })
+                // Anspruchsberechtigter : 35
+                .section("shares").optional()
+                .match("^Anspruchsberechtigter : (?<shares>[.,\\d]+)")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                        // WP-Bestand : 35,000 Dividendenbetrag : EUR 148,17
-                        .section("shares").optional()
-                        .match("^WP-Bestand : (?<shares>[.,\\d]+) .*")
-                        .assign((t, v) -> {
-                            t.setShares(asShares(v.get("shares")));
-                        })
+                // WP-Bestand : 35,000 Dividendenbetrag : EUR 148,17
+                .section("shares").optional()
+                .match("^WP-Bestand : (?<shares>[.,\\d]+) .*")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                })
 
-                        // Ex-Tag : 27.08.2015
-                        .section("date").optional()
-                        .match("^Ex-Tag : (?<date>\\d+.\\d+.\\d{4})")
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                // Ex-Tag : 27.08.2015
+                .section("date").optional()
+                .match("^Ex-Tag : (?<date>\\d+.\\d+.\\d{4})")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                        // Ex-Tag : 29. April 2010 Zahlungsprovision : EUR 0,50
-                        .section("date").optional()
-                        .match("^Ex-Tag : (?<date>\\d+\\. .* \\d{4}) .*")
-                        .assign((t, v) -> {
-                            // Formate the date from 29. April 2010 to 29.05.2010
-                            v.put("date", DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDate.parse(v.get("date"), DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY))));
-                            t.setDateTime(asDate(v.get("date")));
-                        })
+                // Ex-Tag : 29. April 2010 Zahlungsprovision : EUR 0,50
+                .section("date").optional()
+                .match("^Ex-Tag : (?<date>\\d+\\. .* \\d{4}) .*")
+                .assign((t, v) -> {
+                    // Formate the date from 29. April 2010 to 29.05.2010
+                    v.put("date", DateTimeFormatter.ofPattern("dd.MM.yyyy").format(LocalDate.parse(v.get("date"), DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY))));
+                    t.setDateTime(asDate(v.get("date")));
+                })
 
-                        // Gesamtbetrag (in : EUR 0.4
-                        .section("currency", "amount").optional()
-                        .match("^Gesamtbetrag .in : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
-                        .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setAmount(asAmount(convertAmount(v.get("amount"))));
-                        })
+                // Gesamtbetrag (in : EUR 0.4
+                .section("currency", "amount").optional()
+                .match("^Gesamtbetrag .in : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
+                .assign((t, v) -> {
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    t.setAmount(asAmount(convertAmount(v.get("amount"))));
+                })
 
-                        // Dividende Netto : EUR 127,54
-                        .section("currency", "amount").optional()
-                        .match("^Dividende Netto : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
-                        .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setAmount(asAmount(convertAmount(v.get("amount"))));
-                        })
+                // Dividende Netto : EUR 127,54
+                .section("currency", "amount").optional()
+                .match("^Dividende Netto : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
+                .assign((t, v) -> {
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    t.setAmount(asAmount(convertAmount(v.get("amount"))));
+                })
 
-                        // Brutto-Betrag : USD 0.7
-                        // Devisenkurs : 0.888889
-                        // Gesamtbetrag (in : EUR 0.4
-                        .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
-                        .match("^Brutto-Betrag : (?<fxCurrency>[\\w]{3}) (?<fxAmount>['.,\\d]+)")
-                        .match("^Devisenkurs : (?<exchangeRate>[.\\d]+)")
-                        .match("^Gesamtbetrag .in : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
-                        .assign((t, v) -> {
-                            BigDecimal exchangeRate = asExchangeRate(convertExchangeRate(v.get("exchangeRate")));
-                            if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                            {
-                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                            }
+                // Brutto-Betrag : USD 0.7
+                // Devisenkurs : 0.888889
+                // Gesamtbetrag (in : EUR 0.4
+                .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
+                .match("^Brutto-Betrag : (?<fxCurrency>[\\w]{3}) (?<fxAmount>['.,\\d]+)")
+                .match("^Devisenkurs : (?<exchangeRate>[.\\d]+)")
+                .match("^Gesamtbetrag .in : (?<currency>[\\w]{3}) (?<amount>['.,\\d]+)")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(convertExchangeRate(v.get("exchangeRate")));
+                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    {
+                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    }
 
-                            type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
 
-                            if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                            {
-                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                                RoundingMode.HALF_DOWN);
+                    if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                    {
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                        RoundingMode.HALF_DOWN);
 
-                                // check, if forex currency is transaction
-                                // currency or not and swap amount, if necessary
-                                Unit grossValue;
-                                if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
-                                {
-                                    Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                                    asAmount(convertAmount(v.get("fxAmount"))));
-                                    Money amount = Money.of(asCurrencyCode(v.get("currency")),
-                                                    asAmount(convertAmount(v.get("amount"))));
-                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
-                                }
-                                else
-                                {
-                                    Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), 
-                                                    asAmount(convertAmount(v.get("fxAmount"))));
-                                    Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), 
-                                                    asAmount(convertAmount(v.get("amount"))));
-                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
-                                }
-                                t.addUnit(grossValue);
-                            }
-                        })
+                        // check, if forex currency is transaction
+                        // currency or not and swap amount, if necessary
+                        Unit grossValue;
+                        if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
+                        {
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),
+                                            asAmount(convertAmount(v.get("fxAmount"))));
+                            Money amount = Money.of(asCurrencyCode(v.get("currency")),
+                                            asAmount(convertAmount(v.get("amount"))));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
+                        }
+                        else
+                        {
+                            Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), 
+                                            asAmount(convertAmount(v.get("fxAmount"))));
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), 
+                                            asAmount(convertAmount(v.get("amount"))));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
+                        }
+                        t.addUnit(grossValue);
+                    }
+                })
 
-                        .wrap(TransactionItem::new);
+                .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -283,44 +270,54 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                        // Steuer : Quellensteuer
-                        // Steuern : USD 0.18
-                        .section("currency", "tax").optional()
-                        .match("^Steuer : Quellensteuer")
-                        .match("^Steuern : (?<currency>[\\w]{3}) (?<tax>['.,\\d]+)")
-                        .assign((t, v) -> {
-                            v.put("tax", convertAmount(v.get("tax")));
-                            processTaxEntries(t, v, type);
-                        })
+                // Steuer : Quellensteuer
+                // Steuern : USD 0.18
+                .section("currency", "tax").optional()
+                .match("^Steuer : Quellensteuer")
+                .match("^Steuern : (?<currency>[\\w]{3}) (?<tax>['.,\\d]+)")
+                .assign((t, v) -> {
+                    v.put("tax", convertAmount(v.get("tax")));
+                    processTaxEntries(t, v, type);
+                })
 
-                        // Steuer : KESt1
-                        // Steuern : USD 0.18
-                        .section("currency", "tax").optional()
-                        .match("^Steuer : KESt1")
-                        .match("^Steuern : (?<currency>[\\w]{3}) (?<tax>['.,\\d]+)")
-                        .assign((t, v) -> {
-                            v.put("tax", convertAmount(v.get("tax")));
-                            processTaxEntries(t, v, type);
-                        })
+                // Steuer : KESt1
+                // Steuern : USD 0.18
+                .section("currency", "tax").optional()
+                .match("^Steuer : KESt1")
+                .match("^Steuern : (?<currency>[\\w]{3}) (?<tax>['.,\\d]+)")
+                .assign((t, v) -> {
+                    v.put("tax", convertAmount(v.get("tax")));
+                    processTaxEntries(t, v, type);
+                })
 
-                        // WP-Kenn-Nr. : DE0008430026 Fremde Steuer : EUR 53,08
-                        .section("currency", "tax").optional()
-                        .match(".* Fremde Steuer : (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)")
-                        .assign((t, v) -> processTaxEntries(t, v, type))
+                // WP-Kenn-Nr. : DE0008430026 Fremde Steuer : EUR 53,08
+                .section("currency", "tax").optional()
+                .match(".* Fremde Steuer : (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)")
+                .assign((t, v) -> processTaxEntries(t, v, type))
 
-                        // Dividende : EUR 5,750000 KESt : EUR 20,13
-                        .section("currency", "tax").optional()
-                        .match(".* KESt : (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)")
-                        .assign((t, v) -> processTaxEntries(t, v, type));
+                // Dividende : EUR 5,750000 KESt : EUR 20,13
+                .section("currency", "tax").optional()
+                .match(".* KESt : (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)")
+                .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                        // Ex-Tag : 29. April 2010 Zahlungsprovision : EUR 0,50
-                        .section("currency", "fee").optional()
-                        .match(".* Zahlungsprovision : (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)")
-                        .assign((t, v) -> processFeeEntries(t, v, type));
+                // Ex-Tag : 29. April 2010 Zahlungsprovision : EUR 0,50
+                .section("currency", "fee").optional()
+                .match(".* Zahlungsprovision : (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Wertpapier: VOESTALPINE AG AKT. Tradinggebühren: EUR 9,99
+                .section("currency", "fee").optional()
+                .match(".* Tradinggebühren: (?<currency>[\\w]{3}) (?<fee>[\\d.-]+,\\d+)[-]?")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Wertpapier: BAY.MOTOREN WERKE AG WP-Kommission: EUR 9,99
+                .section("currency", "fee").optional()
+                .match(".* WP-Kommission: (?<currency>[\\w]{3}) (?<fee>[\\d.-]+,\\d+)[-]?")
+                .assign((t, v) -> processFeeEntries(t, v, type));
     }
 
     private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)


### PR DESCRIPTION
Integration in the PDFExtractorUtils.java (fee's and tax's)

**Hinweis:**
Mit diesem und den anderen Pull-Requests werden die
PDF-Importer im Aufbau, Funktion und Source gleich gemacht.

Folgenden PDF-Importer sind somit fertig überarbeitet:
- Commerzbank
- KeyTrade Bank
- 1822Direkt
- Postbank
- Weberbank
- s.Broker / Sparkasse
- DreiBankenEDV
- Erste Bank
- LGT-Bank
- MPL-Bank
- DZBank
- JustTrade