### PR TITLE
Delete PDF Author functions in all pdf extractors

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -939,7 +939,6 @@ public class Messages extends NLS
     public static String PDFImportWizardAssistant;
     public static String PDFImportWizardErroneousFiles;
     public static String PDFImportWizardExtractor;
-    public static String PDFImportDebugAuthor;
     public static String PDFImportErrorParsingDocument;
     public static String PerformanceChartLabelEntirePortfolio;
     public static String PerformanceChartLabelCPI;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.ui.handlers;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.MessageFormat;
 
 import javax.inject.Named;
 
@@ -41,8 +40,7 @@ public class CreateTextFromPDFHandler
             PDFInputFile inputFile = new PDFInputFile(file);
             inputFile.convertPDFtoText();
 
-            String text = MessageFormat.format(Messages.PDFImportDebugAuthor, inputFile.getAuthor());
-            text += "\nPDFBox Version: " + inputFile.getPDFBoxVersion().toString(); //$NON-NLS-1$
+            String text = "PDFBox Version: " + inputFile.getPDFBoxVersion().toString(); //$NON-NLS-1$
             text += "\n-----------------------------------------\n"; //$NON-NLS-1$
             text += inputFile.getText().replace("\r","");   // CRLF to spac; //$NON-NLS-1$ //$NON-NLS-2$
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1878,8 +1878,6 @@ NewFileWizardTaxonomyDescription = Taxonomies are used for portfolio analysis al
 
 NewFileWizardTaxonomyTitle = Add Taxonomies
 
-PDFImportDebugAuthor = PDF author: ''{0}''
-
 PDFImportDebugTextExtraction = Debug: Extract text from PDF
 
 PDFImportErrorParsingDocument = Error reading or converting PDF document: {0} (Check error log for details)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1041,9 +1041,9 @@ LabelChartDetailMovingAverage_90days = 90 Tage
 
 LabelChartDetailSettings = Einstellungen
 
-LabelChartDetailSettingsShowLimits = Zeige Limits
-
 LabelChartDetailSettingsShowDataLabel = Zahlenwerte anzeigen
+
+LabelChartDetailSettingsShowLimits = Zeige Limits
 
 LabelChartDetailSettingsShowMarkerLines = Darstellung mit Markierungslinien
 
@@ -1870,8 +1870,6 @@ NewFileWizardSecurityTitle = Wertpapiere hinzuf\u00FCgen
 NewFileWizardTaxonomyDescription = Klassifizierungen erm\u00F6glichen die Analyse der Gesamtportfolio\nmit Hilfe von Kuchen- und Fl\u00E4chdiagrammen sowie Baumkarten.
 
 NewFileWizardTaxonomyTitle = Klassifizierungen hinzuf\u00FCgen
-
-PDFImportDebugAuthor = PDF Autor: ''{0}''
 
 PDFImportDebugTextExtraction = Debug: Text aus PDF extrahieren
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1041,9 +1041,9 @@ LabelChartDetailMovingAverage_90days = 90 d\u00EDas
 
 LabelChartDetailSettings = Opini\u00F3n
 
-LabelChartDetailSettingsShowLimits = = Mostrar l\u00EDmites
-
 LabelChartDetailSettingsShowDataLabel = Mostrar etiquetas de datos
+
+LabelChartDetailSettingsShowLimits = = Mostrar l\u00EDmites
 
 LabelChartDetailSettingsShowMarkerLines = Mostrar con l\u00EDneas de marcador
 
@@ -1864,8 +1864,6 @@ NewFileWizardSecurityTitle = A\u00F1adir instrumentos
 NewFileWizardTaxonomyDescription = A\u00F1adir taxonom\u00EDas para analizar la cartera a lo largo de varias dimensiones\nusando gr\u00E1ficos circulares, mapas de \u00E1rbol, y gr\u00E1ficos de l\u00EDnea apilados.
 
 NewFileWizardTaxonomyTitle = A\u00F1adir taxonom\u00EDas
-
-PDFImportDebugAuthor = Autor PDF: ''{0}''
 
 PDFImportDebugTextExtraction = Debug: extraer el texto de PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1042,9 +1042,9 @@ LabelChartDetailMovingAverage_90days = 90 jours
 
 LabelChartDetailSettings = Param\u00E8tres
 
-LabelChartDetailSettingsShowLimits = = Afficher les limites
-
 LabelChartDetailSettingsShowDataLabel = Afficher \u00E9tiquettes de donn\u00E9es
+
+LabelChartDetailSettingsShowLimits = = Afficher les limites
 
 LabelChartDetailSettingsShowMarkerLines = Afficher les lignes de marqueurs
 
