### PR TITLE
Optional linear interpolation of security quotes

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityPriceLookupTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityPriceLookupTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.time.LocalDate;
 
 import name.abuchen.portfolio.SecurityBuilder;
+import name.abuchen.portfolio.model.SecurityPriceInterpolator.LinearSecurityPriceInterpolator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class SecurityPriceLookupTest
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-06")).getValue(), is(5L));
     }
 
+
     @Test
     public void testLookupIfHistoricQuotesContainGaps()
     {
@@ -47,6 +49,19 @@ public class SecurityPriceLookupTest
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-10-31")).getValue(), is(1L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-01")).getValue(), is(1L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-02")).getValue(), is(1L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-03")).getValue(), is(3L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-04")).getValue(), is(3L));
+    }
+
+    @Test
+    public void testLookupIfHistoricQuotesContainGapsLinearInterpolation()
+    {
+        security.setSecurityPriceInterpolator(LinearSecurityPriceInterpolator.getInstance());
+        security.removePrice(security.getSecurityPrice(LocalDate.parse("2014-11-02")));
+
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-10-31")).getValue(), is(1L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-01")).getValue(), is(1L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-02")).getValue(), is(2L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-03")).getValue(), is(3L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-04")).getValue(), is(3L));
     }
@@ -81,6 +96,19 @@ public class SecurityPriceLookupTest
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-02")).getValue(), is(2L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-03")).getValue(), is(3L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-04")).getValue(), is(3L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-05")).getValue(), is(10L));
+    }
+
+    @Test
+    public void preferHistoricOverLatestIfLatestIsTooOldDespiteGapsLinearInterpolation()
+    {
+        security.setSecurityPriceInterpolator(LinearSecurityPriceInterpolator.getInstance());
+        security.addPrice(new SecurityPrice(LocalDate.parse("2014-11-05"), 10));
+        security.setLatest(new LatestSecurityPrice(LocalDate.parse("2014-11-03"), 5));
+
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-02")).getValue(), is(2L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-03")).getValue(), is(3L));
+        assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-04")).getValue(), is(7L));
         assertThat(security.getSecurityPrice(LocalDate.parse("2014-11-05")).getValue(), is(10L));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -51,7 +51,7 @@ public class SecurityTest
                 skipped++;
         }
 
-        assertThat(skipped, equalTo(12));
+        assertThat(skipped, equalTo(13));
 
         Security target = source.deepCopy();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -678,6 +678,9 @@ public class Messages extends NLS
     public static String LabelJSONPathToLow;
     public static String LabelJSONPathToHigh;
     public static String LabelJSONPathToVolume;
+    public static String LabelInterpolationMethode;
+    public static String LabelInterpolationMethodeTakeLast;
+    public static String LabelInterpolationMethodeLinear;
     public static String LabelKeyIndicators;
     public static String LabelMaxDrawdown;
     public static String LabelMaxDrawdownDuration;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1216,6 +1216,12 @@ LabelJSONPathToLow = Path to Day's Low
 
 LabelJSONPathToVolume = Path to Volume
 
+LabelInterpolationMethode = Interpolation method (for holidays, weekends, etc):
+
+LabelInterpolationMethodeTakeLast = Take last quote
+
+LabelInterpolationMethodeLinear = Linear interpolation
+
 LabelKeyIndicators = Key Indicators
 
 LabelLanguage = Language

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1207,7 +1207,13 @@ LabelJSONPathToHigh = Pfad zu Tageshoch
 
 LabelJSONPathToLow = Pfad zu Tagestief
 
-LabelJSONPathToVolume = Pfad zu Volumen  
+LabelJSONPathToVolume = Pfad zu Volumen
+
+LabelInterpolationMethode = Interpolationsmethode (für Feiertage, Wochenende, etc):
+
+LabelInterpolationMethodeTakeLast = Letzten Preis nehmen
+
+LabelInterpolationMethodeLinear = Lineare Interpolation
 
 LabelKeyIndicators = Kennzahlen
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AbstractQuoteProviderPage.java
@@ -359,6 +359,23 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         data.bottom = new FormAttachment(grpQuoteFeed, -10, SWT.BOTTOM);
         buttonArea.setLayoutData(data);
 
+        int sizeBelow = getSizeAdditionalContentBelow();
+        Composite belowArea = null;
+        if(sizeBelow > 0)
+        {
+            belowArea = new Composite(container, SWT.NONE);
+            belowArea.setLayout(new RowLayout(SWT.VERTICAL));
+            
+            data = new FormData();
+            data.top = new FormAttachment(100, -sizeBelow - 10);
+            data.left = new FormAttachment(0, 10);
+            data.right = new FormAttachment(100, -10);
+            data.bottom = new FormAttachment(100, -10);
+            belowArea.setLayoutData(data);
+            
+            createAdditionalContentBelow(belowArea);
+        }
+
         Composite sampleArea = new Composite(container, SWT.NONE);
         sampleArea.setLayout(new FillLayout());
         createSampleArea(sampleArea);
