### PR TITLE
Fix DAB PDF-Importer account statements, add new buy and dividende format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABDividend10.txt
@@ -1,0 +1,74 @@
+﻿PDF Autor: 'DAB-BNP-Paribas'
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=5123456789
+Erträgnisgutschrift aus Wertpapieren DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Vorname Name
+Ausschüttung für ADRESSZEILE3=Strasse-Str. 19
+01.12.2020 - 30.11.2021 ADRESSZEILE4=12345 Stadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+5123456789 81234456789 / 01.07.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=25427
+Vorname Name SEITENNUMMER=1
+Strasse-Str. 19 STEUERERSTATTUNG=N
+12345 Stadt Depotinhaber
+Vorname Name
+München, 01.07.2021
+Erträgnisgutschrift
+Gattungsbezeichnung ISIN
+iShs V-MSCI W.C.St.Sec.U.ETF Reg. Shs USD Dis. oN IE00BJ5JP329
+Nominal Ex-Tag Zahltag Ausschüttungsbetrag pro Stück
+STK 315,000 17.06.2021 30.06.2021 USD 0,079700
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+30.06.2021 5325658010 USD 20,49
+Ertrag für 2020/21 USD 25,11
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Steuerpflichtiger Ausschüttungsbetrag EUR 14,75
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 14,75
+einbehaltene Kapitalertragsteuer EUR 3,68
+einbehaltener Solidaritätszuschlag EUR 0,20
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 2,34
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 1,23
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 047/220/12345.
+Steuerlicher Stichtag: 30.06.2021
+Devisenkurs: EUR/USD 1,1914
+Fondsart: Aktienfonds (§ 2 Abs. 6 InvStG)
+Angewendete Teilfreistellungsquote: 30%
+Im Steuerabzugsverfahren werden generell - auch bei betrieblichen Anlegern - die Teilfreistellungsquoten (TFQ) für
+Privatanleger herangezogen.
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.17/ABREEREIERTR/GDBERTRG/025427/010721/230015
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+5123456789 81234456789 2 DEPOTNUMMER=5123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Vorname Name
+Verwahrart: Wertpapierrechnung Lagerland: Irland ADRESSZEILE3=Strasse-Str. 19
+ADRESSZEILE4=12345 Stadt
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=25427
+SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.17/ABREEREIERTR/GDBERTRG/025427/010721/230015

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABKauf9.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABKauf9.txt
@@ -1,0 +1,75 @@
+PDF author: 'DAB-BNP-Paribas'
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=5113659006
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Kauf Limitauftrag ADRESSZEILE2=Max Mustermann
+Kommissionsgeschäft ADRESSZEILE3=Musterstraße 123
+ADRESSZEILE4=12345 Musterstadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+123456789 123456 / 18.06.2021 ADRESSZEILE6=
+Herr BELEGNUMMER=1711
+Max Mustermann SEITENNUMMER=1
+Musterstraße 123 STEUERERSTATTUNG=N
+12345 Musterstadt Depotinhaber
+Max Mustermann
+München, 18.06.2021
+Wir haben für Sie gekauft
+Gattungsbezeichnung Fälligkeit näch. Zinstermin ISIN
+4,75% Ranft Invest GmbH Inh.-Schv. 01.07.2030 01.07.2021 DE000A2LQLH9
+v.2018(2030)
+Nominal Kurs
+EUR 1.000,000 100,0000 %
+Handelstag 18.06.2021 Kurswert EUR 1.000,00-
+Handelszeit 08:56* Stückzinsen EUR 22,56-
+Zinstage 171 Provision EUR 4,00-
+Börse Frankfurt/EDF Handelsplatzentgelt EUR 2,24-
+Verwahrart Girosammelverwahrung Variabl. Transaktionsentgelt EUR 0,75-
+Wert Konto-Nr. Betrag zu Ihren Lasten
+22.06.2021 5113659006 EUR 1.029,55
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Stückzinsaufwand EUR 22,56
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern (negativ) EUR 22,56
+Steuerausgleich nach § 43a EStG:
+Kapitalertragsteuer EUR 5,64
+Solidaritätszuschlag EUR 0,31
+Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
+18.06.2021 5113659006 32347039 EUR 5,95
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 9,55
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,52
+Es folgt Seite 2
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDKFDI/POC1618/001711/180621/110709
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. EMAILVERSAND=N
+5113659006 23028939 2 DEPOTNUMMER=123456789123
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Max Mustermann
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem ADRESSZEILE3=Prenzlauer Allee 216
+Finanzamt Frankfurt/M. V-Höchst, Steuernummer 047/220/15370. ADRESSZEILE4=10405 Berlin
+ADRESSZEILE5=
+ADRESSZEILE6=
+Wir werden in Ihrem Depot wie angegeben buchen. BELEGNUMMER=1711
+SEITENNUMMER=2
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland STEUERERSTATTUNG=N
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+3.19/ABREABHNHANDKFDI/POC1618/001711/180621/110709

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -377,7 +377,7 @@ public class DABPDFExtractorTest
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-06-18T08:56")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10)));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1029.55))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -1636,7 +1636,7 @@ public class DABPDFExtractorTest
         t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).collect(Collectors.toList())
                         .get(1).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(300))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2019-07-15T00:00")));
 
