### PR TITLE
FIX DAB PDF-Importer to support taxes and fees

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +44,7 @@ public class DABPDFExtractorTest
     }
 
     @Test
-    public void testWertpapierKauf() throws IOException
+    public void testWertpapierKauf()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -74,11 +73,14 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 150_00L)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-01-06T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.91920)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testWertpapierKauf2() throws IOException
+    public void testWertpapierKauf2()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -107,11 +109,14 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 60_00)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-05-04T09:15")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.42270)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 4_95L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.95))));
     }
 
     @Test
-    public void testWertpapierKauf3() throws IOException
+    public void testWertpapierKauf3()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -136,11 +141,14 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 325_00)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-04T09:15")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10.9468)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testWertpapierKauf4() throws IOException
+    public void testWertpapierKauf4()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -162,15 +170,20 @@ public class DABPDFExtractorTest
         BuySellEntry entry = (BuySellEntry) item.get().getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4798.86))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-07-29T16:30")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 11_96L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.97))));
     }
 
     @Test
-    public void testWertpapierKauf5() throws IOException
+    public void testWertpapierKauf5()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -196,11 +209,14 @@ public class DABPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.46))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-03-01T13:31")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.0499)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testWertpapierKauf6() throws IOException
+    public void testWertpapierKauf6()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -226,12 +242,14 @@ public class DABPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1381.58))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-18T14:15")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.58))));
     }
 
     @Test
-    public void testWertpapierKauf7() throws IOException
+    public void testWertpapierKauf7()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -257,10 +275,14 @@ public class DABPDFExtractorTest
                         is(Money.of("CHF", Values.Amount.factorize(6123.98))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-23T12:13")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(125)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("CHF", Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of("CHF", Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testWertpapierKauf8() throws IOException
+    public void testWertpapierKauf8()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -286,10 +308,14 @@ public class DABPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1146.44))));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-01-05T16:52")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(20)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(29.41))));
     }
 
     @Test
-    public void testWertpapierVerkauf() throws IOException
+    public void testWertpapierVerkauf1()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -318,13 +344,14 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 1994_12)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-12-23T10:25")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(43)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, 10_09)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, 45_88 + 2_52 + 4_12)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(45.88 + 2.52 + 4.12))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.09))));
     }
 
     @Test
-    public void testWertpapierVerkauf2() throws IOException
+    public void testWertpapierVerkauf2()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -356,6 +383,8 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.28))));
 
         // check tax-refund transaction
         item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
@@ -364,12 +393,13 @@ public class DABPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 90_09)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-08-24T00:00")));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(90.09))));
     }
 
     @Test
-    public void testWertpapierVerkauf3() throws IOException
+    public void testWertpapierVerkauf3()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -401,6 +431,8 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.24))));
 
         // check tax-refund transaction
         item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
@@ -409,12 +441,13 @@ public class DABPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 98_08)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-08-24T00:00")));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.08))));
     }
 
     @Test
-    public void testWertpapierVerkauf4() throws IOException
+    public void testWertpapierVerkauf4()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -446,6 +479,8 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1900)));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
 
         // check tax-refund transaction
         item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
@@ -454,12 +489,13 @@ public class DABPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 16_46)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-07T00:00")));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.46))));
     }
 
     @Test
-    public void testMultipleWertpapierKaufVerkauf1() throws IOException
+    public void testMultipleWertpapierKaufVerkauf1()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -475,29 +511,29 @@ public class DABPDFExtractorTest
         Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
         assertThat(item.isPresent(), is(true));
         Security security = ((SecurityItem) item.get()).getSecurity();
+        assertThat(security.getIsin(), is("US01609W1027"));
+        assertThat(security.getName(), is("Alibaba Group Holding Ltd. Reg.Shs (sp.ADRs)/8 DL-,000025"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        item = results.stream().filter(i -> i instanceof SecurityItem).skip(1).findFirst();
+        assertThat(item.isPresent(), is(true));
+        security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("US34959E1091"));
         assertThat(security.getName(), is("Fortinet Inc. Registered Shares DL -,001"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        item = results.stream().filter(i -> i instanceof SecurityItem).skip(1).findFirst();
+        item = results.stream().filter(i -> i instanceof SecurityItem).skip(2).findFirst();
         assertThat(item.isPresent(), is(true));
         security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("US09247X1019"));
         assertThat(security.getName(), is("Blackrock Inc. Reg. Shares Class A DL -,01"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        item = results.stream().filter(i -> i instanceof SecurityItem).skip(2).findFirst();
+        item = results.stream().filter(i -> i instanceof SecurityItem).skip(3).findFirst();
         assertThat(item.isPresent(), is(true));
         security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("US8447411088"));
         assertThat(security.getName(), is("Southwest Airlines Co. Registered Shares DL 1"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        item = results.stream().filter(i -> i instanceof SecurityItem).skip(3).findFirst();
-        assertThat(item.isPresent(), is(true));
-        security = ((SecurityItem) item.get()).getSecurity();
-        assertThat(security.getIsin(), is("US01609W1027"));
-        assertThat(security.getName(), is("Alibaba Group Holding Ltd. Reg.Shs (sp.ADRs)/8 DL-,000025"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         item = results.stream().filter(i -> i instanceof SecurityItem).skip(4).findFirst();
@@ -507,23 +543,25 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("Sarepta Therapeutics Inc. Registered Shares DL -,0001"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transactions
+        // check 1st buy sell transactions
         Optional<Item> t = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
         BuySellEntry entry = (BuySellEntry) t.get().getSubject();
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-30T09:59")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(619.92))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-27T16:08")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(6)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(679.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // second transaction
+        // check 2nd buy sell transactions
         t = results.stream().filter(i -> i instanceof BuySellEntryItem).skip(1).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
@@ -532,82 +570,86 @@ public class DABPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-27T16:08")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(6)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(585.70))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-24T19:25")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(619.92))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // third transaction
+        // check 3rd buy sell transactions
         t = results.stream().filter(i -> i instanceof BuySellEntryItem).skip(2).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
         entry = (BuySellEntry) t.get().getSubject();
-
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-24T19:25")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(573.02))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-24T14:21")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(14)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(585.70))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // fourth transaction
+        // check 4th buy sell transactions
         t = results.stream().filter(i -> i instanceof BuySellEntryItem).skip(3).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
         entry = (BuySellEntry) t.get().getSubject();
-
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-24T14:21")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(14)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(685.50))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-20T20:41")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(573.02))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // fifth transaction
+        // check 5th buy sell transactions
         t = results.stream().filter(i -> i instanceof BuySellEntryItem).skip(4).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
         entry = (BuySellEntry) t.get().getSubject();
-
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-20T20:41")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(565.10))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-20T15:32")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(5)));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(685.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // sixth transaction
+        // check 6th buy sell transactions
         t = results.stream().filter(i -> i instanceof BuySellEntryItem).skip(5).findFirst();
         assertThat(t.isPresent(), is(true));
         assertThat(t.get().getSubject(), instanceOf(BuySellEntry.class));
         entry = (BuySellEntry) t.get().getSubject();
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-20T15:32")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(5)));
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(679.50))));
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-30T09:59")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(565.10))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
     }
 
     @Test
