### PR TITLE
FIX HelloBank PDF-Importer to support fees

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
@@ -36,12 +36,11 @@ import name.abuchen.portfolio.money.Values;
 public class HelloBankPDFExtractorTest
 {
     @Test
-    public void testErtrag01() throws IOException
+    public void testErtrag01()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
-        List<Exception> errors = new ArrayList<>();
-
+        List<Exception> errors = new ArrayList<Exception>();
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ertrag01.txt"), errors);
 
         assertThat(errors, empty());
@@ -49,40 +48,36 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("NO0003054108"));
-        assertThat(security.getName(), is("M a r i n e  H a r v est ASA"));
+        assertThat(security.getName(), is("M a r i n e  H a r v est ASA Navne-Aksjer NK 7,50"));
         assertThat(security.getCurrencyCode(), is("NOK"));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        // check dividend transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-09-06T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(48.71))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95 + 0.19 + (176.01 / 9.308)))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(200)));
-
-        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(640 / 9.308))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("NOK", Values.Amount.factorize(640))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.308), 10, RoundingMode.HALF_UP)));
-
-        assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
-                        is(transaction.getMonetaryAmount().getAmount()));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(48.71))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.76))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(19.10))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95))));
     }
 
     @Test
-    public void testErtrag01WithExistingSecurity() throws IOException
+    public void testErtrag01WithExistingSecurity()
     {
-        Security security = new Security("Marine Harvest ASA", CurrencyUnit.EUR);
+        Security security = new Security("Marine Harvest ASA Navne-Aksjer NK 7,50", CurrencyUnit.EUR);
         security.setIsin("NO0003054108");
 
         Client client = new Client();
@@ -103,23 +98,27 @@ public class HelloBankPDFExtractorTest
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+        
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-09-06T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(48.71))));
-
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95 + 0.19 + (176.01 / 9.308)))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(200)));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(48.71))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.76))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(19.10))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95))));
     }
 
     @Test
-    public void testErtrag02() throws IOException
+    public void testErtrag02()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
-
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ertrag02.txt"), errors);
 
         assertThat(errors, empty());
@@ -127,43 +126,38 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US56035L1044"));
-        assertThat(security.getName(), is("M a i n  S t r e e t Capital Corp."));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(security.getName(), is("M a i n  S t r e e t Capital Corp. Registered Shares DL -,01"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        // check dividend transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-05-15T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.34))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(
-                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95 + 0.19 + ((3.05 + 2.55) / 1.0942)))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(110)));
-
-        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(20.35 / 1.0942))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(20.35))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.0942), 10, RoundingMode.HALF_UP)));
-
-        assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
-                        is(transaction.getMonetaryAmount().getAmount()));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.34))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(18.60))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.31))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95))));
     }
 
     @Test
-    public void testErtrag03() throws IOException
+    public void testErtrag03()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
-
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ertrag03.txt"), errors);
 
         assertThat(errors, empty());
@@ -171,37 +165,38 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("NL0012325773"));
-        assertThat(security.getName(), is("R o y a l  D u t c h Shell PLC"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(security.getName(), is("R o y a l  D u t c h Shell PLC Anrechte A (Wahldividende)"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        // check dividend transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-26T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(41.43))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95 + 0.19 + 8.81 + 7.34))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(140)));
-
-        assertThat(Values.Amount.factorize(58.72) - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
-                        is(transaction.getMonetaryAmount().getAmount()));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(41.43))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(58.72))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.81 + 7.34 + 0.19))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95))));
     }
 
     @Test
-    public void testErtrag04() throws IOException
+    public void testErtrag04()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
-
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ertrag04.txt"), errors);
 
         assertThat(errors, empty());
@@ -209,38 +204,34 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US3682872078"));
-        assertThat(security.getName(), is("G a z p r o m  P J S C"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(security.getName(), is("G a z p r o m  P J S C Nam.Akt.(Sp.ADRs)/2 RL 5"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        // check dividend transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(true));
         assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
         assertThat(transaction.getSecurity(), is(security));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-08-21T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(116.91))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of(CurrencyUnit.EUR,
-                        Values.Amount.factorize(0.19 + 0.95 + ((32.14 + 26.79 + 16) / 1.1805)))));
         assertThat(transaction.getShares(), is(Values.Share.factorize(800)));
-
-        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(214.28 / 1.1805))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(214.28))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.1805), 10, RoundingMode.HALF_UP)));
-
-        assertThat(grossValueUnit.getAmount().getAmount() - transaction.getUnitSum(Unit.Type.TAX).getAmount(),
-                        is(transaction.getMonetaryAmount().getAmount()));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(116.91))));
+        assertThat(transaction.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(181.52))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.11))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.50))));
     }
 
     @Test
