### PR TITLE
Fixes StatementOfAssetsView model update issue

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -205,7 +205,10 @@ public class StatementOfAssetsView extends AbstractFinanceView
         assetViewer.setToolBarManager(getViewToolBarManager());
 
         updateTitle(getDefaultTitle());
-        assetViewer.getColumnHelper().addListener(() -> updateTitle(getDefaultTitle()));
+        assetViewer.getColumnHelper().addListener(() -> {
+            updateTitle(getDefaultTitle());
+            notifyModelUpdated();
+        });
 
         hookContextMenu(assetViewer.getTableViewer().getControl(),
                         manager -> assetViewer.hookMenuListener(manager, StatementOfAssetsView.this));


### PR DESCRIPTION
This fixes the issue where the model of the StatementOfAssetsView (Vermögensverwaltung) is not updated properly after switching  between views (Ansicht) created by the user in the toolbar. Switching between multiple custom views on the StatementOfAssetsView currently results to blank columns after repeating the clicking through the custum views. As a workaround, the model is updated - and the blank columns disapear - after switching to (and back from) a different finance view e.g. security view (Alle Wertpapiere).