@@ -1865,8 +1865,6 @@ NewFileWizardSecurityTitle = Ajouter instruments
 NewFileWizardTaxonomyDescription = Les taxonomies permettent d'analyser un portfolio sous tous les angles,\n\u00E0 l'aide de diagrammes circulaires, cartes proportionnelles, ou histogrammes.
 
 NewFileWizardTaxonomyTitle = Ajouter taxonomies
-
-PDFImportDebugAuthor = Auteur PDF : ''{0}''
 
 PDFImportDebugTextExtraction = Debug : extraire texte depuis PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1041,9 +1041,9 @@ LabelChartDetailMovingAverage_90days = 90 giorni
 
 LabelChartDetailSettings = Impostazioni
 
-LabelChartDetailSettingsShowLimits = = Mostra i limiti
-
 LabelChartDetailSettingsShowDataLabel = Mostra etichette dati
+
+LabelChartDetailSettingsShowLimits = = Mostra i limiti
 
 LabelChartDetailSettingsShowMarkerLines = Mostra con linee di marcatura
 
@@ -1870,8 +1870,6 @@ NewFileWizardSecurityTitle = Aggiungi strumenti
 NewFileWizardTaxonomyDescription = Le tassonomie vengono utilizzate per l'analisi del portafoglio in varie dimensioni\nutilizzando grafici a torta, mappa ad albero e grafici a linee impilate.
 
 NewFileWizardTaxonomyTitle = Aggiungi tassonomie
-
-PDFImportDebugAuthor = Autore PDF: "{0}"
 
 PDFImportDebugTextExtraction = Debug: Estrai testo da PDF
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1041,9 +1041,9 @@ LabelChartDetailMovingAverage_90days = 90 dagen
 
 LabelChartDetailSettings = Instelling
 
-LabelChartDetailSettingsShowLimits = = Toon Grenzen
-
 LabelChartDetailSettingsShowDataLabel = Toon datalabels
+
+LabelChartDetailSettingsShowLimits = = Toon Grenzen
 
 LabelChartDetailSettingsShowMarkerLines = Weergeven met markeringslijnen
 
@@ -1864,8 +1864,6 @@ NewFileWizardSecurityTitle = Instrumenten toevoegen
 NewFileWizardTaxonomyDescription = Voeg taxonomie\u00EBn toe om de portfolio in verschillende dimensies te analyseren \ndoor taartdiagrammen, boomkaarten en gestapelde lijnen te gebruiken.
 
 NewFileWizardTaxonomyTitle = Voeg taxonomie\u00EBn toe
-
-PDFImportDebugAuthor = PDF-auteur: ''{0}''
 
 PDFImportDebugTextExtraction = Debug: tekst uit PDF extraheren
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1041,9 +1041,9 @@ LabelChartDetailMovingAverage_90days = 90 dias
 
 LabelChartDetailSettings = Defini\u00E7\u00F5es
 
-LabelChartDetailSettingsShowLimits = = Mostrar limites
-
 LabelChartDetailSettingsShowDataLabel = Mostrar r\u00F3tulos de dados
+
+LabelChartDetailSettingsShowLimits = = Mostrar limites
 
 LabelChartDetailSettingsShowMarkerLines = Mostrar com linhas de marcador
 
@@ -1864,8 +1864,6 @@ NewFileWizardSecurityTitle = Adicionar instrumentos
 NewFileWizardTaxonomyDescription = Taxonomias s\u00E3o usadas para analisar o portf\u00F3lio em v\u00E1rias dimens\u00F5es, usando gr\u00E1ficos de pizza, mapa hier\u00E1rquico e gr\u00E1ficos de linhas empilhadas.
 
 NewFileWizardTaxonomyTitle = Adicionar taxonomias
-
-PDFImportDebugAuthor = Autor do PDF: ''{0}''
 
 PDFImportDebugTextExtraction = Depurar: extrair texto do PDF
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -70,11 +70,6 @@ public abstract class AbstractPDFExtractor implements Extractor
         return bankIdentifier;
     }
 
-    public String getPDFAuthor()
-    {
-        return null;
-    }
-
     @Override
     public List<Item> extract(SecurityCache securityCache, Extractor.InputFile inputFile, List<Exception> errors)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -37,12 +37,6 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
     }
 
-    @Override
-    public String getPDFAuthor()
-    {
-        return "Scalable Capital Vermögensverwaltung GmbH"; //$NON-NLS-1$
-    }
-
     @SuppressWarnings("nls")
     private void addBuyTransaction()
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -34,11 +34,6 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
     {
         return "Bank SLM AG"; //$NON-NLS-1$
     }
