### PR TITLE
Fixed security prices not getting updated in timezones "behind" UTC (and improved JSON date format tool tip).

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/checks/impl/CrossEntryCheckTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/checks/impl/CrossEntryCheckTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -265,7 +266,7 @@ public class CrossEntryCheckTest
 
         applyFixes(client, issues);
 
-        ClientSnapshot.create(client, new TestCurrencyConverter(), LocalDate.now());
+        ClientSnapshot.create(client, new TestCurrencyConverter(), LocalDate.now(ZoneOffset.UTC));
     }
 
     private void applyFixes(Client client, List<Issue> issues)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/NPVFunctionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/NPVFunctionTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -21,7 +22,7 @@ public class NPVFunctionTest
     @Test(expected = UnsupportedOperationException.class)
     public void testInvalidArguments()
     {
-        new NPVFunction(Arrays.asList(LocalDate.now()), new ArrayList<Double>());
+        new NPVFunction(Arrays.asList(LocalDate.now(ZoneOffset.UTC)), new ArrayList<Double>());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class AccountTest
         account.setCurrencyCode(CurrencyUnit.EUR);
 
         this.transaction = new AccountTransaction();
-        transaction.setDateTime(LocalDate.now().atStartOfDay());
+        transaction.setDateTime(LocalDate.now(ZoneOffset.UTC).atStartOfDay());
         transaction.setType(AccountTransaction.Type.DEPOSIT);
         transaction.setAmount(10000);
         transaction.setCurrencyCode(CurrencyUnit.EUR);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -165,7 +166,7 @@ public class InvestmentPlanTest
     public void testNoGenerationWithStartInFuture() throws IOException
     {
         investmentPlan.setAccount(account);
-        investmentPlan.setStart(LocalDate.now().minusMonths(6));
+        investmentPlan.setStart(LocalDate.now(ZoneOffset.UTC).minusMonths(6));
         investmentPlan.setInterval(12);
 
         investmentPlan.generateTransactions(new TestCurrencyConverter());
@@ -174,7 +175,7 @@ public class InvestmentPlanTest
         // given is an investment plan with existing transactions,
         // the user changes the start date to be in the future
 
-        investmentPlan.setStart(LocalDate.now().plusMonths(12));
+        investmentPlan.setStart(LocalDate.now(ZoneOffset.UTC).plusMonths(12));
         investmentPlan.setInterval(1);
         investmentPlan.generateTransactions(new TestCurrencyConverter());
 
@@ -182,7 +183,7 @@ public class InvestmentPlanTest
         assertThat(investmentPlan.getTransactions(), hasSize(previousTransactionCount));
 
         // generation resumes at start date
-        LocalDate resumeDate = LocalDate.now().minusMonths(1).minusDays(10);
+        LocalDate resumeDate = LocalDate.now(ZoneOffset.UTC).minusMonths(1).minusDays(10);
         investmentPlan.setStart(resumeDate);
         investmentPlan.generateTransactions(new TestCurrencyConverter());
         assertThat(investmentPlan.getTransactions(), hasSize(previousTransactionCount + 2));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/PortfolioTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/PortfolioTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 
@@ -42,7 +43,7 @@ public class PortfolioTest
     {
         transaction = new PortfolioTransaction();
         transaction.setType(Type.DELIVERY_INBOUND);
-        transaction.setDateTime(LocalDate.now().atStartOfDay());
+        transaction.setDateTime(LocalDate.now(ZoneOffset.UTC).atStartOfDay());
         transaction.setSecurity(security);
 
         portfolio.addTransaction(transaction);
@@ -52,7 +53,7 @@ public class PortfolioTest
     {
         transactionWithPlan = new PortfolioTransaction();
         transactionWithPlan.setType(Type.DELIVERY_INBOUND);
-        transactionWithPlan.setDateTime(LocalDate.now().atStartOfDay());
+        transactionWithPlan.setDateTime(LocalDate.now(ZoneOffset.UTC).atStartOfDay());
         transactionWithPlan.setSecurity(security);
 
         plan.getTransactions().add(transactionWithPlan);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -12,6 +12,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -80,17 +81,17 @@ public class SecurityTest
         Security security = new Security();
         assertThat(security.setLatest(null), is(false));
 
-        LatestSecurityPrice latest = new LatestSecurityPrice(LocalDate.now(), 1);
+        LatestSecurityPrice latest = new LatestSecurityPrice(LocalDate.now(ZoneOffset.UTC), 1);
         assertThat(security.setLatest(latest), is(true));
         assertThat(security.setLatest(latest), is(false));
         assertThat(security.setLatest(null), is(true));
         assertThat(security.setLatest(null), is(false));
 
-        LatestSecurityPrice second = new LatestSecurityPrice(LocalDate.now(), 2);
+        LatestSecurityPrice second = new LatestSecurityPrice(LocalDate.now(ZoneOffset.UTC), 2);
         assertThat(security.setLatest(latest), is(true));
         assertThat(security.setLatest(second), is(true));
 
-        LatestSecurityPrice same = new LatestSecurityPrice(LocalDate.now(), 2);
+        LatestSecurityPrice same = new LatestSecurityPrice(LocalDate.now(ZoneOffset.UTC), 2);
         assertThat(security.setLatest(same), is(false));
     }
 
@@ -167,9 +168,9 @@ public class SecurityTest
 
         assertThat(security.getLatestTwoSecurityPrices().isPresent(), is(false));
 
-        SecurityPrice pYesterday = new SecurityPrice(LocalDate.now().plusDays(-2), 90);
-        SecurityPrice pToday = new LatestSecurityPrice(LocalDate.now(), 100);
-        SecurityPrice pTommorrow = new SecurityPrice(LocalDate.now().plusDays(1), 110);
+        SecurityPrice pYesterday = new SecurityPrice(LocalDate.now(ZoneOffset.UTC).plusDays(-2), 90);
+        SecurityPrice pToday = new LatestSecurityPrice(LocalDate.now(ZoneOffset.UTC), 100);
+        SecurityPrice pTommorrow = new SecurityPrice(LocalDate.now(ZoneOffset.UTC).plusDays(1), 110);
 
         // test that nothing is returned if only the latest security price
         // exists

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAEDTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderAEDTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -23,10 +24,10 @@ public class ExchangeRateProviderAEDTest
         ExchangeRateProviderFactory factory = new ExchangeRateProviderFactory(new Client());
 
         ExchangeRateTimeSeries usd_aed = factory.getTimeSeries("USD", "AED");
-        assertThat(usd_aed.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("3.6725")));
+        assertThat(usd_aed.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("3.6725")));
 
         ExchangeRateTimeSeries aed_usd = factory.getTimeSeries("AED", "USD");
-        assertThat(aed_usd.lookupRate(LocalDate.now()).get().getValue(),
+        assertThat(aed_usd.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(),
                         comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("3.6725"), 10, RoundingMode.HALF_DOWN)));
 
         // EUR -> USD -> AED
@@ -34,7 +35,7 @@ public class ExchangeRateProviderAEDTest
         double calculatedRate = 1.0836d * 3.6725d;
 
         ExchangeRateTimeSeries eur_aed = factory.getTimeSeries("EUR", "AED");
-        assertThat(eur_aed.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        assertThat(eur_aed.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBXTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderGBXTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -24,20 +25,20 @@ public class ExchangeRateProviderGBXTest
 
         // default value EUR -> GBP is 0.72666
         ExchangeRateTimeSeries eur_gbx = factory.getTimeSeries("EUR", "GBX");
-        assertThat(eur_gbx.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("72.666")));
+        assertThat(eur_gbx.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("72.666")));
 
         // inverse of default EUR -> GBP
         ExchangeRateTimeSeries gbx_eur = factory.getTimeSeries("GBX", "EUR");
-        assertThat(gbx_eur.lookupRate(LocalDate.now()).get().getValue(),
+        assertThat(gbx_eur.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(),
                         comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("72.666"), 12, RoundingMode.HALF_DOWN)));
 
         // GBX -> GBP
         ExchangeRateTimeSeries gbx_gbp = factory.getTimeSeries("GBX", "GBP");
