### PR TITLE
Fix sBroker PDF-Importer negative flag is not reset

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -57,7 +57,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^(?<type>Verkauf)(.*)?$")
+                .match("^(?<type>Kauf|Verkauf|Wertpapier Abrechnung Ausgabe Investmentfonds)(.*)?$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf"))
                     {


### PR DESCRIPTION
Fix sBroker PDF-Importer negative flag is not reset
The regEx condition is not correct that the negative flag can be removed
if we have multiple entries in the document