### PR TITLE
fixes issue with new "show limits" feature when empty limit attribute assigned to security

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -949,8 +949,8 @@ public class SecuritiesChart
     private void addLimitLines(ChartInterval chartInterval, ChartRange range)
     {
         this.security.getAttributes().getMap().forEach((key, val) -> {
-            // not Limit Price --> ignore
-            if (val.getClass() != LimitPrice.class)
+            // null OR not Limit Price --> ignore
+            if (val == null || val.getClass() != LimitPrice.class)
                 return;
 
             LimitPrice limitAttribute = (LimitPrice) val;


### PR DESCRIPTION
When a limit price attribute is assigned to a security, limit is not filled and the "show limits" option is active, a NullPointerException was thrown.