-        assertThat(gbx_gbp.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
+        assertThat(gbx_gbp.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
 
         // GBP -> GBX
         ExchangeRateTimeSeries gbp_gbx = factory.getTimeSeries("GBP", "GBX");
-        assertThat(gbp_gbx.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
+        assertThat(gbp_gbx.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
 
         // GBX -> USD
         // default value EUR -> GBP is 0.72666
@@ -45,14 +46,14 @@ public class ExchangeRateProviderGBXTest
         double calculatedRate = 0.01d * (1 / 0.72666d) * 1.0836d;
 
         ExchangeRateTimeSeries gbx_usd = factory.getTimeSeries("GBX", "USD");
-        assertThat(gbx_usd.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        assertThat(gbx_usd.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
 
         // USD -> GBX
         calculatedRate = (1 / 1.0836d) * 0.72666d * 100;
 
         ExchangeRateTimeSeries usd_gbx = factory.getTimeSeries("USD", "GBX");
-        assertThat(usd_gbx.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        assertThat(usd_gbx.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
 
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILATest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderILATest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -23,20 +24,20 @@ public class ExchangeRateProviderILATest
 
         // default value EUR -> ILS is 422.10
         ExchangeRateTimeSeries eur_ILA = factory.getTimeSeries("EUR", "ILA");
-        assertThat(eur_ILA.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("422.1")));
+        assertThat(eur_ILA.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("422.1")));
 
         // inverse of default EUR -> ILS
         ExchangeRateTimeSeries ILA_eur = factory.getTimeSeries("ILA", "EUR");
-        assertThat(ILA_eur.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(
+        assertThat(ILA_eur.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(
                         BigDecimal.ONE.divide(new BigDecimal("422.099999949897"), 12, RoundingMode.HALF_DOWN)));
 
         // ILA -> ILS
         ExchangeRateTimeSeries ILA_ILS = factory.getTimeSeries("ILA", "ILS");
-        assertThat(ILA_ILS.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
+        assertThat(ILA_ILS.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
 
         // ILS -> ILA
         ExchangeRateTimeSeries ILS_ILA = factory.getTimeSeries("ILS", "ILA");
-        assertThat(ILS_ILA.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
+        assertThat(ILS_ILA.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
 
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/money/impl/ExchangeRateProviderZACTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -24,34 +25,34 @@ public class ExchangeRateProviderZACTest
 
         // default value EUR -> ZAR is 17.975
         ExchangeRateTimeSeries eur_zar = factory.getTimeSeries("EUR", "ZAR");
-        assertThat(eur_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("17.975")));
+        assertThat(eur_zar.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("17.975")));
 
         // inverse of default EUR -> GBP
         ExchangeRateTimeSeries gbx_eur = factory.getTimeSeries("ZAC", "EUR");
-        assertThat(gbx_eur.lookupRate(LocalDate.now()).get().getValue(),
+        assertThat(gbx_eur.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(),
                         comparesEqualTo(BigDecimal.ONE.divide(new BigDecimal("1797.5"), 12, RoundingMode.HALF_DOWN)));
 
         // ZAC -> ZAR
         ExchangeRateTimeSeries zac_zar = factory.getTimeSeries("ZAC", "ZAR");
-        assertThat(zac_zar.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
+        assertThat(zac_zar.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal("0.01")));
 
         // ZAR -> ZAC
         ExchangeRateTimeSeries zar_zac = factory.getTimeSeries("ZAR", "ZAC");
-        assertThat(zar_zac.lookupRate(LocalDate.now()).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
+        assertThat(zar_zac.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue(), comparesEqualTo(new BigDecimal(100.0)));
 
         // ZAC -> EUR
         // default value EUR -> ZAR is 17.975
         double calculatedRate = 0.01d * (1 / 17.975d);
 
         ExchangeRateTimeSeries zac_eur = factory.getTimeSeries("ZAC", "EUR");
-        assertThat(zac_eur.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        assertThat(zac_eur.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
 
         // EUR -> ZAC
         calculatedRate = 17.975d * 100;
 
         ExchangeRateTimeSeries eur_zac = factory.getTimeSeries("EUR", "ZAC");
-        assertThat(eur_zac.lookupRate(LocalDate.now()).get().getValue().doubleValue(),
+        assertThat(eur_zac.lookupRate(LocalDate.now(ZoneOffset.UTC)).get().getValue().doubleValue(),
                         closeTo(calculatedRate, 0.00000001));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeedTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,9 +74,9 @@ public class YahooFinanceQuoteFeedTest
         LocalDate date = feed.caculateStart(security);
         assertThat(date, equalTo(nineteenHundred));
 
-        security.addPrice(new SecurityPrice(LocalDate.now(), 100));
+        security.addPrice(new SecurityPrice(LocalDate.now(ZoneOffset.UTC), 100));
         date = feed.caculateStart(security);
-        assertThat(date, equalTo(LocalDate.now()));
+        assertThat(date, equalTo(LocalDate.now(ZoneOffset.UTC)));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/FactoryTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/FactoryTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Iterator;
 
 import org.junit.Test;
@@ -40,7 +41,7 @@ public class FactoryTest
     {
         VariableURL url = Factory.fromString("https://192.0.2.1/quotes.php?whatever={TODAY}");
         Iterator<String> iterator = url.iterator();
-        assertThat(iterator.next(), is("https://192.0.2.1/quotes.php?whatever=" + LocalDate.now()));
+        assertThat(iterator.next(), is("https://192.0.2.1/quotes.php?whatever=" + LocalDate.now(ZoneOffset.UTC)));
         assertThat(iterator.hasNext(), is(false));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/FormattedDateTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/FormattedDateTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -31,7 +32,7 @@ public class FormattedDateTest
     @Test
     public void testVariations()
     {
-        LocalDate date = LocalDate.now();
+        LocalDate date = LocalDate.now(ZoneOffset.UTC);
         assertVariations(new Security(),
                         Arrays.asList(date, date.minusMonths(1), date.minusMonths(2), date.minusMonths(3)));
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/TodayMacroTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/TodayMacroTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -18,34 +19,34 @@ public class TodayMacroTest
     public void testToday()
     {
         Today today = new Today("TODAY");
-        assertThat(today.resolve(new Security()), is(LocalDate.now().toString()));
+        assertThat(today.resolve(new Security()), is(LocalDate.now(ZoneOffset.UTC).toString()));
     }
 
     @Test
     public void testTodayWithFormat()
     {
         Today today = new Today("TODAY:yyyy-MM-dd");
-        assertThat(today.resolve(new Security()), is(LocalDate.now().toString()));
+        assertThat(today.resolve(new Security()), is(LocalDate.now(ZoneOffset.UTC).toString()));
     }
 
     @Test
     public void testMinusOneYear()
     {
         Today today = new Today("TODAY:yyyy-MM-dd:-P1Y");
-        assertThat(today.resolve(new Security()), is(LocalDate.now().minusYears(1).toString()));
+        assertThat(today.resolve(new Security()), is(LocalDate.now(ZoneOffset.UTC).minusYears(1).toString()));
     }
 
     @Test
     public void testPlusTwoYears()
     {
         Today today = new Today("TODAY:yyyy-MM-dd:P2Y");
-        assertThat(today.resolve(new Security()), is(LocalDate.now().plusYears(2).toString()));
+        assertThat(today.resolve(new Security()), is(LocalDate.now(ZoneOffset.UTC).plusYears(2).toString()));
     }
 
     @Test
     public void testMinusTwoMonths()
     {
         Today today = new Today("TODAY:yyyy-MM-dd:-P2M");
-        assertThat(today.resolve(new Security()), is(LocalDate.now().minusMonths(2).toString()));
+        assertThat(today.resolve(new Security()), is(LocalDate.now(ZoneOffset.UTC).minusMonths(2).toString()));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/VariableURLTests.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/variableurl/VariableURLTests.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
@@ -41,7 +42,7 @@ public class VariableURLTests
 
         assertTrue(iter.hasNext());
         assertThat(iter.next(), is("https://www.server.de/LU0635178014/historische_kurse?month="
-                        + LocalDate.now().format(FORMATTER) + "&currency=EUR"));
+                        + LocalDate.now(ZoneOffset.UTC).format(FORMATTER) + "&currency=EUR"));
     }
 
     @Test
@@ -55,7 +56,7 @@ public class VariableURLTests
         Iterator<String> iter = url.iterator();
 
         assertTrue(iter.hasNext());
-        assertThat(iter.next(), is("https://www.server.de/historische_kurse?month=" + LocalDate.now().format(FORMATTER)
+        assertThat(iter.next(), is("https://www.server.de/historische_kurse?month=" + LocalDate.now(ZoneOffset.UTC).format(FORMATTER)
                         + "&isin=LU0635178014"));
     }
 
@@ -72,7 +73,7 @@ public class VariableURLTests
         assertTrue(iter.hasNext());
         assertThat(iter.next(),
                         is("https://www.server.de/historische_kurse?month="
-                                        + LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-32"))
+                                        + LocalDate.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-32"))
                                         + "&isin=LU0635178014&ticker=E127&wkn=ETF127&currency=EUR"));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class PerformanceIndexTest
         private PerformanceIndexStub(LocalDate[] dates, long[] totals, double[] delta)
         {
             super(new Client(), new TestCurrencyConverter(),
-                            new ReportingPeriod.LastX(1, 0).toInterval(LocalDate.now()));
+                            new ReportingPeriod.LastX(1, 0).toInterval(LocalDate.now(ZoneOffset.UTC)));
 
             this.dates = dates;
             this.totals = totals;
@@ -78,8 +79,8 @@ public class PerformanceIndexTest
     @Test
     public void testTransactionsOnTheFirstDayOfIntervalAreIncludedInAbsoluteInvestedCapital()
     {
-        LocalDate[] dates = new LocalDate[] { LocalDate.now().minusYears(1),
-                        LocalDate.now().minusYears(1).plusDays(1) };
+        LocalDate[] dates = new LocalDate[] { LocalDate.now(ZoneOffset.UTC).minusYears(1),
+                        LocalDate.now(ZoneOffset.UTC).minusYears(1).plusDays(1) };
         long[] totals = new long[] { 1000, 1100 };
         double[] delta = new double[] { 0, 0.1 };
 
@@ -92,7 +93,7 @@ public class PerformanceIndexTest
         account.addTransaction(new AccountTransaction(LocalDateTime.now().minusYears(1).withHour(10), CurrencyUnit.EUR,
                         Values.Amount.factorize(1), null, AccountTransaction.Type.DEPOSIT));
 
-        account.addTransaction(new AccountTransaction(LocalDate.now().minusYears(1).plusDays(1).atStartOfDay(),
+        account.addTransaction(new AccountTransaction(LocalDate.now(ZoneOffset.UTC).minusYears(1).plusDays(1).atStartOfDay(),
                         CurrencyUnit.EUR, Values.Amount.factorize(1), null, AccountTransaction.Type.DEPOSIT));
 
         Portfolio portfolio = new Portfolio();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentMonthTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentMonthTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class CurrentMonthTest
     @Test
     public void testToInterval() throws IOException
     {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LocalDate intervalStart = LocalDate.of(today.getYear(), today.getMonthValue(), 1).minusDays(1);
         LocalDate intervalEnd = LocalDate.of(today.getYear(), today.getMonthValue(), today.lengthOfMonth());
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearToDateTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearToDateTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class YearToDateTest
     @Test
     public void testToInterval() throws IOException
     {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LocalDate intervalStart = LocalDate.of(today.getYear(), 1, 1).minusDays(1);
         LocalDate intervalEnd = LocalDate.of(today.getYear(), 12, 31);
         ReportingPeriod period = ReportingPeriod.from("X");

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import org.hamcrest.number.IsCloseTo;
@@ -174,7 +175,7 @@ public class CurrencyTestCase
         ReportingPeriod period = new ReportingPeriod.FromXtoY(LocalDate.parse("2015-01-02"),
                         LocalDate.parse("2015-01-14"));
         ClientPerformanceSnapshot performance = new ClientPerformanceSnapshot(client, converter,
-                        period.toInterval(LocalDate.now()));
+                        period.toInterval(LocalDate.now(ZoneOffset.UTC)));
 
         // calculating the totals is tested with #testClientSnapshot
         assertThat(performance.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 4131_99)));

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/SimpleMovingAverageTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
@@ -57,7 +58,7 @@ public class SimpleMovingAverageTest
     @Test
     public void testSecurityHasOnlyOnePrice()
     {
-        ChartInterval interval = new ChartInterval(securityOnePrice.getPrices().get(0).getDate(), LocalDate.now());
+        ChartInterval interval = new ChartInterval(securityOnePrice.getPrices().get(0).getDate(), LocalDate.now(ZoneOffset.UTC));
         ChartLineSeriesAxes sma = new SimpleMovingAverage(200, this.securityOnePrice, interval).getSMA();
         assertThat(sma.getDates(), is(IsNull.nullValue()));
     }
@@ -65,7 +66,7 @@ public class SimpleMovingAverageTest
     @Test
     public void testSecurityIsNull()
     {
-        ChartInterval interval = new ChartInterval(securityOnePrice.getPrices().get(0).getDate(), LocalDate.now());
+        ChartInterval interval = new ChartInterval(securityOnePrice.getPrices().get(0).getDate(), LocalDate.now(ZoneOffset.UTC));
         ChartLineSeriesAxes sma = new SimpleMovingAverage(200, null, interval).getSMA();
         assertThat(sma.getDates(), is(IsNull.nullValue()));
     }
@@ -73,7 +74,7 @@ public class SimpleMovingAverageTest
     @Test
     public void testCorrectSMAEntries()
     {
-        ChartInterval interval = new ChartInterval(securityTenPrices.getPrices().get(0).getDate(), LocalDate.now());
+        ChartInterval interval = new ChartInterval(securityTenPrices.getPrices().get(0).getDate(), LocalDate.now(ZoneOffset.UTC));
         ChartLineSeriesAxes sma = new SimpleMovingAverage(10, this.securityTenPrices, interval).getSMA();
         assertThat(sma, is(IsNull.notNullValue()));
         assertThat(sma.getValues().length, is(1));
@@ -92,7 +93,7 @@ public class SimpleMovingAverageTest
             date = date.plusDays(1);
         }
 
-        ChartInterval interval = new ChartInterval(security.getPrices().get(0).getDate(), LocalDate.now());
+        ChartInterval interval = new ChartInterval(security.getPrices().get(0).getDate(), LocalDate.now(ZoneOffset.UTC));
 
         ChartLineSeriesAxes sma = new SimpleMovingAverage(10, security, interval).getSMA();
         assertThat(sma, is(IsNull.notNullValue()));
@@ -112,7 +113,7 @@ public class SimpleMovingAverageTest
         }
         LocalDate startDate = LocalDate.parse("2016-06-01");
         Date isStartDate = java.sql.Date.valueOf(startDate);
-        ChartLineSeriesAxes sma = new SimpleMovingAverage(10, security, new ChartInterval(startDate, LocalDate.now()))
+        ChartLineSeriesAxes sma = new SimpleMovingAverage(10, security, new ChartInterval(startDate, LocalDate.now(ZoneOffset.UTC)))
                         .getSMA();
         assertThat(sma, is(IsNull.notNullValue()));
         assertThat(sma.getDates()[0], is(isStartDate));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.dialogs;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.function.Predicate;
 
@@ -17,7 +18,7 @@ import name.abuchen.portfolio.ui.Messages;
 
 public class DateSelectionDialog extends Dialog
 {
-    private LocalDate selection = LocalDate.now();
+    private LocalDate selection = LocalDate.now(ZoneOffset.UTC);
     private Predicate<LocalDate> validator;
 
     public DateSelectionDialog(Shell parentShell)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.dialogs;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.Year;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -230,7 +231,7 @@ public class ReportingPeriodDialog extends Dialog
         else
             throw new IllegalArgumentException();
 
-        Interval interval = template.toInterval(LocalDate.now());
+        Interval interval = template.toInterval(LocalDate.now(ZoneOffset.UTC));
 
         dateFrom.setSelection(interval.getStart());
         dateSince.setSelection(interval.getStart());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/SecurityPriceDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/SecurityPriceDialog.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.dialogs;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -16,7 +17,7 @@ public class SecurityPriceDialog extends AbstractDialog
     static class SecurityPriceModel extends BindingHelper.Model
     {
         private final Security security;
-        private LocalDate date = LocalDate.now();
+        private LocalDate date = LocalDate.now(ZoneOffset.UTC);
         private long price;
 
         public SecurityPriceModel(Client client, Security security)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
@@ -44,7 +45,7 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
 
     protected Portfolio portfolio;
     protected Security security;
-    protected LocalDate date = LocalDate.now();
+    protected LocalDate date = LocalDate.now(ZoneOffset.UTC);
     protected LocalTime time = LocalTime.MIDNIGHT;
     protected long shares;
     protected BigDecimal quote = BigDecimal.ONE;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionDialog.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -337,7 +338,7 @@ public class AccountTransactionDialog extends AbstractTransactionDialog // NOSON
         });
 
         WarningMessages warnings = new WarningMessages(this);
-        warnings.add(() -> model().getDate().isAfter(LocalDate.now()) ? Messages.MsgDateIsInTheFuture : null);
+        warnings.add(() -> model().getDate().isAfter(LocalDate.now(ZoneOffset.UTC)) ? Messages.MsgDateIsInTheFuture : null);
         model.addPropertyChangeListener(Properties.date.name(), e -> warnings.check());
 
         model.firePropertyChange(Properties.exchangeRateCurrencies.name(), "", model().getExchangeRateCurrencies()); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
@@ -45,7 +46,7 @@ public class AccountTransactionModel extends AbstractModel
 
     private Security security;
     private Account account;
-    private LocalDate date = LocalDate.now();
+    private LocalDate date = LocalDate.now(ZoneOffset.UTC);
     private LocalTime time = LocalTime.MIDNIGHT;
     private long shares;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferDialog.java
@@ -8,6 +8,7 @@ import static name.abuchen.portfolio.ui.util.SWTHelper.widest;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -201,7 +202,7 @@ public class AccountTransferDialog extends AbstractTransactionDialog // NOSONAR
         });
 
         WarningMessages warnings = new WarningMessages(this);
-        warnings.add(() -> model().getDate().isAfter(LocalDate.now()) ? Messages.MsgDateIsInTheFuture : null);
+        warnings.add(() -> model().getDate().isAfter(LocalDate.now(ZoneOffset.UTC)) ? Messages.MsgDateIsInTheFuture : null);
         model.addPropertyChangeListener(Properties.date.name(), e -> warnings.check());
 
         model.firePropertyChange(Properties.exchangeRateCurrencies.name(), "", model().getExchangeRateCurrencies()); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
@@ -38,7 +39,7 @@ public class AccountTransferModel extends AbstractModel
 
     private Account sourceAccount;
     private Account targetAccount;
-    private LocalDate date = LocalDate.now();
+    private LocalDate date = LocalDate.now(ZoneOffset.UTC);
     private LocalTime time = LocalTime.MIDNIGHT;
 
     private long fxAmount;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanDialog.java
@@ -7,6 +7,7 @@ import static name.abuchen.portfolio.ui.util.SWTHelper.widest;
 
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -205,7 +206,7 @@ public class InvestmentPlanDialog extends AbstractTransactionDialog
         startingWith(lblName).width(widest);
 
         WarningMessages warnings = new WarningMessages(this);
-        warnings.add(() -> model().getStart().isAfter(LocalDate.now()) ? Messages.MsgDateIsInTheFuture : null);
+        warnings.add(() -> model().getStart().isAfter(LocalDate.now(ZoneOffset.UTC)) ? Messages.MsgDateIsInTheFuture : null);
         warnings.add(() -> model().getSecurity() != null && model().getSecurity().getPrices().isEmpty()
                         ? Messages.MsgSecurityHasNoQuotes
                         : null);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanModel.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.dialogs.transactions;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
@@ -37,7 +38,7 @@ public class InvestmentPlanModel extends AbstractModel
 
     private boolean autoGenerate;
 
-    private LocalDate start = LocalDate.now();
+    private LocalDate start = LocalDate.now(ZoneOffset.UTC);
 
     private int interval = 1;
     private long amount;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
@@ -8,6 +8,7 @@ import static name.abuchen.portfolio.ui.util.SWTHelper.widest;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 
@@ -274,7 +275,7 @@ public class SecurityTransactionDialog extends AbstractTransactionDialog // NOSO
         });
 
         WarningMessages warnings = new WarningMessages(this);
-        warnings.add(() -> model().getDate().isAfter(LocalDate.now()) ? Messages.MsgDateIsInTheFuture : null);
+        warnings.add(() -> model().getDate().isAfter(LocalDate.now(ZoneOffset.UTC)) ? Messages.MsgDateIsInTheFuture : null);
         warnings.add(() -> new StockSplitWarning().check(model().getSecurity(), model().getDate()));
         model.addPropertyChangeListener(Properties.security.name(), e -> warnings.check());
         model.addPropertyChangeListener(Properties.date.name(), e -> warnings.check());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferModel.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 
 import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.core.runtime.IStatus;
@@ -38,7 +39,7 @@ public class SecurityTransferModel extends AbstractModel
     private Security security;
     private Portfolio sourcePortfolio;
     private Portfolio targetPortfolio;
-    private LocalDate date = LocalDate.now();
+    private LocalDate date = LocalDate.now(ZoneOffset.UTC);
     private LocalTime time = LocalTime.MIDNIGHT;
 
     private long shares;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/SaveErrorLogHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/SaveErrorLogHandler.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import javax.inject.Named;
 
@@ -34,7 +35,7 @@ public class SaveErrorLogHandler
 
         FileDialog dialog = new FileDialog(shell, SWT.SAVE);
         dialog.setOverwrite(true);
-        dialog.setFileName(MessageFormat.format("pp-error-{0}.log", LocalDate.now().toString())); //$NON-NLS-1$
+        dialog.setFileName(MessageFormat.format("pp-error-{0}.log", LocalDate.now(ZoneOffset.UTC).toString())); //$NON-NLS-1$
         dialog.setFilterPath(System.getProperty("user.home")); //$NON-NLS-1$
 
         String path = dialog.open();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1196,7 +1196,7 @@ LabelInvestmentPlans = Investment Plans
 
 LabelJSONDateFormat = Date Format
 
-LabelJSONDateFormatHint = Date format like dd.MM.yyyy or MM/dd/yyyy.\n\nLeave empty for ISO date format or if the date is represented\nby the number of milliseconds or dayes since 1970-01-01.  
+LabelJSONDateFormatHint = Date format like dd.MM.yyyy or MM/dd/yyyy.\n\nLeave empty for ISO date format or if the date is\nrepresented by the number of milliseconds, seconds\nor days since 1970-01-01 (Unix Epoch Time).  
 
 LabelJSONPathHint = Path must yield an array with either dates or closing price.\nPP is using the library https://github.com/json-path/JsonPath.\n\nFor example, given this JSON:\n\n{\n    "isin": "IE00B3WJKG14",\n    "data": [\n        { "close": 11.756, "date": "2020-02-14" },\n        { "close": 11.75, "date": "2020-02-13" }]\n}\n\nPath to date: $.data[*].date\nPath to close: $.data[*].close
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1189,7 +1189,7 @@ LabelInvestmentPlans = Sparpl\u00E4ne
 
 LabelJSONDateFormat = Datumsformat
 
-LabelJSONDateFormatHint = Datumsformat wie dd.MM.yyyy oder MM/dd/yyyy.\n\nLeer lassen f\u00FCr das ISO-Datumsformat oder falls das Datum durch die\nAnzahl Millisekunden oder Tage seit dem 01.01.1970 repr\u00E4sentiert wird.
+LabelJSONDateFormatHint = Datumsformat wie dd.MM.yyyy oder MM/dd/yyyy.\n\nLeer lassen f\u00FCr das ISO-Datumsformat oder falls das\nDatum durch die Anzahl Millisekunden, Sekunden\noder Tage seit dem 01.01.1970 repr\u00E4sentiert wird\n(Unix Epoch Time).
 
 LabelJSONPathHint = Der Pfad muss ein Array mit Datum oder Schlusskurs ergeben.\nPP verwendet die Bibliothek https://github.com/json-path/JsonPath.\n\nBeispiel JSON:\n\n{\n    "isin": "IE00B3WJKG14",\n    "data": [\n        { "close": 11.756, "date": "2020-02-14" },\n        { "close": 11.75, "date": "2020-02-13" }]\n}\n\nPfad zu Datum: $.data[*].date\nPfad zu Kurs: $.data[*].close
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.preferences;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -86,7 +87,7 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
         if (calendar == null)
             return ""; //$NON-NLS-1$
 
-        Collection<Holiday> holidays = calendar.getHolidays(LocalDate.now().getYear());
+        Collection<Holiday> holidays = calendar.getHolidays(LocalDate.now(ZoneOffset.UTC).getYear());
 
         StringBuilder buffer = new StringBuilder();
         holidays.stream().sorted((r, l) -> r.getDate().compareTo(l.getDate()))

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DatePicker.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DatePicker.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
 
 import org.eclipse.core.runtime.Platform;
@@ -77,9 +78,9 @@ public class DatePicker
 
             if (d == null)
             {
-                Date now = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+                Date now = Date.from(LocalDate.now(ZoneOffset.UTC).atStartOfDay(ZoneId.systemDefault()).toInstant());
                 ((CDateTime) control).setSelection(now);
-                return LocalDate.now();
+                return LocalDate.now(ZoneOffset.UTC);
             }
             else
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/QuotesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/QuotesTableViewer.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.util;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.eclipse.jface.layout.TableColumnLayout;
@@ -42,7 +43,7 @@ public class QuotesTableViewer
 
         // for sorting purposes: if the element is a string (i.e. an error
         // message) then use the current date
-        ColumnViewerSorter.create(element -> element instanceof String ? LocalDate.now()
+        ColumnViewerSorter.create(element -> element instanceof String ? LocalDate.now(ZoneOffset.UTC)
                         : ((LatestSecurityPrice) element).getDate()).attachTo(tableViewer, viewerColumn, SWT.UP);
 
         TableColumn column = new TableColumn(tableViewer.getTable(), SWT.None);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.util;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 
@@ -43,7 +44,7 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
 
         setMenuListener(this);
         setLabel(selected.toString());
-        setToolTip(selected.toInterval(LocalDate.now()).toString());
+        setToolTip(selected.toInterval(LocalDate.now(ZoneOffset.UTC)).toString());
     }
 
     @Override
@@ -101,7 +102,7 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
         selected = period;
         part.setSelectedPeriod(period);
         setLabel(period.toString());
-        setToolTip(selected.toInterval(LocalDate.now()).toString());
+        setToolTip(selected.toInterval(LocalDate.now(ZoneOffset.UTC)).toString());
     }
 
     private Action createActionFor(final ReportingPeriod period)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/SimpleDateTimeDateSelectionProperty.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/SimpleDateTimeDateSelectionProperty.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.util;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
 
 import org.eclipse.jface.databinding.swt.WidgetValueProperty;
@@ -42,7 +43,7 @@ public class SimpleDateTimeDateSelectionProperty extends WidgetValueProperty<Con
             // cannot be removed. PP always needs a date, however. Therefore the
             // date is set to today if missing.
 
-            LocalDate now = LocalDate.now();
+            LocalDate now = LocalDate.now(ZoneOffset.UTC);
             if (date == null)
             {
                 doSetValue(source, now);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +46,7 @@ public class AccountBalanceChart extends TimelineChart // NOSONAR
             if (tx.isEmpty())
                 return;
 
-            LocalDate now = LocalDate.now();
+            LocalDate now = LocalDate.now(ZoneOffset.UTC);
             LocalDate start = tx.get(0).getDateTime().toLocalDate();
             LocalDate end = tx.get(tx.size() - 1).getDateTime().toLocalDate();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
@@ -52,7 +53,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
                         HoldingsPieChartView.class.getSimpleName(), filter -> notifyModelUpdated());
 
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
-        snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now());
+        snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now(ZoneOffset.UTC));
     }
 
     @Override
@@ -65,7 +66,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
     public void notifyModelUpdated()
     {
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
-        snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now());
+        snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now(ZoneOffset.UTC));
 
         browser.refresh();
         updateWarningInToolBar();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -6,6 +6,7 @@ import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import javax.annotation.PostConstruct;
 
@@ -168,7 +169,7 @@ public class PerformanceChartView extends AbstractHistoricView
 
     private void setChartSeries()
     {
-        Interval interval = getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         Lists.reverse(picker.getSelectedDataSeries())
                         .forEach(series -> seriesBuilder.build(series, interval, aggregationPeriod));
     }
@@ -256,7 +257,7 @@ public class PerformanceChartView extends AbstractHistoricView
                     protected void writeToFile(File file) throws IOException
                     {
                         PerformanceIndex index = seriesBuilder.getCache().lookup(series,
-                                        getReportingPeriod().toInterval(LocalDate.now()));
+                                        getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC)));
                         if (aggregationPeriod != null)
                             index = Aggregation.aggregate(index, aggregationPeriod);
                         index.exportTo(file);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views;
 
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.function.Function;
 
 import javax.inject.Inject;
@@ -117,7 +118,7 @@ public class PerformanceView extends AbstractHistoricView
     @Override
     public void reportingPeriodUpdated()
     {
-        Interval period = getReportingPeriod().toInterval(LocalDate.now());
+        Interval period = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views;
 
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
@@ -238,7 +239,7 @@ public class PortfolioListView extends AbstractListView implements ModificationL
             @Override
             public String getText(Object element)
             {
-                PortfolioSnapshot snapshot = PortfolioSnapshot.create((Portfolio) element, converter, LocalDate.now());
+                PortfolioSnapshot snapshot = PortfolioSnapshot.create((Portfolio) element, converter, LocalDate.now(ZoneOffset.UTC));
                 return Values.Money.format(snapshot.getValue(), getClient().getBaseCurrency());
             }
         });
@@ -246,8 +247,8 @@ public class PortfolioListView extends AbstractListView implements ModificationL
         column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
             CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
 
-            PortfolioSnapshot p1 = PortfolioSnapshot.create((Portfolio) o1, converter, LocalDate.now());
-            PortfolioSnapshot p2 = PortfolioSnapshot.create((Portfolio) o2, converter, LocalDate.now());
+            PortfolioSnapshot p1 = PortfolioSnapshot.create((Portfolio) o1, converter, LocalDate.now(ZoneOffset.UTC));
+            PortfolioSnapshot p2 = PortfolioSnapshot.create((Portfolio) o2, converter, LocalDate.now(ZoneOffset.UTC));
 
             if (p1 == null)
                 return p2 == null ? 0 : -1;
@@ -285,14 +286,14 @@ public class PortfolioListView extends AbstractListView implements ModificationL
 
                 ClientFilter clientFilter = new PortfolioClientFilter(portfolio);
 
-                statementOfAssets.setInput(clientFilter, LocalDate.now(), converter);
+                statementOfAssets.setInput(clientFilter, LocalDate.now(ZoneOffset.UTC), converter);
             }
             else
             {
                 transactions.setInput(null);
                 transactions.refresh();
                 CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
-                statementOfAssets.setInput(new EmptyFilter(), LocalDate.now(), converter);
+                statementOfAssets.setInput(new EmptyFilter(), LocalDate.now(ZoneOffset.UTC), converter);
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.function.ToDoubleFunction;
 
 import javax.annotation.PostConstruct;
@@ -255,7 +256,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
 
     private void setChartSeries()
     {
-        Interval interval = getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
 
         Lists.reverse(configurator.getSelectedDataSeries()).forEach(series -> {
             PerformanceIndex index = cache.lookup(series, interval);
@@ -306,7 +307,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
                 @Override
                 protected void writeToFile(File file) throws IOException
                 {
-                    PerformanceIndex index = cache.lookup(series, getReportingPeriod().toInterval(LocalDate.now()));
+                    PerformanceIndex index = cache.lookup(series, getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC)));
                     index.exportVolatilityData(file);
                 }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAmount;
@@ -328,7 +329,7 @@ public class SecuritiesChart
         addConfigButton(buttons);
 
         Function<TemporalAmount, ChartInterval> nowMinus = temporalAmount -> {
-            LocalDate now = LocalDate.now();
+            LocalDate now = LocalDate.now(ZoneOffset.UTC);
             return new ChartInterval(now.minus(temporalAmount), now);
         };
 
@@ -349,7 +350,7 @@ public class SecuritiesChart
         addButton(buttons, Messages.SecurityTabChart10Y, Messages.SecurityTabChart10YToolTip,
                         s -> nowMinus.apply(Period.ofYears(10)));
         addButton(buttons, Messages.SecurityTabChartYTD, Messages.SecurityTabChartYTDToolTip,
-                        s -> nowMinus.apply(Period.ofDays(LocalDate.now().getDayOfYear() - 1)));
+                        s -> nowMinus.apply(Period.ofDays(LocalDate.now(ZoneOffset.UTC).getDayOfYear() - 1)));
 
         addButton(buttons, Messages.SecurityTabChartHoldingPeriod, Messages.SecurityTabChartHoldingPeriodToolTip, s -> {
             List<TransactionPair<?>> tx = s.getTransactions(client);
@@ -357,11 +358,11 @@ public class SecuritiesChart
                 return null;
 
             Collections.sort(tx, new TransactionPair.ByDate());
-            boolean hasHoldings = ClientSnapshot.create(client, converter, LocalDate.now()).getPositionsByVehicle()
+            boolean hasHoldings = ClientSnapshot.create(client, converter, LocalDate.now(ZoneOffset.UTC)).getPositionsByVehicle()
                             .containsKey(s);
 
             return new ChartInterval(tx.get(0).getTransaction().getDateTime().toLocalDate(),
-                            hasHoldings ? LocalDate.now()
+                            hasHoldings ? LocalDate.now(ZoneOffset.UTC)
                                             : tx.get(tx.size() - 1).getTransaction().getDateTime().toLocalDate());
 
         });
@@ -721,7 +722,7 @@ public class SecuritiesChart
             if (chartIntervalFunction != null)
                 chartInterval = chartIntervalFunction.apply(security);
             if (chartInterval == null)
-                chartInterval = new ChartInterval(LocalDate.now().minusYears(2), LocalDate.now());
+                chartInterval = new ChartInterval(LocalDate.now(ZoneOffset.UTC).minusYears(2), LocalDate.now(ZoneOffset.UTC));
 
             // determine index range for given interval in prices list
 
@@ -1482,7 +1483,7 @@ public class SecuritiesChart
             return Optional.empty();
 
         return getPurchasePrice(new ClientSecurityFilter(security).filter(client),
-                        converter.with(security.getCurrencyCode()), LocalDate.now());
+                        converter.with(security.getCurrencyCode()), LocalDate.now(ZoneOffset.UTC));
     }
 
     private Optional<Double> getPurchasePrice(Client filteredClient, CurrencyConverter currencyConverter,

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1334,7 +1335,7 @@ public class SecuritiesPerformanceView extends AbstractListView implements Repor
     @Override
     public void reportingPeriodUpdated()
     {
-        Interval period = dropDown.getSelectedPeriod().toInterval(LocalDate.now());
+        Interval period = dropDown.getSelectedPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
         Client filteredClient = clientFilter.filter(getClient());
         records.setInput(SecurityPerformanceSnapshot.create(filteredClient, converter, period).getRecords());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -317,7 +318,7 @@ public final class SecuritiesTable implements ModificationListener
             public String getText(Object e)
             {
                 Security security = (Security) e;
-                SecurityPrice latest = security.getSecurityPrice(LocalDate.now());
+                SecurityPrice latest = security.getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
                 if (latest == null)
                     return null;
 
@@ -329,8 +330,8 @@ public final class SecuritiesTable implements ModificationListener
             }
         });
         column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
-            SecurityPrice p1 = ((Security) o1).getSecurityPrice(LocalDate.now());
-            SecurityPrice p2 = ((Security) o2).getSecurityPrice(LocalDate.now());
+            SecurityPrice p1 = ((Security) o1).getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
+            SecurityPrice p2 = ((Security) o2).getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
 
             if (p1 == null)
                 return p2 == null ? 0 : -1;
@@ -474,7 +475,7 @@ public final class SecuritiesTable implements ModificationListener
             @Override
             public String getText(Object element)
             {
-                SecurityPrice latest = ((Security) element).getSecurityPrice(LocalDate.now());
+                SecurityPrice latest = ((Security) element).getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
                 return latest != null ? Values.Date.format(latest.getDate()) : null;
             }
 
@@ -482,7 +483,7 @@ public final class SecuritiesTable implements ModificationListener
             public Color getBackground(Object element)
             {
                 Security security = (Security) element;
-                SecurityPrice latest = security.getSecurityPrice(LocalDate.now());
+                SecurityPrice latest = security.getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
                 if (latest == null)
                     return null;
 
@@ -490,13 +491,13 @@ public final class SecuritiesTable implements ModificationListener
                 if (QuoteFeed.MANUAL.equals(feed))
                     return null;
 
-                LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
+                LocalDate sevenDaysAgo = LocalDate.now(ZoneOffset.UTC).minusDays(7);
                 return latest.getDate().isBefore(sevenDaysAgo) ? Colors.theme().warningBackground() : null;
             }
         });
         column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
-            SecurityPrice p1 = ((Security) o1).getSecurityPrice(LocalDate.now());
-            SecurityPrice p2 = ((Security) o2).getSecurityPrice(LocalDate.now());
+            SecurityPrice p1 = ((Security) o1).getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
+            SecurityPrice p2 = ((Security) o2).getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
 
             if (p1 == null)
                 return p2 == null ? 0 : -1;
@@ -538,7 +539,7 @@ public final class SecuritiesTable implements ModificationListener
                     return null;
 
                 SecurityPrice latest = prices.get(prices.size() - 1);
-                if (!((Security) element).isRetired() && latest.getDate().isBefore(LocalDate.now().minusDays(7)))
+                if (!((Security) element).isRetired() && latest.getDate().isBefore(LocalDate.now(ZoneOffset.UTC).minusDays(7)))
                     return Colors.theme().warningBackground();
                 else
                     return null;
@@ -568,7 +569,7 @@ public final class SecuritiesTable implements ModificationListener
 
         BiFunction<Object, ReportingPeriod, Double> valueProvider = (element, option) -> {
 
-            Interval interval = option.toInterval(LocalDate.now());
+            Interval interval = option.toInterval(LocalDate.now(ZoneOffset.UTC));
 
             Security security = (Security) element;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
@@ -112,7 +113,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
         GridDataFactory.fillDefaults().grab(true, true).applyTo(chart);
         GridDataFactory.fillDefaults().grab(true, false).align(SWT.CENTER, SWT.FILL).applyTo(legend);
 
-        Interval interval = getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         Lists.reverse(configurator.getSelectedDataSeries()).forEach(series -> seriesBuilder.build(series, interval));
 
         return composite;
@@ -158,7 +159,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
             for (ISeries s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
 
-            Interval interval = getReportingPeriod().toInterval(LocalDate.now());
+            Interval interval = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
             Lists.reverse(configurator.getSelectedDataSeries())
                             .forEach(series -> seriesBuilder.build(series, interval));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views;
 
 import java.beans.PropertyChangeListener;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -59,7 +60,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
     public void notifyModelUpdated()
     {
         CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
-        assetViewer.setInput(clientFilter.getSelectedFilter(), snapshotDate.orElse(LocalDate.now()), converter);
+        assetViewer.setInput(clientFilter.getSelectedFilter(), snapshotDate.orElse(LocalDate.now(ZoneOffset.UTC)), converter);
         updateTitle(getDefaultTitle());
     }
 
@@ -121,7 +122,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
     {
         DropDown dropDown = new DropDown(Messages.LabelPortfolioTimeMachine, Images.CALENDAR_OFF, SWT.NONE);
         dropDown.setMenuListener(manager -> {
-            manager.add(new LabelOnly(Values.Date.format(snapshotDate.orElse(LocalDate.now()))));
+            manager.add(new LabelOnly(Values.Date.format(snapshotDate.orElse(LocalDate.now(ZoneOffset.UTC)))));
             manager.add(new Separator());
 
             SimpleAction action = new SimpleAction(Messages.LabelToday, a -> {
@@ -134,13 +135,13 @@ public class StatementOfAssetsView extends AbstractFinanceView
 
             manager.add(new SimpleAction(Messages.MenuPickOtherDate, a -> {
                 DateSelectionDialog dialog = new DateSelectionDialog(getActiveShell());
-                dialog.setSelection(snapshotDate.orElse(LocalDate.now()));
+                dialog.setSelection(snapshotDate.orElse(LocalDate.now(ZoneOffset.UTC)));
                 if (dialog.open() != DateSelectionDialog.OK)
                     return;
                 if (snapshotDate.isPresent() && snapshotDate.get().equals(dialog.getSelection()))
                     return;
 
-                snapshotDate = LocalDate.now().equals(dialog.getSelection()) ? Optional.empty()
+                snapshotDate = LocalDate.now(ZoneOffset.UTC).equals(dialog.getSelection()) ? Optional.empty()
                                 : Optional.of(dialog.getSelection());
                 notifyModelUpdated();
                 dropDown.setImage(!snapshotDate.isPresent() ? Images.CALENDAR_OFF : Images.CALENDAR_ON);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.columns;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -188,7 +189,7 @@ public class AttributeColumn extends Column
             if (limit == null)
                 return null;
 
-            SecurityPrice latestSecurityPrice = security.getSecurityPrice(LocalDate.now());
+            SecurityPrice latestSecurityPrice = security.getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
             if (latestSecurityPrice == null)
                 return null;
 
@@ -338,7 +339,7 @@ public class AttributeColumn extends Column
                     return null;
 
                 LocalDate value = (LocalDate) attributable.getAttributes().get(attribute);
-                return value == null ? null : String.valueOf(ChronoUnit.DAYS.between(value, LocalDate.now()));
+                return value == null ? null : String.valueOf(ChronoUnit.DAYS.between(value, LocalDate.now(ZoneOffset.UTC)));
             }
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.ui.util.FormDataFactory.startingWith;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -52,7 +53,7 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         private String baseCurrency = CurrencyUnit.EUR;
         private long termValue;
         private String termCurrency = CurrencyUnit.USD;
-        private LocalDate date = LocalDate.now();
+        private LocalDate date = LocalDate.now(ZoneOffset.UTC);
 
         @Override
         public void applyChanges()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractTradesWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractTradesWidget.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -91,7 +92,7 @@ import name.abuchen.portfolio.util.TextUtil;
     @Override
     public Supplier<TradeDetailsView.Input> getUpdateTask()
     {
-        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         ClientFilter clientFilter = get(ClientFilterConfig.class).getSelectedFilter();
         CacheKey key = new CacheKey(TradeCollector.class, clientFilter, interval);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -230,7 +231,7 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
     @Override
     public Supplier<List<TransactionPair<?>>> getUpdateTask()
     {
-        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         ClientFilter clientFilter = get(ClientFilterConfig.class).getSelectedFilter();
         CacheKey key = new CacheKey(TransactionPair.class, clientFilter, interval);
 
@@ -255,7 +256,7 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
             toolTip.setDefaultValueFormat(new DecimalFormat(chartType == ChartType.COUNT ? "#" : "#,##0.00")); //$NON-NLS-1$ //$NON-NLS-2$
 
             IAxis xAxis = chart.getAxisSet().getXAxis(0);
-            Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+            Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
             List<YearMonth> yearMonths = interval.getYearMonths();
 
             chart.setData(yearMonths);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.text.DecimalFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
@@ -233,7 +234,7 @@ public class ChartWidget extends WidgetDelegate<Object>
         List<DataSeries> series = new DataSeriesSerializer().fromString(dataSeriesSet,
                         get(ChartConfig.class).getData());
 
-        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
 
         return () -> {
             series.forEach(s -> cache.lookup(s, interval));
@@ -259,7 +260,7 @@ public class ChartWidget extends WidgetDelegate<Object>
                             new DataSeriesSerializer().fromString(dataSeriesSet, get(ChartConfig.class).getData()));
 
             Interval reportingPeriod = get(ReportingPeriodConfig.class).getReportingPeriod()
-                            .toInterval(LocalDate.now());
+                            .toInterval(LocalDate.now(ZoneOffset.UTC));
 
             switch (useCase)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CurrentDateWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CurrentDateWidget.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.function.Supplier;
@@ -60,6 +61,6 @@ public class CurrentDateWidget extends WidgetDelegate<Object>
     @Override
     public void update(Object data)
     {
-        this.title.setText(TextUtil.tooltip(getWidget().getLabel()) + ' ' + formatter.format(LocalDate.now()));
+        this.title.setText(TextUtil.tooltip(getWidget().getLabel()) + ' ' + formatter.format(LocalDate.now(ZoneOffset.UTC)));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ExchangeRateWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ExchangeRateWidget.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Optional;
@@ -61,7 +62,7 @@ public class ExchangeRateWidget extends WidgetDelegate<Object>
         InfoToolTip.attach(indicator, () -> {
             ReportingPeriod period = get(ReportingPeriodConfig.class).getReportingPeriod();
             ExchangeRateTimeSeries series = get(ExchangeRateSeriesConfig.class).getSeries();
-            Optional<ExchangeRate> rate = series.lookupRate(period.toInterval(LocalDate.now()).getEnd());
+            Optional<ExchangeRate> rate = series.lookupRate(period.toInterval(LocalDate.now(ZoneOffset.UTC)).getEnd());
             return rate.isPresent() ? MessageFormat.format(Messages.TooltipDateOfExchangeRate,
                             formatter.format(rate.get().getTime())) : ""; //$NON-NLS-1$
         });
@@ -90,7 +91,7 @@ public class ExchangeRateWidget extends WidgetDelegate<Object>
 
         ReportingPeriod period = get(ReportingPeriodConfig.class).getReportingPeriod();
         ExchangeRateTimeSeries series = get(ExchangeRateSeriesConfig.class).getSeries();
-        Optional<ExchangeRate> rate = series.lookupRate(period.toInterval(LocalDate.now()).getEnd());
+        Optional<ExchangeRate> rate = series.lookupRate(period.toInterval(LocalDate.now(ZoneOffset.UTC)).getEnd());
 
         this.indicator.setText(series.getBaseCurrency() + '/' + series.getTermCurrency() + ' '
                         + (rate.isPresent() ? Values.ExchangeRate.format(rate.get().getValue()) : '-'));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/IndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/IndicatorWidget.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -118,7 +119,7 @@ public class IndicatorWidget<N extends Number> extends AbstractIndicatorWidget<N
 
         if (tooltip != null)
             InfoToolTip.attach(indicator, () -> tooltip.apply(get(DataSeriesConfig.class).getDataSeries(),
-                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now())));
+                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC))));
 
         return container;
     }
@@ -127,7 +128,7 @@ public class IndicatorWidget<N extends Number> extends AbstractIndicatorWidget<N
     public Supplier<N> getUpdateTask()
     {
         return () -> provider.apply(get(DataSeriesConfig.class).getDataSeries(),
-                        get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
+                        get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC)));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.function.Supplier;
@@ -48,7 +49,7 @@ public class MaxDrawdownDurationWidget extends AbstractIndicatorWidget<Performan
     {
         return () -> getDashboardData().getDataSeriesCache() //
                         .lookup(get(DataSeriesConfig.class).getDataSeries(), get(ReportingPeriodConfig.class)
-                                        .getReportingPeriod().toInterval(LocalDate.now()));
+                                        .getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC)));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -160,7 +161,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
     {
         return () -> {
             PerformanceIndex index = getDashboardData().calculate(get(DataSeriesConfig.class).getDataSeries(),
-                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
+                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC)));
             return index.getClientPerformanceSnapshot().orElseThrow(IllegalArgumentException::new);
         };
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodConfig.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 
@@ -102,7 +103,7 @@ public class ReportingPeriodConfig implements WidgetConfig
         label.append(Messages.LabelReportingPeriod).append(": "); //$NON-NLS-1$
         label.append(getReportingPeriod().toString());
 
-        Interval interval = getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
         label.append(" (").append(formatter.format(interval.getStart())) //$NON-NLS-1$
                         .append(" - ") //$NON-NLS-1$
                         .append(formatter.format(interval.getEnd())).append(")"); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/EarningsHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/EarningsHeatmapWidget.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.dashboard.heatmap;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Objects;
 import java.util.function.Function;
@@ -141,7 +142,7 @@ public class EarningsHeatmapWidget extends AbstractHeatmapWidget<Long>
     {
         int numDashboardColumns = getDashboardData().getDashboard().getColumns().size();
 
-        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
 
         // adapt interval to include the first and last month fully
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.dashboard.heatmap;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Arrays;
 import java.util.function.DoubleBinaryOperator;
@@ -36,7 +37,7 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
     {
         int numDashboardColumns = getDashboardData().getDashboard().getColumns().size();
 
-        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
+        Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
 
         // adapt interval to include the first and last month fully
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/YearlyPerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/YearlyPerformanceHeatmapWidget.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.dashboard.heatmap;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ public class YearlyPerformanceHeatmapWidget extends AbstractHeatmapWidget<Double
     {
         int numDashboardColumns = getDashboardData().getDashboard().getColumns().size();
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
 
         // fill the table lines according to the supplied period
         // calculate the performance with a temporary reporting period

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsAccumulatedChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsAccumulatedChartTab.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.earnings;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.ZoneOffset;
 
 import org.eclipse.swt.SWT;
 import org.swtchart.ILineSeries;
@@ -22,7 +23,7 @@ public class EarningsAccumulatedChartTab extends AbstractChartTab
     @Override
     protected void createSeries()
     {
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
         boolean isJanuary = now.getMonth() == Month.JANUARY;
 
         for (int index = 0; index < model.getNoOfMonths(); index += 12)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsPerYearChartTab.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -131,7 +132,7 @@ public class EarningsPerYearChartTab extends AbstractChartTab
     private void updateCategorySeries()
     {
         int startYear = model.getStartYear();
-        String[] labels = new String[LocalDate.now().getYear() - startYear + 1];
+        String[] labels = new String[LocalDate.now(ZoneOffset.UTC).getYear() - startYear + 1];
         for (int ii = 0; ii < labels.length; ii++)
             labels[ii] = String.valueOf(startYear + ii);
         getChart().getAxisSet().getXAxis(0).setCategorySeries(labels);
@@ -144,7 +145,7 @@ public class EarningsPerYearChartTab extends AbstractChartTab
 
         int startYear = model.getStartYear();
 
-        double[] series = new double[LocalDate.now().getYear() - startYear + 1];
+        double[] series = new double[LocalDate.now(ZoneOffset.UTC).getYear() - startYear + 1];
 
         boolean hasNegativeNumber = false;
 
@@ -178,7 +179,7 @@ public class EarningsPerYearChartTab extends AbstractChartTab
                 IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,
                                 String.valueOf(year));
 
-                double[] seriesX = new double[LocalDate.now().getYear() - startYear + 1];
+                double[] seriesX = new double[LocalDate.now(ZoneOffset.UTC).getYear() - startYear + 1];
                 seriesX[i] = series[i];
 
                 barSeries.setYSeries(seriesX);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsView.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.EnumSet;
 
 import javax.annotation.PostConstruct;
@@ -58,7 +59,7 @@ public class EarningsView extends AbstractFinanceView
         model = new EarningsViewModel(preferences, converter, client);
 
         int year = preferences.getInt(KEY_YEAR);
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
         if (year < 1900 || year > now.getYear())
             year = now.getYear() - 2;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/EarningsViewModel.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.earnings;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -268,7 +269,7 @@ public class EarningsViewModel
     private void calculate()
     {
         // determine the number of full months within period
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
         if (startYear > now.getYear())
             throw new IllegalArgumentException();
         this.noOfmonths = (now.getYear() - startYear) * 12 + now.getMonthValue();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/StartYearSelectionDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/earnings/StartYearSelectionDropDown.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.earnings;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
@@ -31,7 +32,7 @@ import name.abuchen.portfolio.ui.util.SimpleAction;
     @Override
     public void menuAboutToShow(IMenuManager manager)
     {
-        int now = LocalDate.now().getYear();
+        int now = LocalDate.now(ZoneOffset.UTC).getYear();
 
         for (int ii = 0; ii < 10; ii++)
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -601,7 +602,7 @@ import name.abuchen.portfolio.util.TextUtil;
                     return null;
 
                 CurrencyConverter converter = getModel().getCurrencyConverter();
-                ExchangeRate rate = converter.getRate(LocalDate.now(), baseCurrency);
+                ExchangeRate rate = converter.getRate(LocalDate.now(ZoneOffset.UTC), baseCurrency);
 
                 if (useIndirectQuotation)
                     rate = rate.inverse();
@@ -651,7 +652,7 @@ import name.abuchen.portfolio.util.TextUtil;
                     return Values.Money.format(
                                     getModel().getCurrencyConverter()
                                                     .with(node.getAssignment().getInvestmentVehicle().getCurrencyCode())
-                                                    .convert(LocalDate.now(), node.getActual()),
+                                                    .convert(LocalDate.now(ZoneOffset.UTC), node.getActual()),
                                     getModel().getCurrencyCode());
                 }
                 else

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/ReBalancingViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/ReBalancingViewer.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import javax.inject.Inject;
 
@@ -180,7 +181,7 @@ public class ReBalancingViewer extends AbstractNodeTreeViewer
                 if (security == null || security.getCurrencyCode() == null)
                     return null;
 
-                SecurityPrice price = security.getSecurityPrice(LocalDate.now());
+                SecurityPrice price = security.getSecurityPrice(LocalDate.now(ZoneOffset.UTC));
                 return Values.Quote.format(security.getCurrencyCode(), price.getValue(), getModel().getCurrencyCode());
             }
         });
@@ -226,7 +227,7 @@ public class ReBalancingViewer extends AbstractNodeTreeViewer
                     return null;
 
                 String priceCurrency = security.getCurrencyCode();
-                long price = security.getSecurityPrice(LocalDate.now()).getValue();
+                long price = security.getSecurityPrice(LocalDate.now(ZoneOffset.UTC)).getValue();
                 long weightedPrice = Math.round(node.getWeight() * price / (double) Classification.ONE_HUNDRED_PERCENT);
                 if (weightedPrice == 0L)
                     return Values.Share.format(0L);
@@ -240,7 +241,7 @@ public class ReBalancingViewer extends AbstractNodeTreeViewer
                 if (!deltaCurrency.equals(priceCurrency))
                 {
                     delta = getModel().getCurrencyConverter().with(priceCurrency)
-                                    .convert(LocalDate.now(), Money.of(deltaCurrency, delta)).getAmount();
+                                    .convert(LocalDate.now(ZoneOffset.UTC), Money.of(deltaCurrency, delta)).getAmount();
                 }
 
                 long shares = Math

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.text.DecimalFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,12 +125,12 @@ public class StackedChartViewer extends AbstractChartPage
     {
         super(model, renderer);
 
-        Interval interval = part.getSelectedPeriod().toInterval(LocalDate.now());
+        Interval interval = part.getSelectedPeriod().toInterval(LocalDate.now(ZoneOffset.UTC));
 
         Period weekly = Aggregation.Period.WEEKLY;
 
         final LocalDate start = interval.getStart();
-        final LocalDate now = LocalDate.now();
+        final LocalDate now = LocalDate.now(ZoneOffset.UTC);
         final LocalDate end = interval.getEnd().isAfter(now) ? now : interval.getEnd();
         LocalDate current = weekly.getStartDateFor(start);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -115,7 +116,7 @@ public final class TaxonomyModel
         this.converter = new CurrencyConverterImpl(factory, client.getBaseCurrency());
 
         this.filteredClient = client;
-        this.snapshot = ClientSnapshot.create(client, converter, LocalDate.now());
+        this.snapshot = ClientSnapshot.create(client, converter, LocalDate.now(ZoneOffset.UTC));
 
         this.attachedModels.add(new RecalculateTargetsAttachedModel());
         this.attachedModels.add(new ExpectedReturnsAttachedModel());
@@ -368,7 +369,7 @@ public final class TaxonomyModel
             this.converter = new CurrencyConverterImpl(factory, filteredClient.getBaseCurrency());
 
         this.filteredClient = filteredClient;
-        this.snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now());
+        this.snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now(ZoneOffset.UTC));
 
         recalculate();
         fireTaxonomyModelChange(getVirtualRootNode());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/events/CustomEventModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/events/CustomEventModel.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.wizards.events;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
@@ -10,7 +11,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
 public class CustomEventModel extends BindingHelper.Model
 {
     private Security security;
-    private LocalDate date = LocalDate.now();
+    private LocalDate date = LocalDate.now(ZoneOffset.UTC);
     private SecurityEvent.Type type = SecurityEvent.Type.NOTE;
     private String message = ""; //$NON-NLS-1$
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.wizards.splits;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import name.abuchen.portfolio.model.Client;
@@ -14,7 +15,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
 public class StockSplitModel extends BindingHelper.Model
 {
     private Security security;
-    private LocalDate exDate = LocalDate.now();
+    private LocalDate exDate = LocalDate.now(ZoneOffset.UTC);
     private int newShares = 1;
     private int oldShares = 1;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
@@ -5,6 +5,7 @@ import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -173,7 +174,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
         LocalDateTime date = getDate(dateField, null, rawValues, field2column);
         if (date == null)
-            date = LocalDate.now().atStartOfDay();
+            date = LocalDate.now(ZoneOffset.UTC).atStartOfDay();
 
         return Optional.of(new SecurityPrice(date.toLocalDate(), Math.abs(amount)));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -241,7 +242,7 @@ public class CSVExporter
 
             // write quotes
             LocalDate pointer = earliestDate;
-            LocalDate today = LocalDate.now();
+            LocalDate today = LocalDate.now(ZoneOffset.UTC);
 
             while (pointer.compareTo(today) <= 0)
             {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioExtractor.java
@@ -4,6 +4,7 @@ import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -89,7 +90,7 @@ import name.abuchen.portfolio.money.Money;
         // determine remaining fields
         LocalDateTime date = getDate(Messages.CSVColumn_DateValue, Messages.CSVColumn_Time, rawValues, field2column);
         if (date == null)
-            date = LocalDate.now().atStartOfDay();
+            date = LocalDate.now(ZoneOffset.UTC).atStartOfDay();
 
         String note = getText(Messages.CSVColumn_Note, rawValues, field2column);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/VINISExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/VINISExporter.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,20 +46,20 @@ public class VINISExporter
         final String baseCurrency = client.getBaseCurrency();
         CurrencyConverter converter = new CurrencyConverterImpl(factory, baseCurrency);
 
-        LocalDate lastYear = LocalDate.now().minusYears(1);
-        LocalDate firstYear = LocalDate.now().minusYears(100);
+        LocalDate lastYear = LocalDate.now(ZoneOffset.UTC).minusYears(1);
+        LocalDate firstYear = LocalDate.now(ZoneOffset.UTC).minusYears(100);
 
         ReportingPeriod periodCurrentYear = new ReportingPeriod.YearToDate();
         ReportingPeriod periodLastYear = new ReportingPeriod.YearX(lastYear.getYear());
         ReportingPeriod periodAllYears = new ReportingPeriod.FromXtoY(
-                        firstYear.with(TemporalAdjusters.firstDayOfYear()), LocalDate.now());
+                        firstYear.with(TemporalAdjusters.firstDayOfYear()), LocalDate.now(ZoneOffset.UTC));
 
         ClientPerformanceSnapshot performanceAllYears = new ClientPerformanceSnapshot(client, converter,
-                        periodAllYears.toInterval(LocalDate.now()));
+                        periodAllYears.toInterval(LocalDate.now(ZoneOffset.UTC)));
         ClientPerformanceSnapshot performanceCurrentYear = new ClientPerformanceSnapshot(client, converter,
-                        periodCurrentYear.toInterval(LocalDate.now()));
+                        periodCurrentYear.toInterval(LocalDate.now(ZoneOffset.UTC)));
         ClientPerformanceSnapshot performanceLastYear = new ClientPerformanceSnapshot(client, converter,
-                        periodLastYear.toInterval(LocalDate.now()));
+                        periodLastYear.toInterval(LocalDate.now(ZoneOffset.UTC)));
 
         Money earningsCurrentYear = performanceCurrentYear.getValue(CategoryType.EARNINGS);
         Money earningsLastYear = performanceLastYear.getValue(CategoryType.EARNINGS);
@@ -78,12 +79,12 @@ public class VINISExporter
         MutableMoney currentTotalValue = MutableMoney.of(baseCurrency);
 
         SecurityPerformanceSnapshot securityPerformance = SecurityPerformanceSnapshot.create(client, converter,
-                        Interval.of(LocalDate.MIN, LocalDate.now()), SecurityPerformanceIndicator.Costs.class);
+                        Interval.of(LocalDate.MIN, LocalDate.now(ZoneOffset.UTC)), SecurityPerformanceIndicator.Costs.class);
 
         List<AssetPosition> assets = performanceCurrentYear.getEndClientSnapshot().getAssetPositions()
                         .collect(Collectors.toList());
 
-        MonetaryOperator toBaseCurrency = converter.at(LocalDate.now());
+        MonetaryOperator toBaseCurrency = converter.at(LocalDate.now(ZoneOffset.UTC));
 
         for (AssetPosition asset : assets)
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -364,7 +365,7 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
         LocalDate transactionDate = getDateOfNextTransactionToBeGenerated();
         List<TransactionPair<?>> newlyCreated = new ArrayList<>();
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
 
         while (!transactionDate.isAfter(now))
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.model;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -17,6 +18,7 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Strings;
 
+import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.util.Pair;
 
@@ -397,7 +399,8 @@ public final class Security implements Attributable, InvestmentVehicle
         if (newPrices.isEmpty())
             return false;
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC); // Assumes all quotes are
+                                                       // provided as UTC.
 
         LocalDate last = null;
         if (!this.prices.isEmpty())
@@ -411,6 +414,11 @@ public final class Security implements Attributable, InvestmentVehicle
                 boolean doOverwrite = p.getDate().equals(last);
                 boolean isAdded = addPrice(p, doOverwrite);
                 isUpdated = isUpdated || isAdded;
+            }
+            else
+            {
+                PortfolioLog.error("A security price was not added because its date (" + p.getDate() //$NON-NLS-1$
+                                + ") lies in the future. Does the quote provider provide use UTC timezone?"); //$NON-NLS-1$
             }
         }
         return isUpdated;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -489,7 +489,7 @@ public final class Security implements Attributable, InvestmentVehicle
         if (list.size() < 2)
             return Optional.empty();
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
 
         SecurityPrice today = null;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyConverterImpl.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyConverterImpl.java
