### PR TITLE
Allow setting securities active, even for multiple selection

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -984,10 +984,11 @@ public class Messages extends NLS
     public static String SecurityMenuDebugGetHistoricalQuotes;
     public static String SecurityMenuDeleteAllPrices;
     public static String SecurityMenuDeleteLatestQuote;
-    public static String SecurityMenuDeletePrice;
-    public static String SecurityMenuDeleteSecurity;
-    public static String SecurityMenuDeleteSingleSecurityConfirm;
+    public static String SecurityMenuDeleteMultipleSecurity;
     public static String SecurityMenuDeleteMultipleSecurityConfirm;
+    public static String SecurityMenuDeletePrice;
+    public static String SecurityMenuDeleteSingleSecurity;
+    public static String SecurityMenuDeleteSingleSecurityConfirm;
     public static String SecurityMenuDividends;
     public static String SecurityMenuEditSecurity;
     public static String SecurityMenuErrorMessageRoundingMustBeBetween0AndX;
@@ -1002,6 +1003,14 @@ public class Messages extends NLS
     public static String SecurityMenuRoundToXDecimalPlaces;
     public static String SecurityMenuSearch4Securities;
     public static String SecurityMenuSell;
+    public static String SecurityMenuSetMultipleSecurityActive;
+    public static String SecurityMenuSetMultipleSecurityActiveConfirm;
+    public static String SecurityMenuSetMultipleSecurityInactive;
+    public static String SecurityMenuSetMultipleSecurityInactiveConfirm;
+    public static String SecurityMenuSetSingleSecurityActive;
+    public static String SecurityMenuSetSingleSecurityActiveConfirm;
+    public static String SecurityMenuSetSingleSecurityInactive;
+    public static String SecurityMenuSetSingleSecurityInactiveConfirm;
     public static String SecurityMenuStockSplit;
     public static String SecurityMenuAddEvent;
     public static String SecurityMenuLabelNumberOfDecimalPlaces;
@@ -1086,9 +1095,6 @@ public class Messages extends NLS
     public static String HoldingsWarningAssetsWithNegativeValuation;
     public static String HoldingsWarningAssetsWithNegativeValuationDetails;
     public static String YearlyPerformanceHeatmapToolTip;
