### PR TITLE
Linux CSV importer column packing (fixes #1723 / #1536)

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/CSVImportDefinitionPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/CSVImportDefinitionPage.java
@@ -543,12 +543,16 @@ public class CSVImportDefinitionPage extends AbstractWizardPage
             tableViewer.refresh();
             tableViewer.getTable().pack();
 
-            // see #1723 and #1536: under Linux, the first column is extended to
-            // the full size of the table
 
-            if (!Platform.getWS().equals(Platform.WS_GTK))
-                for (TableColumn column : tableViewer.getTable().getColumns())
-                    column.pack();
+            TableColumn[] columns = tableViewer.getTable().getColumns();
+            for (TableColumn column : columns)
+                column.pack();
+
+            // see #1723 and #1536: under Linux, the first column is extended to
+            // the full size of the table. Re-packing it after all other columns
+            // have been packed resolves this.
+            if (Platform.getWS().equals(Platform.WS_GTK) && columns.length > 0)
+                tableViewer.getTable().getColumns()[0].pack();
 
             doUpdateErrorMessages();
         }


### PR DESCRIPTION
Previous fixes omitted column packing entirely, therefore the table
was invisible upon changing any setting in the dialog. It only became
visible again when the window was resized.
Re-packing the first column seems to fix this.
Hopefully once-and-for-all!