@@ -3,13 +3,14 @@ package name.abuchen.portfolio.money;
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Objects;
 
 import name.abuchen.portfolio.Messages;
 
 public class CurrencyConverterImpl implements CurrencyConverter
 {
-    private static final ExchangeRate FALLBACK_EXCHANGE_RATE = new ExchangeRate(LocalDate.now(), BigDecimal.ONE);
+    private static final ExchangeRate FALLBACK_EXCHANGE_RATE = new ExchangeRate(LocalDate.now(ZoneOffset.UTC), BigDecimal.ONE);
 
     private final ExchangeRateProviderFactory factory;
     private final String termCurrency;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/FixedExchangeRateTimeSeries.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/FixedExchangeRateTimeSeries.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.money;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +53,7 @@ public class FixedExchangeRateTimeSeries implements ExchangeRateTimeSeries
     {
         List<ExchangeRate> answer = new ArrayList<>();
         answer.add(new ExchangeRate(seriesStart, rate));
-        answer.add(new ExchangeRate(LocalDate.now(), rate));
+        answer.add(new ExchangeRate(LocalDate.now(ZoneOffset.UTC), rate));
         return answer;
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBUpdater.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/ECBUpdater.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ import name.abuchen.portfolio.util.Dates;
         {
             LocalDate lastModified = LocalDate
                             .from(Instant.ofEpochMilli(data.getLastModified()).atZone(ZoneId.systemDefault()));
-            int days = Dates.daysBetween(lastModified, LocalDate.now());
+            int days = Dates.daysBetween(lastModified, LocalDate.now(ZoneOffset.UTC));
 
             if (days <= 1)
                 f = Feeds.DAILY;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/EmptyExchangeRateTimeSeries.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/impl/EmptyExchangeRateTimeSeries.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.money.impl;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +13,7 @@ import name.abuchen.portfolio.money.ExchangeRateTimeSeries;
 
 public class EmptyExchangeRateTimeSeries implements ExchangeRateTimeSeries
 {
-    private final ExchangeRate exchangeRate = new ExchangeRate(LocalDate.now(), BigDecimal.ONE);
+    private final ExchangeRate exchangeRate = new ExchangeRate(LocalDate.now(ZoneOffset.UTC), BigDecimal.ONE);
     private final String baseCurrency;
     private final String termCurrency;
     

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.Optional;
@@ -157,7 +158,7 @@ public class AlphavantageQuoteFeed implements QuoteFeed
         if (!security.getPrices().isEmpty())
         {
             SecurityPrice lastHistoricalQuote = security.getPrices().get(security.getPrices().size() - 1);
-            int days = Dates.daysBetween(lastHistoricalQuote.getDate(), LocalDate.now());
+            int days = Dates.daysBetween(lastHistoricalQuote.getDate(), LocalDate.now(ZoneOffset.UTC));
             outputSize = days >= DAYS_THRESHOLD ? OutputSize.FULL : OutputSize.COMPACT;
         }
 
@@ -167,7 +168,7 @@ public class AlphavantageQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
         int days = Dates.daysBetween(now.minusMonths(2), now);
         return getHistoricalQuotes(security, true, days >= DAYS_THRESHOLD ? OutputSize.FULL : OutputSize.COMPACT);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BinanceQuoteFeed.java
@@ -44,7 +44,7 @@ public final class BinanceQuoteFeed implements QuoteFeed
     @Override
     public Optional<LatestSecurityPrice> getLatestQuote(Security security)
     {
-        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now());
+        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now(ZoneOffset.UTC));
 
         if (!data.getErrors().isEmpty())
             PortfolioLog.error(data.getErrors());
@@ -73,7 +73,7 @@ public final class BinanceQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        return getHistoricalQuotes(security, true, LocalDate.now().minusMonths(2));
+        return getHistoricalQuotes(security, true, LocalDate.now(ZoneOffset.UTC).minusMonths(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BitfinexQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/BitfinexQuoteFeed.java
@@ -44,7 +44,7 @@ public final class BitfinexQuoteFeed implements QuoteFeed
     @Override
     public Optional<LatestSecurityPrice> getLatestQuote(Security security)
     {
-        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now());
+        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now(ZoneOffset.UTC));
 
         if (!data.getErrors().isEmpty())
             PortfolioLog.error(data.getErrors());
@@ -73,7 +73,7 @@ public final class BitfinexQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        return getHistoricalQuotes(security, true, LocalDate.now().minusMonths(2));
+        return getHistoricalQuotes(security, true, LocalDate.now(ZoneOffset.UTC).minusMonths(2));
     }
 
     @SuppressWarnings("unchecked")
@@ -143,7 +143,7 @@ public final class BitfinexQuoteFeed implements QuoteFeed
         QuoteFeedData data = new QuoteFeedData();
 
         final Long tickerStartEpochSeconds = start.atStartOfDay(ZoneOffset.UTC).toEpochSecond();
-        final String histLatest = ((start.compareTo(LocalDate.now()) == 0) ? "last" : "hist"); //$NON-NLS-1$ //$NON-NLS-2$
+        final String histLatest = ((start.compareTo(LocalDate.now(ZoneOffset.UTC)) == 0) ? "last" : "hist"); //$NON-NLS-1$ //$NON-NLS-2$
         try
         {
             // Ticker: BTCUSD, IOTUSD, ...

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.online.impl;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,7 +30,7 @@ public class DivvyDiaryUploader
         if (apiKey == null)
             return;
 
-        ClientSnapshot snapshot = ClientSnapshot.create(client, converter, LocalDate.now());
+        ClientSnapshot snapshot = ClientSnapshot.create(client, converter, LocalDate.now(ZoneOffset.UTC));
         PortfolioSnapshot portfolio = snapshot.getJointPortfolio();
 
         List<JSONObject> payload = portfolio.getPositions().stream() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/FinnhubQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/FinnhubQuoteFeed.java
@@ -69,7 +69,7 @@ public final class FinnhubQuoteFeed implements QuoteFeed
         if (!security.getPrices().isEmpty())
         {
             LocalDate startDate = security.getPrices().get(security.getPrices().size() - 1).getDate();
-            count = Dates.daysBetween(startDate, LocalDate.now()) + 5;
+            count = Dates.daysBetween(startDate, LocalDate.now(ZoneOffset.UTC)) + 5;
         }
 
         return getHistoricalQuotes(security, collectRawResponse, count);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -12,6 +12,7 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.Year;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
@@ -703,7 +704,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
             spec.column.setValue(cells.get(spec.index), price, languageHint);
 
         if (price.getDate() == null)
-            price.setDate(LocalDate.now());
+            price.setDate(LocalDate.now(ZoneOffset.UTC));
 
         return price;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/KrakenQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/KrakenQuoteFeed.java
@@ -42,7 +42,7 @@ public final class KrakenQuoteFeed implements QuoteFeed
     @Override
     public Optional<LatestSecurityPrice> getLatestQuote(Security security)
     {
-        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now());
+        QuoteFeedData data = getHistoricalQuotes(security, false, LocalDate.now(ZoneOffset.UTC));
 
         if (!data.getErrors().isEmpty())
             PortfolioLog.error(data.getErrors());
@@ -65,7 +65,7 @@ public final class KrakenQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        return getHistoricalQuotes(security, true, LocalDate.now().minusMonths(2));
+        return getHistoricalQuotes(security, true, LocalDate.now(ZoneOffset.UTC).minusMonths(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportQuoteFeed.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Type;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +53,7 @@ public final class PortfolioReportQuoteFeed implements QuoteFeed
     @Override
     public Optional<LatestSecurityPrice> getLatestQuote(Security security)
     {
-        List<LatestSecurityPrice> prices = getHistoricalQuotes(security, true, LocalDate.now()).getLatestPrices();
+        List<LatestSecurityPrice> prices = getHistoricalQuotes(security, true, LocalDate.now(ZoneOffset.UTC)).getLatestPrices();
         return prices.isEmpty() ? Optional.empty() : Optional.of(prices.get(prices.size() - 1));
     }
 
@@ -72,7 +73,7 @@ public final class PortfolioReportQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        return getHistoricalQuotes(security, true, LocalDate.now().minusMonths(2));
+        return getHistoricalQuotes(security, true, LocalDate.now(ZoneOffset.UTC).minusMonths(2));
     }
 
     @SuppressWarnings("unchecked")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -162,7 +162,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
     @Override
     public QuoteFeedData previewHistoricalQuotes(Security security)
     {
-        return internalGetQuotes(security, LocalDate.now().minusMonths(2));
+        return internalGetQuotes(security, LocalDate.now(ZoneOffset.UTC).minusMonths(2));
     }
 
     private QuoteFeedData internalGetQuotes(Security security, LocalDate startDate)
@@ -188,7 +188,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
     @SuppressWarnings("nls")
     private String requestData(Security security, LocalDate startDate) throws IOException
     {
-        int days = Dates.daysBetween(startDate, LocalDate.now());
+        int days = Dates.daysBetween(startDate, LocalDate.now(ZoneOffset.UTC));
 
         // "max" only returns a sample of quotes
         String range = "10y"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.online.impl.variableurl.macros;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAmount;
 import java.util.regex.Matcher;
@@ -46,6 +47,6 @@ public class Today implements Macro
     @Override
     public CharSequence resolve(Security security)
     {
-        return formatter.format(LocalDate.now().plus(delta));
+        return formatter.format(LocalDate.now(ZoneOffset.UTC).plus(delta));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/urls/DateURL.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/urls/DateURL.java
@@ -5,6 +5,7 @@ import name.abuchen.portfolio.online.impl.variableurl.iterators.DateIterator;
 import name.abuchen.portfolio.online.impl.variableurl.macros.Macro;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -35,7 +36,7 @@ public class DateURL extends BaseURL
     public Iterator<String> iterator()
     {
         List<SecurityPrice> prices = security.getPrices();
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(ZoneOffset.UTC);
 
         if (prices.isEmpty())
             return new DateIterator(this, now, LocalDate.MIN, -1);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot;
 
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.List;
@@ -29,10 +30,10 @@ import name.abuchen.portfolio.util.Interval;
         Interval interval = getReportInterval();
 
         // the actual interval should not extend into the future
-        if (interval.getEnd().isAfter(LocalDate.now()))
+        if (interval.getEnd().isAfter(LocalDate.now(ZoneOffset.UTC)))
         {
             LocalDate start = interval.getStart();
-            LocalDate end = LocalDate.now();
+            LocalDate end = LocalDate.now(ZoneOffset.UTC);
 
             if (start.isAfter(end))
                 start = end;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/QuoteQualityMetrics.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/QuoteQualityMetrics.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.snapshot;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -77,7 +78,7 @@ public class QuoteQualityMetrics
 
         final LocalDate start = copy.get(0).getDate();
         final LocalDate end = QuoteFeed.MANUAL.equals(security.getFeed()) ? copy.get(copy.size() - 1).getDate()
-                        : LocalDate.now();
+                        : LocalDate.now(ZoneOffset.UTC);
 
         this.checkInterval = Interval.of(start, end);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ReportingPeriod.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ReportingPeriod.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.snapshot;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.function.Predicate;
@@ -448,7 +449,7 @@ public abstract class ReportingPeriod
         @Override
         public Interval toInterval(LocalDate relativeTo)
         {
-            LocalDate startDate = LocalDate.now().withDayOfMonth(1).minusDays(1);
+            LocalDate startDate = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1).minusDays(1);
 
             if (startDate.isBefore(relativeTo))
                 return Interval.of(startDate, relativeTo);
@@ -494,7 +495,7 @@ public abstract class ReportingPeriod
         {
             // a reporting period is half-open, i.e. it excludes the first day
             // but includes the last day
-            LocalDate startDate = LocalDate.now().withDayOfMonth(1).withMonth(1).minusDays(1);
+            LocalDate startDate = LocalDate.now(ZoneOffset.UTC).withDayOfMonth(1).withMonth(1).minusDays(1);
 
             if (startDate.isBefore(relativeTo))
                 return Interval.of(startDate, relativeTo);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -82,7 +83,7 @@ public class Trade implements Adaptable
         }
         else
         {
-            LocalDate now = LocalDate.now();
+            LocalDate now = LocalDate.now(ZoneOffset.UTC);
 
             long marketValue = BigDecimal.valueOf(shares) //
                             .movePointLeft(Values.Share.precision()) //
@@ -129,7 +130,7 @@ public class Trade implements Adaptable
 
         if (end == null)
         {
-            dates.add(LocalDate.now());
+            dates.add(LocalDate.now(ZoneOffset.UTC));
             values.add(exitValue.getAmount() / Values.Amount.divider());
         }
 


### PR DESCRIPTION
Fixes #2106 (hopefully). The issue, that a security price is not getting updated, might still exist, when a quote provider uses a different timezone then UTC. Removing this "is the date in the future"-check would solve this (and be more robust), but I don't know if this check is important for something.

Clarify JSON date format tool tip as mentioned in #2215.

*Update:* I noticed there were a "few" (193 to be precise) other occurrences, that used the local time zone. I changed it consistently to UTC.