-    public void testDividend() throws IOException
+    public void testDividend()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -624,7 +666,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("EUWAX AG Inhaber-Aktien o.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -632,13 +674,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 326_00)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-07-02T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(326.00))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(326.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividendForeignCurrency() throws IOException
+    public void testDividendForeignCurrency()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -656,7 +705,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("Procter & Gamble Co., The Registered Shares o.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -664,13 +713,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, 56_91)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-05-16T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(56.91))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(56.91))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividendInForeignCurrencyButSecurityListedInEuro() throws IOException
+    public void testDividendInForeignCurrencyButSecurityListedInEuro()
     {
         Client client = new Client();
 
@@ -690,7 +746,7 @@ public class DABPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.USD);
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -698,13 +754,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, 56_91)));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-05-16T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(56.91))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(56.91))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend3() throws IOException
+    public void testDividend3()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -721,7 +784,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("Roche Holding AG Inhaber-Genußscheineo.N."));
         assertThat(security.getCurrencyCode(), is("CHF"));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -729,13 +792,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(82.92))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2006-03-02T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(80)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(82.92))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(82.92))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend4() throws IOException
+    public void testDividend4()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -752,7 +822,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("Patterson Companies Inc. Registered Shares DL -,01"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -760,13 +830,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(80.92))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-29T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(500)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(80.92))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(80.92))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend5() throws IOException
+    public void testDividend5()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -783,7 +860,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("MTN Group Ltd. Registered Shares RC -,0001"));
         assertThat(security.getCurrencyCode(), is("ZAR"));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -791,13 +868,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(586.80))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-03-30T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(1300)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(586.80))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(788.18))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(201.38))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend6() throws IOException
+    public void testDividend6()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -814,7 +898,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("Linde AG Inhaber-Aktien o.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -822,17 +906,27 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(198.79))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-05-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(198.79))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(270.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(71.21))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend7withUSDAccount() throws IOException
+    public void testDividend7withUSDAccount()
     {
         Client client = new Client();
         DABPDFExtractor extractor = new DABPDFExtractor(client);
 
+        /***
+         * Add Security exits in currency EUR
+         */
         Security existingSecurity = new Security("Paychex Inc. Registered Shares DL -,01", CurrencyUnit.EUR);
         existingSecurity.setIsin("US7043261079");
         client.addSecurity(existingSecurity);
@@ -844,19 +938,23 @@ public class DABPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.USD);
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4.64))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-08-27T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(10)));
-
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4.64))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.56))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
         Unit grossValue = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
         assertThat(grossValue.getAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.20))));
@@ -869,11 +967,10 @@ public class DABPDFExtractorTest
         account.setCurrencyCode(CurrencyUnit.USD);
         Status s = c.process(transaction, account);
         assertThat(s, is(Status.OK_STATUS));
-
     }
 
     @Test
-    public void testDividend8() throws IOException
+    public void testDividend8()
     {
         Client client = new Client();
         DABPDFExtractor extractor = new DABPDFExtractor(client);
@@ -891,7 +988,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("VISA Inc. Reg. Shares Class A DL -,0001"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -899,19 +996,27 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.76))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-09-01T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(4)));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.76))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.01))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.25))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testDividend8withSecurityinEUR() throws IOException
+    public void testDividend8withSecurityinEUR()
     {
         Client client = new Client();
         DABPDFExtractor extractor = new DABPDFExtractor(client);
 
+        /***
+         * Add Security in currency EUR
+         */
         Security existingSecurity = new Security("VISA Inc. Reg. Shares Class A DL -,0001", CurrencyUnit.EUR);
         existingSecurity.setIsin("US92826C8394");
         client.addSecurity(existingSecurity);
@@ -923,22 +1028,27 @@ public class DABPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.76))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-09-01T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(4)));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.76))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.01))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.25))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testProceeds1() throws IOException
+    public void testProceeds1()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -955,7 +1065,7 @@ public class DABPDFExtractorTest
         assertThat(security.getName(), is("iShsIII-Core EO Corp.Bd U.ETF Registered Shares o.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -963,13 +1073,20 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.47))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-01-27T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(3.4256)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.47))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.47))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testProceeds2() throws IOException
+    public void testProceeds2()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());
 
@@ -984,9 +1101,9 @@ public class DABPDFExtractorTest
         Security security = getSecurity(results);
         assertThat(security.getIsin(), is("LU0480132876"));
         assertThat(security.getName(), is("UBS-ETF - UBS-ETF MSCI Em.Mkts Inhaber-Anteile A o.N."));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check buy sell transaction
+        // check dividend transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
@@ -994,10 +1111,15 @@ public class DABPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.06))));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-02-07T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(14.3755)));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.13))));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.06))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.81))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.75))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Map;
 import java.util.Optional;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -23,10 +24,8 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("DAB Bank"); //$NON-NLS-1$
         addBankIdentifier("BNP Paribas S.A. Niederlassung Deutschland"); //$NON-NLS-1$
 
