### PR TITLE
Add org.eclipse.swt.win32.win32.x86_64 to JUnit lauch configurations.

### DIFF
--- a/portfolio-app/eclipse/name.abuchen.portfolio.tests.launch
+++ b/portfolio-app/eclipse/name.abuchen.portfolio.tests.launch
@@ -150,6 +150,7 @@
         <setEntry value="org.eclipse.osgi@-1:true"/>
         <setEntry value="org.eclipse.swt.cocoa.macosx.x86_64@default:false"/>
         <setEntry value="org.eclipse.swt@default:default"/>
+        <setEntry value="org.eclipse.swt.win32.win32.x86_64@default:default"/>
         <setEntry value="org.eclipse.team.core@default:default"/>
         <setEntry value="org.eclipse.ui.cocoa@default:false"/>
         <setEntry value="org.eclipse.ui.forms@default:default"/>

--- a/portfolio-app/eclipse/name.abuchen.portfolio.ui.tests.launch
+++ b/portfolio-app/eclipse/name.abuchen.portfolio.ui.tests.launch
@@ -148,6 +148,7 @@
         <setEntry value="org.eclipse.osgi@-1:true"/>
         <setEntry value="org.eclipse.swt.cocoa.macosx.x86_64@default:false"/>
         <setEntry value="org.eclipse.swt@default:default"/>
+        <setEntry value="org.eclipse.swt.win32.win32.x86_64@default:default"/>
         <setEntry value="org.eclipse.team.core@default:default"/>
         <setEntry value="org.eclipse.ui.cocoa@default:false"/>
         <setEntry value="org.eclipse.ui.forms@default:default"/>


### PR DESCRIPTION
On my machine (Windows 10 x64, Eclipse IDE for Eclipse Committers - 2020-12) this was necassary to get the JUnit test running. (I got a lots of java.lang.NoClassDefFoundError: org/eclipse/swt/…