### PR TITLE
Improvements to data quality pane

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -33,6 +33,8 @@ import name.abuchen.portfolio.ui.views.SecurityQuoteQualityMetricsViewer;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.Pair;
 import name.abuchen.portfolio.util.TextUtil;
+import name.abuchen.portfolio.util.TradeCalendar;
+import name.abuchen.portfolio.util.TradeCalendarManager;
 
 public class HistoricalPricesDataQualityPane implements InformationPanePage
 {
@@ -40,11 +42,13 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
     private IPreferenceStore preferences;
 
     private Label completeness;
+    private Label tradeCalendar;
     private Label checkInterval;
     private TableViewer missing;
     private TableViewer unexpected;
 
     private Security security;
+    private TradeCalendar calendar;
 
     @Override
     public String getLabel()
@@ -68,6 +72,10 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
         completeness = new Label(container, SWT.NONE);
         completeness.setToolTipText(TextUtil.wordwrap(Messages.ColumnMetricCompleteness_Description));
 
+        Label lTradeCalendar = new Label(container, SWT.NONE);
+        lTradeCalendar.setText(Messages.LabelSecurityCalendar);
+        tradeCalendar = new Label(container, SWT.NONE);
+
         checkInterval = new Label(container, SWT.NONE);
 
         Label missingLabel = new Label(container, SWT.NONE);
@@ -89,6 +97,8 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
         unexpected = unexpectedPair.getRight();
 
         FormDataFactory.startingWith(completeness, lCompleteness).right(new FormAttachment(100))
+                        .thenBelow(lTradeCalendar).left(new FormAttachment(0)) //
+                        .thenRight(tradeCalendar).right(new FormAttachment(100)) //
                         .thenBelow(checkInterval).left(new FormAttachment(0)).right(new FormAttachment(100))
                         .thenBelow(missingLabel) //
                         .thenBelow(missingTable).bottom(new FormAttachment(100));
@@ -151,7 +161,9 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
 
         if (security == null)
         {
+            calendar = null;
             completeness.setText(""); //$NON-NLS-1$
+            tradeCalendar.setText(""); //$NON-NLS-1$
             checkInterval.setText(""); //$NON-NLS-1$
             missing.setInput(new ArrayList<>());
             unexpected.setInput(new ArrayList<>());
@@ -159,8 +171,10 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
         else
         {
             QuoteQualityMetrics metrics = new QuoteQualityMetrics(security);
+            calendar = TradeCalendarManager.getInstance(security);
 
             completeness.setText(Values.Percent2.format(metrics.getCompleteness()));
+            tradeCalendar.setText(calendar != null ? calendar.getDescription() : ""); //$NON-NLS-1$
             checkInterval.setText(metrics.getCheckInterval()
                             .map(i -> MessageFormat.format(Messages.LabelMetricCheckInterval,
                                             Values.Date.format(i.getStart()), Values.Date.format(i.getEnd())))

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.panes;
 
 import java.util.ArrayList;
+import java.time.LocalDate;
 
 import javax.inject.Inject;
 
@@ -30,6 +31,7 @@ import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.ui.views.SecurityQuoteQualityMetricsViewer;
+import name.abuchen.portfolio.util.Holiday;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.Pair;
 import name.abuchen.portfolio.util.TextUtil;
@@ -132,10 +134,11 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
                 Interval interval = (Interval) element;
 
                 if (interval.getStart().equals(interval.getEnd()))
-                    return Values.Date.format(interval.getStart());
+                    return formatDateWithHoliday(interval.getStart(), calendar);
                 else
-                    return MessageFormat.format(Messages.LabelDateXToY, Values.Date.format(interval.getStart()),
-                                    Values.Date.format(interval.getEnd()));
+                    return MessageFormat.format(Messages.LabelDateXToY,
+                                    formatDateWithHoliday(interval.getStart(), calendar),
+                                    formatDateWithHoliday(interval.getEnd(), calendar));
             }
         });
         column.setSorter(ColumnViewerSorter.create(e -> ((Interval) e).getStart()), SWT.UP);
@@ -190,5 +193,16 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
     {
         if (security != null)
             setInput(security);
+    }
+
+    private static String formatDateWithHoliday(LocalDate date, TradeCalendar calendar)
+    {
+        String result = Values.Date.format(date);
+        if (calendar == null)
+            return result;
+        Holiday holiday = calendar.getHoliday(date);
+        if (holiday != null)
+            result += " (" + holiday.getLabel() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
+        return result;
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -101,7 +101,7 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
         FormDataFactory.startingWith(completeness, lCompleteness).right(new FormAttachment(100))
                         .thenBelow(lTradeCalendar).left(new FormAttachment(0)) //
                         .thenRight(tradeCalendar).right(new FormAttachment(100)) //
-                        .thenBelow(checkInterval).left(new FormAttachment(0)).right(new FormAttachment(100))
+                        .thenBelow(checkInterval).left(new FormAttachment(0)).right(new FormAttachment(100)) //
                         .thenBelow(missingLabel) //
                         .thenBelow(missingTable).bottom(new FormAttachment(100));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -105,8 +105,9 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
                         .thenBelow(missingLabel) //
                         .thenBelow(missingTable).bottom(new FormAttachment(100));
 
-        FormDataFactory.startingWith(missingTable) //
-                        .thenRight(unexpectedTable, 20).top(new FormAttachment(missingTable, 0, SWT.TOP))
+        FormDataFactory.startingWith(missingTable).right(new FormAttachment(50, -10)) //
+                        .thenRight(unexpectedTable, 10).right(new FormAttachment(100)) //
+                        .top(new FormAttachment(missingTable, 0, SWT.TOP)) //
                         .bottom(new FormAttachment(100)) //
                         .thenUp(unexpectedLabel);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -72,7 +72,7 @@ public class TradeCalendar implements Comparable<TradeCalendar>
 
         return cache.get(date.getYear()).containsKey(date);
     }
-    
+
     public Holiday getHoliday(LocalDate date)
     {
         return cache.get(date.getYear()).get(date);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -73,6 +73,11 @@ public class TradeCalendar implements Comparable<TradeCalendar>
         return cache.get(date.getYear()).containsKey(date);
     }
     
+    public Holiday getHoliday(LocalDate date)
+    {
+        return cache.get(date.getYear()).get(date);
+    }
+
     /**
      * @return {@code date}, if date is not a holiday. Otherwise the earliest date after {@code date}, that is not a holiday. 
      */

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -157,7 +157,7 @@ public class TradeCalendarManager
         tc.add(fixed(SECOND_CHRISTMAS_DAY, Month.DECEMBER, 26));
         tc.add(fixed(NEW_YEARS_EVE, Month.DECEMBER, 31));
         CACHE.put(tc.getCode(), tc);
-        
+
         // see Vienna Stock Exchange trading days on their official website:
         // https://www.wienerborse.at/handel/handelsinformationen/handelskalender/
         tc = new TradeCalendar("vse", Messages.LabelTradeCalendarVSE); //$NON-NLS-1$
@@ -169,7 +169,7 @@ public class TradeCalendarManager
         tc.add(fixed(CHRISTMAS_EVE, Month.DECEMBER, 24));
         tc.add(fixed(NEW_YEARS_EVE, Month.DECEMBER, 31));
         CACHE.put(tc.getCode(), tc);
-        
+
         // see Moscow Exchange trading days on their official website:
         // https://www.moex.com/s371
         // https://de.wikipedia.org/wiki/Feiertage_in_Russland
@@ -188,7 +188,7 @@ public class TradeCalendarManager
         tc.add(fixed(NATION_DAY, Month.JUNE, 12).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(fixed(UNITY_DAY, Month.NOVEMBER, 4).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         CACHE.put(tc.getCode(), tc);
-        
+
         // see Toronto Stock Exchange trading days on their official website:
         // https://www.tsx.com/trading/calendars-and-trading-hours/calendar
         tc = new TradeCalendar("tsx", Messages.LabelTradeCalendarTSX); //$NON-NLS-1$
@@ -214,7 +214,7 @@ public class TradeCalendarManager
         tc.add(fixed(FIRST_CHRISTMAS_DAY, Month.DECEMBER, 25));
         tc.add(fixed(SECOND_CHRISTMAS_DAY, Month.DECEMBER, 26));
         CACHE.put(tc.getCode(), tc);
-        
+
         tc = new TradeCalendar(FIRST_OF_THE_MONTH_CODE,  Messages.LabelTradeCalendarFirstOfTheMonth)
         {
             @Override


### PR DESCRIPTION
A few improvements to the data quality pane:
* Say which trade calendar was used for determining completeness and missing/unexpected dates.
* Name the holiday that causes a quote to be unexpected, instead of just giving the date.
* Make the missing and unexpected tables equal size, and use the whole width. Especially important since they can’t be resized by the user, unlike columns in a single table.

This is what it looks like:
![data quality pane with improvements](https://user-images.githubusercontent.com/1127374/127561729-c398304f-7be5-4783-b674-96bf99ea4bb3.png)
For review, I recommend looking at the individual commits.