-        addBuyTransaction();
-        addSellTransaction();
+        addBuySellTransaction();
         addDividendTransaction();
-        addProceedsTransaction();
     }
 
     @Override
@@ -42,238 +41,112 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     }
 
     @SuppressWarnings("nls")
-    private void addBuyTransaction()
+    private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("Kauf");
+        DocumentType type = new DocumentType("(Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^Kauf .*$", "Dieser Beleg wird .*$");
-        type.addBlock(block);
-        block.set(new Transaction<BuySellEntry>()
-
-                        .subject(() -> {
-                            BuySellEntry entry = new BuySellEntry();
-                            entry.setType(PortfolioTransaction.Type.BUY);
-                            return entry;
-                        })
-
-                        .section("isin", "name", "currency") //
-                        .find("Gattungsbezeichnung ISIN") //
-                        .match("^(?<name>.*) (?<isin>[^ ]*)$")
-                        .match("STK [\\d.]+(,\\d+)? (?<currency>\\w{3}) ([\\d.]+,\\d+)$")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        .section("shares") //
-                        .find("Nominal Kurs") //
-                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) (\\w{3}) ([\\d.]+,\\d+)$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        .section("amount", "currency").optional() //
-                        .find("Wert Konto-Nr\\. Betrag zu Ihren Lasten")
-                        .match("^(\\d+\\.\\d+\\.\\d{4}) ([0-9]*) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        .section("amount", "currency", "exchangeRate").optional() //
-                        .find("Wert Konto-Nr\\. Devisenkurs Betrag zu Ihren Lasten")
-                        .match("^(\\d+\\.\\d+\\.\\d{4}) ([0-9]*) \\w{3}\\/\\w{3} (?<exchangeRate>[\\d.,]+) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            type.getCurrentContext().put("exchangeRate", v.get("exchangeRate"));
-                        })
-
-                        .section("date") //
-                        .match("^Handelstag (?<date>\\d+\\.\\d+\\.\\d{4}) .*$")
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
-
-                        .section("date", "time").optional() //
-                        .match("^Handelstag (?<date>\\d+\\.\\d+\\.\\d{4}) .*$") //
-                        .match("^Handelszeit (?<time>\\d+:\\d+).*$").assign((t, v) -> {
-                            if (v.get("time") != null)
-                            {
-                                t.setDate(asDate(v.get("date"), v.get("time")));
-                            }
-                            else
-                            {
-                                t.setDate(asDate(v.get("date")));
-                            }
-                        })
-
-                        .section("fees", "currency").optional() //
-                        .match("^.* Registrierungsspesen (?<currency>\\w{3}+) (?<fees>[\\d.]+,\\d+)-$")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fees"))))))
-
-                        .section("fees", "currency").optional() //
-                        .match("^.* Provision (?<currency>\\w{3}+) (?<fees>[\\d.]+,\\d+)-$").assign((t, v) -> {
-                            String currency = asCurrencyCode(v.get("currency"));
-
-                            if (currency.equals(t.getAccountTransaction().getCurrencyCode()))
-                            {
-                                t.getPortfolioTransaction().addUnit(
-                                                new Unit(Unit.Type.FEE, Money.of(currency, asAmount(v.get("fees")))));
-                            }
-                            else
-                            {
-                                BigDecimal exchangeRate = asExchangeRate(type.getCurrentContext().get("exchangeRate"));
-                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                                RoundingMode.HALF_DOWN);
-
-                                long fxfees = asAmount(v.get("fees"));
-                                long fees = new BigDecimal(fxfees).divide(exchangeRate, 10, RoundingMode.HALF_DOWN).longValue();
-                                t.getPortfolioTransaction().addUnit(
-                                                new Unit(Unit.Type.FEE, Money.of(t.getAccountTransaction().getCurrencyCode(), fees), Money.of(currency, fxfees), inverseRate));
-                            }
-                        })
-
-                        .section("fees", "currency").optional() //
-                        .match("^.* Handelsplatzentgelt (?<currency>\\w{3}) (?<fees>[\\d.]+,\\d+)-$").assign((t, v) -> {
-                            String currency = asCurrencyCode(v.get("currency"));
-
-                            if (currency.equals(t.getAccountTransaction().getCurrencyCode()))
-                            {
-                                t.getPortfolioTransaction().addUnit(
-                                                new Unit(Unit.Type.FEE, Money.of(currency, asAmount(v.get("fees")))));
-                            }
-                            else
-                            {
-                                BigDecimal exchangeRate = asExchangeRate(type.getCurrentContext().get("exchangeRate"));
-                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
-                                                RoundingMode.HALF_DOWN);
-
-                                long fxfees = asAmount(v.get("fees"));
-                                long fees = new BigDecimal(fxfees).divide(exchangeRate, 10, RoundingMode.HALF_DOWN).longValue();
-                                t.getPortfolioTransaction().addUnit(
-                                                new Unit(Unit.Type.FEE, Money.of(t.getAccountTransaction().getCurrencyCode(), fees), Money.of(currency, fxfees), inverseRate));
-                            }
-                        })
-
-                        .section("amount", "currency", "exchangeRate", "forex", "forexCurrency", "curr").optional() //
-                        .find("^Handel.* (Ausmachender Betrag|Kurswert) (?<forexCurrency>\\w{3}) (?<forex>[\\d.]+,\\d+)-")
-                        .find("Wert Konto-Nr. Devisenkurs Betrag zu Ihren Lasten")
-                        .match("^(\\d+\\.\\d+\\.\\d{4}) ([0-9]*) (?<curr>\\w{3})\\/\\w{3} (?<exchangeRate>[\\d.]+,\\d+) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-
-                            Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
-                            t.setMonetaryAmount(amount);
-
-                            BigDecimal exchangeRate = BigDecimal.ONE.divide( //
-                                            asExchangeRate(v.get("exchangeRate")), 10, RoundingMode.HALF_DOWN);
-
-                            // if curr is not the transaction currency, we need
-                            // to use the reverse rate
-                            if (!amount.getCurrencyCode().equals(v.get("curr")))
-                            {
-                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                            }
-
-                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
-
-                            // the amount needs to be adjusted for fees already deducted
-                            Money fees = t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE);
-                            
-                            amount = amount.subtract(fees);
-                            
-                            Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, forex, exchangeRate);
-                            t.getPortfolioTransaction().addUnit(grossValue);
-                        })
-
-                        .wrap(t -> {
-                            if (t.getPortfolioTransaction().getAmount() == 0L)
-                                throw new IllegalArgumentException("No amount found");
-
-                            return new BuySellEntryItem(t);
-                        }));
-    }
-
-    @SuppressWarnings("nls")
-    private void addSellTransaction()
-    {
-        DocumentType type = new DocumentType("Verkauf");
-        this.addDocumentTyp(type);
-
-        Block block = new Block("^Verkauf .*$", "Dieser Beleg wird .*$");
-        type.addBlock(block);
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
             BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.SELL);