-    public void testKauf01() throws IOException
+    public void testKauf01()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
@@ -253,38 +244,35 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("NO0003054108"));
-        assertThat(security.getName(), is("M a r i n e  H a r v est ASA"));
+        assertThat(security.getName(), is("M a r i n e  H a r v est ASA Navne-Aksjer NK 7,50"));
         assertThat(security.getCurrencyCode(), is("NOK"));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
-
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
-        PortfolioTransaction tx = entry.getPortfolioTransaction();
-
-        assertThat(tx.getType(), is(PortfolioTransaction.Type.BUY));
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(tx.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1118.8))));
-        assertThat(tx.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
-        assertThat(tx.getShares(), is(Values.Share.factorize(74)));
-        assertThat(tx.getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.20 + 1.46))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-06-30T09:00:10")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(74)));
 
-        Unit grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(1092.14))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("NOK", Values.Amount.factorize(10360))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(9.486), 10, RoundingMode.HALF_UP)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1118.80))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1092.14))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.20 + 1.46))));
     }
 
     @Test
-    public void testKauf01WithExistingSecurity() throws IOException
+    public void testKauf01WithExistingSecurity()
     {
         Security security = new Security("Marine Harvest ASA", CurrencyUnit.EUR);
         security.setIsin("NO0003054108");
@@ -302,25 +290,29 @@ public class HelloBankPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check transaction
+        // check buy sell transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
-
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
-        PortfolioTransaction tx = entry.getPortfolioTransaction();
-
-        assertThat(tx.getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(tx.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1118.8))));
-        assertThat(tx.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
-        assertThat(tx.getShares(), is(Values.Share.factorize(74)));
-        assertThat(tx.getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.20 + 1.46))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-06-30T09:00:10")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(74)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1118.80))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1092.14))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.20 + 1.46))));
     }
 
     @Test
-    public void testKauf02() throws IOException
+    public void testKauf02()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
@@ -333,38 +325,35 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("GB00B03MLX29"));
-        assertThat(security.getName(), is("R o y a l  D u t c h Shell"));
+        assertThat(security.getName(), is("R o y a l  D u t c h Shell Reg. Shares Class A EO -,07"));
         assertThat(security.getCurrencyCode(), is("GBP"));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
-
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
-        PortfolioTransaction tx = entry.getPortfolioTransaction();
-
-        assertThat(tx.getType(), is(PortfolioTransaction.Type.BUY));
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(tx.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1314.03))));
-        assertThat(tx.getDateTime(), is(LocalDateTime.parse("2017-04-27T00:00")));
-        assertThat(tx.getShares(), is(Values.Share.factorize(55)));
-        assertThat(tx.getUnitSum(Unit.Type.FEE), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.53 + 1.55))));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-04-27T16:36:18")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(55)));
 
-        Unit grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(1305.95))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("GBP", Values.Amount.factorize(1100))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(0.8423), 10, RoundingMode.HALF_UP)));
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1314.03))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1305.95))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.53 + 1.55))));
     }
 
     @Test
-    public void testVerkauf01() throws IOException
+    public void testVerkauf01()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
@@ -377,45 +366,35 @@ public class HelloBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Optional<Item> item = results.stream().filter(i -> i instanceof SecurityItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        Security security = ((SecurityItem) item.get()).getSecurity();
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("AU000000SHV6"));
-        assertThat(security.getName(), is("S E L E C T  H A R V EST LTD."));
+        assertThat(security.getName(), is("S E L E C T  H A R V EST LTD. Registered Shares o.N."));
         assertThat(security.getCurrencyCode(), is("AUD"));
 
