### PR TITLE
Delete or disable unnecessary code in the PDF importers.

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -78,22 +78,24 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(BuySellEntryItem::new);
 
-        addTaxesSectionsTransaction(pdfTransaction, type);
+        // At this time there are no known tax or similar in the PDF debugs.
+        // addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
-    {
-        //transaction
-        // At this time there are no known tax or similar in the PDF debugs.
-        // IF you found some, add this here like
-        
-        // Example
-        // some taxes
-        // .section("tax", "currency").optional()
-        // .match("^ABC (?<tax>[.,\\d]+)[-]? (?<currency>[\\w]{3})$")
-        // .assign((t, v) -> processTaxEntries(t, v, type));
-    }
+    /***
+     * At this time there are no known tax or similar in the PDF debugs.
+     * If you have found some, activate the 
+     * the function , processTaxEntries();
+     * and add them here.
+     */
+//    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
+//    {
+//        transaction
+//                .section("tax", "currency").optional()
+//                .match("^ABC (?<tax>[.,\\d]+)[-]? (?<currency>[\\w]{3})$")
+//                .assign((t, v) -> processTaxEntries(t, v, type));
+//    }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
@@ -105,19 +107,19 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 
-    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
-        }
-        else
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
-        }
-    }
+//    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+//    {
+//        if (t instanceof name.abuchen.portfolio.model.Transaction)
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+//        }
+//        else
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+//        }
+//    }
 
     private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
@@ -215,7 +215,21 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
+        /***
+         * At this time there are no known tax or similar in the PDF debugs.
+         * If you have found some, activate the 
+         * the function , processTaxEntries();
+         * and add them here.
+         */
         transaction
+                /***
+                 * Here is an implementation example
+                 * processTaxEntries();
+                 */
+                // .section("tax", "currency").optional()
+                // .match("^ABC (?<tax>[.,\\d]+)[-]? (?<currency>[\\w]{3})$")
+                // .assign((t, v) -> processTaxEntries(t, v, type));
+        
                 // Einbehaltene Quellensteuer 15 % auf 12,12 USD 1,53- EUR
                 .section("quellensteinbeh", "currency").optional()
                 .match("^Einbehaltende Quellensteuer [.,\\d]+ % .* (?<quellensteinbeh>[.,\\d]+)- (?<currency>[\\w]{3})$")
@@ -279,19 +293,19 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
         return true;
     }
 
-    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
-        }
-        else
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
-        }
-    }
+//    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+//    {
+//        if (t instanceof name.abuchen.portfolio.model.Transaction)
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+//        }
+//        else
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+//        }
+//    }
 
     private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -123,22 +123,24 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(t -> new BuySellEntryItem(t));
 
-        addTaxesSectionsTransaction(pdfTransaction, type);
+        // At this time there are no known tax or similar in the PDF debugs.
+        // addTaxesSectionsTransaction(pdfTransaction, type);;
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
-    {
-        //transaction
-        // At this time there are no known tax or similar in the PDF debugs.
-        // If you found some, add this here like
-
-        // Example
-        // some tax's
-        // .section("tax", "currency").optional()
-        // .match("^ABC (?<tax>[.,\\d]+) (?<currency>[\\w]{3})$")
-        // .assign((t, v) -> processTaxEntries(t, v, type));
-    }
+    /***
+     * At this time there are no known tax or similar in the PDF debugs.
+     * If you have found some, activate the 
+     * the function , processTaxEntries();
+     * and add them here.
+     */
+//    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
+//    {
+//        transaction
+//                .section("tax", "currency").optional()
+//                .match("^ABC (?<tax>[.,\\d]+) (?<currency>[\\w]{3})$")
+//                .assign((t, v) -> processTaxEntries(t, v, type));
+//    }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
@@ -164,19 +166,19 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 
-    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
-        }
-        else
-        {
-            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
-            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
-        }
-    }
+//    private void processTaxEntries(Object t, Map<String, String> v, DocumentType type)
+//    {
+//        if (t instanceof name.abuchen.portfolio.model.Transaction)
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
+//        }
+//        else
+//        {
+//            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+//            PDFExtractorUtils.checkAndSetTax(tax, ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+//        }
+//    }
 
     private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -105,7 +105,8 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .wrap(BuySellEntryItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
-        addFeesSectionsTransaction(pdfTransaction, type);
+        // At this time there are no known fee or similar in the PDF debugs.
+        // addFeesSectionsTransaction(pdfTransaction, type);
     }
 
     private void addDividendeTransaction()
@@ -204,7 +205,8 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
-        addFeesSectionsTransaction(pdfTransaction, type);
+        // At this time there are no known fee or similar in the PDF debugs.
+        // addFeesSectionsTransaction(pdfTransaction, type);
 
         block.set(pdfTransaction);
     }
@@ -236,18 +238,19 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> addTax(type, t, v, "quellenstanr"));
     }
 
-    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
-    {
-        //transaction
-            // At this time there are no known fees or similar in the PDF debugs.
-            // IF you found some, add this here like
-            
-            // Example
-            // some fees
-            // .section("fee", "currency").optional()
-            // .match("^ABC (?<fee>[.,\\d]+)[-]? (?<currency>[\\w]{3})$")
-            // .assign((t, v) -> processFeeEntries(t, v, type));
-    }
+    /***
+     * At this time there are no known fee or similar in the PDF debugs.
+     * If you have found some, activate the 
+     * the function , processFeeEntries();
+     * and add them here.
+     */
+//    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+//    {
+//        transaction
+//                .section("fee", "currency").optional()
+//                .match("^ABC (?<fee>[.,\\d]+)[-]? (?<currency>[\\w]{3})$")
+//                .assign((t, v) -> processFeeEntries(t, v, type));
+//    }
 
     private void addTax(DocumentType type, Object t, Map<String, String> v, String taxtype)
     {
@@ -288,19 +291,19 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
         }
     }
 
-    private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
-            PDFExtractorUtils.checkAndSetFee(fee, 
-                            (name.abuchen.portfolio.model.Transaction) t, type);
-        }
-        else
-        {
-            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
-            PDFExtractorUtils.checkAndSetFee(fee,
-                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
-        }
-    }
+//    private void processFeeEntries(Object t, Map<String, String> v, DocumentType type)
+//    {
+//        if (t instanceof name.abuchen.portfolio.model.Transaction)
+//        {
+//            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+//            PDFExtractorUtils.checkAndSetFee(fee, 
+//                            (name.abuchen.portfolio.model.Transaction) t, type);
+//        }
+//        else
+//        {
+//            Money fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+//            PDFExtractorUtils.checkAndSetFee(fee,
+//                            ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
+//        }
+//    }
 }


### PR DESCRIPTION
Delete or disable unnecessary code in the PDF importers
Fixes #2341

This source was only disabled for later implementation of PDF-Debugs.
When we need this, it can be easily activated.