+            entry.setType(PortfolioTransaction.Type.BUY);
             return entry;
         });
-        block.set(pdfTransaction);
 
-        pdfTransaction.section("isin", "name", "currency") //
-                        .find("Gattungsbezeichnung ISIN") //
-                        .match("^(?<name>.*) (?<isin>[^ ]*)$")
-                        .match("STK [\\d.]+(,\\d+)? (?<currency>\\w{3}) ([\\d.]+,\\d+)$")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+        Block firstRelevantLine = new Block("^(Kauf|Verkauf) .*$", "Dieser Beleg wird .*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
 
-                        .section("shares") //
-                        .find("Nominal Kurs") //
-                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) (\\w{3}) ([\\d.]+,\\d+)$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+        pdfTransaction
+                // Is type --> "Verkauf" change from BUY to SELL
+                .section("type").optional()
+                .match("^(?<type>Verkauf) .*")
+                .assign((t, v) -> {
+                    if (v.get("type").equals("Verkauf"))
+                    {
+                        t.setType(PortfolioTransaction.Type.SELL);
+                    }
+                })
 
-                        .section("amount", "currency").optional() //
-                        .find("Wert Konto-Nr. Betrag zu Ihren Gunsten")
-                        .match("^(\\d+\\.\\d+\\.\\d{4}+) ([0-9]*) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
+                // ComStage-MSCI USA TRN UCIT.ETF Inhaber-Anteile I o.N. LU0392495700
+                // STK 43,000 EUR 47,8310
+                .section("isin", "name", "shares", "currency")
+                .find("Gattungsbezeichnung ISIN")
+                .match("^(?<name>.*) (?<isin>[\\w]{12})$")
+                .match("STK (?<shares>[.,\\d]+) (?<currency>[\\w]{3}) [.,\\d]+$")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        .section("amount", "currency", "exchangeRate", "forex", "forexCurrency").optional() //
-                        .find(".* Ausmachender Betrag (?<forexCurrency>\\w{3}) (?<forex>[\\d.]+,\\d+)")
-                        .find("Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten")
-                        .match("^(\\d+\\.\\d+\\.\\d{4}+) ([0-9]*) .../... (?<exchangeRate>[\\d.]+,\\d+) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
+                // Handelstag 24.08.2015  Kurswert                    USD 5.205,00
+                .section("date")
+                .match("^Handelstag (?<date>\\d+.\\d+.\\d{4}) .*$")
+                .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
-                            Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
-                            t.setMonetaryAmount(amount);
+                // Handelstag 24.08.2015  Kurswert                    USD 5.205,00
+                // Handelszeit 16:38* Provision USD 13,01-
+                .section("date", "time").optional()
+                .match("^Handelstag (?<date>\\d+.\\d+.\\d{4}) .*$")
+                .match("^Handelszeit (?<time>\\d+:\\d+).*$")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                            BigDecimal exchangeRate = BigDecimal.ONE.divide( //
-                                            asExchangeRate(v.get("exchangeRate")), 10, RoundingMode.HALF_DOWN);
-                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
+                // 24.11.2020  EUR 685,50
+                // 08.01.2015 8022574001 EUR 150,00
+                .section("amount", "currency").optional()
+                .match("^\\d+.\\d+.\\d{4} .* (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                })
 
-                            Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, forex, exchangeRate);
-                            t.getPortfolioTransaction().addUnit(grossValue);
-                        })
+                // 03.08.2015 0000000000 EUR/USD 1,100297 EUR 4.798,86
+                .section("amount", "currency", "fxCurrency", "exchangeRate").optional()
+                .match("^\\d+.\\d+.\\d{4} [\\d]+ [\\w]{3}\\/(?<fxCurrency>[\\w]{3}) (?<exchangeRate>[.,\\d]+) (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                })
 
-                        .section("date") //
-                        .match("^Handelstag (?<date>\\d+\\.\\d+\\.\\d{4}+) .*$")
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+                // Börse USA/NAN Ausmachender Betrag USD 5.280,17-
+                // 03.08.2015 0000000000 EUR/USD 1,100297 EUR 4.798,86
+                .section("fxcurrency", "fxamount", "exchangeRate").optional()
+                .match("^.* (Ausmachender Betrag|Kurswert) (?<fxcurrency>[\\w]{3}) (?<fxamount>[.,\\d]+)[-]?$")
+                .match("^\\d+.\\d+.\\d{4} [\\d]+ [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[.,\\d]+) [\\w]{3} [.,\\d]+$")
+                .assign((t, v) -> {
+                    // read the forex currency, exchange rate and gross
+                    // amount in forex currency
+                    String forex = asCurrencyCode(v.get("fxcurrency"));
+                    if (t.getPortfolioTransaction().getSecurity().getCurrencyCode().equals(forex))
+                    {
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal reverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                        RoundingMode.HALF_DOWN);
 
-                        .section("date", "time").optional() //
-                        .match("^Handelstag (?<date>\\d+\\.\\d+\\.\\d{4}+) .*$")
-                        .match("^Handelszeit (?<time>\\d+:\\d+).*$").assign((t, v) -> {
-                            if (v.get("time") != null)
-                            {
-                                t.setDate(asDate(v.get("date"), v.get("time")));
-                            }
-                        })
+                        // gross given in forex currency
+                        long fxAmount = asAmount(v.get("fxamount"));
+                        long amount = reverseRate.multiply(BigDecimal.valueOf(fxAmount))
+                                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
 
-                        .section("fees", "currency").optional()
-                        .match("^.*Provision (?<currency>\\w{3}) (?<fees>[\\d.]+,\\d+)-$").assign((t, v) -> {
-                            String currency = asCurrencyCode(v.get("currency"));
-                            if (currency.equals(t.getAccountTransaction().getCurrencyCode()))
-                            {
-                                t.getPortfolioTransaction().addUnit(
-                                                new Unit(Unit.Type.FEE, Money.of(currency, asAmount(v.get("fees")))));
-                            }
-                        })
+                        Unit grossValue = new Unit(Unit.Type.GROSS_VALUE,
+                                        Money.of(t.getPortfolioTransaction().getCurrencyCode(), amount),
+                                        Money.of(forex, fxAmount), reverseRate);
 
-                        .wrap(t -> {
-                            if (t.getPortfolioTransaction().getAmount() == 0L)
-                                throw new IllegalArgumentException("No amount found");
+                        t.getPortfolioTransaction().addUnit(grossValue);
+                    }
+                })
 
-                            return new BuySellEntryItem(t);
-                        });
+                .wrap(BuySellEntryItem::new);
 