@@ -367,7 +384,10 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
         data.top = new FormAttachment(grpQuoteFeed, 5);
         data.left = new FormAttachment(0, 10);
         data.right = new FormAttachment(100, -10);
-        data.bottom = new FormAttachment(100, -10);
+        if(sizeBelow > 0)
+            data.bottom = new FormAttachment(belowArea, -10);
+        else 
+            data.bottom = new FormAttachment(100, -10);
         sampleArea.setLayoutData(data);
 
         setupInitialData();
@@ -376,6 +396,15 @@ public abstract class AbstractQuoteProviderPage extends AbstractPage
     }
 
     protected void createAdditionalButtons(Composite container)
+    {
+    }
+
+    protected int getSizeAdditionalContentBelow()
+    {
+        return 0;
+    }
+
+    protected void createAdditionalContentBelow(Composite container)
     {
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityModel.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Classification.Assignment;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPriceInterpolator;
 import name.abuchen.portfolio.model.SecurityProperty;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.model.Taxonomy.Visitor;
@@ -187,6 +188,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
     private String latestFeed;
     private String latestFeedURL;
     private boolean isRetired;
+    private SecurityPriceInterpolator interpolator;
 
     /**
      * Used to pipe the status of a manually validated quote provider into the
@@ -220,6 +222,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
         this.latestFeed = security.getLatestFeed();
         this.latestFeedURL = security.getLatestFeedURL();
         this.isRetired = security.isRetired();
+        this.interpolator = security.getSecurityPriceInterpolator();
 
         for (Taxonomy taxonomy : client.getTaxonomies())
             this.taxonomies.add(new TaxonomyDesignation(taxonomy, security));
@@ -378,6 +381,16 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
         firePropertyChange("retired", this.isRetired, this.isRetired = isRetired); //$NON-NLS-1$ //NOSONAR
     }
 
+    public SecurityPriceInterpolator getSecurityPriceInterpolator()
+    {
+        return interpolator;
+    }
+
+    public void setSecurityPriceInterpolator(SecurityPriceInterpolator interpolator)
+    {
+        this.interpolator = interpolator;
+    }
+
     public String getStatusHistoricalQuotesProvider()
     {
         return statusHistoricalQuotesProvider;
@@ -457,6 +470,7 @@ import name.abuchen.portfolio.ui.util.BindingHelper;
         security.setLatestFeed(latestFeed);
         security.setLatestFeedURL(latestFeedURL);
         security.setRetired(isRetired);
+        security.setSecurityPriceInterpolator(interpolator);
 
         Attributes a = new Attributes();
         for (AttributeDesignation attribute : attributes)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/HistoricalQuoteProviderPage.java
@@ -16,13 +16,18 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
 
 import name.abuchen.portfolio.model.Exchange;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPriceInterpolator.LinearSecurityPriceInterpolator;
+import name.abuchen.portfolio.model.SecurityPriceInterpolator.TakeLastSecurityPriceInterpolator;
 import name.abuchen.portfolio.model.SecurityProperty;
 import name.abuchen.portfolio.online.Factory;
 import name.abuchen.portfolio.online.QuoteFeed;
@@ -178,6 +183,56 @@ public class HistoricalQuoteProviderPage extends AbstractQuoteProviderPage
         composite.setLayout(layout);
 
         tableSampleData = new QuotesTableViewer(composite);
+    }
+
+    @Override
+    protected int getSizeAdditionalContentBelow()
+    {
+        return 56;
+    }
+    
+    @Override
+    protected void createAdditionalContentBelow(Composite container)
+    {
+        Label interpolationMethode = new Label(container, SWT.NONE);
+        interpolationMethode.setText(Messages.LabelInterpolationMethode);
+
+        Button takeLast = new Button(container, SWT.RADIO);
+        takeLast.setText(Messages.LabelInterpolationMethodeTakeLast);
+        Button linear = new Button(container, SWT.RADIO);
+        linear.setText(Messages.LabelInterpolationMethodeLinear);
+        
+        if(getModel().getSecurityPriceInterpolator() instanceof TakeLastSecurityPriceInterpolator)
+        {
+            takeLast.setSelection(true);
+        }
+        else if(getModel().getSecurityPriceInterpolator() instanceof LinearSecurityPriceInterpolator)
+        {
+            linear.setSelection(true);
+        }
+        
+        SelectionAdapter selectionAadapter = new SelectionAdapter()
+        {
+            @Override
+            public void widgetSelected(SelectionEvent e)
+            {
+                Button source=  (Button) e.getSource();
+                 
+                if (source.getSelection())
+                {
+                    if (source == takeLast)
+                    {
+                        getModel().setSecurityPriceInterpolator(TakeLastSecurityPriceInterpolator.getInstance());
+                    }
+                    else if (source == linear)
+                    {
+                        getModel().setSecurityPriceInterpolator(LinearSecurityPriceInterpolator.getInstance());
+                    }
+                }
+            }
+        };
+        takeLast.addSelectionListener(selectionAadapter);
+        linear.addSelectionListener(selectionAadapter);
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPriceInterpolator.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityPriceInterpolator.java
@@ -1,0 +1,80 @@
+package name.abuchen.portfolio.model;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public interface SecurityPriceInterpolator
+{
+    public static SecurityPriceInterpolator getDefaultSecurityPriceInterpolator()
+    {
+        return TakeLastSecurityPriceInterpolator.getInstance();
+    }
+    
+    /**
+     * Calculate an interpolated security price to fill in gaps in the security
+     * prices (i.e. due to holidays or weekends)
+     * 
+     * @param prices
+     *            Ordered list of all security prices
+     * @param lastIndexBefore
+     *            The index such that {@code prices.get(lastIndexBefore)} is
+     *            strictly before and {@code prices.get(lastIndexBefore + 1)} is strictly after
+     *            {@code requestedDate}. Both
+     *            {@code prices.get(lastIndexBefore)} and
+     *            {@code prices.get(lastIndexBefore + 1)} must exist.
+     * @param requestedDate The requested date
+     * @return An interpoled security price for {@code requestedDate}.
+     */
+    public SecurityPrice interpolate(List<SecurityPrice> prices, int lastIndexBefore, LocalDate requestedDate);
+
+    public static class TakeLastSecurityPriceInterpolator implements SecurityPriceInterpolator
+    {
+        private static TakeLastSecurityPriceInterpolator INSTANCE;
+        
+        public static TakeLastSecurityPriceInterpolator getInstance()
+        {
+            if (INSTANCE == null)
+                INSTANCE = new TakeLastSecurityPriceInterpolator();
+            return INSTANCE;
+        }
+        
+        private TakeLastSecurityPriceInterpolator()
+        {
+        }
+        
+        @Override
+        public SecurityPrice interpolate(List<SecurityPrice> prices, int lastIndexBefore, LocalDate requestedDate)
+        {
+            return prices.get(lastIndexBefore);
+        }
+
+    }
+    
+    public static class LinearSecurityPriceInterpolator implements SecurityPriceInterpolator
+    {
+        private static LinearSecurityPriceInterpolator INSTANCE;
+        
+        public static LinearSecurityPriceInterpolator getInstance()
+        {
+            if (INSTANCE == null)
+                INSTANCE = new LinearSecurityPriceInterpolator();
+            return INSTANCE;
+        }
+        
+        private LinearSecurityPriceInterpolator()
+        {
+        }
+        
+        @Override
+        public SecurityPrice interpolate(List<SecurityPrice> prices, int lastIndexBefore, LocalDate requestedDate)
+        {
+            int indexAfter = lastIndexBefore + 1;
+            long gapDays = ChronoUnit.DAYS.between(prices.get(lastIndexBefore).getDate(), prices.get(indexAfter).getDate());
+            long positionInGap = ChronoUnit.DAYS.between(prices.get(lastIndexBefore).getDate(), requestedDate);
+            long interpolatedValue = prices.get(lastIndexBefore).getValue() + Math.round(((double) positionInGap) / ((double) gapDays)
+                            * (double) (prices.get(indexAfter).getValue() - prices.get(lastIndexBefore).getValue()));
+            return new SecurityPrice(requestedDate, interpolatedValue);
+        }
+    }
+}


### PR DESCRIPTION
Lets the user select how to deal with gaps in historical quote data (take last and linear interpolation are available for now).
“Take last” (which is used right now implicitly) stays the default option.
I think this is can be usefull when rather few quotes are available, e.g., for the HCPI indices (that are only updated once per month) or maybe for real estate (I saw that some people are adding this to PP: https://der-finanzfisch.de/immobilien-in-portfolio-performance-abbilden/ )

In the GUI I added this to the Historical Quote Provider Page:
![image](https://user-images.githubusercontent.com/10776736/124970782-a666ca00-e028-11eb-8f4d-ff4dabe3ad2d.png)
