### PR TITLE
Bugfix data quality pane

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -69,7 +69,8 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
         Composite table = createTable(container);
 
         FormDataFactory.startingWith(completeness, lCompleteness).right(new FormAttachment(100))
-                        .thenBelow(checkInterval).left(new FormAttachment(0)).thenBelow(table)
+                        .thenBelow(checkInterval).left(new FormAttachment(0)).right(new FormAttachment(100))
+                        .thenBelow(table)
                         .bottom(new FormAttachment(100));
 
         return container;


### PR DESCRIPTION
Bug: If data quality pane was opened without a select security and then a security was selected, the check interval was not visible.

This seems to fix it, but I have to admit I don’t understand fully what is going on.