### PR TITLE
Fix DAB PDF-Importer negative flag is not reset

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -68,7 +68,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^(?<type>Verkauf) .*")
+                .match("^(?<type>(Kauf|Verkauf)) .*")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf"))
                     {


### PR DESCRIPTION
The regEx condition is not correct that the negative flag can be removed 
if we have multiple entries in the document