### PR TITLE
Fix for Sonar issues: Use yyyy instead of YYYY in DateTimeFormatter

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/AboutDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/AboutDialog.java
@@ -78,7 +78,7 @@ public class AboutDialog extends Dialog
     {
         String aboutText = MessageFormat.format(Messages.AboutText,
                         PortfolioPlugin.getDefault().getBundle().getVersion().toString(), //
-                        DateTimeFormatter.ofPattern("MMM YYYY").format(BuildInfo.INSTANCE.getBuildTime()), //$NON-NLS-1$
+                        DateTimeFormatter.ofPattern("MMM yyyy").format(BuildInfo.INSTANCE.getBuildTime()), //$NON-NLS-1$
                         System.getProperty("osgi.os"), //$NON-NLS-1$
                         System.getProperty("osgi.arch"), //$NON-NLS-1$
                         System.getProperty("java.vm.version"), //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
@@ -107,7 +107,7 @@ public class WelcomePart
         // version
         Label version = new Label(composite, SWT.NONE);
         version.setText(PortfolioPlugin.getDefault().getBundle().getVersion().toString() + " (" //$NON-NLS-1$
-                        + DateTimeFormatter.ofPattern("MMM YYYY").format(BuildInfo.INSTANCE.getBuildTime()) //$NON-NLS-1$
+                        + DateTimeFormatter.ofPattern("MMM yyyy").format(BuildInfo.INSTANCE.getBuildTime()) //$NON-NLS-1$
                         + ")"); //$NON-NLS-1$
 
         FormDataFactory.startingWith(image) //


### PR DESCRIPTION
Y is week of year, which is not what is intended here.

See the examples on Sonar:

```
Date date = new SimpleDateFormat("yyyy/MM/dd").parse("2015/12/31");
String result = new SimpleDateFormat("YYYY/MM/dd").format(date);   //Noncompliant; yields '2016/12/31'
result = DateTimeFormatter.ofPattern("YYYY/MM/dd").format(date); //Noncompliant; yields '2016/12/31'
```