-        addTaxesSectionsTransaction(type, pdfTransaction);
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
 
         Block taxBlock = new Block("zu versteuern \\(negativ\\).*");
         type.addBlock(taxBlock);
@@ -283,24 +156,25 @@ public class DABPDFExtractor extends AbstractPDFExtractor
             return t;
         })
 
-                        .section("amount", "currency", "date") //
-                        .match("Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten")
-                        .match("^(?<date>\\d+\\.\\d+\\.\\d{4}+) ([0-9]*) ([0-9]*) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setDateTime(asDate(v.get("date")));
-                        }).wrap(t -> new TransactionItem(t)));
+                .section("amount", "currency", "date")
+                .match("Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten")
+                .match("^(?<date>\\d+.\\d+.\\d{4}+) ([\\d]+) ([\\d]+) (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    t.setDateTime(asDate(v.get("date")));
+                })
 
+                .wrap(t -> new TransactionItem(t)));
     }
 
     @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
-        DocumentType type = new DocumentType("Dividende");
+        DocumentType type = new DocumentType("(Dividende|Ertr.gnisgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^Dividendengutschrift.*$");
+        Block block = new Block("^(Dividendengutschrift|Erträgnisgutschrift (?!aus)).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
@@ -308,265 +182,295 @@ public class DABPDFExtractor extends AbstractPDFExtractor
             entry.setType(AccountTransaction.Type.DIVIDENDS);
             return entry;
         });
