### PR TITLE
ISSUE-CHECK PDF-Importerroutine

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -635,6 +635,97 @@ public class DABPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf7()
+    {
+        DABPDFExtractor extractor = new DABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DABVerkauf7.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = getSecurity(results);
+        assertThat(security.getIsin(), is("NL0015436031"));
+        assertThat(security.getName(), is("CureVac N.V. Namensaktien   o.N."));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-05-31T08:50")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(300)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(26252.00))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(26253.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
+
+        // check tax-refund transaction
+        item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
+        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-05-31T00:00")));
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(551.08))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf8()
+    {
+        DABPDFExtractor extractor = new DABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DABVerkauf8.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = getSecurity(results);
+        assertThat(security.getIsin(), is("NL0015436031"));
+        assertThat(security.getName(), is("CureVac N.V. Namensaktien   o.N."));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.isPresent(), is(true));
+        assertThat(item.get().getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.get().getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-05-26T09:01")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(300)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(27911.45))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(28293.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(335.29 + 18.44 + 26.82))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
+    }
+
+    @Test
     public void testMultipleWertpapierKaufVerkauf1()
     {
         DABPDFExtractor extractor = new DABPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf7.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf7.txt
@@ -1,0 +1,75 @@
+﻿PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=987656432
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Verkauf  ADRESSZEILE2=Karl Ascheimer
+Kommissionsgeschäft ADRESSZEILE3=Teststr. 10
+ADRESSZEILE4=55555 Teststadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+987656432 12106108 / 31.05.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=2502
+Karl Ascheimer SEITENNUMMER=1
+Teststr. 10 STEUERERSTATTUNG=N
+55555 Teststadt Depotinhaber
+Karl Ascheimer
+München, 31.05.2021
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+CureVac N.V. Namensaktien   o.N. NL0015436031
+Nominal Kurs
+STK 300,000 EUR 87,5100
+Handelstag 31.05.2021 Kurswert EUR 26.253,00 
+Handelszeit 08:50* Provision EUR 1,00-
+Börse Sekunden-Handel Aktien L&S
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+02.06.2021 987656432 EUR 26.252,00
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsverlust Aktien EUR 1.981,00
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern (negativ) EUR 1.981,00
+Steuerausgleich nach § 43a EStG:
+Kapitalertragsteuer EUR 485,54
+Solidaritätszuschlag EUR 26,70
+Kirchensteuer EUR 38,84
+Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
+31.05.2021 987656432 31148108 EUR 551,08
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 14.628,43
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 804,56
+im laufenden Jahr einbehaltene Kirchensteuer EUR 1.170,27
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002502/310521/111150
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+987656432 12106108 2 DEPOTNUMMER=987656432
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Karl Ascheimer
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem ADRESSZEILE3=Teststr. 10
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 777/333/12345. ADRESSZEILE4=55555 Teststadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+Wir werden in Ihrem Depot wie angegeben buchen. BELEGNUMMER=2502
+SEITENNUMMER=2
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland STEUERERSTATTUNG=N
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002502/310521/111150

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf8.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf8.txt
@@ -1,0 +1,72 @@
+﻿PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=987656432
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Verkauf  ADRESSZEILE2=Karl Ascheimer
+Kommissionsgeschäft ADRESSZEILE3=Teststr. 10
+ADRESSZEILE4=55555 Teststadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+987656432 43214321 / 26.05.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=2435
+Karl Ascheimer SEITENNUMMER=1
+Teststr. 10 STEUERERSTATTUNG=N
+55555 Teststadt Depotinhaber
+Karl Ascheimer
+München, 26.05.2021
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+CureVac N.V. Namensaktien   o.N. NL0015436031
+Nominal Kurs
+STK 300,000 EUR 94,3100
+Handelstag 26.05.2021 Kurswert EUR 28.293,00 
+Handelszeit 09:01* Provision EUR 1,00-
+Börse Sekunden-Handel Aktien L&S Kapitalertragsteuer EUR 335,29-
+Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 18,44-
+Kirchensteuer EUR 26,82-
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+28.05.2021 987656432 EUR 27.911,45
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Aktien EUR 1.368,00
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 1.368,00
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 15.128,67
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 832,07
+im laufenden Jahr einbehaltene Kirchensteuer EUR 1.210,29
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 777/333/12345.
+Wir werden in Ihrem Depot wie angegeben buchen.
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002435/260521/110553
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+987656432 43214321 2 DEPOTNUMMER=987656432
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Karl Ascheimer
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland ADRESSZEILE3=Teststr. 10
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit). ADRESSZEILE4=55555 Teststadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=2435
+SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002435/260521/110553

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf9.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABVerkauf9.txt
@@ -1,0 +1,144 @@
+﻿PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=987656432
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Verkauf  ADRESSZEILE2=Karl Ascheimer
+Kommissionsgeschäft ADRESSZEILE3=Teststr. 10
+ADRESSZEILE4=55555 Teststadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+987656432 12106108 / 31.05.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=2502
+Karl Ascheimer SEITENNUMMER=1
+Teststr. 10 STEUERERSTATTUNG=N
+55555 Teststadt Depotinhaber
+Karl Ascheimer
+München, 31.05.2021
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+CureVac N.V. Namensaktien   o.N. NL0015436031
+Nominal Kurs
+STK 300,000 EUR 87,5100
+Handelstag 31.05.2021 Kurswert EUR 26.253,00 
+Handelszeit 08:50* Provision EUR 1,00-
+Börse Sekunden-Handel Aktien L&S
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+02.06.2021 987656432 EUR 26.252,00
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsverlust Aktien EUR 1.981,00
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern (negativ) EUR 1.981,00
+Steuerausgleich nach § 43a EStG:
+Kapitalertragsteuer EUR 485,54
+Solidaritätszuschlag EUR 26,70
+Kirchensteuer EUR 38,84
+Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
+31.05.2021 987656432 31148108 EUR 551,08
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 14.628,43
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 804,56
+im laufenden Jahr einbehaltene Kirchensteuer EUR 1.170,27
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002502/310521/111150
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+987656432 12106108 2 DEPOTNUMMER=987656432
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Karl Ascheimer
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem ADRESSZEILE3=Teststr. 10
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 777/333/12345. ADRESSZEILE4=55555 Teststadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+Wir werden in Ihrem Depot wie angegeben buchen. BELEGNUMMER=2502
+SEITENNUMMER=2
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland STEUERERSTATTUNG=N
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002502/310521/111150
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=987656432
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Verkauf  ADRESSZEILE2=Karl Ascheimer
+Kommissionsgeschäft ADRESSZEILE3=Teststr. 10
+ADRESSZEILE4=55555 Teststadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+987656432 43214321 / 26.05.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=2435
+Karl Ascheimer SEITENNUMMER=1
+Teststr. 10 STEUERERSTATTUNG=N
+55555 Teststadt Depotinhaber
+Karl Ascheimer
+München, 26.05.2021
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+CureVac N.V. Namensaktien   o.N. NL0015436031
+Nominal Kurs
+STK 300,000 EUR 94,3100
+Handelstag 26.05.2021 Kurswert EUR 28.293,00 
+Handelszeit 09:01* Provision EUR 1,00-
+Börse Sekunden-Handel Aktien L&S Kapitalertragsteuer EUR 335,29-
+Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 18,44-
+Kirchensteuer EUR 26,82-
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+28.05.2021 987656432 EUR 27.911,45
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Aktien EUR 1.368,00
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 1.368,00
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 15.128,67
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 832,07
+im laufenden Jahr einbehaltene Kirchensteuer EUR 1.210,29
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 777/333/12345.
+Wir werden in Ihrem Depot wie angegeben buchen.
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002435/260521/110553
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+987656432 43214321 2 DEPOTNUMMER=987656432
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Karl Ascheimer
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland ADRESSZEILE3=Teststr. 10
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit). ADRESSZEILE4=55555 Teststadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=2435
+SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDVFDI/POC1618/002435/260521/110553


