### PR TITLE
Fix invested capital widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -88,7 +88,7 @@ public enum WidgetFactory
                                     .with(Values.Amount) //
                                     .with((ds, period) -> {
                                         long[] d = data.calculate(ds, period).calculateInvestedCapital();
-                                        return d.length > 0 ? d[d.length - 1] : 0L;
+                                        return d.length > 0 ? d[d.length - 1] - d[0]: 0L;
                                     }) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),


### PR DESCRIPTION
The portfolio value at begin of the reporting period is no longer counted as invested capital (for the reporting period).

Given the title “Invested Capital _for reporting period_”, I don’t see why investments before the reporting periode (and their returns) should count towards this.
