### PR TITLE
Change securities filter to show non-zero holdings

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -997,7 +997,7 @@ public class Messages extends NLS
     public static String PrefTitleQuandl;
     public static String SecurityFilter;
     public static String SecurityFilterSharesHeldEqualZero;
-    public static String SecurityFilterSharesHeldGreaterZero;
+    public static String SecurityFilterSharesHeldNotZero;
     public static String SecurityListFilter;
     public static String SecurityListFilterHideInactive;
     public static String SecurityListFilterOnlyExchangeRates;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2018,7 +2018,7 @@ SecurityFilter = Filter securities based on the shares held
 
 SecurityFilterSharesHeldEqualZero = Shares held = 0
 
-SecurityFilterSharesHeldGreaterZero = Shares held > 0
+SecurityFilterSharesHeldNotZero = Shares held \u2260 0
 
 SecurityListFilter = Filter securities
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2011,7 +2011,7 @@ SecurityFilter = Wertpapiere anhand des Bestandes ausfiltern
 
 SecurityFilterSharesHeldEqualZero = Bestand = 0
 
-SecurityFilterSharesHeldGreaterZero = Bestand > 0
+SecurityFilterSharesHeldNotZero = Bestand \u2260 0
 
 SecurityListFilter = Wertpapiere filtern
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -2005,7 +2005,7 @@ SecurityFilter = Filtrar activos segun las acciones en posesi\u00F3n
 
 SecurityFilterSharesHeldEqualZero = Acciones en posesi\u00F3n = 0
 
-SecurityFilterSharesHeldGreaterZero = Acciones en posesi\u00F3n > 0
+SecurityFilterSharesHeldNotZero = Acciones en posesi\u00F3n \u2260 0
 
 SecurityListFilter = Filtrar valores
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -2006,7 +2006,7 @@ SecurityFilter = Filtrer les titres en fonction des parts d\u00E9tenues
 
 SecurityFilterSharesHeldEqualZero = Parts d\u00E9tenues = 0
 
-SecurityFilterSharesHeldGreaterZero = Parts d\u00E9tenues > 0
+SecurityFilterSharesHeldNotZero = Parts d\u00E9tenues \u2260 0
 
 SecurityListFilter = Filtrer titres
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -2011,7 +2011,7 @@ SecurityFilter = Filtra i titoli in base alle azioni detenute
 
 SecurityFilterSharesHeldEqualZero = Azioni detenute = 0
 
-SecurityFilterSharesHeldGreaterZero = Azioni detenute > 0
+SecurityFilterSharesHeldNotZero = Azioni detenute \u2260 0
 
 SecurityListFilter = Filtra titoli
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -2005,7 +2005,7 @@ SecurityFilter = Effecten filteren op basis van de aandelen in bezit
 
 SecurityFilterSharesHeldEqualZero = Aandelen in bezit = 0
 
-SecurityFilterSharesHeldGreaterZero = Aandelen aangehouden > 0
+SecurityFilterSharesHeldNotZero = Aandelen aangehouden \u2260 0
 
 SecurityListFilter = Effecten filteren
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -2005,7 +2005,7 @@ SecurityFilter = Filtrar ativos com base nas a\u00E7\u00F5es detidas
 
 SecurityFilterSharesHeldEqualZero = A\u00E7\u00F5es detidas = 0
 