+
+        pdfTransaction
+                // Paychex Inc. Registered Shares DL -,01 US7043261079
+                // STK 10,000 31.07.2020 27.08.2020 USD 0,620000
+                .section("isin", "name", "shares", "currency")
+                .find("Gattungsbezeichnung ISIN")
+                .match("^(?<name>.*) (?<isin>[\\w]{12})$")
+                .match("^STK (?<shares>[.,\\d]+) \\d+.\\d+.\\d{4} \\d+.\\d+.\\d{4} (?<currency>[\\w]{3}) [.,\\d]+$")
+                .assign((t, v) -> {
+                    t.setShares(asShares(v.get("shares")));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
+
+                // 08.01.2015 8022574001 EUR 150,00
+                .section("date", "amount", "currency").optional()
+                .find("Nominal Ex-Tag Zahltag .*")
+                .match("^(?<date>\\d+.\\d+.\\d{4}) [\\d]+ (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setDateTime(asDate(v.get("date")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    t.setAmount(asAmount(v.get("amount")));
+                })
+
+                // 27.08.2020  USD 4,64
+                .section("date", "amount", "currency").optional()
+                .find("Wert *Konto-Nr. *Betrag *zu *Ihren *Gunsten")
+                .match("^(?<date>\\d+.\\d+.\\d{4})([\\s]+)?(?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setDateTime(asDate(v.get("date")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                    t.setAmount(asAmount(v.get("amount")));
+                })
+
+                // 30.03.2015 0000000000 EUR/ZAR 13,195 EUR 586,80
+                .section("date", "amount", "currency", "forexCurrency", "exchangeRate").optional()
+                .find("Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten")
+                .match("^(?<date>\\d+.\\d+.\\d{4}) [\\d]+ [\\w]{3}\\/(?<forexCurrency>[\\w]{3}) (?<exchangeRate>[.,\\d]+) (?<currency>[\\w]{3}) (?<amount>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setDateTime(asDate(v.get("date")));
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
+                                    RoundingMode.HALF_DOWN);
+                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+
+                    Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")),
+                                    Math.round(t.getAmount() / inverseRate.doubleValue()));
+                    Unit unit = new Unit(Unit.Type.GROSS_VALUE, t.getMonetaryAmount(), forex, inverseRate);
+                    if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                        t.addUnit(unit);
+                })
+
+                /***
+                 * this section is needed, if the dividend is payed in
+                 * the forex currency to a account in forex curreny but
+                 * the security is listed in local currency
+                 */
+                .section("forex", "localCurrency", "forexCurrency", "exchangeRate").optional() //
+                .find("Wert Konto-Nr. Betrag zu Ihren Gunsten")
+                .match("^(\\d{2}.\\d{2}\\.\\d{4}) ([0-9]*) (\\w{3}) (?<forex>[\\d.]+,\\d+)$")
+                .match("^Devisenkurs: (?<localCurrency>\\w{3})/(?<forexCurrency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+)$")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
+                                    RoundingMode.HALF_DOWN);
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+
+                    Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
+                    Money localAmount = Money.of(v.get("localCurrency"), Math.round(forex.getAmount()
+                                    / Double.parseDouble(v.get("exchangeRate").replace(',', '.'))));
+
+                    t.setAmount(forex.getAmount());
+                    t.setCurrencyCode(forex.getCurrencyCode());
+
+                    Unit unit = new Unit(Unit.Type.GROSS_VALUE, forex, localAmount, exchangeRate);
+
+                    if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                        t.addUnit(unit);
+                })
+
+                /***
+                 * if gross dividend is given in document, we need to fix the unit.
+                 * if security currency and transaction currency differ
+                 */
+                // ausländische Dividende EUR 5,25
+                // Devisenkurs: EUR/USD 1,1814
+                .section("fxCurrency", "fxAmount", "currency", "exchangeRate").optional()
+                .match("^ausl.ndische Dividende [\\w]{3} (?<fxAmount>[.,\\d]+)$")
+                .match("^Devisenkurs: (?<fxCurrency>[\\w]{3})\\/(?<currency>[\\w]{3}) (?<exchangeRate>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                    {
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+
+                        // check, if forex currency is transaction
+                        // currency or not and swap amount, if necessary
+                        Unit grossValue;
+                        if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
+                        {
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),
+                                            asAmount(v.get("fxAmount")));
+                            long localAmount = exchangeRate.multiply(BigDecimal.valueOf(fxAmount.getAmount()))
+                                            .longValue();
+                            Money amount = Money.of(asCurrencyCode(v.get("currency")), localAmount);
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
+                        }
+                        else
+                        {
+                            Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")),
+                                            asAmount(v.get("fxAmount")));
+                            long forexAmount = exchangeRate.multiply(BigDecimal.valueOf(amount.getAmount()))
+                                            .longValue();
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), forexAmount);
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
+                        }
+                        // remove existing unit to replace with new one
+                        Optional<Unit> grossUnit = t.getUnit(Unit.Type.GROSS_VALUE);
+                        if (grossUnit.isPresent())
+                        {
+                            t.removeUnit(grossUnit.get());
+                        }
+                        t.addUnit(grossValue);
+                    }
+                })
+
+                // Devisenkurs: EUR/USD 1,1814
+                .section("exchangeRate", "fxCurrency").optional()
+                .match("^Devisenkurs: [\\w]{3}/(?<fxCurrency>[\\w]{3}) (?<exchangeRate>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    {
+                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    }
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                })
+
+                .wrap(TransactionItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
+
         block.set(pdfTransaction);
-
-        pdfTransaction.section("isin", "name", "currency") //
-                        .find("Gattungsbezeichnung ISIN") //
-                        .match("^(?<name>.*) (?<isin>[^ ]*)$") //
-                        .match("STK ([\\d.]+(,\\d+)?) (\\d{2}\\.\\d{2}\\.\\d{4}) (\\d{2}\\.\\d{2}\\.\\d{4}) (?<currency>\\w{3}) (\\d+,\\d+)")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        .section("shares") //
-                        .find("Nominal Ex-Tag Zahltag .*") //
-                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) .*$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        .section("date", "amount", "currency") //
-                        .optional() //
-                        .find("Wert *Konto-Nr. *Betrag *zu *Ihren *Gunsten")
-                        .match("^(?<date>\\d{2}\\.\\d{2}\\.\\d{4}) ([0-9]*) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        .section("date", "amount", "currency", "forexCurrency", "exchangeRate") //
-                        .optional() //
-                        .find("Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten")
-                        .match("^(?<date>\\d{2}\\.\\d{2}\\.\\d{4}) ([0-9]*) \\w{3}/(?<forexCurrency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+) (?<currency>\\w{3}) (?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-
-                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
-                                            RoundingMode.HALF_DOWN);
-                            BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
-                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")),
-                                            Math.round(t.getAmount() / inverseRate.doubleValue()));
-                            Unit unit = new Unit(Unit.Type.GROSS_VALUE, t.getMonetaryAmount(), forex, inverseRate);
-                            if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                                t.addUnit(unit);
-                        })
-
-                        // this section is needed, if the dividend is payed in
-                        // the forex currency to a account in forex curreny but
-                        // the security is listed in local currency
-                        .section("forex", "localCurrency", "forexCurrency", "exchangeRate") //
-                        .optional() //
-                        .find("Wert Konto-Nr. Betrag zu Ihren Gunsten")
-                        .match("^(\\d{2}.\\d{2}\\.\\d{4}) ([0-9]*) (\\w{3}) (?<forex>[\\d.]+,\\d+)$")
-                        .match("Devisenkurs: (?<localCurrency>\\w{3})/(?<forexCurrency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+)")
-                        .assign((t, v) -> {
-                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate")).setScale(10,
-                                            RoundingMode.HALF_DOWN);
-                            Money forex = Money.of(asCurrencyCode(v.get("forexCurrency")), asAmount(v.get("forex")));
-                            Money localAmount = Money.of(v.get("localCurrency"), Math.round(forex.getAmount()
-                                            / Double.parseDouble(v.get("exchangeRate").replace(',', '.'))));
-                            t.setAmount(forex.getAmount());
-                            t.setCurrencyCode(forex.getCurrencyCode());
-                            Unit unit = new Unit(Unit.Type.GROSS_VALUE, forex, localAmount, exchangeRate);
-                            if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                                t.addUnit(unit);
-                        })
-
-                        // if gross dividend is given in document, we need to
-                        // fix the unit, if security currency and transaction
-                        // currency differ
-                        .section("fxCurrency", "fxAmount", "currency", "exchangeRate") //
-                        .optional() //
-                        // this line seems to give the gross dividend always in
-                        // EUR
-                        .match("ausl.ndische Dividende \\w{3} (?<fxAmount>[\\d.]+,\\d+)")
-                        .match("Devisenkurs: (?<fxCurrency>\\w{3})/(?<currency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+)")
-                        .assign((t, v) -> {
-
-                            if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                            {
-                                BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-
-                                // check, if forex currency is transaction
-                                // currency or not and swap amount, if necessary
-                                Unit grossValue;
-                                if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
-                                {
-                                    Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                                    asAmount(v.get("fxAmount")));
-                                    long localAmount = exchangeRate.multiply(BigDecimal.valueOf(fxAmount.getAmount()))
-                                                    .longValue();
-                                    Money amount = Money.of(asCurrencyCode(v.get("currency")), localAmount);
-                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
-                                }
-                                else
-                                {
-                                    Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                                    asAmount(v.get("fxAmount")));
-                                    long forexAmount = exchangeRate.multiply(BigDecimal.valueOf(amount.getAmount()))
-                                                    .longValue();
-                                    Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), forexAmount);
-                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, exchangeRate);
-                                }
-                                // remove existing unit to replace with new one
-                                Optional<Unit> grossUnit = t.getUnit(Unit.Type.GROSS_VALUE);
-                                if (grossUnit.isPresent())
-                                {
-                                    t.removeUnit(grossUnit.get());
-                                }
-                                t.addUnit(grossValue);
-                            }
-                        })
-
-                        .wrap(t -> {
-                            if (t.getAmount() == 0)
-                                throw new IllegalArgumentException("No dividend amount found.");
-                            return new TransactionItem(t);
-                        });
-
-        addTaxesSectionsTransaction(type, pdfTransaction);
     }
 
     @SuppressWarnings("nls")
