### PR TITLE
Feature: Limits in Chart darstellen

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -517,6 +517,7 @@ public class Messages extends NLS
     public static String LabelChartDetailMovingAverage_100days;
     public static String LabelChartDetailMovingAverage_200days;
     public static String LabelChartDetailSettings;
+    public static String LabelChartDetailSettingsShowLimits;
     public static String LabelChartDetailSettingsShowMarkerLines;
     public static String LabelChartDetailSettingsShowDataLabel;
     public static String LabelChartDetailSettingsShowMissingTradingDays;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1048,6 +1048,8 @@ LabelChartDetailMovingAverage_90days = 90 days
 
 LabelChartDetailSettings = Settings
 
+LabelChartDetailSettingsShowLimits = Show limits
+
 LabelChartDetailSettingsShowDataLabel = Show data labels
 
 LabelChartDetailSettingsShowMarkerLines = Show with marker lines

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1041,6 +1041,8 @@ LabelChartDetailMovingAverage_90days = 90 Tage
 
 LabelChartDetailSettings = Einstellungen
 
+LabelChartDetailSettingsShowLimits = Zeige Limits
+
 LabelChartDetailSettingsShowDataLabel = Zahlenwerte anzeigen
 
 LabelChartDetailSettingsShowMarkerLines = Darstellung mit Markierungslinien

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1041,6 +1041,8 @@ LabelChartDetailMovingAverage_90days = 90 d\u00EDas
 
 LabelChartDetailSettings = Opini\u00F3n
 
+LabelChartDetailSettingsShowLimits = = Mostrar l\u00EDmites
+
 LabelChartDetailSettingsShowDataLabel = Mostrar etiquetas de datos
 
 LabelChartDetailSettingsShowMarkerLines = Mostrar con l\u00EDneas de marcador

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1042,6 +1042,8 @@ LabelChartDetailMovingAverage_90days = 90 jours
 
 LabelChartDetailSettings = Param\u00E8tres
 
+LabelChartDetailSettingsShowLimits = = Afficher les limites
+
 LabelChartDetailSettingsShowDataLabel = Afficher \u00E9tiquettes de donn\u00E9es
 
 LabelChartDetailSettingsShowMarkerLines = Afficher les lignes de marqueurs

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1041,6 +1041,8 @@ LabelChartDetailMovingAverage_90days = 90 giorni
 
 LabelChartDetailSettings = Impostazioni
 
+LabelChartDetailSettingsShowLimits = = Mostra i limiti
+
 LabelChartDetailSettingsShowDataLabel = Mostra etichette dati
 
 LabelChartDetailSettingsShowMarkerLines = Mostra con linee di marcatura

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1041,6 +1041,8 @@ LabelChartDetailMovingAverage_90days = 90 dagen
 
 LabelChartDetailSettings = Instelling
 
+LabelChartDetailSettingsShowLimits = = Toon Grenzen
+
 LabelChartDetailSettingsShowDataLabel = Toon datalabels
 
 LabelChartDetailSettingsShowMarkerLines = Weergeven met markeringslijnen

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1041,6 +1041,8 @@ LabelChartDetailMovingAverage_90days = 90 dias
 
 LabelChartDetailSettings = Defini\u00E7\u00F5es
 
+LabelChartDetailSettingsShowLimits = = Mostrar limites
+
 LabelChartDetailSettingsShowDataLabel = Mostrar r\u00F3tulos de dados
 
 LabelChartDetailSettingsShowMarkerLines = Mostrar com linhas de marcador

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Attributes.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Attributes.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.model;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -32,5 +33,12 @@ public class Attributes
     {
         return map.values().stream();
     }
+    
+    public Map<String, Object> getMap()
+    {
+        return Collections.unmodifiableMap(map);
+    }
+    
+    
 
 }


### PR DESCRIPTION
Hallo,
mit dem Feature #1330 sind die Limits in die Wertpapiertabelle hinein gekommen.
Ich fände eine Darstellung der Limits als horizontale Linien im Chart sehr hilfreich und habe mich mal dran gesetzt.

So sieht mein Vorschlag dazu aus:
![grafik](https://user-images.githubusercontent.com/90478568/133496819-76cc0b08-72ff-4019-a6cf-b543f5635cb1.png)

Bei folgenden Punkten bin ich mir unsicher:
* Farbe der Linien ok?
* In der LineId (für die Legende) wäre der Spaltenname oder der Attributsname besser geeignet (im Beispiel oben wären das "Limit1" und "Limit2"). Ich habe bisher keinen einfachen Weg gefunden an diesen heranzukommen. Deshalb steht erstmal nur "LimitPrice" davor.
* Ist das Sub-Einstellungsmenü "Markierungen" für die Option geeignet oder ist ein anderes vorteilhafter?

Grüße
OnkelDok