### PR TITLE
Add support for Postfinance interest statement PDF extraction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinancePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinancePDFExtractorTest.java
@@ -307,4 +307,114 @@ public class PostfinancePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-03T00:00")));
     }
+    
+    @Test
+    public void testZinsabschluss01()
+    {
+        Client client = new Client();
+
+        PostfinancePDFExtractor extractor = new PostfinancePDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        //test format used before 2018
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "PostfinanceZinsabschluss01.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+       
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", Values.Amount.factorize(4.59))));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-31T00:00")));
+    }
+    
+    @Test
+    public void testZinsabschluss02()
+    {
+        Client client = new Client();
+
+        PostfinancePDFExtractor extractor = new PostfinancePDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        //test format used before 2018
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "PostfinanceZinsabschluss02.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+       
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(116.66))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", Values.Amount.factorize(75.83))));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-31T00:00")));
+        
+        Optional<Unit> unit = transaction.getUnit(Unit.Type.TAX);
+        assertThat("Expect tax unit", unit.isPresent());
+        assertThat(unit.get().getAmount(), is(Money.of("CHF", Values.Amount.factorize(40.83))));
+    }
+    
+    @Test
+    public void testZinsabschlussBefore2018_01()
+    {
+        Client client = new Client();
+
+        PostfinancePDFExtractor extractor = new PostfinancePDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        //test format used before 2018
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "PostfinanceZinsabschlussBefore2018_01.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+       
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", Values.Amount.factorize(1.00))));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-12-31T00:00")));
+    }
+    
+    @Test
+    public void testZinsabschlussBefore2018_02()
+    {
+        Client client = new Client();
+
+        PostfinancePDFExtractor extractor = new PostfinancePDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        //test format used before 2018
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "PostfinanceZinsabschlussBefore2018_02.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+       
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(400.00))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", Values.Amount.factorize(260.00))));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-31T00:00")));
+
+        Optional<Unit> unit = transaction.getUnit(Unit.Type.TAX);
+        assertThat("Expect tax unit", unit.isPresent());
+        assertThat(unit.get().getAmount(), is(Money.of("CHF", Values.Amount.factorize(140.00))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschluss01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschluss01.txt
@@ -1,0 +1,33 @@
+PDF Autor: 'PostFinance AG'
+PDFBox Version: 1.8.16
+-----------------------------------------
+PostFinance AG 
+Sie werden betreut von 
+Betreuer und Team Post  CH  AG 
+Telefon +41 111 222 333 
+Fax +41 11 222 333 44 P.  P.  CH- 4808  Ort A- PRIORITY 
+www.postfinance.ch 
+Herr 
+Vorname Nachname 
+Nachname Vorname Strasse 123 
+Stadt 1234 Stadt 
+E-Sparkonto Seite: 1 / 1 
+Zinsabschluss 01.01.2019 - 31.12.2019 Datum: 01.01.2020 
+IBAN CH64 0900 0000 1111 2222 1 CHF 
+Kontonummer 11-112222-1 
+BIC POFICHBEXXX 
+Datum Text Gutschrift Lastschrift Saldo 
+31.12.2019 Kontostand 10 000.00 
+Habenzins 
+01.01.2019 – 31.10.2019 0.05% 4.17 
+01.11.2019 – 31.12.2019 0.025% 0.42 
+Bruttozins 4.59 0.00 
+Zins 4.59 
+Zins verrechnungssteuerfrei 4.59 
+Nettozins 4.59 
+31.12.2019 Kontostand nach Zinsabschluss 10 004.59 
+Bitte überprüfen Sie den Zinsabschluss. Ohne Ihren Gegenbericht innert 30 Tagen gilt er als genehmigt. 
+Bitte aufbewahren! Dient als Nachweis für Ihre Steuererklärung. 
+Freundliche Grüsse 
+PostFinance AG 
+00648 DE   000019.00 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschluss02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschluss02.txt
@@ -1,0 +1,33 @@
+PDF Autor: 'PostFinance AG'
+PDFBox Version: 1.8.16
+-----------------------------------------
+PostFinance AG 
+Sie werden betreut von 
+Betreuer und Team Post  CH  AG 
+Telefon +41 111 222 333 
+Fax +41 11 222 333 44 P.  P.  CH- 4808  Ort A- PRIORITY 
+www.postfinance.ch 
+Herr 
+Vorname Nachname 
+Nachname Vorname Strasse 123 
+Stadt 1234 Stadt 
+E-Sparkonto Seite: 1 / 1 
+Zinsabschluss 01.01.2019 - 31.12.2019 Datum: 01.01.2020 
+IBAN CH64 0900 0000 1111 2222 1 CHF 
+Kontonummer 11-112222-1 
+BIC POFICHBEXXX 
+Datum Text Gutschrift Lastschrift Saldo 
+31.12.2019 Kontostand 10 000.00 
+Habenzins 
+01.01.2019 – 31.10.2019 1.00% 83.33 
+01.11.2019 – 31.12.2019 2.00% 33.33 
+Bruttozins 116.66 0.00 
+Zins 116.66 
+Verrechnungssteuer 35.00% 40.83 
+Nettozins 75.83 
+31.12.2019 Kontostand nach Zinsabschluss 10 075.83 
+Bitte überprüfen Sie den Zinsabschluss. Ohne Ihren Gegenbericht innert 30 Tagen gilt er als genehmigt. 
+Bitte aufbewahren! Dient als Nachweis für Ihre Steuererklärung. 
+Freundliche Grüsse 
+PostFinance AG 
+00648 DE   000019.00 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschlussBefore2018_01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschlussBefore2018_01.txt
@@ -1,0 +1,33 @@
+PDF Autor: 'PostFinance'
+PDFBox Version: 1.8.16
+-----------------------------------------
+PostFinance AG
+Sie werden betreut von
+Max Mustermann und Team Post CH AG
+Telefon +41 000 000 000
+Fax +41 00 000 00 00 P.P. CH-0000 Stadt A-PRIORITY
+www.postfinance.ch
+Herr
+Vorname Nachname
+Nachname Vorname Strasse 01
+Gemeinde 1324 Gemeinde
+Privatkonto Seite: 1 / 1
+Zinsabschluss 01.01.2015 - 31.12.2015 Datum: 01.01.2016
+Kontonummer 11-22222-0 CHF
+IBAN CH11 0900 0000 1102 2222 0
+BIC POFICHBEXXX
+Datum Text Gutschrift Lastschrift Saldo
+31.12.2015 Kontostand 10 000.00
+HABENZINS
+010115 - 311215 0.01 % 1.00
+BRUTTOZINS 1.00
+ZINS VERRECHNUNGSSTEUERFREI 1.00
+NETTOZINS 1.00
+31.12.2015 Kontostand nach Zinsabschluss 10 001.00
+Gebührenausweis 01.01.2015 - 31.12.2015
+Zusammenstellung der belasteten Kontoführungsgebühr: CHF 60.00
+Bitte überprüfen Sie den Zinsabschluss. Ohne Ihren Gegenbericht innert 30 Tagen gilt er als genehmigt.
+Bitte aufbewahren! Dient als Nachweis für Ihre Steuererklärung.
+Freundliche Grüsse
+PostFinance AG
+00044  DE

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschlussBefore2018_02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinanceZinsabschlussBefore2018_02.txt
@@ -1,0 +1,33 @@
+PDF Autor: 'PostFinance'
+PDFBox Version: 1.8.16
+-----------------------------------------
+PostFinance AG
+Sie werden betreut von
+Max Mustermann und Team Post CH AG
+Telefon +41 000 000 000
+Fax +41 00 000 00 00 P.P. CH-0000 Stadt A-PRIORITY
+www.postfinance.ch
+Herr
+Vorname Nachname
+Nachname Vorname Strasse 01
+Gemeinde 1324 Gemeinde
+Privatkonto Seite: 1 / 1
+Zinsabschluss 01.01.2017 - 31.12.2017 Datum: 01.01.2018
+Kontonummer 11-22222-0 CHF
+IBAN CH11 0900 0000 1102 2222 0
+BIC POFICHBEXXX
+Datum Text Gutschrift Lastschrift Saldo
+31.12.2017 Kontostand 100 000.00
+HABENZINS
+010117 - 311217 4.00 % 400.00
+BRUTTOZINS 400.00
+VERRECHNUNGSSTEUER 35% 140.00
+NETTOZINS 260.00
+31.12.2017 Kontostand nach Zinsabschluss 100 260.00
+Gebührenausweis 01.01.2017 - 31.12.2017
+Zusammenstellung der belasteten Kontoführungsgebühr: CHF 60.00
+Bitte überprüfen Sie den Zinsabschluss. Ohne Ihren Gegenbericht innert 30 Tagen gilt er als genehmigt.
+Bitte aufbewahren! Dient als Nachweis für Ihre Steuererklärung.
+Freundliche Grüsse
+PostFinance AG
+00044  DE


### PR DESCRIPTION
Adding PDF extraction for Swiss Postfinance interest statements. Both current format and pre-2018 documents are supported. Test documents are sanitized regarding personal sensitive data.