### PR TITLE
Add p.a. 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -722,6 +722,7 @@ public class Messages extends NLS
     public static String LabelTransfer;
     public static String LabelTransferTo;
     public static String LabelTTWROR;
+    public static String LabelTTWROR_Annualized;
     public static String LabelTTWROROneDay;
     public static String LabelUnknownVersion;
     public static String LabelUnnamedFile;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1414,7 +1414,9 @@ LabelSuffix_HICP = \ (HICP)
 
 LabelSuffix_PreTax = \ (before taxes)
 
-LabelTTWROR = True Time-Weighted Rate of Return
+LabelTTWROR = True Time-Weighted Rate of Return (cumulative)
+
+LabelTTWROR_Annualized = True Time-Weighted Rate of Return (annualized)
 
 LabelTTWROROneDay = Last Day
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1407,7 +1407,9 @@ LabelSuffix_HICP = \ (HVPI)
 
 LabelSuffix_PreTax = \ (vor Steuern)
 
-LabelTTWROR = True Time-Weighted Rate of Return
+LabelTTWROR = True Time-Weighted Rate of Return (kummulativ)
+
+LabelTTWROR_Annualized = True Time-Weighted Rate of Return (annualisiert)
 
 LabelTTWROROneDay = Letzter Tag
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -39,7 +39,7 @@ public enum WidgetFactory
     
     TTWROR_Annualized(Messages.LabelTTWROR_Annualized, Messages.ClientEditorLabelPerformance, //
                     (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
-                                    .with(Values.Percent2) //
+                                    .with(Values.AnnualizedPercent2) //
                                     .with((ds, period) -> {
                                         PerformanceIndex index = data.calculate(ds, period);
                                         return index.getFinalAccumulatedAnnualizedPercentage();
@@ -55,7 +55,7 @@ public enum WidgetFactory
 
     IRR(Messages.LabelIRR, Messages.ClientEditorLabelPerformance, //
                     (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
-                                    .with(Values.Percent2) //
+                                    .with(Values.AnnualizedPercent2) //
                                     .with((ds, period) -> data.calculate(ds, period).getPerformanceIRR()) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -36,8 +36,16 @@ public enum WidgetFactory
                                     }) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
+    
+    TTWROR_Annualized(Messages.LabelTTWROR_Annualized, Messages.ClientEditorLabelPerformance, //
+                    (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
+                                    .with(Values.Percent2) //
+                                    .with((ds, period) -> {
+                                        PerformanceIndex index = data.calculate(ds, period);
+                                        return index.getFinalAccumulatedAnnualizedPercentage();
+                                    }).build()),
 
-    TTWROR(Messages.LabelTTWROR, Messages.ClientEditorLabelPerformance, //
+    TTWROR(Messages.LabelTTWROR, Messages.ClientEditorLabelPerformance, // cumulative
                     (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
                                     .with(Values.Percent2) //
                                     .with((ds, period) -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -381,6 +381,15 @@ public abstract class Values<E>
         }
     };
 
+    public static final Values<Double> AnnualizedPercent2 = new Values<Double>("0.00% 'p.a.'", 0) //$NON-NLS-1$
+    {
+        @Override
+        public String format(Double percent)
+        {
+            return String.format("%,.2f%% p.a.", percent * 100); //$NON-NLS-1$
+        }
+    };
+
     public static final Values<Double> Percent5 = new Values<Double>("0.00000%", 0) //$NON-NLS-1$
     {
         @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -163,6 +163,13 @@ public class PerformanceIndex
         return accumulated != null ? accumulated[accumulated.length - 1] : 0;
     }
 
+    public double getFinalAccumulatedAnnualizedPercentage()
+    {
+        double accumulatedPercentage = getFinalAccumulatedPercentage();
+        long days = getActualInterval().getDays();
+        return Math.pow(1 + accumulatedPercentage, 365d / ((double) days)) - 1;
+    }
+
     public double[] getDeltaPercentage()
     {
         return delta;


### PR DESCRIPTION
Blocked. Depends on #2321 

Adds "p.a." to annualized performance measuers. (I.e. "7% p.a." instead of just "7%")