-    @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
 
     private void addBuySellTransaction()
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraGoAndGrowPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraGoAndGrowPDFExtractor.java
@@ -22,6 +22,12 @@ public class BondoraGoAndGrowPDFExtractor extends AbstractPDFExtractor
         addAccountStatementTransaction();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Bondora"; //$NON-NLS-1$
+    }
+
     private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType(ACCOUNT_STATEMENT_DOCUMENT_TYPE);
@@ -76,11 +82,5 @@ public class BondoraGoAndGrowPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             return new TransactionItem(t);
                         });
-    }
-
-    @Override
-    public String getLabel()
-    {
-        return "Bondora"; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -51,12 +51,6 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Comdirect Bank AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
@@ -33,12 +33,6 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Commonwealth Securities Limited"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -33,6 +33,12 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
         addKontoauszugGiro();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Commerzbank"; //$NON-NLS-1$
+    }
+
     private void addBuySellTransaction()
     {
         DocumentType type = new DocumentType("W e r t p a p i e r (k a u f|v e r k a u f)");
@@ -485,11 +491,5 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
     private String stripBlanks(String input)
     {
         return input.replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
-    }
-
-    @Override
-    public String getLabel()
-    {
-        return "Commerzbank"; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -57,12 +57,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Consorsbank"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -27,12 +27,6 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Credit Suisse AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -37,12 +37,6 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "DAB Bank / BNP Paribas S.A."; //$NON-NLS-1$
@@ -278,8 +272,9 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Netto in USD zugunsten IBAN DE90 209,38 USD
+                // Netto zugunsten IBAN DE11 7603 0080 0111 1111 14 437,22 EUR
                 .section("amount", "currency").optional()
-                .match("^Netto .* zugunsten IBAN .* (?<amount>[.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Netto (.*)?zugunsten IBAN .* (?<amount>[.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(v.get("currency"));
                     t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -38,12 +38,6 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "DADAT / Bankhaus Schelhammer & Schattera AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankPDFExtractor.java
@@ -39,12 +39,6 @@ public class DZBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "DZBank"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "DZBank"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -42,12 +42,6 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         return "DEGIRO"; //$NON-NLS-1$
     }
 
-    @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
     private static class FxChange
     {
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -29,12 +29,6 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Deutsche Bank Privat- und Geschäftskunden AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -30,12 +30,6 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "1822direkt"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "1822direkt"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -48,9 +48,9 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
+    public String getLabel()
     {
-        return "DKB AG"; //$NON-NLS-1$
+        return "Deutsche Kreditbank AG"; //$NON-NLS-1$
     }
 
     private void addBuyTransaction()
@@ -1084,11 +1084,5 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(TransactionItem::new));
-    }
-
-    @Override
-    public String getLabel()
-    {
-        return "DKB"; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
@@ -28,12 +28,6 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "3BankenEDV"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "3BankenEDV"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -34,12 +34,6 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Erste Bank Gruppe / BrokerJet"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
@@ -29,12 +29,6 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "FIL Fondsbank GmbH (Fidelity Group)"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -41,12 +41,6 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "flatexDEGIRO Bank AG / FinTech Group Bank AG / biw AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GLSBankengemeinschaftPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GLSBankengemeinschaftPDFExtractor.java
@@ -31,12 +31,6 @@ public class GLSBankengemeinschaftPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "GLS Gemeinschaftsbank eG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -29,12 +29,6 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Hello Bank"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaExtractor.java
@@ -53,12 +53,6 @@ public class INGDiBaExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "ING-DiBa"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "ING-DiBa AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -42,12 +42,6 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Sutor Bank / justTRADE"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -28,12 +28,6 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Keytrade Bank"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -29,12 +29,6 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "LGT Bank AG"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "LGT Bank AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -23,12 +23,6 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "MLP Banking AG"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "MLP Banking AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -51,6 +51,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
         addAdvanceTaxTransaction();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Onvista-Bank"; //$NON-NLS-1$
+    }
+
     private void addBuyTransaction()
     {
         DocumentType type = new DocumentType("Wir haben für Sie gekauft");
@@ -1793,10 +1799,5 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                                         + t.getCurrencyCode()));
 
         block.set(advanceTaxTransaction);
