### PR TITLE
Fix the calculation for the heatmap widget for monthly investments

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -590,6 +590,7 @@ public class Messages extends NLS
     public static String LabelLinkToPortfolioReportNet;
     public static String LabelNamePlusCopy;
     public static String LabelNet;
+    public static String LabelNetInvest;
     public static String LabelNewClassification;
     public static String LabelNewFieldByType;
     public static String LabelNewTaxonomy;
@@ -661,7 +662,9 @@ public class Messages extends NLS
     public static String LabelGreenWhiteRed;
     public static String LabelGreenYellowRed;
     public static String LabelGross;
+    public static String LabelGrossInvest;
     public static String LabelGrossNetCalculation;
+    public static String LabelGrossNetInvestCalculation;
     public static String LabelHeading;
     public static String LabelHeatmap;
     public static String LabelHeatmapEarnings;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1162,7 +1162,11 @@ LabelGreenYellowRed = Green - Yellow - Red
 
 LabelGross = Gross
 
+LabelGrossInvest = Gross investment
+
 LabelGrossNetCalculation = Gross / Net
+
+LabelGrossNetInvestCalculation = Gross investment / Net investment
 
 LabelHeading = Heading
 
@@ -1257,6 +1261,8 @@ LabelMetricYearsFormatter = {0,number,0.#} years
 LabelNamePlusCopy = {0} (copy)
 
 LabelNet = Net
+
+LabelNetInvest = Net investment
 
 LabelNewClassification = New Classification
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1155,7 +1155,11 @@ LabelGreenYellowRed = Gr\u00FCn - Gelb - Rot
 
 LabelGross = Brutto
 
+LabelGrossInvest = Bruttoinvestition
+
 LabelGrossNetCalculation = Brutto / Netto
+
+LabelGrossNetInvestCalculation = Bruttoinvestition / Nettoinvestition
 
 LabelHeading = \u00DCberschrift
 
@@ -1250,6 +1254,8 @@ LabelMetricYearsFormatter = {0,number,0.#} Jahre
 LabelNamePlusCopy = {0} (Kopie)
 
 LabelNet = Netto
+
+LabelNetInvest = Nettoinvestition
 
 LabelNewClassification = Neue Kategorie
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1153,9 +1153,13 @@ LabelGreenWhiteRed = Verde - blanco - rojo
 
 LabelGreenYellowRed = Verde - amarillo - rojo
 
-LabelGross = Bruto
+LabelGross = Bruta
+
+LabelGrossInvest = Inversi\u00F3n bruta
 
 LabelGrossNetCalculation = Bruto / Neto
+
+LabelGrossNetInvestCalculation = Inversi\u00F3n bruta / Inversi\u00F3n neta
 
 LabelHeading = T\u00EDtulo
 
@@ -1244,6 +1248,8 @@ LabelMetricYearsFormatter = {0,number,0.#} a\u00F1os
 LabelNamePlusCopy = {0} (copia)
 
 LabelNet = Neto
+
+LabelNetInvest = Inversi\u00F3n neta
 
 LabelNewClassification = Nueva Clasificaci\u00F3n
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1153,13 +1153,13 @@ LabelGreenWhiteRed = Verde - blanco - rojo
 
 LabelGreenYellowRed = Verde - amarillo - rojo
 
-LabelGross = Bruta
+LabelGross = Bruto
 
-LabelGrossInvest = Inversi\u00F3n bruta
+LabelGrossInvest = Inversi\u00F3n bruto
 
 LabelGrossNetCalculation = Bruto / Neto
 
-LabelGrossNetInvestCalculation = Inversi\u00F3n bruta / Inversi\u00F3n neta
+LabelGrossNetInvestCalculation = Inversi\u00F3n bruto / Inversi\u00F3n neta
 
 LabelHeading = T\u00EDtulo
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1156,7 +1156,11 @@ LabelGreenYellowRed = Vert - Jaune - Rouge
 
 LabelGross = Brut
 
+LabelGrossInvest = Investissement brut
+
 LabelGrossNetCalculation = Brut / Net
+
+LabelGrossNetInvestCalculation = Investissement brut / Investissement net
 
 LabelHeading = Titre
 
@@ -1245,6 +1249,8 @@ LabelMetricYearsFormatter = {0,number,0.#} ann\u00E9es
 LabelNamePlusCopy = {0} (copier)
 
 LabelNet = Net
+
+LabelNetInvest = Investissement net
 
 LabelNewClassification = Nouvelle classification
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1155,7 +1155,11 @@ LabelGreenYellowRed = Verde - Giallo - Rosso
 
 LabelGross = Lordo
 
+LabelGrossInvest = Investimento lordo
+
 LabelGrossNetCalculation = Lordo / Netto
+
+LabelGrossNetInvestCalculation = Investimento lordo / Investimento netto
 
 LabelHeading = Intestazione
 
@@ -1250,6 +1254,8 @@ LabelMetricYearsFormatter = {0,number,0.#} anni
 LabelNamePlusCopy = {0} (copia)
 
 LabelNet = Netto
+
+LabelNetInvest = Investimento netto
 
 LabelNewClassification = Nuova Classificatione
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1155,7 +1155,11 @@ LabelGreenYellowRed = Groen - Geel - Rood
 
 LabelGross = Bruto
 
+LabelGrossInvest = Bruto-investering
+
 LabelGrossNetCalculation = Bruto / Netto
+
+LabelGrossNetInvestCalculation = Bruto-investering / Netto-investering
 
 LabelHeading = Koers
 
@@ -1244,6 +1248,8 @@ LabelMetricYearsFormatter = {0,number,0.#} jaar
 LabelNamePlusCopy = {0} (kopi\u00EBren)
 
 LabelNet = Netto
+
+LabelNetInvest = Netto-investering
 
 LabelNewClassification = Nieuwe classificatie
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1155,7 +1155,11 @@ LabelGreenYellowRed = Verde - Amarelo - Vermelho
 
 LabelGross = Bruto
 
+LabelGrossInvest = Investimento bruto
+
 LabelGrossNetCalculation = Bruto / L\u00EDquido
+
+LabelGrossNetInvestCalculation = Investimento bruto / Investimento l\u00EDquido
 
 LabelHeading = Cabe\u00E7alho
 
@@ -1244,6 +1248,8 @@ LabelMetricYearsFormatter = {0,number,0.#} anos
 LabelNamePlusCopy = {0} (c\u00F3pia)
 
 LabelNet = L\u00EDquido
+
+LabelNetInvest = Investimento l\u00EDquido
 
 LabelNewClassification = Nova classifica\u00E7\u00E3o
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/InvestmentHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/InvestmentHeatmapWidget.java
@@ -69,8 +69,13 @@ public class InvestmentHeatmapWidget extends AbstractHeatmapWidget<Long>
 
     enum GrossNetType
     {
-        NET(Messages.LabelNet, t -> t.getMonetaryAmount()), //
-        GROSS(Messages.LabelGross, t -> t.getGrossValue());
+        /***
+         * Net investment = gross investment minus costs
+         * Gross investment = total of all investments made
+         */
+        
+        NET(Messages.LabelNetInvest, t -> t.getMonetaryAmount()),
+        GROSS(Messages.LabelGrossInvest, t -> t.getGrossValue());
 
         private String label;
         private Function<PortfolioTransaction, Money> valueExtractor;
@@ -97,7 +102,7 @@ public class InvestmentHeatmapWidget extends AbstractHeatmapWidget<Long>
     {
         public GrossNetConfig(WidgetDelegate<?> delegate)
         {
-            super(delegate, Messages.LabelGrossNetCalculation, GrossNetType.class, Dashboard.Config.NET_GROSS,
+            super(delegate, Messages.LabelGrossNetInvestCalculation, GrossNetType.class, Dashboard.Config.NET_GROSS,
                             Policy.EXACTLY_ONE);
         }
     }


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/dashboard-widget-der-monatlichen-investments-brutto-netto-vertauscht/16343

Hallo @buchen
wir denken hier ist ein Fehler in der Berechnung für die monatliche Investment-Heatmap vorhanden.
_Bruttoinvestition = Gesamtheit aller getätigten Investitionen
Nettoinvestitionen = Bruttoinvestitionen minus Anschaffungskosten_

Es liegt vielleicht auch daran, dass das Widget Handelaktivität (Ordervolumen) zwar auch den Investitionsbetrag ausgibt, aber eben als Bruttoinvestitionbetrag.
Ich habe daher auch die Labels erweitert, da Brutto/Netto ungleich Bruttoinvestition/Nettoinvestitionen ist.
Vielleicht sollte man das Widget Handelsaktivität auch um diese Option erweitern... 
