### PR TITLE
Added log scale option to performance diagramm

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/PerformanceChartSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/PerformanceChartSeriesBuilder.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.views.dataseries;
 
+import java.util.Arrays;
+
 import org.swtchart.IBarSeries;
 import org.swtchart.ILineSeries;
 
@@ -30,7 +32,7 @@ public class PerformanceChartSeriesBuilder extends AbstractChartSeriesBuilder
             if (aggregationPeriod != null)
                 index = Aggregation.aggregate(index, aggregationPeriod);
 
-            ILineSeries lineSeries = getChart().addDateSeries(index.getDates(), index.getAccumulatedPercentage(),
+            ILineSeries lineSeries = getChart().addDateSeries(index.getDates(), performanceIndexToDataSeries(index),
                             series.getLabel());
             configure(series, lineSeries);
         }
@@ -45,7 +47,7 @@ public class PerformanceChartSeriesBuilder extends AbstractChartSeriesBuilder
         switch ((ClientDataSeries) series.getInstance())
         {
             case TOTALS:
-                ILineSeries lineSeries = getChart().addDateSeries(index.getDates(), index.getAccumulatedPercentage(),
+                ILineSeries lineSeries = getChart().addDateSeries(index.getDates(), performanceIndexToDataSeries(index),
                                 series.getLabel());
                 configure(series, lineSeries);
                 break;
@@ -61,5 +63,10 @@ public class PerformanceChartSeriesBuilder extends AbstractChartSeriesBuilder
             default:
                 break;
         }
+    }
+    
+    private double[] performanceIndexToDataSeries(PerformanceIndex index)
+    {
+        return Arrays.stream(index.getAccumulatedPercentage()).map(x -> x + 1d).toArray();
     }
 }


### PR DESCRIPTION
This feature was requested several times, but I not implemented because the graph drawing library swtchart “does not support log scale with negative values”. Well, that is not really a limitation of swtchart, the log function is simply defined only for positive values and using a log scale with negative/zero values makes mathematically no sense.

However, it makes sense when you start with 100% and not 0% (as long as you don’t lose everything or more than your invested amount). I implemented this, but tweaked the scale to start still with 0% in the GUI. The implemenation is in a very similar fashion   to the security chart.

Here is an example how it looks:
![MSCI World Log Scale](https://user-images.githubusercontent.com/10776736/117508351-b6aaec00-af88-11eb-965a-7d9f2e1a548c.PNG)

and here are the GUI controls to activate the log scale:
![Log Scale GUI](https://user-images.githubusercontent.com/10776736/117508410-cfb39d00-af88-11eb-9b28-6074b5c2a54c.PNG)
I think it would be nice to have more ticks/labels in the log scale, but found no way to do this. I think this is really a limitation of the swtchart library.

The users scale choice (linear or log) is currently not stored in the .xml file, because I don't know how to do this here. (In contrast to the security chart view, we dont have access to the `name.abuchen.portfolio.model.Client` object here.

Fixes #208
Fixes #1461
Fixes #1449