### PR TITLE
2 more trade calendars

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/Messages.java
@@ -163,6 +163,8 @@ public class Messages extends NLS
     public static String LabelTradeCalendarNYSE;
     public static String LabelTradeCalendarSix;
     public static String LabelTradeCalendarTSX;
+    public static String LabelTradeCalendarTARGET2;
+    public static String LabelTradeCalendarFirstOfTheMonth;
     public static String LabelTradeCalendarUseDefault;
     public static String LabelTradeCalendarVSE;
     public static String LabelTradeCalendarEmpty;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages.properties
@@ -330,6 +330,10 @@ LabelTradeCalendarSix = Swiss Exchange (SIX)
 
 LabelTradeCalendarTSX = Toronto Stock Exchange
 
+LabelTradeCalendarTARGET2 = TARGET2 (Eurozone banking day)
+
+LabelTradeCalendarFirstOfTheMonth = First of the month
+
 LabelTradeCalendarUseDefault = (Use globally configured calendar: {0})
 
 LabelTradeCalendarVSE = Vienna Stock Exchange

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_de.properties
@@ -330,6 +330,10 @@ LabelTradeCalendarSix = Schweizer B\u00F6rse (SIX)
 
 LabelTradeCalendarTSX = Torontoer B\u00F6rse
 
+LabelTradeCalendarTARGET2 = TARGET2 (Bankarbeitstag in der Eurozone)
+
+LabelTradeCalendarFirstOfTheMonth = Monatserste
+
 LabelTradeCalendarUseDefault = (Global konfigurierten Kalendar nutzen: {0})
 
 LabelTradeCalendarVSE = Wiener B\u00F6rse

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -44,7 +44,10 @@ import static name.abuchen.portfolio.util.HolidayType.weekday;
 
 import java.text.MessageFormat;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.Month;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -196,6 +199,40 @@ public class TradeCalendarManager
         tc.add(weekday(THANKSGIVING, 2, DayOfWeek.MONDAY, Month.OCTOBER));
         tc.add(fixed(CHRISTMAS, Month.DECEMBER, 25).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(fixed(BOXING_DAY, Month.DECEMBER, 26).moveIf(DayOfWeek.MONDAY, 1).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 2));
+        CACHE.put(tc.getCode(), tc);
+
+        // TARGET2 (banking day in euro zone)
+        // see https://www.ecb.europa.eu/press/pr/date/2000/html/pr001214_4.en.html
+        tc = new TradeCalendar("TARGET2", Messages.LabelTradeCalendarTARGET2); //$NON-NLS-1$
+        tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
+        tc.add(easter(GOOD_FRIDAY, -2));
+        tc.add(easter(EASTER_MONDAY, 1));
+        tc.add(fixed(LABOUR_DAY, Month.MAY, 1));
+        tc.add(fixed(FIRST_CHRISTMAS_DAY, Month.DECEMBER, 25));
+        tc.add(fixed(SECOND_CHRISTMAS_DAY, Month.DECEMBER, 26));
+        CACHE.put(tc.getCode(), tc);
+        
+        tc = new TradeCalendar("first-of-the-month",  Messages.LabelTradeCalendarFirstOfTheMonth) //$NON-NLS-1$
+        {
+            @Override
+            /* package */ void add(HolidayType type)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isHoliday(LocalDate date)
+            {
+                return date.getDayOfMonth() != 1;
+            }
+
+            @Override
+            public Collection<Holiday> getHolidays(int year)
+            {
+                // Only used for GUI
+                return Collections.emptySet();
+            }
+        };
         CACHE.put(tc.getCode(), tc);
 
         tc = new TradeCalendar(TradeCalendar.EMPTY_CODE, Messages.LabelTradeCalendarEmpty);


### PR DESCRIPTION
This adds trade calendars for TARGET2 and the first of each month.

The TARGET2 calendar is necessary for the EONIA Index (and maybe other money market products).
The first of the month calendar is useful for monthly data, e.g. the HCPI indices.