### PR TITLE
Fix charts to actually show 5 years when selected

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -170,7 +170,7 @@ public class SecuritiesChart
                 case Y3:
                     return new ChartInterval(now.minus(Period.ofYears(3)), now);
                 case Y5:
-                    return new ChartInterval(now.minus(Period.ofYears(4)), now);
+                    return new ChartInterval(now.minus(Period.ofYears(5)), now);
                 case Y10:
                     return new ChartInterval(now.minus(Period.ofYears(10)), now);
                 case YTD:


### PR DESCRIPTION
Fix bug introduced in commit 6fd8630f46786336b2d2f6fd35d8095f7988a834 where 5-year securities charts only showed 4 years.