@@ -1660,7 +1660,7 @@ public class DABPDFExtractorTest
         t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).collect(Collectors.toList())
                         .get(4).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(300.00))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2019-08-13T00:00")));
 
@@ -1668,7 +1668,7 @@ public class DABPDFExtractorTest
         t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).collect(Collectors.toList())
                         .get(5).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(300.00))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2019-09-13T00:00")));
     }
@@ -1694,7 +1694,7 @@ public class DABPDFExtractorTest
         AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
                         .collect(Collectors.toList()).get(0).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-01-13T00:00")));
 
@@ -1702,7 +1702,7 @@ public class DABPDFExtractorTest
         t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).collect(Collectors.toList())
                         .get(1).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-02-18T00:00")));
 
@@ -1710,7 +1710,7 @@ public class DABPDFExtractorTest
         t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).collect(Collectors.toList())
                         .get(2).getSubject();
 
-        assertThat(t.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(t.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-03-15T00:00")));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -199,7 +199,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("(Dividende|Ertr.gnisgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Erträgnisgutschrift (?!aus)).*$");
+        Block block = new Block("^(Dividendengutschrift|Ertr.gnisgutschrift(?! aus))(.*)?$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -109,7 +109,10 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     if (!v.get("name1").startsWith("Nominal"))
                         v.put("name", v.get("name") + " " + v.get("name1"));
 
-                    t.setShares(asShares(v.get("shares")));
+                    /***
+                     * Workaround for bonds 
+                     */
+                    t.setShares((asShares(v.get("shares")) / 100));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -569,7 +572,10 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     if (!v.get("name1").startsWith("Nominal"))
                         v.put("name", v.get("name") + " " + v.get("name1"));
 
-                    t.setShares(asShares(v.get("shares")));
+                    /***
+                     * Workaround for bonds 
+                     */
+                    t.setShares((asShares(v.get("shares")) / 100));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -599,15 +599,24 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                             return transaction;
                         })
 
-                        // Is type --> "SEPA-Lastschrift" change from DEPOSIT to REMOVAL
-                        .section("type").optional()
-                        .match("^(?<type>SEPA-Gutschrift|SEPA-Lastschrift) [^Lastschrift].*$")
-                        .assign((t, v) -> {
-                            if (v.get("type").equals("SEPA-Lastschrift"))
-                            {
-                                t.setType(AccountTransaction.Type.REMOVAL);
-                            }
-                        })
+                        /***
+                         * A regular "SEPA-Lastschrift" is a deposit (delivery inbound) 
+                         * form a account to the reference account. (automatic savings plan)
+                         */
+
+                        // Is type --> "SEPA-XXXX" change from DEPOSIT to REMOVAL
+                        // 
+                        // At this time, we don't know the correct regEX for
+                        // a removal transaction.
+                        // 
+                        // .section("type").optional()
+                        // .match("^(?<type>SEPA-XXXX) .*$")
+                        // .assign((t, v) -> {
+                        //    if (v.get("type").equals("SEPA-XXXX"))
+                        //    {
+                        //       t.setType(AccountTransaction.Type.REMOVAL);
+                        //    }
+                        // })
 
                         // SEPA-Lastschrift Max Mustermann 15.07.19 300,00
                         // SEPA-Gutschrift Max Mustermann 05.07.19 15.000,00
@@ -644,7 +653,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(SEPA-Lastschrift Lastschrift Managementgeb.hr) .*$");
+        Block block = new Block("^SEPA-Lastschrift Lastschrift Managementgeb.hr .*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -74,6 +74,12 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }
+
+                    /***
+                     * If we have multiple entries in the document,
+                     * with taxes and tax refunds,
+                     * then the "negative" flag must be removed.
+                     */
                     type.getCurrentContext().remove("negative");
                 })
 
@@ -177,7 +183,14 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.DIVIDENDS);
+
+            /***
+             * If we have multiple entries in the document,
+             * with taxes and tax refunds,
+             * then the "negative" flag must be removed.
+             */
             type.getCurrentContext().remove("negative");
+
             return entry;
         });
 
@@ -413,7 +426,14 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             PortfolioTransaction entry = new PortfolioTransaction();
             entry.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
+
+            /***
+             * If we have multiple entries in the document,
+             * with taxes and tax refunds,
+             * then the "negative" flag must be removed.
+             */
             type.getCurrentContext().remove("negative");
+
             return entry;
         });
 
@@ -683,7 +703,10 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
-        // if we have a tax return, we set a flag and don't book tax below
+        /***
+         * if we have a tax refunds,
+         * we set a flag and don't book tax below
+         */
         transaction
                 .section("n").optional()
                 .match("zu versteuern \\(negativ\\) (?<n>.*)")


### PR DESCRIPTION
A regular "SEPA-Lastschrift" is a deposit (delivery inbound) 
form a account to the reference account. (automatic savings plan)

At this time... we dont know the regEx for an removal transaction,
so i deactivate the regEx switch.

Thanks to @felschr for the smart conference 
and for explaining the problem.

Edit:
Add some small descriptions for reset the "negative" flags

Edit:
Add new buy format

Edit
Add new dividende format