-        // check transaction
-        item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
-
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
-        PortfolioTransaction tx = entry.getPortfolioTransaction();
-
-        assertThat(tx.getType(), is(PortfolioTransaction.Type.SELL));
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
-        assertThat(tx.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3096.85))));
-        assertThat(tx.getDateTime(), is(LocalDateTime.parse("2017-10-12T00:00")));
-        assertThat(tx.getShares(), is(Values.Share.factorize(1000)));
-        assertThat(tx.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-10-12T07:30:01")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3096.85))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3511.96))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(385.75))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.99 + 6.42 + 7.95))));
-        assertThat(tx.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(254.1 / 1.5181))));
-
-        Unit grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).get();
-        assertThat(grossValueUnit.getAmount(), is(Money.of("EUR", Values.Amount.factorize(5000 / 1.5181))));
-        assertThat(grossValueUnit.getForex(), is(Money.of("AUD", Values.Amount.factorize(5000))));
-        assertThat(grossValueUnit.getExchangeRate(),
-                        is(BigDecimal.ONE.divide(BigDecimal.valueOf(1.5181), 10, RoundingMode.HALF_UP)));
-
-        assertThat(grossValueUnit.getAmount().getAmount() - tx.getUnitSum(Unit.Type.TAX).getAmount()
-                        - tx.getUnitSum(Unit.Type.FEE).getAmount(), is(tx.getMonetaryAmount().getAmount()));
-
     }
 
     @Test
-    public void testVerkauf01WithExistingSecurity() throws IOException
+    public void testVerkauf01WithExistingSecurity()
     {
         Security security = new Security("SELECT HARVEST LTD.", CurrencyUnit.EUR);
         security.setIsin("AU000000SHV6");
@@ -433,33 +412,33 @@ public class HelloBankPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check transaction
+        // check buy sell transaction
         Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
 
-        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
-        PortfolioTransaction tx = entry.getPortfolioTransaction();
-
-        assertThat(tx.getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
-        assertThat(tx.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3096.85))));
-        assertThat(tx.getDateTime(), is(LocalDateTime.parse("2017-10-12T00:00")));
-        assertThat(tx.getShares(), is(Values.Share.factorize(1000)));
-        assertThat(tx.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-10-12T07:30:01")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3096.85))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3511.96))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(385.75))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.99 + 6.42 + 7.95))));
-        assertThat(tx.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(254.1 / 1.5181))));
     }
 
     @Test
-    public void testInboundDelivery01() throws IOException
+    public void testInboundDelivery01()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
-
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "InboundDelivery01.txt"), errors);
 
         assertThat(errors, empty());
@@ -471,7 +450,7 @@ public class HelloBankPDFExtractorTest
         assertThat(item.isPresent(), is(true));
         Security security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("DK0060534915"));
-        assertThat(security.getName(), is("N o v o - N o r d i s k AS"));
+        assertThat(security.getName(), is("N o v o - N o r d i s k AS Navne-Aktier B DK -,20"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check transaction
@@ -489,12 +468,11 @@ public class HelloBankPDFExtractorTest
     }
 
     @Test
-    public void testInboundDelivery02() throws IOException
+    public void testInboundDelivery02()
     {
         HelloBankPDFExtractor extractor = new HelloBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
-
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "InboundDelivery02.txt"), errors);
 
         assertThat(errors, empty());
@@ -506,7 +484,7 @@ public class HelloBankPDFExtractorTest
         assertThat(item.isPresent(), is(true));
         Security security = ((SecurityItem) item.get()).getSecurity();
         assertThat(security.getIsin(), is("US56035L1044"));
