### PR TITLE
Fix French translation

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_fr.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/messages_fr.properties
@@ -62,7 +62,7 @@ CSVColumn_PortfolioName = Compte-titres
 
 CSVColumn_PortfolioName2nd = Compte de compensation
 
-CSVColumn_Quote = Cotisation
+CSVColumn_Quote = Cotation
 
 CSVColumn_SecurityName = Nom du titre
 


### PR DESCRIPTION
There is a small glitch in the french translation.
When you import historical quotes, the field is mapped with "Cotisation" which means in english "Contribution".
So in this case `s/Cotisation/Cotation`