### PR TITLE
Allow searching securities when Yahoo symbol search fails

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.ClientSettings;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
 import name.abuchen.portfolio.util.WebAccess;
+import name.abuchen.portfolio.util.WebAccess.WebAccessException;
 
 /* package */ class YahooSymbolSearch
 {
@@ -96,32 +97,39 @@ import name.abuchen.portfolio.util.WebAccess;
     {
         List<Result> answer = new ArrayList<>();
 
-        @SuppressWarnings("nls")
-        String html = new WebAccess("s.yimg.com", "/aq/autoc") //
-                        .addParameter("query", query) //
-                        .addParameter("region", "DE") //
-                        .addParameter("lang", "de-DE") //
-                        .addParameter("callback", "YAHOO.util.ScriptNodeDataSource.callbacks") //
-                        .get();
-
-        // strip away java script call back method
-        int start = html.indexOf('(');
-        int end = html.lastIndexOf(')');
-        html = html.substring(start + 1, end);
-
-        JSONObject responseData = (JSONObject) JSONValue.parse(html);
-        if (responseData != null)
+        try
         {
-            JSONObject resultSet = (JSONObject) responseData.get("ResultSet"); //$NON-NLS-1$
-            if (resultSet != null)
+            @SuppressWarnings("nls")
+            String html = new WebAccess("s.yimg.com", "/aq/autoc") //
+                            .addParameter("query", query) //
+                            .addParameter("region", "DE") //
+                            .addParameter("lang", "de-DE") //
+                            .addParameter("callback", "YAHOO.util.ScriptNodeDataSource.callbacks") //
+                            .get();
+
+
+            // strip away java script call back method
+            int start = html.indexOf('(');
+            int end = html.lastIndexOf(')');
+            html = html.substring(start + 1, end);
+
+            JSONObject responseData = (JSONObject) JSONValue.parse(html);
+            if (responseData != null)
             {
-                JSONArray result = (JSONArray) resultSet.get("Result"); //$NON-NLS-1$
-                if (result != null)
+                JSONObject resultSet = (JSONObject) responseData.get("ResultSet"); //$NON-NLS-1$
+                if (resultSet != null)
                 {
-                    for (int ii = 0; ii < result.size(); ii++)
-                        answer.add(Result.from((JSONObject) result.get(ii)));
+                    JSONArray result = (JSONArray) resultSet.get("Result"); //$NON-NLS-1$
+                    if (result != null)
+                    {
+                        for (int ii = 0; ii < result.size(); ii++)
+                            answer.add(Result.from((JSONObject) result.get(ii)));
+                    }
                 }
             }
+        }
+        catch(WebAccessException ex)
+        {
         }
 
         return answer.stream();


### PR DESCRIPTION
Fixes #2346 

It looks like the service used to get the symbols for securities (s.yimg.com) is no longer working, or at least it hasn't been working for a few days.

I was able to add new securities to my portfolio by compiling the application with this patch. In my opinion, not being able to fetch the symbol (image) of a security should not prevent a user from adding a new security.

This is just a workaround, for the time being, while this service is not working. I think a longer term solution would be to find whether this service will be back or how to get the symbols in a more reliable way, maybe from another service.