-        assertThat(security.getName(), is("M a i n  S t r e e t Capital Corp."));
+        assertThat(security.getName(), is("M a i n  S t r e e t Capital Corp. Registered Shares DL -,01"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check transaction

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/hellobank/HelloBankPDFExtractorTest.java
@@ -5,9 +5,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -3,9 +3,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -26,327 +23,210 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("Hellobank"); //$NON-NLS-1$
         addBankIdentifier("Hello bank!"); //$NON-NLS-1$
 
-        addBuyTransaction();
-        addSellTransaction();
+        addBuySellTransaction();
         addDividendTransaction();
         addInboundDelivery();
     }
 
-    @SuppressWarnings("nls")
-    private void addBuyTransaction()
+    @Override
+    public String getPDFAuthor()
     {
-        DocumentType type = new DocumentType("Geschäftsart: Kauf");
-        this.addDocumentTyp(type);
+        return ""; //$NON-NLS-1$
+    }
 
-        Block block = new Block("Geschäftsart: Kauf");
-        type.addBlock(block);
-        block.set(new Transaction<BuySellEntry>()
-
-                        .subject(() -> {
-                            BuySellEntry entry = new BuySellEntry();
-                            entry.setType(PortfolioTransaction.Type.BUY);
-                            return entry;
-                        })
-
-                        .section("isin", "name", "currency") //
-                        .match("Titel: (?<isin>\\S*) (?<name>.*)$") //
-                        .match("Kurs: [\\d+,.]* (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        .section("shares") //
-                        .match("^Zugang: (?<shares>[\\d+,.]*) Stk.*")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        .section("amount", "currency") //
-                        .match("Zu Lasten .* -(?<amount>[\\d+,.]*) (?<currency>\\w{3}+) *$").assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        .section("date") //
-                        .match("Handelszeit: (?<date>\\d+.\\d+.\\d{4}+).*")
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
-
-                        .section("fee", "currency") //
-                        .optional() //
-                        .match("Grundgebühr: -(?<fee>[\\d+,.]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
-
-                        .section("fee", "currency") //
-                        .optional() //
-                        .match("Fremde Spesen: -(?<fee>[\\d+,.]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
-
-                        .section("gross", "currency", "exchangeRate") //
-                        .optional() //
-                        .match("Kurswert: -(?<gross>[\\d+,.-]*) (?<currency>\\w{3}+) *") //
-                        .match("-[\\d+,.-]* \\w{3}+ *")
-                        .match("Devisenkurs: (?<exchangeRate>[\\d+,.]*) \\(\\d+.\\d+.\\d{4}+\\) -[\\d+,.]* \\w{3}+ *")
-                        .assign((t, v) -> {
-                            long gross = asAmount(v.get("gross"));
-                            String currency = asCurrencyCode(v.get("currency"));
-                            BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(v.get("exchangeRate")), 10,
-                                            RoundingMode.HALF_UP);
-
-                            PortfolioTransaction tx = t.getPortfolioTransaction();
-                            if (currency.equals(tx.getSecurity().getCurrencyCode()))
-                            {
-                                long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                .setScale(0, RoundingMode.HALF_UP).longValue();
-
-                                tx.addUnit(new Unit(Unit.Type.GROSS_VALUE,
-                                                Money.of(tx.getCurrencyCode(), convertedGross),
-                                                Money.of(currency, gross), exchangeRate));
-                            }
-                        })
-
-                        .wrap(BuySellEntryItem::new));
+    @Override
+    public String getLabel()
+    {
+        return "Hello Bank"; //$NON-NLS-1$
     }
 
     @SuppressWarnings("nls")
-    private void addSellTransaction()
+    private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("Geschäftsart: Verkauf");
+        DocumentType type = new DocumentType("Geschäftsart: (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("Geschäftsart: Verkauf");
-        type.addBlock(block);
-        block.set(new Transaction<BuySellEntry>()
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        pdfTransaction.subject(() -> {
+            BuySellEntry entry = new BuySellEntry();
+            entry.setType(PortfolioTransaction.Type.BUY);
+            return entry;
+        });
 
-                        .subject(() -> {
-                            BuySellEntry entry = new BuySellEntry();
-                            entry.setType(PortfolioTransaction.Type.SELL);
-                            return entry;
-                        })
+        Block firstRelevantLine = new Block("^Geschäftsart: (Kauf|Verkauf)");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
 
-                        .section("isin", "name", "currency") //
-                        .match("Titel: (?<isin>\\S*) (?<name>.*)$") //
-                        .match("Kurs: [\\d+,.]* (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+        pdfTransaction
+                // Is type --> "Verkauf" change from BUY to SELL
+                .section("type").optional()
+                .match("^Geschäftsart: (?<type>Verkauf)")
+                .assign((t, v) -> {
+                    if (v.get("type").equals("Verkauf"))
+                    {
+                        t.setType(PortfolioTransaction.Type.SELL);
+                    }
+                })
 
-                        .section("shares") //
-                        .match("^Abgang: (?<shares>[\\d+,.]*) Stk.*")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                // Titel: NO0003054108  M a r i n e  H a r v est ASA   
+                // Kurs: 140 NOK 
+                .section("isin", "name", "name1", "currency")
+                .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
+                .match("^(?<name1>.*)$")
+                .match("^Kurs: [-.,\\d]+ (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Kurs"))
+                        v.put("name", v.get("name").trim() + " " + v.get("name1"));
 
-                        .section("amount", "currency") //
-                        .match("Zu Gunsten .* (?<amount>[\\d+,.]*) (?<currency>\\w{3}+) *$").assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        .section("date") //
-                        .match("Handelszeit: (?<date>\\d+.\\d+.\\d{4}+).*")
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+                // Handelszeit: 30.6.2017 um 09:00:10 Uhr
+                .section("date", "time")
+                .match("^Handelszeit: (?<date>\\d+.\\d+.[\\d]{4}) .* (?<time>\\d+:\\d+:\\d+) .*$")
+                .assign((t, v) -> {
+                    if (v.get("time") != null)
+                        t.setDate(asDate(v.get("date"), v.get("time")));
+                    else
+                        t.setDate(asDate(v.get("date")));
+                })
 
-                        .section("fee", "currency") //
-                        .optional() //
-                        .match("Grundgebühr: -(?<fee>[\\d+,.]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
+                // Zugang: 74 Stk Teilausführung
+                .section("shares")
+                .match("^(Zugang|Abgang): (?<shares>[.,\\d]+) Stk.*$")
+                .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("fee", "currency") //
-                        .optional() //
-                        .match("Fremde Spesen: -(?<fee>[\\d+,.]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
+                // Zu Lasten IBAN AT44 1925 0654 0668 9002 -1.118,80 EUR 
+                .section("amount", "currency")
+                .match("^(Zu Lasten|Zu Gunsten) .* [-]?(?<amount>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                })
 
-                        .section("fee", "currency") //
-                        .optional() //
-                        .match("Eigene Spesen: -(?<fee>[\\d+,.]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.getPortfolioTransaction()
-                                        .addUnit(new Unit(Unit.Type.FEE,
-                                                        Money.of(asCurrencyCode(v.get("currency")),
-                                                                        asAmount(v.get("fee"))))))
+                // Kurswert: -10.360,-- NOK 
+                // -10.360,-- NOK 
+                // Devisenkurs: 9,486 (3.7.2017) -1.092,14 EUR 
+                .section("gross", "currency", "exchangeRate").optional()
+                .match("^Kurswert: [-]?(?<gross>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .match("^[-]?[-.,\\d]+ [\\w]{3}.*$")
+                .match("^Devisenkurs: (?<exchangeRate>[.,\\d]+) \\(\\d+.\\d+.\\d{4}\\) [-]?[-.,\\d]+ [\\w]{3}.*$")
+                .assign((t, v) -> {
+                    long gross = asAmount(v.get("gross"));
+                    String currency = asCurrencyCode(v.get("currency"));
+                    BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(v.get("exchangeRate")), 10,
+                                    RoundingMode.HALF_UP);
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
 
-                        .section("gross", "tax", "currency", "exchangeRate") //
-                        // .optional() //
-                        .match("Kurswert: (?<gross>[\\d+,.-]*) (?<currency>\\w{3}+) *") //
-                        .match("Kapitalertragsteuer: -(?<tax>[\\d+,.-]*) \\w{3}+ *") //
-                        .match("[\\d+,.-]* \\w{3}+ *") //
-                        .match("Devisenkurs: (?<exchangeRate>[\\d+,.]*) \\(\\d+.\\d+.\\d{4}+\\) [\\d+,.]* \\w{3}+ *")
-                        .assign((t, v) -> {
-                            long gross = asAmount(v.get("gross"));
-                            long tax = asAmount(v.get("tax"));
-                            String currency = asCurrencyCode(v.get("currency"));
-                            BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(v.get("exchangeRate")), 10,
-                                            RoundingMode.HALF_UP);
+                    PortfolioTransaction tx = t.getPortfolioTransaction();
+                    if (currency.equals(tx.getSecurity().getCurrencyCode()))
+                    {
+                        long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
+                                        .setScale(0, RoundingMode.HALF_UP).longValue();
 
-                            PortfolioTransaction tx = t.getPortfolioTransaction();
-                            if (currency.equals(tx.getSecurity().getCurrencyCode()))
-                            {
-                                long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                .setScale(0, RoundingMode.HALF_UP).longValue();
-                                tx.addUnit(new Unit(Unit.Type.GROSS_VALUE,
-                                                Money.of(tx.getCurrencyCode(), convertedGross),
-                                                Money.of(currency, gross), exchangeRate));
+                        tx.addUnit(new Unit(Unit.Type.GROSS_VALUE,
+                                        Money.of(tx.getCurrencyCode(), convertedGross),
+                                        Money.of(currency, gross), exchangeRate));
+                    }
+                })
 
-                                long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                                .setScale(0, RoundingMode.HALF_UP).longValue();
-                                tx.addUnit(new Unit(Unit.Type.TAX, Money.of(tx.getCurrencyCode(), convertedTax),
-                                                Money.of(currency, tax), exchangeRate));
-                            }
-                            else
-                            {
-                                long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                                .setScale(0, RoundingMode.HALF_UP).longValue();
-                                tx.addUnit(new Unit(Unit.Type.TAX, Money.of(tx.getCurrencyCode(), convertedTax)));
-                            }
-                        })
+                .wrap(BuySellEntryItem::new);
 
-                        .wrap(BuySellEntryItem::new));
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
     }
 
     @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
-        DocumentType type = new DocumentType("Geschäftsart: Ertrag", (context, lines) -> {
-            Pattern exchangeRatePattern = Pattern.compile(
-                            "Devisenkurs: (?<exchangeRate>[\\d+,.]*) \\(\\d+.\\d+.\\d{4}+\\) [\\d+,.]* \\w{3}+ *");
-
-            for (String line : lines)
-            {
-                Matcher matcher = exchangeRatePattern.matcher(line);
-                if (matcher.matches())
-                    context.put("exchangeRate", matcher.group(1));
-            }
-        });
+        DocumentType type = new DocumentType("Geschäftsart: Ertrag");
         this.addDocumentTyp(type);
 
         Block block = new Block("Geschäftsart: Ertrag");
         type.addBlock(block);
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
+            .subject(() -> {
+                AccountTransaction entry = new AccountTransaction();
+                entry.setType(AccountTransaction.Type.DIVIDENDS);
+                return entry;
+            });
 
-        BiConsumer<AccountTransaction, Map<String, String>> taxProcessor = (t, v) -> {
+        pdfTransaction
+                // Titel: NO0003054108  M a r i n e  H a r v est ASA                 
+                // Navne-Aksjer NK 7,50               
+                // Dividende: 3,2 NOK 
+                .section("isin", "name", "name1", "currency")
+                .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
+                .match("^(?<name1>.*)$")
+                .match("^Dividende: [-.,\\d]+ (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Dividende"))
+                        v.put("name", v.get("name").trim() + " " + v.get("name1"));
 
-            long tax = asAmount(v.get("tax"));
-            String currency = asCurrencyCode(v.get("currency"));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-            // logic: if taxes are in the transaction currency, simply add them
-            // if taxes are in forex then convert them, but add them with forex
-            // only if the security is actually also in forex
+                // 200 Stk
+                .section("shares")
+                .match("^(Abgang: )?(?<shares>[.,\\d]+) Stk.*$")
+                .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-            if (currency.equals(t.getCurrencyCode()))
-            {
-                t.addUnit(new Unit(Unit.Type.TAX, Money.of(t.getCurrencyCode(), tax)));
-            }
-            else
-            {
-                String exchangeRateString = type.getCurrentContext().get("exchangeRate");
+                // Valuta 6.9.2017
+                .section("date")
+                .match("Valuta (?<date>\\d+.\\d+.\\d{4}+)")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                if (exchangeRateString != null)
-                {
-                    BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(exchangeRateString), 10,
-                                    RoundingMode.HALF_UP);
+                // Zu Gunsten IBAN AT44 1925 0654 0668 9002 48,71 EUR 
+                .section("amount", "currency").optional()
+                .match("Zu Gunsten .* (?<amount>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
 
-                    if (currency.equals(t.getSecurity().getCurrencyCode()))
+                // 463,99 NOK 
+                // Devisenkurs: 9,308 (5.9.2017) 49,85 EUR 
+                .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
+                .match("^[-]?(?<fxAmount>[-.,\\d]+) (?<fxCurrency>[\\w]{3})[^Stk].*$")
+                .match("^Devisenkurs: (?<exchangeRate>[.,\\d]+) \\(\\d+.\\d+.\\d{4}\\) (?<amount>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
                     {
-                        long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                        .setScale(0, RoundingMode.HALF_UP).longValue();
-                        t.addUnit(new Unit(Unit.Type.TAX, Money.of(t.getCurrencyCode(), convertedTax),
-                                        Money.of(currency, tax), exchangeRate));
+                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                     }
-                    else
+                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+
+                    if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                     {
-                        long convertedTax = BigDecimal.valueOf(tax).multiply(exchangeRate)
-                                        .setScale(0, RoundingMode.HALF_UP).longValue();
-                        t.addUnit(new Unit(Unit.Type.TAX, Money.of(t.getCurrencyCode(), convertedTax)));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                        RoundingMode.HALF_DOWN);
+
+                        // check, if forex currency is transaction
+                        // currency or not and swap amount, if necessary
+                        Unit grossValue;
+                        if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
+                        {
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")),asAmount(v.get("fxAmount")));
+                            Money amount = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("amount")));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
+                        }
+                        else
+                        {
+                            Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
+                            Money fxAmount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
+                            grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
+                        }
+                        t.addUnit(grossValue);
                     }
-                }
-            }
-        };
+                })
 