-    public static String SecurityMenuSetSecurityInactive;
-    public static String SecurityMenuSetMultipleSecurityInactiveConfirm;
-    public static String SecurityMenuSetSingleSecurityInactiveConfirm;
     static
     {
         // initialize resource bundle

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1994,11 +1994,13 @@ SecurityMenuDeleteAllPrices = Delete All
 
 SecurityMenuDeleteLatestQuote = Delete latest price
 
+SecurityMenuDeleteMultipleSecurity = Delete {0} securities
+
 SecurityMenuDeleteMultipleSecurityConfirm = Do you really want to delete {0} securities?
 
 SecurityMenuDeletePrice = Delete
 
-SecurityMenuDeleteSecurity = Delete Security
+SecurityMenuDeleteSingleSecurity = Delete security
 
 SecurityMenuDeleteSingleSecurityConfirm = Do you really want to delete the security ''{0}''?
 
@@ -2032,9 +2034,19 @@ SecurityMenuSearch4Securities = Search for instruments...
 
 SecurityMenuSell = Sell
 
+SecurityMenuSetMultipleSecurityActive = Set {0} securities active
+
+SecurityMenuSetMultipleSecurityActiveConfirm = Do you really want to set {0} securities active?
+
+SecurityMenuSetMultipleSecurityInactive = Set {0} securities inactive
+
 SecurityMenuSetMultipleSecurityInactiveConfirm = Do you really want to set {0} securities inactive?
 
-SecurityMenuSetSecurityInactive = Set Security inactive
+SecurityMenuSetSingleSecurityActive = Set security active
+
+SecurityMenuSetSingleSecurityActiveConfirm = Do you really want to set the security ''{0}'' active?
+
+SecurityMenuSetSingleSecurityInactive = Set security inactive
 
 SecurityMenuSetSingleSecurityInactiveConfirm = Do you really want to set the security ''{0}'' inactive?
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1987,11 +1987,13 @@ SecurityMenuDeleteAllPrices = Alle l\u00F6schen
 
 SecurityMenuDeleteLatestQuote = Letzten Kurs l\u00F6schen
 
+SecurityMenuDeleteMultipleSecurity = {0} Wertpapiere l\u00F6schen
+
 SecurityMenuDeleteMultipleSecurityConfirm = M\u00F6chten Sie diese {0} Wertpapiere wirklich l\u00F6schen?
 
 SecurityMenuDeletePrice = L\u00F6schen
 
-SecurityMenuDeleteSecurity = Wertpapier l\u00F6schen
+SecurityMenuDeleteSingleSecurity = Wertpapier l\u00F6schen
 
 SecurityMenuDeleteSingleSecurityConfirm = M\u00F6chten Sie das Wertpapier ''{0}'' wirklich l\u00F6schen?
 
@@ -2025,9 +2027,19 @@ SecurityMenuSearch4Securities = Nach Wertpapieren suchen...
 
 SecurityMenuSell = Verkauf
 
+SecurityMenuSetMultipleSecurityActive = {0} Wertpapiere aktiv setzen
+
+SecurityMenuSetMultipleSecurityActiveConfirm = M\u00F6chten Sie diese {0} Wertpapiere wirklich aktiv setzen?
+
+SecurityMenuSetMultipleSecurityInactive = {0} Wertpapiere inaktiv setzen
+
 SecurityMenuSetMultipleSecurityInactiveConfirm = M\u00F6chten Sie diese {0} Wertpapiere wirklich inaktiv setzen?
 
-SecurityMenuSetSecurityInactive = Wertpapier inaktiv setzen
+SecurityMenuSetSingleSecurityActive = Wertpapier aktiv setzen
+
+SecurityMenuSetSingleSecurityActiveConfirm = M\u00F6chten Sie das Wertpapier ''{0}'' wirklich aktiv setzen?
+
+SecurityMenuSetSingleSecurityInactive = Wertpapier inaktiv setzen
 
 SecurityMenuSetSingleSecurityInactiveConfirm = M\u00F6chten Sie das Wertpapier ''{0}'' wirklich inaktiv setzen?
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1975,13 +1975,15 @@ SecurityMenuDeleteAllPrices = Eliminar todo
 
 SecurityMenuDeleteLatestQuote = Eliminar \u00FAltimo precio
 
-SecurityMenuDeleteMultipleSecurityConfirm = \u00BFRealmente quiere eliminar {0} valores?
+SecurityMenuDeleteMultipleSecurity = Eliminar {0} valores
+
+SecurityMenuDeleteMultipleSecurityConfirm = \u00BFRealmente quieres eliminar {0} valores?
 
 SecurityMenuDeletePrice = Eliminar
 
-SecurityMenuDeleteSecurity = Eliminar Valor
+SecurityMenuDeleteSingleSecurity = Eliminar valor
 
-SecurityMenuDeleteSingleSecurityConfirm = \u00BFRealmente quieres borrar la seguridad ''{0}''?
+SecurityMenuDeleteSingleSecurityConfirm = \u00BFRealmente quieres borrar el valor ''{0}''?
 
 SecurityMenuDividends = Dividendo
 
@@ -2013,9 +2015,21 @@ SecurityMenuSearch4Securities = Buscar...
 
 SecurityMenuSell = Vender
 
+SecurityMenuSetMultipleSecurityActive = Poner {0} valores activos
+
+SecurityMenuSetMultipleSecurityActiveConfirm = \u00BFRealmente quieres poner {0} valores activos?
+
+SecurityMenuSetMultipleSecurityInactive = Poner {0} valores inactivos
+
 SecurityMenuSetMultipleSecurityInactiveConfirm = \u00BFRealmente quieres poner {0} valores inactivos?
 
-SecurityMenuSetSingleSecurityInactiveConfirm = \u00BFRealmente quieres poner la valor''{0}'' inactiva?
+SecurityMenuSetSingleSecurityActive = Poner este valor activo
+
+SecurityMenuSetSingleSecurityActiveConfirm = \u00BFRealmente quieres poner el valor ''{0}'' activo?
+
+SecurityMenuSetSingleSecurityInactive = Poner este valor inactivo
+
+SecurityMenuSetSingleSecurityInactiveConfirm = \u00BFRealmente quieres poner el valor ''{0}'' inactivo?
 
 SecurityMenuStockSplit = Split de acciones...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1976,11 +1976,13 @@ SecurityMenuDeleteAllPrices = Tout supprimer
 
 SecurityMenuDeleteLatestQuote = Supprimer le dernier prix
 
+SecurityMenuDeleteMultipleSecurity = Supprimer {0} titres
+
 SecurityMenuDeleteMultipleSecurityConfirm = Souhaitez-vous r\u00E9llement supprimer {0} titres ?
 
 SecurityMenuDeletePrice = Supprimer
 
-SecurityMenuDeleteSecurity = Supprimer titre
+SecurityMenuDeleteSingleSecurity = Supprimer titre
 
 SecurityMenuDeleteSingleSecurityConfirm = Souhaitez-vous r\u00E9llement supprimer le titre ''{0}'' ?
 
@@ -2014,7 +2016,21 @@ SecurityMenuSearch4Securities = Chercher des instruments...
 
 SecurityMenuSell = Vendre
 
-SecurityMenuSetMultipleSecurityInactiveConfirm = Voulez-vous vraiment rendre ces titres inactifs ?
+SecurityMenuSetMultipleSecurityActive = Rendre {0} titres actifs
+
+SecurityMenuSetMultipleSecurityActiveConfirm = Voulez-vous vraiment rendre ces {0} titres actifs ?
+
+SecurityMenuSetMultipleSecurityInactive = Rendre {0} titres inactifs
+
+SecurityMenuSetMultipleSecurityInactiveConfirm = Voulez-vous vraiment rendre ces {0} titres inactifs ?
+
+SecurityMenuSetSingleSecurityActive = Rendre ce titre actif
+
+SecurityMenuSetSingleSecurityActiveConfirm = Voulez-vous vraiment rendre le titre ''{0}'' actif ?
+
+SecurityMenuSetSingleSecurityInactive = Rendre ce titre inactif
+
+SecurityMenuSetSingleSecurityInactiveConfirm = Voulez-vous vraiment rendre le titre ''{0}'' inactif ?
 
 SecurityMenuStockSplit = Fractionnement de parts...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1975,13 +1975,15 @@ SecurityMenuDeleteAllPrices = Alles verwijderen
 
 SecurityMenuDeleteLatestQuote = Laatste prijs verwijderen
 
-SecurityMenuDeleteMultipleSecurityConfirm = Wilt u effecten ''{0}'' echt verwijderen?
+SecurityMenuDeleteMultipleSecurity = {0} effecten verwijderen
+
+SecurityMenuDeleteMultipleSecurityConfirm = Wil je deze {0} effecten echt verwijderen?
 
 SecurityMenuDeletePrice = Verwijderen
 
-SecurityMenuDeleteSecurity = Effecten verwijderen
+SecurityMenuDeleteSingleSecurity = Effect verwijderen
 
-SecurityMenuDeleteSingleSecurityConfirm = Weet je zeker dat je effect "{0}" wilt verwijderen?
+SecurityMenuDeleteSingleSecurityConfirm = Wil je het effect ''{0}'' echt verwijderen?
 
 SecurityMenuDividends = Dividend
 
@@ -2013,9 +2015,21 @@ SecurityMenuSearch4Securities = Zoek naar effecten
 
 SecurityMenuSell = Verkoop
 
-SecurityMenuSetMultipleSecurityInactiveConfirm = Wil je echt {0} effecten inactief zetten?
+SecurityMenuSetMultipleSecurityActive = {0} effecten actief zetten
 
-SecurityMenuSetSingleSecurityInactiveConfirm = Wil je echt de beveiliging ''{0}'' inactief maken?
+SecurityMenuSetMultipleSecurityActiveConfirm = Wil je deze {0} effecten echt actief zetten?
+
+SecurityMenuSetMultipleSecurityInactive = {0} effecten inactief zetten
+
+SecurityMenuSetMultipleSecurityInactiveConfirm = Wil je deze {0} effecten echt inactief zetten?
+
+SecurityMenuSetSingleSecurityActive = Effect actief zetten
+
+SecurityMenuSetSingleSecurityActiveConfirm = Wil je het effect ''{0}'' echt actief zetten?
+
+SecurityMenuSetSingleSecurityInactive = Effect inactief zetten
+
+SecurityMenuSetSingleSecurityInactiveConfirm = Wil je het effect ''{0}'' echt inactief zetten?
 
 SecurityMenuStockSplit = Aandelensplitsing...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfirmActionWithSelection.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfirmActionWithSelection.java
@@ -20,10 +20,11 @@ public class ConfirmActionWithSelection extends Action
     private final IStructuredSelection selection;
     private final Runnable runnable;
 
-    public ConfirmActionWithSelection(String title, String singleSelectionMessage, String multiSelectionMessage,
+    public ConfirmActionWithSelection(String singleSelectionTitle, String multiSelectionTitle,
+                    String singleSelectionMessage, String multiSelectionMessage,
                     IStructuredSelection selection, Runnable runnable)
     {
-        super(title);
+        super(selection.size() > 1 ? MessageFormat.format(multiSelectionTitle, selection.size()) : singleSelectionTitle);
         this.singleSelectionMessage = singleSelectionMessage;
         this.multiSelectionMessage = multiSelectionMessage;
         this.selection = selection;


### PR DESCRIPTION
Fixes #2226. In the security list, the context menu allows
the user to activate/inactivate the selected securites
based on their current state. To show accurate messages,
this commit adapts some messages (and translations) to
handle single/multiple securities.

Open for debate: if the user has marked 2 active and
1 inactive security, should the context menu and dialog
read "mark 3 inactive" (as implemented here), or
"mark 2 inactive" (i.e., only count those that will actually
change state)?