### PR TITLE
Add a widget for performance-neutral transfers

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -712,6 +712,7 @@ public class Messages extends NLS
     public static String LabelMetricDaysFormatter;
     public static String LabelMetricYears;
     public static String LabelMetricYearsFormatter;
+    public static String LabelPNTransfers;
     public static String LabelPreviousTradingDay;
     public static String LabelStartTyping;
     public static String LabelStatementOfAssets;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1322,6 +1322,8 @@ LabelPerformanceMetric = Return metric
 
 LabelPerformanceTTWROR = Return (TTWROR)
 
+LabelPNTransfers = Performance-neutral transfers
+
 LabelPortfolioFeeRate = Portfolio Fee Rate
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1315,6 +1315,8 @@ LabelPerformanceMetric = Renditekennzahl
 
 LabelPerformanceTTWROR = Rendite (TTWROR)
 
+LabelPNTransfers = Performanceneutrale Bewegungen
+
 LabelPortfolioFeeRate = Portfolio-Geb\u00FChrenquote
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1309,6 +1309,8 @@ LabelPerformanceMetric = M\u00E9trica de rendimiento
 
 LabelPerformanceTTWROR = Retorno (TTWROR)
 
+LabelPNTransfers = Transferencias neutrales
+
 LabelPortfolioFeeRate = Tasa de tarifa de cartera
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1310,6 +1310,8 @@ LabelPerformanceMetric = M\u00E9trique rendement
 
 LabelPerformanceTTWROR = Rendement (TTWROR)
 
+LabelPNTransfers = Transferts neutres
+
 LabelPortfolioFeeRate = Ratio de frais de portefeuille
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1315,6 +1315,8 @@ LabelPerformanceMetric = Metrica di rendimento
 
 LabelPerformanceTTWROR = Rendimento (TTWROR)
 
+LabelPNTransfers = Trasferimenti a performance neutre
+
 LabelPortfolioFeeRate = Tasso di commissione del portafoglio
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1309,6 +1309,8 @@ LabelPerformanceMetric = Statistiek retourneren
 
 LabelPerformanceTTWROR = Opbrengst (TTWROR)
 
+LabelPNTransfers = Neutrale overdrachten
+
 LabelPortfolioFeeRate = Portefeuillevergoedingsratio
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1309,6 +1309,8 @@ LabelPerformanceMetric = M\u00E9trica de Retorno
 
 LabelPerformanceTTWROR = Retorno (TTWROR)
 
+LabelPNTransfers = Transfer\u00EAncias neutras para a Performance
+
 LabelPortfolioFeeRate = Taxa de taxa de portf\u00F3lio
 
 LabelPortfolioPerformance = Portfolio Performance

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -91,6 +91,17 @@ public enum WidgetFactory
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
 
+    SAVINGS(Messages.LabelPNTransfers, Messages.LabelStatementOfAssets, //
+                    (widget, data) -> IndicatorWidget.<Long>create(widget, data) //
+                                    .with(Values.Amount) //
+                                    .with((ds, period) -> {
+                                        long[] d = data.calculate(ds, period).getTransferals();
+                                        return d.length > 1 ? LongStream.of(d).skip(1).sum() : 0L;
+                                            // skip d[0] because it refers to the day before start
+                                    }) //
+                                    .withBenchmarkDataSeries(false) //
+                                    .build()),
+
     INVESTED_CAPITAL(Messages.LabelInvestedCapital, Messages.LabelStatementOfAssets, //
                     (widget, data) -> IndicatorWidget.<Long>create(widget, data) //
                                     .with(Values.Amount) //


### PR DESCRIPTION
Create a new widget that displays the savings done during the reporting period, i.e. the performance-neutral transfers. It is similar to the invested capital widget, but does not include the starting value of the portfolio.