-    private void addProceedsTransaction()
-    {
-        DocumentType type = new DocumentType("Erträgnisgutschrift");
-        this.addDocumentTyp(type);
-
-        // Block zweimal vorhanden, finde direkt 2. Block
-        Block block = new Block("^Erträgnisgutschrift (?!aus).*$");
-        type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.DIVIDENDS);
-            return entry;
-        });
-        block.set(pdfTransaction);
-
-        pdfTransaction.section("name", "isin").find("Gattungsbezeichnung ISIN").match("^(?<name>.*) (?<isin>[^ ]*)$") //
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        .section("shares").find("Nominal Ex-Tag Zahltag .*")
-                        .match("^STK (?<shares>[\\d.]+(,\\d+)?) .*$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        // No exchange rate
-                        .section("date", "amount", "currency").optional() //
-                        .find("Wert\\s*Konto-Nr.\\s*Betrag\\s*zu\\s*Ihren\\s*Gunsten")
-                        .match("^(?<date>\\d+\\.\\d+\\.\\d{4}+)\\s*([0-9]*) (?<currency>\\w{3})\\s*(?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        // With exchange rate
-                        .section("date", "amount", "currency") //
-                        .optional() //
-                        .find("Wert\\s*Konto-Nr.\\s*Devisenkurs\\s*Betrag\\s*zu\\s*Ihren\\s*Gunsten")
-                        .match("^(?<date>\\d+\\.\\d+\\.\\d{4}+)\\s*([0-9]*)\\s*(\\w{3})\\/(\\w{3})\\s*([\\d.]+(,\\d+)?)\\s*(?<currency>\\w{3})\\s*(?<amount>[\\d.]+,\\d+)$")
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        .wrap(t -> {
-                            if (t.getAmount() == 0)
-                                throw new IllegalArgumentException("No dividend amount found.");
-                            return new TransactionItem(t);
-                        });
-
-        addTaxesSectionsTransaction(type, pdfTransaction);
-    }
-
-    @SuppressWarnings("nls")
-    private <T extends Transaction<?>> void addTaxesSectionsTransaction(DocumentType documentType, T pdfTransaction)
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         // if we have a tax return, we set a flag and don't book tax below
-        pdfTransaction.section("n").optional() //
-                        .match("zu versteuern \\(negativ\\) (?<n>.*)").assign((t, v) -> {
-                            documentType.getCurrentContext().put("negative", "X");
-                        });
+        transaction
+                .section("n").optional()
+                .match("zu versteuern \\(negativ\\) (?<n>.*)")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put("negative", "X");
+                });
 
