### PR TITLE
Add a "latest trade" column to trades overview

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -200,7 +200,6 @@ public class Messages extends NLS
     public static String ColumnLabel;
     public static String ColumnLastDividendPayment;
     public static String ColumnLastDividendPayment_MenuLabel;
-    public static String ColumnLastTrade;
     public static String ColumnLatest;
     public static String ColumnLatestDate;
     public static String ColumnLatestHistoricalDate;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -436,8 +436,6 @@ ColumnLastDividendPayment = last payment
 
 ColumnLastDividendPayment_MenuLabel = Date of last dividend payment
 
-ColumnLastTrade = Last Trade
-
 ColumnLatest = Latest
 
 ColumnLatestDate = Latest (Date)
@@ -588,7 +586,7 @@ ColumnSharesOwned = Shares
 
 ColumnSource = Source
 
-ColumnStartDate = Start Date
+ColumnStartDate = Start date
 
 ColumnStatus = Status
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -353,7 +353,7 @@ ColumnEarnings = Ertr\u00E4ge
 
 ColumnEarnings_Description = Dividenden + Zinsen
 
-ColumnEndDate = Endedatum
+ColumnEndDate = Enddatum
 
 ColumnEntity = Objekt
 
@@ -428,8 +428,6 @@ ColumnLastDate = Letzte Ausf\u00FChrung
 ColumnLastDividendPayment = zuletzt am
 
 ColumnLastDividendPayment_MenuLabel = Datum letzter Dividendenzahlung
-
-ColumnLastTrade = Letzter Handel
 
 ColumnLatest = Letzter
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -429,8 +429,6 @@ ColumnLastDividendPayment = \u00DAltimo pago
 
 ColumnLastDividendPayment_MenuLabel = Fecha del \u00FAltimo pago de dividendos
 
-ColumnLastTrade = Operacion anterior
-
 ColumnLatest = \u00DAltimo
 
 ColumnLatestDate = \u00DAltima (Fecha)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -430,8 +430,6 @@ ColumnLastDividendPayment = Dernier dividende
 
 ColumnLastDividendPayment_MenuLabel = Date du dernier dividende per\u00E7u
 
-ColumnLastTrade = Dernier ordre
-
 ColumnLatest = Derni\u00E8re
 
 ColumnLatestDate = Derni\u00E8re (Date)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -429,8 +429,6 @@ ColumnLastDividendPayment = ultimo pagamento
 
 ColumnLastDividendPayment_MenuLabel = Data ultimo pagamento dividendo
 
-ColumnLastTrade = Ultimo scambio
-
 ColumnLatest = Ultima
 
 ColumnLatestDate = Ultima (Data)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -429,8 +429,6 @@ ColumnLastDividendPayment = laatste betaling
 
 ColumnLastDividendPayment_MenuLabel = Datum van laatste dividendbetaling
 
-ColumnLastTrade = Laatste transactie
-
 ColumnLatest = Nieuwste
 
 ColumnLatestDate = Nieuwste (datum)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -429,8 +429,6 @@ ColumnLastDividendPayment = \u00FAltimo pagamento
 
 ColumnLastDividendPayment_MenuLabel = Data do \u00FAltimo pagamento de dividendos
 
-ColumnLastTrade = \u00DAltima transa\u00E7\u00E3o
-
 ColumnLatest = Mais recente
 
 ColumnLatestDate = Mais recente (data)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -182,7 +182,7 @@ public class TradesTableViewer
                         new MoneyColorLabelProvider(element -> ((Trade) element).getProfitLoss(), view.getClient()));
         column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getProfitLoss()));
         support.addColumn(column);
-        
+
         column = new Column("gpl", Messages.ColumnGrossProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setLabelProvider(
                         new MoneyColorLabelProvider(element -> ((Trade) element).getGrossProfitLoss(), view.getClient()));
@@ -200,6 +200,19 @@ public class TradesTableViewer
             }
         });
         column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getHoldingPeriod()));
+        support.addColumn(column);
+
+        column = new Column("latesttrade", Messages.ColumnLatestTrade, SWT.None, 80); //$NON-NLS-1$
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                Trade t = (Trade) e;
+                return Values.DateTime.format(t.getLastTransaction().getTransaction().getDateTime());
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getLastTransaction().getTransaction().getDateTime()));
         support.addColumn(column);
 
         column = new Column("irr", Messages.ColumnIRR, SWT.RIGHT, 80); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,8 +102,7 @@ public class Trade implements Adaptable
 
         // let's sort again because the list might not be sorted anymore due to
         // transfers
-        Collections.sort(transactions,
-                        (p1, p2) -> p1.getTransaction().getDateTime().compareTo(p2.getTransaction().getDateTime()));
+        Collections.sort(transactions, Comparator.comparing(p -> p.getTransaction().getDateTime()));
 
         // re-set start date from first entry after sorting
         this.setStart(transactions.get(0).getTransaction().getDateTime());
@@ -174,6 +174,13 @@ public class Trade implements Adaptable
     public List<TransactionPair<PortfolioTransaction>> getTransactions()
     {
         return transactions;
+    }
+
+
+    public TransactionPair<PortfolioTransaction> getLastTransaction()
+    {
+        // transactions have been sorted by calculate(), which is called once after creation
+        return transactions.get(transactions.size() - 1);
     }
 
     public Money getEntryValue()


### PR DESCRIPTION
Fixes #2260. For tax purposes, it may be helpful to know the
date of the most recent transaction in an open trade. With this
change, the information is more readily available (and sortable).