### PR TITLE
Change default file format for exporting chart images from JPEG to PNG.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -26,7 +26,7 @@ import name.abuchen.portfolio.util.TextUtil;
     private Chart chart;
     private Menu contextMenu;
     
-    private static int lastUsedFileExtension = 0;
+    private static int lastUsedFileExtension = 2;
 
     public ChartContextMenu(Chart chart)
     {


### PR DESCRIPTION
The exported chart images are a lot smaller in PNG (and have no lossy compression artefacts), so PNG should be the default format.