-        pdfTransaction.section("exchangeRate", "fxCurrency").optional() //
-                        .match("Devisenkurs: (\\w{3})/(?<fxCurrency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+)")
-                        .assign((t, v) -> {
+        transaction
+                // davon anrechenbare US-Quellensteuer 15% EUR 0,79
+                // davon anrechenbare Quellensteuer 15% ZAR 1.560,00
+                // davon anrechenbare Quellensteuer Fondseingangsseite EUR 1,62
+                .section("tax", "currency").optional()
+                .match("(^(.*)?davon anrechenbare) (US-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})[\\s+]? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                            if (getTransaction(t).getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                            {
-                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                            }
-                            documentType.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-                        })
+                // Börse Sekunden-Handel Fonds L&S Kapitalertragsteuer EUR 45,88-
+                .section("tax", "currency", "label").optional()
+                .match("^(?<label>.*) Kapitalertragsteuer ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")) 
+                                    && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltene"))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                        .section("exchangeRate", "fxCurrency").optional() //
-                        .match("^Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten$")
-                        .match("\\d{2}\\.\\d{2}\\.\\d{4} \\d+ (\\w{3})/(?<fxCurrency>\\w{3}) (?<exchangeRate>[\\d.]+,\\d+) .*")
-                        .assign((t, v) -> {
-                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                            if (getTransaction(t).getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                            {
-                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                            }
-                            documentType.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-                        })
+                // Kapitalertragsteuer EUR 14,51
+                .section("tax", "currency").optional()
+                .match("^Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                        .section("tax", "currency", "label").optional()
-                        .match("^(?<label>.*)US-Quellensteuer.* (?<currency>\\w{3}) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> {
-                            if (!"davon anrechenbare".equals(v.get("label").trim()))
-                            {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-                                PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
-                            }
-                        })
+                // Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 2,52-
+                .section("tax", "currency", "label").optional()
+                .match("^(?<label>.*) Solidarit.tszuschlag ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")) 
+                                    && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltene"))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                        .section("tax", "currency", "label").optional()
-                        .match("^(?<label>.*) Kapitalertragsteuer (?<currency>\\w{3}) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> {
-                            if (!"X".equals(documentType.getCurrentContext().get("negative"))
-                                            && !"im laufenden Jahr einbehaltene".equals(v.get("label")))
-                            {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-                                PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
-                            }
-                        })
+                // Solidaritätszuschlag EUR 0,79
+                .section("tax", "currency").optional()
+                .match("^Solidarit.tszuschlag ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                        .section("tax", "currency", "label").optional()
-                        .match("^(?<label>.*) Solidaritätszuschlag (?<currency>\\w{3}) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> {
-                            if (!"X".equals(documentType.getCurrentContext().get("negative"))
-                                            && !"im laufenden Jahr einbehaltener".equals(v.get("label")))
-                            {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-                                PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
-                            }
-                        })
+                // einbehaltene Kirchensteuer EUR 0,15
+                .section("tax", "currency", "label").optional()
+                .match("^(?<label>.*) Kirchensteuer ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative"))
+                                    && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltene"))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                })
 
-                        .section("tax", "currency", "label").optional()
-                        .match("^(?<label>.*) ?Kirchensteuer (?<currency>\\w{3}) (?<tax>[\\d.]+,\\d+)-?$")
-                        .assign((t, v) -> {
-                            if (!"X".equals(documentType.getCurrentContext().get("negative"))
-                                            && !"im laufenden Jahr einbehaltene".equals(v.get("label")))
-                            {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-                                PDFExtractorUtils.checkAndSetTax(tax, getTransaction(t), documentType);
-                            }
-                        });
+                // Kirchensteuer EUR 4,12-
+                .section("tax", "currency").optional()
+                .match("^Kirchensteuer ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[.,\\d]+)[-]?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
+                });
     }
 
-    private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
+    @SuppressWarnings("nls")
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction
+                // Handelszeit 14:15* Registrierungsspesen EUR 0,58-
+                .section("fee", "currency").optional()
+                .match("^.* Registrierungsspesen (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)-$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Handelszeit 16:38* Provision USD 18,78-
+                .section("fee", "currency").optional()
+                .match("^.* Provision (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)-$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Börse USA/NAN Handelsplatzentgelt USD 17,44-
+                .section("fee", "currency").optional()
+                .match("^.* Handelsplatzentgelt (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)-$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Verwahrart Wertpapierrechnung Abwicklungskosten Ausland USD 0,10-
+                .section("fee", "currency").optional()
+                .match("^.* Abwicklungskosten.* (?<currency>[\\w]{3}) (?<fee>[.,\\d]+)-$")
+                .assign((t, v) -> processFeeEntries(t, v, type));
+    }
+
+    @SuppressWarnings("nls")
+    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
     {
         if (t instanceof name.abuchen.portfolio.model.Transaction)
         {
-            return ((name.abuchen.portfolio.model.Transaction) t);
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
         }
         else
         {
-            return ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction();
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
+    }
+    
+    @SuppressWarnings("nls")
+    private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee, 
+                            (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee,
+                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
         }
     }
 }


### PR DESCRIPTION
Merge buy and sell transaction
Merge dividend and proceed transaction
Fix missing/wrong tax's
Fix missing/wrong fee's
Fix in testcases many missing fee's and tax's
Optimize some regEx
Integration in the PDFExtractorUtils.java (fee's and tax's)

Hallo @buchen
ich habe den DAB PDF-Importer überarbeitet und mir sind diverse Fehler aufgefallen

TestFile --> Fault
---
DABDividend5.txt --> Quellsteuer fehlt
DABDividend6.txt --> Kapitalertragsteuer + Solidaritätszuschlag fehlt
DABDividendForeignCurrency.txt --> Quellsteuer wird nicht angerechnet (regEx-Fehler)
DABKauf4.txt --> Rundungsfehler in Gebühren
DABKauf8.txt --> Rundungsfehler in Gebühren
DABVerkauf2.txt --> Provision, Abwicklungskosten Ausland fehlt
DABVerkauf3.txt --> Handelsplatzentgelt, Provision, Abwicklungskosten Ausland fehlt
DABVerkauf4.txt --> Provision fehlt
DABProceeds2.txt --> Kirchensteuer fehlt, Falsche security currency

Ich hoffe das dieser nun korrekt funktioniert...

Grüße Alex