### PR DESCRIPTION
Hallo @buchen 
ich habe hier ein PDF-Importer Problem, was du dir bitte mal anschauen könntest.
https://forum.portfolio-performance.info/t/pdf-import-smartbroker-dab-bank/7684/131

**Buchung als komplettes PDF (Fehlerfall):**
Das Dokument wird von der Bank als _"Ein"-PDF-Dokument_ geliefert.
[Buchung1 + Buchung2.pdf](https://github.com/buchen/portfolio/files/6710347/Buchung1.%2B.Buchung2.pdf)
![grafik](https://user-images.githubusercontent.com/45203494/123289408-beaaf500-d510-11eb-9c1d-fd8c829532cb.png)

---

**Buchung mit gesplitteten PDF (Buchung 1 und Buchung 2)**
Das Dokument wurde manuell gesplittet in zwei PDF-Dokumente.
[Buchung1.pdf](https://github.com/buchen/portfolio/files/6710352/Buchung1.pdf)
[Buchung2.pdf](https://github.com/buchen/portfolio/files/6710353/Buchung2.pdf)
![grafik](https://user-images.githubusercontent.com/45203494/123289321-a89d3480-d510-11eb-8985-a38d8a5f8b19.png)

Ich habe die Befürchtung, dass dies ebenfalls bei den Buchungen _Gebühr + Gebührenerstattung_, sowie _Zins + Zinsbelastung_ passieren kann.

Leider habe ich bisher nur diese PDF's als fehlerfall zur Verfügung.

Ich finde dafür keine Lösung und dieser Pull-Request ist zur Prüfung der gesplitteten Dokumente.
Ein TestCase des "kompleten" PDF's liefer immer den Fehlerfall...

Ich vermute, dass der Fehler im PDFParser.java im Block liegt.
https://github.com/buchen/portfolio/blob/08ecd0160d70edaf05a6fb1d373066bbf0c65bb3/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java#L118


Gruß
Alex