-    }
-    @Override
-    public String getLabel()
-    {
-        return "Onvista-Bank"; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
@@ -9,7 +9,6 @@ import java.util.Scanner;
 
 import org.apache.pdfbox.exceptions.CryptographyException;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.util.PDFTextStripper;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Version;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
@@ -19,7 +19,6 @@ import name.abuchen.portfolio.datatransfer.Extractor;
 public class PDFInputFile extends Extractor.InputFile
 {
     private String text;
-    private String author;
 
     public PDFInputFile(File file)
     {
@@ -64,11 +63,6 @@ public class PDFInputFile extends Extractor.InputFile
         return text;
     }
 
-    public String getAuthor()
-    {
-        return author;
-    }
-
     public Version getPDFBoxVersion()
     {
         return FrameworkUtil.getBundle(PDDocument.class).getVersion();
@@ -84,8 +78,6 @@ public class PDFInputFile extends Extractor.InputFile
                 document.decrypt(""); //$NON-NLS-1$
                 document.setAllSecurityToBeRemoved(true);
             }
-            PDDocumentInformation pdd = document.getDocumentInformation();
-            author = pdd.getAuthor() == null ? "" : pdd.getAuthor(); //$NON-NLS-1$
 
             PDFTextStripper textStripper = new PDFTextStripper();
             textStripper.setSortByPosition(true);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
@@ -30,12 +30,6 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return "Deutsche Postbank AG"; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Postbank"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -41,12 +41,6 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "PostFinance AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirionPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirionPDFExtractor.java
@@ -25,6 +25,12 @@ public class QuirionPDFExtractor extends AbstractPDFExtractor
         addPeriodenauszugTransactions();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Quirion"; //$NON-NLS-1$
+    }
+
     @SuppressWarnings("nls")
     private void addPeriodenauszugTransactions()
     {
@@ -380,11 +386,5 @@ public class QuirionPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(BuySellEntryItem::new));
 
-    }
-
-    @Override
-    public String getLabel()
-    {
-        return "Quirion"; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -28,12 +28,6 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Raiffeisenbank Bankgruppe"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
@@ -36,6 +36,12 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         addTransactionWith2021Format();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Renault Bank direkt"; //$NON-NLS-1$
+    }
+
     private void addTransactionWith2019Format()
     {
         DocumentType type = new DocumentType("305 200 37", contextProvider2019());
@@ -159,17 +165,5 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
                 context.put(CONTEXT_KEY_CURRENCY, currencyMatcher.group("currency"));
             }
         }
-    }
-
-    @Override
-    public String getLabel()
-    {
-        return "Renault Bank direkt"; //$NON-NLS-1$
-    }
-    
-    @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -32,12 +32,6 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         return "S Broker AG & Co. KG / Sparkasse"; //$NON-NLS-1$
     }
 
-    @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
     private void addBuySellTransaction()
     {
         DocumentType type = new DocumentType("(Kauf(.*)?|Verkauf(.*)?|Wertpapier Abrechnung Ausgabe Investmentfonds)");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
@@ -29,12 +29,6 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "SelfWealth"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
@@ -30,12 +30,6 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Swissquote Bank AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -58,6 +58,12 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         addDividendTransactionFromTaxDocument();
     }
 
+    @Override
+    public String getLabel()
+    {
+        return "Targobank AG"; //$NON-NLS-1$
+    }
+
     @SuppressWarnings("nls")
     private void addBuyTransaction()
     {
@@ -493,11 +499,4 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         return items;
 
     }
-
-    @Override
-    public String getLabel()
-    {
-        return "TARGO"; //$NON-NLS-1$
-    }
-
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -38,12 +38,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Trade Republic Bank GmbH"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -25,12 +25,6 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "UniCredit Bank AG / HypoVereinsbank (HVB)"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
@@ -28,12 +28,6 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "V-Bank AG"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ViacPDFExtractor.java
@@ -38,12 +38,6 @@ public class ViacPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "WIR Bank Genossenschaft"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -32,12 +32,6 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
-    public String getPDFAuthor()
-    {
-        return ""; //$NON-NLS-1$
-    }
-
-    @Override
     public String getLabel()
     {
         return "Weberbank"; //$NON-NLS-1$


### PR DESCRIPTION
Sometimes a 'BankIdentifier' is recognized as PDF author from the PDF extractors.
This can cause the wrong PDF extractor to be selected and errors to occur.
Since the PDF author is not used when extracting PDF's, we do not set it.
The same is true for the help function when PDF debug is created.

The PDF Author say "Consorbank" but this dokument is Smartbroker/DAB-Bank
![grafik](https://user-images.githubusercontent.com/45203494/134332924-5def80c7-c1e2-4c7c-a67e-666a60f6552b.png)
https://forum.portfolio-performance.info/t/pdf-import-smartbroker-dab-bank/7684/160
