### PR TITLE
[PDF Import] Support importing zip files

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -1,11 +1,19 @@
 package name.abuchen.portfolio.ui.handlers;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import javax.inject.Named;
 
@@ -58,12 +66,32 @@ public class ImportPDFHandler
                         .ifPresent(client -> runImport((PortfolioPart) part.getObject(), shell, client, null, null));
     }
 
+    private static List<File> unzipFileToTempDir(File zipfile, File tempDir) throws IOException
+    {
+        List<File> extractedFiles = new ArrayList<>();
+        try (FileInputStream zipfs = new FileInputStream(zipfile);
+             ZipInputStream zipin = new ZipInputStream(zipfs))
+        {
+            ZipEntry entry;
+            while ((entry = zipin.getNextEntry()) != null)
+            {
+                if (entry.isDirectory() || entry.getName() == null || !entry.getName().endsWith(".pdf")) //$NON-NLS-1$
+                    continue;
+
+                Path tempFile = Paths.get(tempDir.getAbsolutePath(), entry.getName());
+                Files.copy(zipin, tempFile, StandardCopyOption.REPLACE_EXISTING);
+                extractedFiles.add(tempFile.toFile());
+            }
+        }
+        return extractedFiles;
+    }
+
     public static void runImport(PortfolioPart part, Shell shell, Client client, Account account, Portfolio portfolio)
     {
         FileDialog fileDialog = new FileDialog(shell, SWT.OPEN | SWT.MULTI);
         fileDialog.setText(Messages.PDFImportWizardAssistant);
         fileDialog.setFilterNames(new String[] { Messages.PDFImportFilterName });
-        fileDialog.setFilterExtensions(new String[] { "*.pdf" }); //$NON-NLS-1$
+        fileDialog.setFilterExtensions(new String[] { "*.pdf;*.zip" }); //$NON-NLS-1$
         fileDialog.open();
 
         String[] filenames = fileDialog.getFileNames();
@@ -72,10 +100,44 @@ public class ImportPDFHandler
             return;
 
         List<File> files = new ArrayList<>();
-        for (String filename : filenames)
-            files.add(new File(fileDialog.getFilterPath(), filename));
+        List<File> filesToDelete = new ArrayList<>();
+        try
+        {
+            for (String filename : filenames)
+            {
+                File file = new File(fileDialog.getFilterPath(), filename);
+                if (filename.endsWith(".zip")) //$NON-NLS-1$
+                {
+                    File tempDir = Files.createTempDirectory("portfolio_import_").toFile(); //$NON-NLS-1$
+                    filesToDelete.add(tempDir);
+                    List<File> extractedFiles = unzipFileToTempDir(file, tempDir);
+                    // Place files in front of tempDir in deletion list
+                    filesToDelete.addAll(filesToDelete.size() - 1, extractedFiles);
+                    files.addAll(extractedFiles);
+                }
+                else
+                {
+                    files.add(file);
+                }
+            }
 
-        runImportWithFiles(part, shell, client, account, portfolio, files);
+            runImportWithFiles(part, shell, client, account, portfolio, files);
+        }
+        catch (IOException e)
+        {
+            PortfolioPlugin.log(e);
+            String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+            MessageDialog.openError(shell, Messages.LabelError, message);
+        }
+        finally
+        {
+            for (File f : filesToDelete)
+            {
+                boolean deleted = f.delete();
+                if (!deleted)
+                    f.deleteOnExit();
+            }
+        }
     }
 
     public static void runImportWithFiles(PortfolioPart part, Shell shell, Client client, Account account,

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1822,7 +1822,7 @@ PDFImportDebugTextExtraction = Debug: Extract text from PDF
 
 PDFImportErrorParsingDocument = Error reading or converting PDF document: {0} (Check error log for details)
 
-PDFImportFilterName = PDF document (*.pdf)
+PDFImportFilterName = PDF document (*.pdf;*.zip)
 
 PDFImportWizardAssistant = PDF import wizard
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1815,7 +1815,7 @@ PDFImportDebugTextExtraction = Debug: Text aus PDF extrahieren
 
 PDFImportErrorParsingDocument = Fehler beim Einlesen oder Umwandeln der PDF Datei: {0} (F\u00FCr Details, siehe Fehlerprotokoll)
 
-PDFImportFilterName = PDF Dokument (*.pdf)
+PDFImportFilterName = PDF Dokument (*.pdf;*.zip)
 
 PDFImportWizardAssistant = PDF Import Assistent
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1809,7 +1809,7 @@ PDFImportDebugTextExtraction = Debug: extraer el texto de PDF
 
 PDFImportErrorParsingDocument = Error al leer o convertir documentos PDF: {0} (revise el registro de errores para m\u00E1s detalles)
 
-PDFImportFilterName = Documento PDF (*.pdf)
+PDFImportFilterName = Documento PDF (*.pdf;*.zip)
 
 PDFImportWizardAssistant = Asistente de importaci\u00F3n PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1810,7 +1810,7 @@ PDFImportDebugTextExtraction = Debug : extraire texte depuis PDF
 
 PDFImportErrorParsingDocument = Erreur lors de la lecture ou conversion du document PDF : {0} (voir journal d'erreurs pour plus de d\u00E9tails)
 
-PDFImportFilterName = Document PDF (*.pdf)
+PDFImportFilterName = Document PDF (*.pdf;*.zip)
 
 PDFImportWizardAssistant = Assistant d'import PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1815,7 +1815,7 @@ PDFImportDebugTextExtraction = Debug: Estrai testo da PDF
 
 PDFImportErrorParsingDocument = Errore durante la lettura o la conversione del documento PDF: {0} (controlla il registro degli errori per i dettagli)
 
-PDFImportFilterName = Documento PDF (*.pdf)
+PDFImportFilterName = Documento PDF (*.pdf;*.zip)
 
 PDFImportWizardAssistant = Procedura guidata importazione PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1809,7 +1809,7 @@ PDFImportDebugTextExtraction = Debug: tekst uit PDF extraheren
 
 PDFImportErrorParsingDocument = Fout bij lezen of converteren van PDF-document: {0} (Controleer foutenlogboek voor details)
 
-PDFImportFilterName = PDF-bestand (* .pdf)
+PDFImportFilterName = PDF-bestand (*.pdf;*.zip)
 
 PDFImportWizardAssistant = PDF-importwizard
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1809,7 +1809,7 @@ PDFImportDebugTextExtraction = Depurar: extrair texto do PDF
 
 PDFImportErrorParsingDocument = Erro ao ler ou converter documento PDF: {0} (verifique o log de erros para obter detalhes)
 
-PDFImportFilterName = Documento PDF (* .pdf)
+PDFImportFilterName = Documento PDF (*.pdf;*.zip)
 
 PDFImportWizardAssistant = Assistente de importa\u00E7\u00E3o de PDF
 


### PR DESCRIPTION
Hello everyone,
first of all I'd like to thank you for this great piece of software. I really enjoy using it. :)

One little thing however always bothered me: When downloadling multiple documents (orders, etc.) from my DKB-Broker webinterface they come as a zip file containing the pdfs; In order to import them, I first have to extract it to some folder and delete the folder afterwards.

I've implemented a small fix for this, in the simplest and stupidest way I could come up with: 
When a zip file is selected during import, its contents (at least the contents which names end with .pdf) are extracted to a newly created folder in system temp dir. After the import is done, the files and the folder are deleted.

Please share your comments on this. We can also have a discussion on the forum in German if you like :)