-        block.set(new Transaction<AccountTransaction>()
+                .wrap(TransactionItem::new);
 
-                        .subject(() -> {
-                            AccountTransaction transaction = new AccountTransaction();
-                            transaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return transaction;
-                        })
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
 
-                        .section("isin", "name", "currency") //
-                        .match("Titel: (?<isin>\\S*) (?<name>.*)$") //
-                        .match("Dividende: [\\d+,.]* (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        .section("shares") //
-                        .match("^(Abgang: )?(?<shares>[\\d+,.]*) Stk$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        .section("amount", "currency")
-                        .match("Zu Gunsten .* (?<amount>[\\d+,.]*) (?<currency>\\w{3}+) *$").assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
-
-                        .section("date") //
-                        .match("Valuta (?<date>\\d+.\\d+.\\d{4}+)") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
-
-                        // FIXME should be fee (not tax) -> change once dividend
-                        // transactions support fees
-                        .section("tax", "currency") //
-                        .optional() //
-                        .match("Inkassoprovision: -(?<tax>[\\d+,.]*) (?<currency>\\w{3}+) *").assign(taxProcessor)
-
-                        .section("tax", "currency") //
-                        .optional() //
-                        .match("Umsatzsteuer: -(?<tax>[\\d+,.]*) (?<currency>\\w{3}+) *").assign(taxProcessor)
-
-                        .section("tax", "currency") //
-                        .optional() //
-                        .match("Fremde Spesen: -(?<tax>[\\d+,.-]*) (?<currency>\\w{3}+) *") //
-                        .assign(taxProcessor)
-
-                        .section("tax", "currency") //
-                        .optional() //
-                        .match("KESt Ausländische Dividende: -(?<tax>[\\d+,.]*) (?<currency>\\w{3}+) *") //
-                        .assign(taxProcessor)
-
-                        .section("tax", "currency") //
-                        .optional() //
-                        .match("Quellensteuer[^.]*: -(?<tax>[\\d+,.]*) (?<currency>\\w{3}+) *") //
-                        .assign(taxProcessor)
-
-                        .section("gross", "currency") //
-                        .optional() //
-                        .match("Bruttoertrag: (?<gross>[\\d+,.-]*) (?<currency>\\w{3}+) *").assign((t, v) -> {
-
-                            long gross = asAmount(v.get("gross"));
-                            String currency = asCurrencyCode(v.get("currency"));
-
-                            // record fx only if security currency actually
-                            // matches the fx currency of the transaction (many
-                            // users actually do not maintain the security in
-                            // the fx currency)
-
-                            if (currency.equals(t.getSecurity().getCurrencyCode()))
-                            {
-                                String exchangeRateString = type.getCurrentContext().get("exchangeRate");
-
-                                if (exchangeRateString != null)
-                                {
-                                    BigDecimal exchangeRate = BigDecimal.ONE.divide(asExchangeRate(exchangeRateString),
-                                                    10, RoundingMode.HALF_UP);
-
-                                    long convertedGross = BigDecimal.valueOf(gross).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue();
-                                    t.addUnit(new Unit(Unit.Type.GROSS_VALUE,
-                                                    Money.of(t.getCurrencyCode(), convertedGross),
-                                                    Money.of(currency, gross), exchangeRate));
-                                }
-                            }
-                        })
-
-                        .wrap(TransactionItem::new));
+        block.set(pdfTransaction);
     }
 
     @SuppressWarnings("nls")
@@ -359,36 +239,132 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(block);
         block.set(new Transaction<PortfolioTransaction>()
 
-                        .subject(() -> {
-                            PortfolioTransaction transaction = new PortfolioTransaction();
-                            transaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return transaction;
-                        })
+                .subject(() -> {
+                    PortfolioTransaction transaction = new PortfolioTransaction();
+                    transaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
+                    return transaction;
+                })
 
-                        .section("isin", "name", "currency") //
-                        .match("Titel: (?<isin>\\S*) (?<name>.*)$") //
-                        .match("steuerlicher Anschaffungswert: [\\d+,.-]* (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+                // Titel: DK0060534915  N o v o - N o r d i s k AS                    
+                // Navne-Aktier B DK -,20             
+                // Lieferpflichtiger: Depotnummer: 99147 
+                .section("isin", "name", "name1", "currency")
+                .match("^Titel: (?<isin>\\S*) (?<name>.*)$")
+                .match("^(?<name1>.*)$")
+                .match("^steuerlicher Anschaffungswert: [-.,\\d]+ (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Lieferpflichtiger")
+                                    || !v.get("name1").startsWith("Verwahrart"))
+                    v.put("name", v.get("name").trim() + " " + v.get("name1"));
+                    
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
 
-                        .section("shares") //
-                        .match("^Zugang: (?<shares>[\\d+,.]*) Stk.*")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                // Zugang: 80 Stk
+                .section("shares")
+                .match("^Zugang: (?<shares>[.,\\d]+) Stk.*$")
+                .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date") //
-                        .match("Kassatag: (?<date>\\d+.\\d+.\\d{4}+).*")
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                // Kassatag: 29.3.2017
+                .section("date")
+                .match("^Kassatag: (?<date>\\d+.\\d+.\\d{4}).*$")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                        .section("amount", "currency") //
-                        .match("steuerlicher Anschaffungswert: (?<amount>[\\d+,.-]*) (?<currency>\\w{3}+) *")
-                        .assign((t, v) -> t.setMonetaryAmount(
-                                        Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")))))
+                // steuerlicher Anschaffungswert: 3.225,37 EUR
+                .section("amount", "currency")
+                .match("^steuerlicher Anschaffungswert: (?<amount>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> {
+                    t.setMonetaryAmount(Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount"))));
+                })
 
-                        .wrap(TransactionItem::new));
+                .wrap(TransactionItem::new));
     }
 
-    @Override
-    public String getLabel()
+    @SuppressWarnings("nls")
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
-        return "Hello Bank"; //$NON-NLS-1$
+        transaction
+                // Kapitalertragsteuer: -254,10 AUD 
+                .section("tax", "currency").optional()
+                .match("^Kapitalertragsteuer: -(?<tax>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // KESt Ausländische Dividende: -176,01 NOK 
+                .section("tax", "currency").optional()
+                .match("^KESt Ausländische Dividende: -(?<tax>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // Quellensteuer US-Emittent: -3,05 USD 
+                .section("tax", "currency").optional()
+                .match("^Quellensteuer US-Emittent: -(?<tax>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // Quellensteuer: -8,81 EUR 
+                .section("tax", "currency").optional()
+                .match("^Quellensteuer: -(?<tax>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
+                // Umsatzsteuer: -0,19 EUR 
+                .section("tax", "currency").optional()
+                .match("^Umsatzsteuer: -(?<tax>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processTaxEntries(t, v, type));
+    }
+
+    @SuppressWarnings("nls")
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction
+                // Fremde Spesen: -25,20 EUR 
+                .section("fee", "currency").optional()
+                .match("^Fremde Spesen: -(?<fee>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Eigene Spesen: -6,42 EUR 
+                .section("fee", "currency").optional()
+                .match("^Eigene Spesen: -(?<fee>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Inkassoprovision: -0,95 EUR 
+                .section("fee", "currency").optional()
+                .match("^Inkassoprovision: -(?<fee>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processFeeEntries(t, v, type))
+
+                // Grundgebühr: -1,46 EUR 
+                .section("fee", "currency").optional()
+                .match("^Grundgebühr: -(?<fee>[-.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .assign((t, v) -> processFeeEntries(t, v, type));
+    }
+
+    @SuppressWarnings("nls")
+    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+            PDFExtractorUtils.checkAndSetTax(tax,
+                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
+    }
+
+    @SuppressWarnings("nls")
+    private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
+    {
+        if (t instanceof name.abuchen.portfolio.model.Transaction)
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee, 
+                            (name.abuchen.portfolio.model.Transaction) t, type);
+        }
+        else
+        {
+            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+            PDFExtractorUtils.checkAndSetFee(fee,
+                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -41,6 +41,7 @@ public class PDFImportAssistant
         extractors.add(new ConsorsbankPDFExtractor(client));
         extractors.add(new ConsorsbankPre2009PDFExtractor(client));
         extractors.add(new DABPDFExtractor(client));
+        extractors.add(new DADATBankenhausPDFExtractor(client));
         extractors.add(new DegiroPDFExtractor(client));
         extractors.add(new DeutscheBankPDFExtractor(client));
         extractors.add(new Direkt1822BankPDFExtractor(client));


### PR DESCRIPTION
Fixed https://github.com/buchen/portfolio/blob/3159975be79905affea9998d9f075e623e129392/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java#L294
Fix wrong fee's
Fix in testcases missing fee's and tax's
Add full name of securities (nameContinued)
Optimize some regEx
Integration in the PDFExtractorUtils.java (fee's and tax's)

Warum wird im 2ten PR der
   extractors.add(new DADATBankenhausPDFExtractor(client));
hinzugefügt?! Der ist doch schon drin, oder hab ich meinen eigenen rebase verpasst?! 'kopfkratz'