### PR TITLE
Modify PDF/CSV-Importer duplicate detection to support ticker symbol

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
@@ -56,7 +56,7 @@ public class SecurityCacheTest
     public void testThatSecurityIsMatchedByTickerSymbol()
     {
         SecurityCache cache = new SecurityCache(client);
-        Security lookup = cache.lookup(null, "SAP.DE", null, null, () -> new Security());
+        Security lookup = cache.lookup(null, "SAP", null, null, () -> new Security());
         assertThat(client.getSecurities().get(0), is(lookup));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
@@ -23,6 +23,7 @@ public class SecurityCacheTest
         Security security = new Security();
         security.setName("Security Name");
         security.setIsin("DE0007164600");
+        security.setTickerSymbol("SAP.DE");
         security.setWkn("716460");
         client.addSecurity(security);
     }
@@ -48,6 +49,14 @@ public class SecurityCacheTest
     {
         SecurityCache cache = new SecurityCache(client);
         Security lookup = cache.lookup(null, null, null, "Security Name", () -> new Security());
+        assertThat(client.getSecurities().get(0), is(lookup));
+    }
+
+    @Test
+    public void testThatSecurityIsMatchedByTickerSymbol()
+    {
+        SecurityCache cache = new SecurityCache(client);
+        Security lookup = cache.lookup(null, "SAP.DE", null, null, () -> new Security());
         assertThat(client.getSecurities().get(0), is(lookup));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractorTest.java
@@ -82,7 +82,7 @@ public class CSVPortfolioTransactionExtractorTest
 
         List<Exception> errors = new ArrayList<>();
         List<Item> results = extractor.extract(0,
-                        Arrays.<String[]>asList(new String[] { "2013-01-01", "", "DE0007164600", "SAP.DE", "", "SAP SE",
+                        Arrays.<String[]>asList(new String[] { "2013-01-01", "", "DE0007164600", "SAP", "", "SAP SE",
                                         "100", "EUR", "11", "10", "", "", "", "1,2", "TRANSFER_IN", "Notiz" }),
                         buildField2Column(extractor), errors);
 
@@ -122,7 +122,7 @@ public class CSVPortfolioTransactionExtractorTest
 
         List<Exception> errors = new ArrayList<>();
         List<Item> results = extractor.extract(0,
-                        Arrays.<String[]>asList(new String[] { "2013-01-02", "10:00", "DE0007164600", "SAP.DE", "",
+                        Arrays.<String[]>asList(new String[] { "2013-01-02", "10:00", "DE0007164600", "SAP", "",
                                         "SAP SE", "100", "EUR", "11", "", "", "", "", "1,9", "BUY", "Notiz" }),
                         buildField2Column(extractor), errors);
 
@@ -161,7 +161,7 @@ public class CSVPortfolioTransactionExtractorTest
 
         List<Exception> errors = new ArrayList<>();
         List<Item> results = extractor.extract(0,
-                        Arrays.<String[]>asList(new String[] { "2013-01-02", "", "DE0007164600", "SAP.DE", "", "SAP SE",
+                        Arrays.<String[]>asList(new String[] { "2013-01-02", "", "DE0007164600", "SAP", "", "SAP SE",
                                         "-100", "EUR", "", "12", "110", "USD", "0,9091", "1,9", "SELL", "Notiz" }),
                         buildField2Column(extractor), errors);
 
@@ -198,7 +198,7 @@ public class CSVPortfolioTransactionExtractorTest
 
         List<Exception> errors = new ArrayList<>();
         List<Item> results = extractor.extract(0,
-                        Arrays.<String[]>asList(new String[] { "2013-01-02", "12:00", "", "SAP.DE", "", "SAP SE",
+                        Arrays.<String[]>asList(new String[] { "2013-01-02", "12:00", "", "SAP", "", "SAP SE",
                                         "-100", "EUR", "11", "", "", "", "", "1,9", "", "Notiz" }),
                         buildField2Column(extractor), errors);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -51,10 +51,9 @@ public class SecurityTest
                 skipped++;
         }
 
-        assertThat(skipped, equalTo(12));
+        assertThat(skipped, equalTo(13));
 
         Security target = source.deepCopy();
-
         assertThat(target.getUUID(), not(equalTo(source.getUUID())));
 
         // compare
@@ -66,7 +65,7 @@ public class SecurityTest
             if (p.getPropertyType() != String.class && p.getPropertyType() != boolean.class
                             && p.getPropertyType() != int.class)
                 continue;
-
+            
             Object sourceValue = p.getReadMethod().invoke(source);
             Object targetValue = p.getReadMethod().invoke(target);
 
@@ -206,6 +205,12 @@ public class SecurityTest
         assertEquals(security.getExternalIdentifier(), "865985");
 
         security.setTickerSymbol("AAPL");
+        assertEquals(security.getExternalIdentifier(), "AAPL");
+
+        // In some countries there is no ISIN or WKN, only the ticker symbol. 
+        // If historical prices are retrieved from the stock exchange, 
+        // the ticker symbol is expanded. (UMAX --> UMAX.AX)
+        security.setTickerSymbol("AAPL.BA");
         assertEquals(security.getExternalIdentifier(), "AAPL");
 
         security.setIsin("US0378331005");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
@@ -35,10 +35,8 @@ public class SecurityCache
         this.localMaps.add(client.getSecurities().stream().filter(s -> s.getIsin() != null && !s.getIsin().isEmpty())
                         .collect(Collectors.toMap(Security::getIsin, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));
 
-        this.localMaps.add(client.getSecurities().stream()
-                        .filter(s -> s.getTickerSymbol() != null && !s.getTickerSymbol().isEmpty()) //
-                        .collect(Collectors.toMap(Security::getTickerSymbol, s -> s,
-                                        (l, r) -> DUPLICATE_SECURITY_MARKER)));
+        this.localMaps.add(client.getSecurities().stream().filter(s -> s.getTickerSymbol() != null && !s.getTickerSymbol().isEmpty())
+                        .collect(Collectors.toMap(Security::getTickerSymbolWithoutStockMarket, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));
 
         this.localMaps.add(client.getSecurities().stream().filter(s -> s.getWkn() != null && !s.getWkn().isEmpty())
                         .collect(Collectors.toMap(Security::getWkn, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
@@ -109,10 +109,24 @@ public class SecurityCache
 
         if (doNotMatchIfGiven(isin, security.getIsin()))
             return null;
+
         if (doNotMatchIfGiven(tickerSymbol, security.getTickerSymbol()))
-            return null;
+        {
+            // In some countries there is no ISIN or WKN, only the ticker symbol. 
+            // However, as soon as the historical prices are pulled from the stock exchange, 
+            // the ticker symbol is expanded.
+            // PDF importers that use this are for example the SelfWeath and the CommSec
+            // Example UMAX --> UMAX.AX
+            if (doNotMatchIfGiven(tickerSymbol, security.getTickerSymbol().substring(0, security.getTickerSymbol().indexOf('.'))))
+            {
+                return null;
+            }
+        return null;
+        }
+
         if (doNotMatchIfGiven(wkn, security.getWkn()))
             return null;
+
         return security;
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -221,6 +221,17 @@ public final class Security implements Attributable, InvestmentVehicle
         this.updatedAt = Instant.now();
     }
 
+    // In some countries there is no ISIN or WKN, only the ticker symbol. 
+    // If historical prices are retrieved from the stock exchange, 
+    // the ticker symbol is expanded. (UMAX --> UMAX.AX)
+    public String getTickerSymbolWithoutStockMarket()
+    {
+        if (tickerSymbol != null && !tickerSymbol.isEmpty() && tickerSymbol.contains(".")) //$NON-NLS-1$
+            return tickerSymbol.substring(0, tickerSymbol.indexOf('.'));
+        else
+            return tickerSymbol;
+    }
+
     public String getWkn()
     {
         return wkn;
@@ -261,7 +272,13 @@ public final class Security implements Attributable, InvestmentVehicle
         if (isin != null && isin.length() > 0)
             return isin;
         else if (tickerSymbol != null && tickerSymbol.length() > 0)
-            return tickerSymbol;
+            // In some countries there is no ISIN or WKN, only the ticker symbol. 
+            // If historical prices are retrieved from the stock exchange, 
+            // the ticker symbol is expanded. (UMAX --> UMAX.AX)
+            if (tickerSymbol != null && !tickerSymbol.isEmpty() && tickerSymbol.contains(".")) //$NON-NLS-1$
+                return tickerSymbol.substring(0, tickerSymbol.indexOf('.'));
+            else
+                return tickerSymbol;
         else if (wkn != null && wkn.length() > 0)
             return wkn;
         else


### PR DESCRIPTION
Modify PDF-Importer duplicate detection to support ticker symbol
Fixes  #2361

Hallo @buchen 
für die beiden Importer [Commonwealth Securities](https://github.com/buchen/portfolio/pull/2383) und [SelfWealth](https://github.com/buchen/portfolio/pull/2384) wird eine Modifikation benötigt.

**Folgendes Problem:**
Testkauf 1 wird importiert und das Wertpapier stellt. Holt man sich dann die Historischen Kurse, dann wird das Tickersymbol für
das Wertpapier im Testkauf 1 von UMAX zu UMAX.AX (z.B. für australische Börse).
Wenn dann Testkauf 2 importiert wird, wird das Wertpapier aufgrund der Änderung des Tickersymbols nicht erkannt. Es wird neu angelegt. Bei diesen Importern gibt es im PDF-Debug keine ISIN oder WKN, sondern diese werden über die Tickersymbole bestimmt.

Durch die Änderung wird dies behoben. Ich hoffe dass dies so passt.

Testkauf 1 und 2 zum testen
[first buy.pdf](https://github.com/buchen/portfolio/files/6963945/first.buy.pdf)
[second buy.pdf](https://github.com/buchen/portfolio/files/6963946/second.buy.pdf)

Grüße
Alex