-SecurityFilterSharesHeldGreaterZero = A\u00E7\u00F5es detidas > 0
+SecurityFilterSharesHeldNotZero = A\u00E7\u00F5es detidas \u2260 0
 
 SecurityListFilter = Filtrar ativos
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -90,7 +90,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 {
     private class FilterDropDown extends DropDown implements IMenuListener
     {
-        private final Predicate<SecurityPerformanceRecord> sharesGreaterZero = record -> record.getSharesHeld() > 0;
+        private final Predicate<SecurityPerformanceRecord> sharesNotZero = record -> record.getSharesHeld() != 0;
         private final Predicate<SecurityPerformanceRecord> sharesEqualZero = record -> record.getSharesHeld() == 0;
 
         private ClientFilterMenu clientFilterMenu;
@@ -100,7 +100,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
             super(Messages.SecurityFilter, Images.FILTER_OFF, SWT.NONE);
 
             if (preferenceStore.getBoolean(SecuritiesPerformanceView.class.getSimpleName() + "-sharesGreaterZero")) //$NON-NLS-1$
-                recordFilter.add(sharesGreaterZero);
+                recordFilter.add(sharesNotZero);
 
             if (preferenceStore.getBoolean(SecuritiesPerformanceView.class.getSimpleName() + "-sharesEqualZero")) //$NON-NLS-1$
                 recordFilter.add(sharesEqualZero);
@@ -123,7 +123,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
             addDisposeListener(e -> {
                 preferenceStore.setValue(SecuritiesPerformanceView.class.getSimpleName() + "-sharesGreaterZero", //$NON-NLS-1$
-                                recordFilter.contains(sharesGreaterZero));
+                                recordFilter.contains(sharesNotZero));
                 preferenceStore.setValue(SecuritiesPerformanceView.class.getSimpleName() + "-sharesEqualZero", //$NON-NLS-1$
                                 recordFilter.contains(sharesEqualZero));
             });
@@ -145,7 +145,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         @Override
         public void menuAboutToShow(IMenuManager manager)
         {
-            manager.add(createAction(Messages.SecurityFilterSharesHeldGreaterZero, sharesGreaterZero));
+            manager.add(createAction(Messages.SecurityFilterSharesHeldNotZero, sharesNotZero));
             manager.add(createAction(Messages.SecurityFilterSharesHeldEqualZero, sharesEqualZero));
 
             manager.add(new Separator());
@@ -170,10 +170,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                     // uncheck mutually exclusive actions if new filter is added
                     if (!isChecked)
                     {
-                        if (predicate == sharesGreaterZero)
+                        if (predicate == sharesNotZero)
                             recordFilter.remove(sharesEqualZero);
                         else if (predicate == sharesEqualZero)
-                            recordFilter.remove(sharesGreaterZero);
+                            recordFilter.remove(sharesNotZero);
                     }
 
                     setImage(recordFilter.isEmpty() && !clientFilterMenu.hasActiveFilter() ? Images.FILTER_OFF

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -196,7 +196,7 @@ public class SecurityListView extends AbstractFinanceView
         private final Predicate<Security> securityIsNotInactive = record -> !record.isRetired();
         private final Predicate<Security> onlySecurities = record -> !record.isExchangeRate();
         private final Predicate<Security> onlyExchangeRates = record -> record.isExchangeRate();
-        private final Predicate<Security> sharesGreaterZero = record -> getSharesHeld(getClient(), record) > 0;
+        private final Predicate<Security> sharesNotZero = record -> getSharesHeld(getClient(), record) != 0;
         private final Predicate<Security> sharesEqualZero = record -> getSharesHeld(getClient(), record) == 0;
 
         public FilterDropDown(IPreferenceStore preferenceStore)
@@ -218,7 +218,7 @@ public class SecurityListView extends AbstractFinanceView
             if ((savedFilters & (1 << 3)) != 0)
                 filter.add(onlyExchangeRates);
             if ((savedFilters & (1 << 4)) != 0)
-                filter.add(sharesGreaterZero);
+                filter.add(sharesNotZero);
             if ((savedFilters & (1 << 5)) != 0)
                 filter.add(sharesEqualZero);
 
@@ -234,7 +234,7 @@ public class SecurityListView extends AbstractFinanceView
                     savedFilter += (1 << 2);
                 if (filter.contains(onlyExchangeRates))
                     savedFilter += (1 << 3);
-                if (filter.contains(sharesGreaterZero))
+                if (filter.contains(sharesNotZero))
                     savedFilter += (1 << 4);
                 if (filter.contains(sharesEqualZero))
                     savedFilter += (1 << 5);
@@ -283,7 +283,7 @@ public class SecurityListView extends AbstractFinanceView
             manager.add(createAction(Messages.SecurityListFilterHideInactive, securityIsNotInactive));
             manager.add(createAction(Messages.SecurityListFilterOnlySecurities, onlySecurities));
             manager.add(createAction(Messages.SecurityListFilterOnlyExchangeRates, onlyExchangeRates));
-            manager.add(createAction(Messages.SecurityFilterSharesHeldGreaterZero, sharesGreaterZero));
+            manager.add(createAction(Messages.SecurityFilterSharesHeldNotZero, sharesNotZero));
             manager.add(createAction(Messages.SecurityFilterSharesHeldEqualZero, sharesEqualZero));
         }
 
@@ -309,8 +309,8 @@ public class SecurityListView extends AbstractFinanceView
                         else if (predicate == onlyExchangeRates)
                             filter.remove(onlySecurities);
                         else if (predicate == sharesEqualZero)
-                            filter.remove(sharesGreaterZero);
-                        else if (predicate == sharesGreaterZero)
+                            filter.remove(sharesNotZero);
+                        else if (predicate == sharesNotZero)
                             filter.remove(sharesEqualZero);
                     }
 


### PR DESCRIPTION
In lists of securities, there are two corresponding filters: show only entries with no holdings, or entries with positive holdings. They are not exact complements of each other in that negative holdings aren’t shown when either filter is active. This can mask errors in transactions; furthermore, there are users who do short selling and therefore intentionally have negative numbers of shares, even though this is not officially supported.

Change the “number of shares held is greater than zero” filter into “number of shares held is not zero”. This doesn’t change anything as long as the numbers are non-negative, but for users with negative holdings, those are no longer hidden from view.

[Feature request](https://forum.portfolio-performance.info/t/15545)