### PR TITLE
Added ECB Statistical Data Warehouse as Quote Provider.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/InterestRateToSecurityPricesConverterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/InterestRateToSecurityPricesConverterTest.java
@@ -1,0 +1,112 @@
+package name.abuchen.portfolio.online;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.online.InterestRateToSecurityPricesConverter.InterestRateType;
+import name.abuchen.portfolio.util.Pair;
+
+public class InterestRateToSecurityPricesConverterTest
+{
+    private static final List<Pair<LocalDate, Double>> gaplessData;
+    static
+    {
+        gaplessData = new ArrayList<>();
+        gaplessData.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 01), 1d));
+        gaplessData.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 02), 0d));
+        gaplessData.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 03), -1d));
+        gaplessData.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 04), -.5d));
+    }
+    private static final List<Pair<LocalDate, Double>> dataWithGap;
+    static
+    {
+        dataWithGap = new ArrayList<>();
+        dataWithGap.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 01), .1d));
+        dataWithGap.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 04), -.123d));
+        dataWithGap.add(new Pair<LocalDate, Double>(LocalDate.of(2021, 01, 05), -.4565d));
+    }
+    private static final double MAX_ERROR = 0.001d / 36000d;
+    
+    @Test
+    public void testAct360Empty()
+    {
+        InterestRateToSecurityPricesConverter converter = new InterestRateToSecurityPricesConverter(InterestRateType.ACT_360);
+        
+        Collection<LatestSecurityPrice> result = converter.convert(Collections.emptyList());
+        assertEquals(0, result.size());
+    }
+    
+    @Test
+    public void testAct360GaplessData()
+    {
+        InterestRateToSecurityPricesConverter converter = new InterestRateToSecurityPricesConverter(InterestRateType.ACT_360);
+        
+        Collection<LatestSecurityPrice> result = converter.convert(gaplessData);
+        assertEquals(5, result.size());
+        
+        List<Pair<LocalDate, Long>> resultList = toListAndCheck(result);
+        assertEquals(LocalDate.of(2021, 01, 01), resultList.get(0).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 02), resultList.get(1).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 03), resultList.get(2).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 04), resultList.get(3).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 05), resultList.get(4).getLeft());
+        assertEquals(1d / 36000d, ((double) (resultList.get(1).getRight() - resultList.get(0).getRight())) / resultList.get(0).getRight(), MAX_ERROR);
+        assertEquals(0d / 36000d, ((double) (resultList.get(2).getRight() - resultList.get(1).getRight())) / resultList.get(1).getRight(), MAX_ERROR);
+        assertEquals(-1d / 36000d, ((double) (resultList.get(3).getRight() - resultList.get(2).getRight())) / resultList.get(2).getRight(), MAX_ERROR);
+        assertEquals(-.5d / 36000d, ((double) (resultList.get(4).getRight() - resultList.get(3).getRight())) / resultList.get(3).getRight(), MAX_ERROR);
+    }
+    
+    @Test
+    public void testAct360DataWithGap()
+    {
+        InterestRateToSecurityPricesConverter converter = new InterestRateToSecurityPricesConverter(InterestRateType.ACT_360);
+        
+        Collection<LatestSecurityPrice> result = converter.convert(dataWithGap);
+        assertEquals(6, result.size());
+        
+        List<Pair<LocalDate, Long>> resultList = toListAndCheck(result);
+        assertEquals(LocalDate.of(2021, 01, 01), resultList.get(0).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 02), resultList.get(1).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 03), resultList.get(2).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 04), resultList.get(3).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 05), resultList.get(4).getLeft());
+        assertEquals(LocalDate.of(2021, 01, 06), resultList.get(5).getLeft());
+        assertEquals(.1d / 36000d, ((double) (resultList.get(1).getRight() - resultList.get(0).getRight())) / resultList.get(0).getRight(), MAX_ERROR);
+        assertEquals(.1d / 36000d, ((double) (resultList.get(2).getRight() - resultList.get(1).getRight())) / resultList.get(1).getRight(), MAX_ERROR);
+        assertEquals(.1d / 36000d, ((double) (resultList.get(3).getRight() - resultList.get(2).getRight())) / resultList.get(2).getRight(), MAX_ERROR);
+        assertEquals(-.123d / 36000d, ((double) (resultList.get(4).getRight() - resultList.get(3).getRight())) / resultList.get(3).getRight(), MAX_ERROR);
+        assertEquals(-.456d / 36000d, ((double) (resultList.get(5).getRight() - resultList.get(4).getRight())) / resultList.get(4).getRight(), MAX_ERROR);
+    }
+    
+    private List<Pair<LocalDate, Long>> toListAndCheck(Collection<LatestSecurityPrice> collection)
+    {
+        List<Pair<LocalDate, Long>> result = new ArrayList<>();
+        for(LatestSecurityPrice latestSecurityPrice : collection)
+        {
+            assertEquals(LatestSecurityPrice.NOT_AVAILABLE, latestSecurityPrice.getHigh());
+            assertEquals(LatestSecurityPrice.NOT_AVAILABLE, latestSecurityPrice.getLow());
+            assertEquals(LatestSecurityPrice.NOT_AVAILABLE, latestSecurityPrice.getVolume());
+            
+            result.add(new Pair<>(latestSecurityPrice.getDate(), latestSecurityPrice.getValue()));
+        }
+        Collections.sort(result, new Comparator<Pair<LocalDate, Long>>()
+        {
+
+            @Override
+            public int compare(Pair<LocalDate, Long> o1, Pair<LocalDate, Long> o2)
+            {
+                return o1.getLeft().compareTo(o2.getLeft());
+            }
+        });
+        return result;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
@@ -51,6 +51,7 @@ import name.abuchen.portfolio.online.QuoteFeed;
 import name.abuchen.portfolio.online.impl.AlphavantageQuoteFeed;
 import name.abuchen.portfolio.online.impl.BinanceQuoteFeed;
 import name.abuchen.portfolio.online.impl.CSQuoteFeed;
+import name.abuchen.portfolio.online.impl.ECBStatisticalDataWarehouseQuoteProvider;
 import name.abuchen.portfolio.online.impl.EurostatHICPQuoteFeed;
 import name.abuchen.portfolio.online.impl.FinnhubQuoteFeed;
 import name.abuchen.portfolio.online.impl.GenericJSONQuoteFeed;
@@ -317,7 +318,8 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         setFeed(feed.getId());
 
         if (comboExchange != null && feed.getId() != null
-                        && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID)))
+                        && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID)
+                                        || feed.getId().equals(ECBStatisticalDataWarehouseQuoteProvider.ID)))
         {
             Exchange exchange = (Exchange) ((IStructuredSelection) comboExchange.getSelection()).getFirstElement();
             if (exchange != null)
@@ -454,6 +456,7 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
     {
         boolean dropDown = feed != null && feed.getId() != null
                         && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID)
+                                        || feed.getId().equals(ECBStatisticalDataWarehouseQuoteProvider.ID)
                                         || feed.getId().equals(PortfolioReportQuoteFeed.ID));
 
         boolean feedURL = feed != null && feed.getId() != null && (feed.getId().equals(HTMLTableQuoteFeed.ID)
@@ -702,7 +705,8 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         createDetailDataWidgets(feed);
 
         if (model.getTickerSymbol() != null && feed != null && feed.getId() != null
-                        && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID)))
+                        && (feed.getId().startsWith(YAHOO) || feed.getId().equals(EurostatHICPQuoteFeed.ID)
+                                        || feed.getId().equals(ECBStatisticalDataWarehouseQuoteProvider.ID)))
         {
             Exchange exchange = new Exchange(model.getTickerSymbol(), model.getTickerSymbol());
             ArrayList<Exchange> input = new ArrayList<>();

--- a/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
+++ b/name.abuchen.portfolio/META-INF/services/name.abuchen.portfolio.online.QuoteFeed
@@ -4,6 +4,7 @@ name.abuchen.portfolio.online.impl.BitfinexQuoteFeed
 name.abuchen.portfolio.online.impl.BinanceQuoteFeed
 name.abuchen.portfolio.online.impl.FinnhubQuoteFeed
 name.abuchen.portfolio.online.impl.EurostatHICPQuoteFeed
+name.abuchen.portfolio.online.impl.ECBStatisticalDataWarehouseQuoteProvider
 name.abuchen.portfolio.online.impl.KrakenQuoteFeed
 name.abuchen.portfolio.online.impl.PortfolioReportQuoteFeed
 name.abuchen.portfolio.online.impl.QuandlQuoteFeed

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -175,6 +175,8 @@ public class Messages extends NLS
     public static String LabelYahooFinance;
     public static String LabelYahooFinanceAdjustedClose;
     public static String LabelEurostatHICP;
+    public static String LabelECBStatisticalDataWarehouse;
+    public static String LabelEONIA;
     public static String LabelExchangeRateSeriesBasedOnSecurity;
     public static String LabelOtherCategory;
     public static String LabelQuotation;
@@ -200,6 +202,7 @@ public class Messages extends NLS
     public static String MsgErrorDecrypting;
     public static String MsgErrorDownloadYahoo;
     public static String MsgErrorDownloadEurostatHICP;
+    public static String MsgErrorDownloadECBStatisticalDataWarehouse;
     public static String MsgErrorDuplicateISIN;
     public static String MsgErrorDuplicateName;
     public static String MsgErrorDuplicateTicker;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -248,6 +248,10 @@ LabelEuropeanCentralBank = European Central Bank
 
 LabelEurostatHICP = Inflation Rate - Eurostat - Harmonised Indices of Consumer Prices (HICP) 
 
+LabelECBStatisticalDataWarehouse = ECB Statistical Data Warehouse (interest rate indices)
+
+LabelEONIA = EONIA
+
 LabelExchangeRateSeriesBasedOnSecurity = {0} (Security: {1})
 
 LabelHTMLTable = Table on web site
@@ -387,6 +391,8 @@ MsgDeltaWithoutAssets = Warning: Delta without assets: {0} on {1}
 MsgErrorDecrypting = Error while decrypting output: {0}
 
 MsgErrorDownloadEurostatHICP = Download error on attempt {0} for HICP category {1}: {2}
+
+MsgErrorDownloadECBStatisticalDataWarehouse = Download error on attempt {0} for ECB SDW data series {1}: {2}
 
 MsgErrorDownloadYahoo = Download error (attempt {0}) for ticker {1}: {2}
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
@@ -248,6 +248,8 @@ LabelEuropeanCentralBank = Europ\u00E4ische Zentralbank
 
 LabelEurostatHICP = Inflationsrate - Eurostat - Harmonisierte Verbraucherpreisindizes (HVPI)
 
+LabelECBStatisticalDataWarehouse = EZB Statistical Data Warehouse (Zins Indizes)
+
 LabelExchangeRateSeriesBasedOnSecurity = {0} (Wertpapier: {1})
 
 LabelHTMLTable = Tabelle auf einer Webseite
@@ -387,6 +389,8 @@ MsgDeltaWithoutAssets = Warnung: Ver\u00E4nderung ohne Kapital: {0} am {1}
 MsgErrorDecrypting = Fehler w\u00E4hrend der Entschl\u00FCsselung: {0}
 
 MsgErrorDownloadEurostatHICP = HVPI Downloadfehler bei Versuch {0} f\u00FCr Kategorie {1}: {2}
+
+MsgErrorDownloadECBStatisticalDataWarehouse = ECB SDW Downloadfehler bei Versuch {0} f\u00FCr Datenreihe {1}: {2}
 
 MsgErrorDownloadYahoo = Downloadfehler bei Versuch {0} f\u00FCr Ticker Symbol {1}: {2}
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/InterestRateToSecurityPricesConverter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/InterestRateToSecurityPricesConverter.java
@@ -1,0 +1,82 @@
+package name.abuchen.portfolio.online;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.util.Pair;
+
+public class InterestRateToSecurityPricesConverter
+{
+    public static enum InterestRateType
+    {
+        /**
+         * act/360: On each actual date (i.e. 365 or 366 times per year), apply
+         * an interest rate that is 1/360 of the annualized interest rate.
+         * Typically used in the Euro area.
+         */
+        ACT_360;
+    }
+
+    private static final long START_VALUE = 100L * Values.Quote.factor();
+
+    private InterestRateType interestRateType;
+
+    public InterestRateToSecurityPricesConverter(InterestRateType interestRateType)
+    {
+        this.interestRateType = interestRateType;
+    }
+
+    public Collection<LatestSecurityPrice> convert(List<Pair<LocalDate, Double>> interestRates)
+    {
+        Collections.sort(interestRates, new Comparator<Pair<LocalDate, Double>>()
+        {
+            @Override
+            public int compare(Pair<LocalDate, Double> o1, Pair<LocalDate, Double> o2)
+            {
+                return o1.getLeft().compareTo(o2.getLeft());
+            }
+        });
+
+        if (interestRates.size() == 0)
+            return Collections.emptyList();
+        LocalDate lastDate = interestRates.get(0).getKey();
+        long lastValue = START_VALUE;
+        List<LatestSecurityPrice> results = new ArrayList<>();
+        results.add(toLatestSecurityPrice(lastDate, lastValue));
+        int nextInterestRateIndex = 0;
+        do
+        {
+            while ((nextInterestRateIndex + 1) < interestRates.size()
+                            && ! interestRates.get(nextInterestRateIndex + 1).getLeft().isAfter(lastDate))
+                nextInterestRateIndex++;
+            
+            double overNightInterestRate = interestRates.get(nextInterestRateIndex).getRight();
+            long overNightReturn = 0;
+            switch (interestRateType)
+            {
+                case ACT_360:
+                    overNightReturn = Math.round(lastValue * overNightInterestRate / 36000);
+                    break;
+                default: // Necessary for checkstyle
+            }
+            lastDate = lastDate.plusDays(1);
+            lastValue += overNightReturn;
+            results.add(toLatestSecurityPrice(lastDate, lastValue));
+            
+        }
+        while (nextInterestRateIndex + 1 < interestRates.size());
+        return results;
+    }
+
+    private LatestSecurityPrice toLatestSecurityPrice(LocalDate date, long value)
+    {
+        return new LatestSecurityPrice(date, value, LatestSecurityPrice.NOT_AVAILABLE,
+                        LatestSecurityPrice.NOT_AVAILABLE, LatestSecurityPrice.NOT_AVAILABLE);
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ECBStatisticalDataWarehouseQuoteProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/ECBStatisticalDataWarehouseQuoteProvider.java
@@ -1,0 +1,158 @@
+package name.abuchen.portfolio.online.impl;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.model.Exchange;
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.online.InterestRateToSecurityPricesConverter;
+import name.abuchen.portfolio.online.InterestRateToSecurityPricesConverter.InterestRateType;
+import name.abuchen.portfolio.online.QuoteFeed;
+import name.abuchen.portfolio.online.QuoteFeedData;
+import name.abuchen.portfolio.util.Pair;
+import name.abuchen.portfolio.util.WebAccess;
+
+public class ECBStatisticalDataWarehouseQuoteProvider implements QuoteFeed
+{
+
+    public static final String ID = "ECBSDW"; //$NON-NLS-1$
+
+    private static final String ECB_SDW_PROTOCOL = "https"; //$NON-NLS-1$
+    private static final String ECB_SDW_HOST = "sdw-wsrest.ecb.europa.eu"; //$NON-NLS-1$
+    private static final String ECB_SDW_DATA_PATH = "/service/data/"; //$NON-NLS-1$
+    private static final String ECB_SDW_DATE_FORMAT = "yyyy-MM-dd"; //$NON-NLS-1$
+
+    public static enum ECBSDWSeries
+    {
+        EONIA(new Exchange("ECB,EON,1.0/D.EONIA_TO.RATE", Messages.LabelEONIA)); //$NON-NLS-1$
+
+        private final Exchange exchange;
+
+        private ECBSDWSeries(Exchange exchange)
+        {
+            this.exchange = exchange;
+        }
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return Messages.LabelECBStatisticalDataWarehouse;
+    }
+
+    @Override
+    public Optional<LatestSecurityPrice> getLatestQuote(Security security)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public QuoteFeedData getHistoricalQuotes(Security security, boolean collectRawResponse)
+    {
+        if (security.getTickerSymbol() == null)
+        {
+            return QuoteFeedData.withError(
+                            new IOException(MessageFormat.format(Messages.MsgMissingTickerSymbol, security.getName())));
+        }
+
+        QuoteFeedData data = new QuoteFeedData();
+
+        try
+        {
+            String responseBody = requestData(security, collectRawResponse, data);
+            extractQuotes(responseBody, data);
+        }
+        catch (IOException | URISyntaxException | ParserConfigurationException | SAXException e)
+        {
+            data.addError(new IOException(MessageFormat.format(Messages.MsgErrorDownloadECBStatisticalDataWarehouse, 1,
+                            security.getTickerSymbol(), e.getMessage()), e));
+        }
+
+        return data;
+    }
+
+    @SuppressWarnings("nls")
+    private String requestData(Security security, boolean collectRawResponse, QuoteFeedData data)
+                    throws IOException, URISyntaxException
+    {
+        WebAccess webaccess = new WebAccess(ECB_SDW_HOST, ECB_SDW_DATA_PATH + security.getTickerSymbol()) //
+                        .withScheme(ECB_SDW_PROTOCOL); // //$NON-NLS-1$
+
+        String text = webaccess.get();
+
+        if (collectRawResponse)
+            data.addResponse(webaccess.getURL(), text);
+
+        return text;
+    }
+
+    private void extractQuotes(String responseBody, QuoteFeedData data)
+                    throws ParserConfigurationException, SAXException, IOException
+    {
+        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(responseBody)));
+
+        Element root = document.getDocumentElement();
+        NodeList dataList = root.getElementsByTagName("generic:Obs"); //$NON-NLS-1$
+
+        List<Pair<LocalDate, Double>> interestRates = new ArrayList<>();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(ECB_SDW_DATE_FORMAT);
+
+        for (int i = 0; i < dataList.getLength(); i++)
+        {
+            Element node = (Element) dataList.item(i);
+
+            NodeList dateNodeList = node.getElementsByTagName("generic:ObsDimension"); //$NON-NLS-1$
+            if (dateNodeList.getLength() != 1)
+                throw new SAXException("Expected one date, but found: " + dateNodeList.getLength()); //$NON-NLS-1$
+            Element dateElement = (Element) dateNodeList.item(0);
+            String dateString = dateElement.getAttribute("value"); //$NON-NLS-1$
+            LocalDate date = LocalDate.parse(dateString, formatter);
+
+            NodeList interestRateNodeList = node.getElementsByTagName("generic:ObsValue"); //$NON-NLS-1$
+            if (interestRateNodeList.getLength() != 1)
+                throw new SAXException("Expected one value, but found: " + interestRateNodeList.getLength()); //$NON-NLS-1$
+            Element interestRateElement = (Element) interestRateNodeList.item(0);
+            String interestRateString = interestRateElement.getAttribute("value"); //$NON-NLS-1$
+            double interestRate = Double.parseDouble(interestRateString);
+            interestRates.add(new Pair<LocalDate, Double>(date, interestRate));
+        }
+        Collection<LatestSecurityPrice> latestSecurityPrices = new InterestRateToSecurityPricesConverter(
+                        InterestRateType.ACT_360).convert(interestRates);
+        data.addAllPrices(latestSecurityPrices);
+    }
+
+    @Override
+    public List<Exchange> getExchanges(Security subject, List<Exception> errors)
+    {
+        return Arrays.stream(ECBSDWSeries.values()).map(series -> series.exchange).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### Added ECB Statistical Data Warehouse as Quote Provider.
Currently the EONIA Index is the only supported data series. (I plan to add more like the Euribor-Indizes and Long-Term bond indizes in the future). I think this indices are useful as benchmark and a prerequisite to calculate some key portfolio satistics like alpha, beta and R-squared (which I also plan to do at some point).

The Index provides daily rates of returns. These are converted into daily quote feeds (starting with 100 € at the start of the index) to fit into the PP model.

The wizard:
![Add EONIA](https://user-images.githubusercontent.com/10776736/116795965-0ac15680-aad9-11eb-9bf5-91def12dd2b6.png)

EONIA as benchmark:
![EONIA](https://user-images.githubusercontent.com/10776736/116795972-0eed7400-aad9-11eb-8c6c-bf2d3bcfc284.png)
