### PR TITLE
Retain original portfolio in trade transactions

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
@@ -228,7 +228,7 @@ public class TradeCollector
         PortfolioTransaction t = entry.getPortfolioTransaction();
 
         BuySellEntry copy = new BuySellEntry();
-        copy.setPortfolio(portfolio);
+        copy.setPortfolio(entry.getPortfolio());
         copy.setAccount(entry.getAccount());
 
         copy.setDate(t.getDateTime());


### PR DESCRIPTION
When collecting trades, the transactions making up a trade are stored for later display. It is sometimes necessary to split such a transaction, e.g. when a buy transaction belongs to two trades because the bought shares were later sold in separate transactions. Make sure that the split transaction still refers to the portfolio in which it was originally done, instead of any portfolios that it may have been transferred to later.

See https://forum.portfolio-performance.info/t/17792