### PR TITLE
Fix parsing taxes in FlatexVerkauf6

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1325,9 +1325,9 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(tx, hasItem(allOf( //
                         hasProperty("dateTime", is(LocalDateTime.parse("2019-02-06T00:00"))), //
-                        hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
-                        hasProperty("monetaryAmount", is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9.48)))))));
-        assertThat(tx.get(0).getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(5.9))));
+                        hasProperty("type", is(PortfolioTransaction.Type.SELL)))));
+
+        checkValues(tx.get(0), CurrencyUnit.EUR, 15.38, 9.48, 0, 5.9);
     }
 
     @Test
@@ -1355,7 +1355,7 @@ public class FinTechGroupBankPDFExtractorTest
                         hasProperty("dateTime", is(LocalDateTime.parse("2019-04-09T16:52"))), //
                         hasProperty("type", is(PortfolioTransaction.Type.SELL)))));
 
-        checkValues(tx.get(0), 4416.52, 4573.8, 148.87, 8.41);
+        checkValues(tx.get(0), CurrencyUnit.EUR, 4573.8, 4416.52, 148.87, 8.41);
     }
 
     @Test
@@ -1383,19 +1383,7 @@ public class FinTechGroupBankPDFExtractorTest
                         hasProperty("dateTime", is(LocalDateTime.parse("2019-06-20T09:08"))), //
                         hasProperty("type", is(PortfolioTransaction.Type.SELL))))); //
 
-        checkValues(tx.get(0), 9529.81, 9538.22, 0, 8.41);
-    }
-
-    public void checkValues(PortfolioTransaction tx, double monetary, double gross, double tax, double fee)
-    {
-        assertThat(tx.getMonetaryAmount(),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(monetary))));
-        assertThat(tx.getGrossValue(),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(gross))));
-        assertThat(tx.getUnitSum(Unit.Type.TAX),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(tax))));
-        assertThat(tx.getUnitSum(Unit.Type.FEE),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(fee))));
+        checkValues(tx.get(0), CurrencyUnit.EUR, 9538.22, 9529.81, 0, 8.41);
     }
 
     @Test
@@ -1961,5 +1949,13 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getName(), is(name));
         assertThat(security.getCurrencyCode(), is(currencyUnit));
         return security;
+    }
+
+    private void checkValues(PortfolioTransaction tx, String currency, double gross, double net, double tax, double fee)
+    {
+        assertThat(tx.getMonetaryAmount(),       is(Money.of(currency, Values.Amount.factorize(net))));
+        assertThat(tx.getGrossValue(),           is(Money.of(currency, Values.Amount.factorize(gross))));
+        assertThat(tx.getUnitSum(Unit.Type.TAX), is(Money.of(currency, Values.Amount.factorize(tax))));
+        assertThat(tx.getUnitSum(Unit.Type.FEE), is(Money.of(currency, Values.Amount.factorize(fee))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1356,6 +1356,7 @@ public class FinTechGroupBankPDFExtractorTest
                         hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
                         hasProperty("monetaryAmount",
                                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4416.52)))))));
+        assertThat(tx.get(0).getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(148.87))));
         assertThat(tx.get(0).getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(8.41))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1358,18 +1358,6 @@ public class FinTechGroupBankPDFExtractorTest
         checkValues(tx.get(0), 4416.52, 4573.8, 148.87, 8.41);
     }
 
-    public void checkValues(PortfolioTransaction tx, double monetary, double gross, double tax, double fee)
-    {
-        assertThat(tx.getMonetaryAmount(),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(monetary))));
-        assertThat(tx.getGrossValue(),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(gross))));
-        assertThat(tx.getUnitSum(Unit.Type.TAX),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(tax))));
-        assertThat(tx.getUnitSum(Unit.Type.FEE),
-                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(fee))));
-    }
-
     @Test
     public void testWertpapierVerkauf7()
     {
@@ -1393,10 +1381,21 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(tx, hasItem(allOf( //
                         hasProperty("dateTime", is(LocalDateTime.parse("2019-06-20T09:08"))), //
-                        hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
-                        hasProperty("monetaryAmount",
-                                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9529.81)))))));
-        assertThat(tx.get(0).getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(8.41))));
+                        hasProperty("type", is(PortfolioTransaction.Type.SELL))))); //
+
+        checkValues(tx.get(0), 9529.81, 9538.22, 0, 8.41);
+    }
+
+    public void checkValues(PortfolioTransaction tx, double monetary, double gross, double tax, double fee)
+    {
+        assertThat(tx.getMonetaryAmount(),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(monetary))));
+        assertThat(tx.getGrossValue(),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(gross))));
+        assertThat(tx.getUnitSum(Unit.Type.TAX),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(tax))));
+        assertThat(tx.getUnitSum(Unit.Type.FEE),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(fee))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1353,11 +1353,21 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(tx, hasItem(allOf( //
                         hasProperty("dateTime", is(LocalDateTime.parse("2019-04-09T16:52"))), //
-                        hasProperty("type", is(PortfolioTransaction.Type.SELL)), //
-                        hasProperty("monetaryAmount",
-                                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4416.52)))))));
-        assertThat(tx.get(0).getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(148.87))));
-        assertThat(tx.get(0).getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(8.41))));
+                        hasProperty("type", is(PortfolioTransaction.Type.SELL)))));
+
+        checkValues(tx.get(0), 4416.52, 4573.8, 148.87, 8.41);
+    }
+
+    public void checkValues(PortfolioTransaction tx, double monetary, double gross, double tax, double fee)
+    {
+        assertThat(tx.getMonetaryAmount(),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(monetary))));
+        assertThat(tx.getGrossValue(),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(gross))));
+        assertThat(tx.getUnitSum(Unit.Type.TAX),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(tax))));
+        assertThat(tx.getUnitSum(Unit.Type.FEE),
+                is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(fee))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -824,7 +824,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         // Gewinn/Verlust: 1.112,18 EUR **Einbeh. KESt : 305,85
                         // EUR
                         .section("tax", "currency").optional()
-                        .match(".* \\*\\*Einbeh. KESt[\\s:]*(?<tax>[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
+                        .match(".* \\*\\*Einbeh. (KESt|Steuer)[\\s:]*(?<tax>[\\d.]+,\\d+) *(?<currency>\\w{3}+)")
                         .assign((t, v) -> {
                             t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.TAX,
                                             Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")))));


### PR DESCRIPTION
I noticed taxes were not being parsed correctly for my flatex statements. Looking into the code, the FlatexVerkauf6 seems to be similar to the kind of statements I have, and parsing taxes from it was not working. This PR fixes that.

Note: I kept `KESt` being parsed as before because removing it breaks FlatexVerkauf9.