### PR TITLE
Modify Comdirect PDF-Importer to support foreign currency account

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -2833,8 +2833,7 @@ public class ComdirectPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(
-                        PDFInputFile.loadTestCase(getClass(), "Finanzreport02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Finanzreport02.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(11));
@@ -2984,8 +2983,7 @@ public class ComdirectPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(
-                        PDFInputFile.loadTestCase(getClass(), "Finanzreport03.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Finanzreport03.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(13));
@@ -3149,6 +3147,330 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-22T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.16)));
+        }
+    }
+
+    @Test
+    public void testFinanzreport04()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Finanzreport04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(7));
+
+        // check transaction
+        // get transactions
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(7L));
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction1
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-14T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(501.00)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction2
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(2450.87)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction3
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(2450.87)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction4
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.07)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-09T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(1200)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction7
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.USD));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-14T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(554.83)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction6
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.02)));
+        }
+    }
+
+    @Test
+    public void testFinanzreport05()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Finanzreport05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(17));
+
+        // check transaction
+        // get transactions
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(17L));
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction1
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-08-01T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(894.30)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction2
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-04T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.42)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction3
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-04T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(188.58)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction4
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-08T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.36)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-08T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(124.64)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-13T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.30)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.30)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-13T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-22T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.89)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-22T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(129.11)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-28T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.70)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-28T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(257.30)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-11T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(1000)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-08-01T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(2.97)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction5
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-29T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(894.30)));
         }
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport04.txt
@@ -1,0 +1,176 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+comdirect bank AG, 25449 Quickborn 978 56 010
+Frau Erika Musterfrau Telefon: 04106 - 708 25 00
+Herrn Max Mustermann Telefax: 04106 - 708 25 85
+Musterstr. 123 E-Mail: www.comdirect.de/kontakt
+12345 Musterhausen (E-Mail über Kontaktformular)
+Kundennummer: 123 4567890
+Finanzreport Nr. 2 per 03.07.2017
+Sehr geehrte Frau Musterfrau,
+sehr geehrter Herr Mustermann,
+
+in Ihrem aktuellen Finanzreport finden Sie alle Informationen rund um Ihre Konten und Ihr
+Depot.
+Für Fragen zum Finanzreport oder unseren Leistungen stehen Ihnen unsere Kundenbetreuer
+telefonisch unter 04106 - 708 25 00 rund um die Uhr gerne zur Verfügung.
+Mit freundlichen Grüßen
+comdirect bank AG
+Aktuelle Informationen:
+Den comdirect Ratenkredit haben wir für Sie noch einmal verbessert: Ab sofort können Inhaber
+eines Gemeinschaftskontos zusammen von unseren Top-Konditionen profitieren. Mehr
+Informationen: www.comdirect.de/ratenkredit
+Urlaubsplanung für Ihr Depot, damit Ihr Wertpapiervermögen nicht buchstäblich in das Wasser
+fällt. Nutzen Sie vor Urlaubsantritt unsere Komfortorders und sichern Sie Ihr Depot ab. Mehr
+dazu unter www.comdirect.de/komfortorders
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 6 per 03.07.2017 - Seite 2
+Kundennummer 123 4567890
+Kontoübersicht
+Ihre aktuellen Salden IBAN Saldo in Saldo in
+Kontowährung EUR
+Girokonto DE33 2004 1155 1234 5678 00 +46,63
+Tagesgeld PLUS-Konto DE92 2004 1155 1234 5678 05 +0,02
+Währungsanlagekonto (USD) DE31 2004 1155 1234 5678 05 +554,83 +487,76
+Depot +15.670,73
+Visa-Karte 1111 +0,00
+Gesamtsaldo 03.07.2017 +16.205,14
+
+Girokonto Dispositionskredit girocard Tages-/WochenlimitEUR 0 EUR 1.000/EUR 2.000
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.06.2017 +570,26
+12.06.2017 Kontoübertrag UEBERTRAG UNS. -501,00
+14.06.2017 11A111111A1111 REF: AAAAA111111111 01
+111/11 IHRE REF: 111111
+13.06.2017 Kontoübertrag Max Mustermann Uebertrag auf Girokonto +2.450,87
+13.06.2017 AA111111A111 DE92200411551234567805 End-to-End-Ref.: nicht
+4187/1 COBADEHD001 angegeben
+13.06.2017 Wertpapiere LAM RESEARCH CORP. DL-001 -2.482,57
+15.06.2017 1AA1111111111 WPKNR: 869686 ISIN: US5128071082
+111/1
+14.06.2017 Übertrag/Über Gutschrift aus Bonus-Sparen +9,07
+13.06.2017 weisung
+1AA111111111
+1111/1111
+Neuer Saldo 03.07.2017 +46,63
+Tagesgeld PLUS-Konto
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.06.2017 +1.250,87
+09.06.2017 Übertrag/Über Max Mustermann Sparen +1.200,00
+09.06.2017 weisung End-to-End-Ref.: nicht
+AA1111111111 angegeben
+111/11111
+13.06.2017 Übertrag/Über Max Mustermann Uebertrag auf Girokonto -2.450,87
+13.06.2017 weisung DE33200411551234567800 End-to-End-Ref.: nicht
+AA111111A111 COBADEHD001 angegeben
+1111/1
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 6 per 03.07.2017 - Seite 3
+Kundennummer 123 4567890
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+30.06.2017 Kontoabschluss Abschluss Zinsen Kto 12345678EUR +0,02
+30.06.2017 1AA11111A1111 von 31.03.2017 bis 30.06.2017
+111/1111 Habenzinsen
+0,010% ab 31.03. 0,02 EUR
+Abschlussrechnung 0,02 EUR
+Saldo nach Abschluss 0,02 EUR
+Neuer Saldo 03.07.2017 +0,02
+Währungsanlagekonto (USD)
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.06.2017 +0,00
+12.06.2017 Kontoübertrag UEBERTRAG UNS. +554,83
+14.06.2017 11A11111A1111 REF: AAAAA111111111 01
+111/11 IHRE REF: 111111
+Neuer Saldo 03.07.2017 +554,83
+Visa-Karte 1111 Visa Limit Verfügungslimit am GeldautomatEUR 1.000/Monat EUR 600/Tag
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.06.2017 +0,00
+Neuer Saldo 03.07.2017 +0,00
+Depot
+Depotbestand EUR EUR EUR
+Bezeichnung Anzahl/Nominal letzter Währung Kurswert Kaufwert Gewinn/Verlust
+Kurs Stückzinsen
+A1ANQ2 9.000,000 51,945 USD 4.109,93 4.598,63 -488,70
+VENEZUELA 09/19 REGS +136,26
+587800 120,000 49,390 EUR 5.926,80 5.595,00 +331,80
+DMG MORI AG O.N. +0,00
+869686 18,000 122,415 EUR 2.203,47 2.466,00 -262,53
+LAM RESEARCH CORP. DL-001 +0,00
+871981 27,000 122,010 EUR 3.294,27 3.294,00 +0,27
+ADOBE SYST. INC. +0,00
+Gesamtkurswert 15.534,47 15.953,63 -419,16
+Stückzinsen gesamt +136,26
+Gesamtwert 15.670,73
+Die Kaufwerte und damit die Gesamtbewertung in der Depotübersicht stellt lediglich eine vereinfachte
+Gewinn/Verlust-Rechnung dar. Steuerliche Gesichtspunkte werden bei dieser Darstellung nicht berücksichtigt.
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 6 per 03.07.2017 - Seite 4
+Kundennummer 123 4567890
+Steuerübersicht1
+Steuerliche Daten EUR
+Gewinne/Verluste aus Aktien (Verrechnungssaldo) +0,00
+Gewinne/Verluste Sonstige (Verrechnungssaldo) +307,07
+Eingereichter Freibetrag 800,00
+In Anspruch genommener Freibetrag 307,07
+Verbleibender Freibetrag 492,93
+Anrechenbare ausländische Quellensteuer 0,00
+Abgeführte Kapitalertragsteuer 0,00
+Abgeführter Solidaritätszuschlag 0,00
+Abgeführte Kirchensteuer 0,00
+Angerechnete ausländische Quellensteuer 0,00
+1 Dies ist keine Steuerbescheinigung.
+Zinsübersicht
+Girokonto
+Zinssatz für die Inanspruchnahme des Dispositionskredites: 6,50 % p. a. (gültig ab: 03.04.2017)
+Zinssatz für geduldete Überziehungen: 11,00 % p. a. (gültig ab: 03.04.2017)
+Verrechnungskonto/Tagesgeld PLUS-Konto/O&F-Konto
+Zinssatz für geduldete Überziehungen: 11,00 % p. a. (gültig ab: 03.04.2017)
+Zinsgleitklausel für variable Sollzinssätze:
+Die Bank wird variable Sollzinssätze entsprechend den Änderungen des Hauptrefinanzierungszinssatzes der Europäischen Zentralbank
+(nachfolgend EZB-Zinssatz) nach folgender Maßgabe anpassen: Sofern am letzten Bankarbeitstag vor dem 15. eines Kalendermonats von der
+Bank eine Erhöhung des EZB-Zinssatzes um mindestens 0,25 Prozentpunkte gegenüber dem EZB-Zinssatz im Monat der letzten Zinsanpassung
+festgestellt wird, erhöht die Bank den variablen Sollzinssatz entsprechend. Die Bank verpflichtet sich dagegen zur Senkung des variablen
+Sollzinssatzes um die Veränderung des EZB-Zinssatzes, wenn der EZB-Zinssatz um mindestens 0,25 Prozentpunkte gesunken ist. Die
+Zinsanpassungen werden 5 Bankarbeitstage nach dem 15. eines Kalendermonats ohne gesonderte Erklärung gegenüber dem Kontoinhaber bei
+der comdirect bank AG wirksam. Die comdirect bank AG wird den Kontoinhaber in regelmäßigen Zeitabständen im Finanzreport unterrichten.
+Der Kontoinhaber kann die Höhe des EZB-Zinssatzes jederzeit auf der Webseite der comdirect bank AG bzw. in anderen öffentlich zugänglichen
+Medien (insbesondere www.bundesbank.de) einsehen.
+Wichtige Hinweise
+1. Ihre individuellen Vergünstigungen
+Vergünstigungen Gültigkeit
+Kostenlose Depotführung (5,85 EUR pro Quartal gespart) 01.04.2017 bis 30.06.2017
+Details zu Ihren persönlichen Vergünstigungen können Sie bei www.comdirect.de im Persönlichen Bereich unter Verwaltung >
+Depot & Trading > Vergünstigungen einsehen. Es gilt das aktuelle Preis- und Leistungsverzeichnis.
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 6 per 03.07.2017 - Seite 5
+Kundennummer 123 4567890
+2. Einwendungen gegen den Rechnungsabschluss
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieses Rechnungsabschlusses sind gem. Nr. 7.2 unserer allgemeinen
+Geschäftsbedingungen spätestens vor Ablauf von sechs Wochen nach Zugang des Rechnungsabschlusses zu erheben. Sofern
+Sie Ihre Einwendungen schriftlich geltend machen, richten Sie diese bitte unter Angabe Ihrer Kundennummer an die comdirect
+bank AG, Innenrevision, 25449 Quickborn. Es genügt die Absendung innerhalb der Sechs-Wochen-Frist. Das Unterlassen
+rechtzeitiger Einwendungen gilt als Genehmigung.
+3. Ihre Kontodisposition
+Der Kontostand berücksichtigt nicht die Valuta (Wertstellung) der einzelnen Buchungen. Das bedeutet, dass der angezeigte
+Kontostand nicht dem tatsächlichen Kontoguthaben entsprechen muss und bei Verfügungen möglicherweise Zinsen für die
+Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können. Bitte berücksichtigen Sie bei Ihrer
+Disposition daher ggf. die Wertstellungen der Kontoumsätze der letzten Tage.
+4. Hinweis zur Einlagensicherung
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen
+können dem "Informationsbogen für den Einleger" entnommen werden. Diesen finden Sie unter www.comdirect.de/infobogen
+5. Übersicht Ihrer Kontodaten IBAN BIC
+Girokonto DE33 2004 1155 1234 5678 00 COBADEHD001
+Tagesgeld PLUS-Konto DE92 2004 1155 1234 5678 05
+Währungsanlagekonto (USD) DE31 2004 1155 1234 5678 05
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport05.txt
@@ -1,0 +1,178 @@
+PDF Autor: ''
+PDFBox Version: 1.8.16
+-----------------------------------------
+comdirect bank AG, 25449 Quickborn 978 56 010
+Frau Erika Musterfrau Telefon: 04106 - 708 25 00
+Herrn Max Mustermann Telefax: 04106 - 708 25 85
+Musterstr. 123 E-Mail: www.comdirect.de/kontakt
+12345 Musterhausen (E-Mail über Kontaktformular)
+Kundennummer: 123 4567890
+Finanzreport Nr. 2 per 03.07.2017
+Sehr geehrte Frau Musterfrau,
+sehr geehrter Herr Mustermann,
+
+in Ihrem aktuellen Finanzreport finden Sie alle Informationen rund um Ihre Konten und Ihr Depot.
+Für Fragen zum Finanzreport oder unseren Leistungen stehen Ihnen unsere Kundenbetreuer
+telefonisch unter 04106 - 708 25 00 rund um die Uhr gerne zur Verfügung.
+Mit freundlichen Grüßen
+comdirect bank AG
+Aktuelle Informationen:
+Einfach. Überall. Handeln. Die kostenlose comdirect trading App für Android ist da – die perfekte
+Ergänzung zu Ihrem comdirect Depot. Beobachten Sie die Börse in Echtzeit. Stellen Sie automatische
+Kursalarme ein und kaufen oder verkaufen Sie Wertpapiere ganz intuitiv mit wenigen Klicks.
+Weitere Informationen unter www.comdirect.de/tradingapp
+In unserem Top-Preis Fonds Angebot erhalten Sie auf die Fonds unseres renommierten Partners
+Pioneer Investments 100 % Discount auf den regulären Ausgabeaufschlag. Nutzen Sie jetzt unsere
+Sonderkonditionen und bauen Sie schon mit einem Anlagebetrag ab 500 Euro in der Einmalanlage
+oder 25 Euro im Sparplan Vermögen auf. Jetzt abschließen unter www.comdirect.de/pioneer
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 7 per 01.08.2016 - Seite 2
+Kundennummer 123 4567890
+Kontoübersicht
+Ihre aktuellen Salden IBAN Saldo in
+EUR
+Girokonto DE33 2004 1155 1234 5678 00 +1.415,21
+Tagesgeld PLUS-Konto DE92 2004 1155 1234 5678 05 +4.673,08
+Depot +1.133,67
+Visa-Karte 1111 +0,00
+Gesamtsaldo 01.08.2016 +7.221,96
+Girokonto Dispositionskredit girocard Tages-/WochenlimitEUR 0 EUR 1.000/EUR 2.000
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.07.2016 +2.309,51
+01.08.2016 Lastschrift/Belast. comdirect VISA-KARTE NR. -894,30
+01.08.2016 AA11111111111111/111111 Visa-Monatsabrechnung 11111111XXXX1111
+SUMME MONATSABRECHNUNG
+VISA MAX
+MUSTERMANN
+Neuer Saldo 01.08.2016 +1.415,21
+Tagesgeld PLUS-Konto
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.07.2016 +3.670,11
+11.07.2016 Übertrag/Überweisung Max Mustermann Sparen +1.000,00
+11.07.2016 AA11111111111111/11111 End-to-End-Ref.:
+nicht angegeben
+01.08.2016 Übertrag/Überweisung COMDIRECT BANK AG GUTSCHR. WECHSELGELD-SPAREN +2,97
+01.08.2016 AA11111111111111/111111 1111111 111
+End-to-End-Ref.:
+nicht angegeben
+Neuer Saldo 01.08.2016 +4.673,08
+Visa-Karte 1111 Visa Limit Verfügungslimit am GeldautomatEUR 1.000/Monat EUR 600/Tag
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+Alter Saldo 01.07.2016 +0,00
+05.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,42
+04.07.2016 111111111111111
+05.07.2016 Barauszahlung MERCADO SPAR PORT -188,58
+04.07.2016 111111111111111 ELIZABE388 Betrag: -3000,00 ZAR
+Kurs: 15,9087
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 7 per 01.08.2016 - Seite 3
+Kundennummer 123 4567890
+Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
+Valuta Referenz IBAN/BIC Eingang
+11.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,36
+08.07.2016 111111111111111
+11.07.2016 Barauszahlung U P E PORT -124,64
+08.07.2016 111111111111111 ELIZABE388 Betrag: -2000,00 ZAR
+Kurs: 16,0468
+13.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,30
+13.07.2016 111111111111111
+13.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,30
+12.07.2016 111111111111111
+13.07.2016 Barauszahlung U P E PORT -191,70
+13.07.2016 111111111111111 ELIZABE388 Betrag: -3000,00 ZAR
+Kurs: 15,6493
+13.07.2016 Korrektur Barauszahlung Cnr Strandfontein An La Port +191,70
+12.07.2016 111111111111111 Elizabe388 Betrag: 3000,00 ZAR
+Kurs: 15,6493
+13.07.2016 Barauszahlung Cnr Strandfontein An La Port -191,70
+12.07.2016 111111111111111 Elizabe388 Betrag: -3000,00 ZAR
+Kurs: 15,6493
+25.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,89
+22.07.2016 111111111111111
+25.07.2016 Barauszahlung SUPERSPAR SUMMER PORT -129,11
+22.07.2016 111111111111111 ELIZABE388 Betrag: -2000,00 ZAR
+Kurs: 15,4904
+29.07.2016 Wechselgeld-Sparen WECHSELGELD-SPARBETRAG -0,70
+28.07.2016 111111111111111
+29.07.2016 Visa-Kartenabrechnung SUMME MONATSABRECHNUNG +894,30
+29.07.2016 111111111111111 VISA
+29.07.2016 Barauszahlung SUPERSPAR SUMMER PORT -257,30
+28.07.2016 111111111111111 ELIZABE388 Betrag: -4000,00 ZAR
+Kurs: 15,5460
+Neuer Saldo 01.08.2016 +0,00
+Depot
+Depotbestand EUR EUR EUR
+Bezeichnung Anzahl/Nominal letzter Kurs Währung Kurswert Kaufwert Gewinn/Verlust
+Stückzinsen
+A1ANQ2 2.500,000 48,300 USD 1.081,60 885,98 +195,62
+VENEZUELA 09/19 REGS +52,07
+Gesamtkurswert 1.081,60 885,98 +195,62
+Stückzinsen gesamt +52,07
+Gesamtwert 1.133,67
+Die Kaufwerte und damit die Gesamtbewertung in der Depotübersicht stellt lediglich eine vereinfachte Gewinn/Verlust-Rechnung
+dar. Steuerliche Gesichtspunkte werden bei dieser Darstellung nicht berücksichtigt.
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 7 per 01.08.2016 - Seite 4
+Kundennummer 123 4567890
+Steuerübersicht1
+Steuerliche Daten EUR
+Gewinne/Verluste aus Aktien (Verrechnungssaldo) -189,14
+Gewinne/Verluste Sonstige (Verrechnungssaldo) +86,70
+Eingereichter Freibetrag 800,00
+In Anspruch genommener Freibetrag 86,70
+Verbleibender Freibetrag 713,30
+Anrechenbare ausländische Quellensteuer 0,00
+Abgeführte Kapitalertragsteuer 0,00
+Abgeführter Solidaritätszuschlag 0,00
+Abgeführte Kirchensteuer 0,00
+Angerechnete ausländische Quellensteuer 0,00
+1 Dies ist keine Steuerbescheinigung.
+Zinsübersicht
+Girokonto
+Zinssatz für die Inanspruchnahme des Dispositionskredites: 8,95 % p. a. (gültig ab: 23.09.2014)
+Zinssatz für geduldete Überziehungen: 13,45 % p. a. (gültig ab: 23.09.2014)
+Verrechnungskonto / Tagesgeld PLUS-Konto / O&F-Konto
+Zinssatz für geduldete Überziehungen: 13,45 % p. a. (gültig ab: 23.09.2014)
+Zinsgleitklausel für variable Sollzinssätze:
+Die Bank wird variable Sollzinssätze entsprechend den Änderungen des Hauptrefinanzierungszinssatzes der Europäischen Zentralbank (nachfolgend
+EZB-Zinssatz) nach folgender Maßgabe anpassen: Sofern am letzten Bankarbeitstag vor dem 15. eines Kalendermonats von der Bank eine Erhöhung des
+EZB-Zinssatzes um mindestens 0,25 Prozentpunkte gegenüber dem EZB-Zinssatz im Monat der letzten Zinsanpassung festgestellt wird, erhöht die Bank den
+variablen Sollzinssatz entsprechend. Die Bank verpflichtet sich dagegen zur Senkung des variablen Sollzinssatzes um die Veränderung des EZB-Zinssatzes,
+wenn der EZB-Zinssatz um mindestens 0,25 Prozentpunkte gesunken ist. Die Zinsanpassungen werden 5 Bankarbeitstage nach dem 15. eines Kalendermonats ohne
+gesonderte Erklärung gegenüber dem Kontoinhaber bei der comdirect bank AG wirksam. Die comdirect bank AG wird den Kontoinhaber in regelmäßigen
+Zeitabständen im Finanzreport unterrichten. Der Kontoinhaber kann die Höhe des EZB-Zinssatzes jederzeit auf der Webseite der comdirect bank AG bzw. in anderen
+öffentlich zugänglichen Medien (insbesondere www.bundesbank.de) einsehen.
+Wichtige Hinweise:
+1. Ihre individuellen Vergünstigungen
+Vergünstigungen Gültigkeit
+Kostenlose Depotführung (5,85 EUR pro Quartal gespart) 01.07.2016 bis 30.09.2016
+Details zu Ihren persönlichen Vergünstigungen können Sie bei www.comdirect.de im Persönlichen Bereich unter Verwaltung >
+Depot & Trading > Vergünstigungen einsehen. Es gilt das aktuelle Preis- und Leistungsverzeichnis.
+2. Einwendungen zu Konto- und Depotbuchungen
+Sollten Sie Fragen oder Einwendungen zu den Konto- und Depotbuchungen haben, bitten wir Sie, uns dies innerhalb sechs
+Wochen nach Erhalt des Finanzreportes unter Angabe Ihrer Kundennummer mitzuteilen. Ihre schriftliche Einwendung richten Sie
+bitte an die comdirect bank AG, Innenrevision, 25449 Quickborn.
+3. Ihre Kontodisposition
+Der Kontostand berücksichtigt nicht die Valuta (Wertstellung) der einzelnen Buchungen. Das bedeutet, dass der angezeigte
+Kontostand nicht dem tatsächlichen Kontoguthaben entsprechen muss und bei Verfügungen möglicherweise Zinsen für die
+Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können. Bitte berücksichtigen Sie bei Ihrer
+Disposition daher ggf. die Wertstellungen der Kontoumsätze der letzten Tage.
+4. Hinweis zur Einlagensicherung
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können
+dem „Informationsbogen für den Einleger“ entnommen werden. Diesen finden Sie unter www.comdirect.de/infobogen
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn
+Finanzreport Nr. 7 per 01.08.2016 - Seite 5
+Kundennummer 123 4567890
+5. Übersicht Ihrer Kontodaten
+- Girokonto: DE33 2004 1155 1234 5678 00
+- Tagesgeld PLUS-Konto: DE92 2004 1155 1234 5678 05
+BIC: COBADEHD001
+comdirect bank AG USt-ID: DE 812 279 461
+25449 Quickborn

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -7,6 +7,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -939,27 +941,61 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
     private void addFinancialReport()
     {
         DocumentType type = new DocumentType("Finanzreport", (context, lines) -> {
+            Pattern pBaseCurrency = Pattern.compile("^(Kontow.hrung) ([\\w]{3})$");
+            Pattern pForeignCurrencyAccount = Pattern.compile("^(W.hrungsanlagekonto) \\(([\\w]{3})\\) .*$");
+            Pattern pStartForeignCurrency = Pattern.compile("^(W.hrungsanlagekonto) \\(([\\w]{3})\\)$");
+            Pattern pEndForeignCurrency = Pattern.compile("^Neuer Saldo .*$");
+
+            Boolean ForeignCurrencyAccount = false;
+
             // read the current context here
             for (int i = 0; i < lines.length; i++)
             {
-                // After 2013:
-                // Ihre aktuellen Salden IBAN Saldo in EUR
+                // Ihre aktuellen Salden IBAN Saldo in
+                // EUR
                 if (lines[i].compareTo("Ihre aktuellen Salden IBAN Saldo in") == 0)
                 {
                     context.put("currency", lines[i+1]);
                 }
-                // Until 2013:
-                // Ihre aktuellen Salden Saldo in IBAN EUR
+                // Ihre aktuellen Salden Saldo in
+                // IBAN EUR
                 if ((lines[i].compareTo("Ihre aktuellen Salden Saldo in") == 0) && (lines[i+1].substring(0,4).compareTo("IBAN") == 0))
                 {
                     context.put("currency", lines[i+1].substring(5, 8));
+                }
+                // Kontowährung EUR
+                Matcher m = pBaseCurrency.matcher(lines[i]);
+                if (m.matches())
+                {
+                    context.put("currency", m.group(2));
+                }
+                // Währungsanlagekonto (USD) DE31 2004 1155 1234 5678 05 +554,83 +487,76
+                m = pForeignCurrencyAccount.matcher(lines[i]);
+                if (m.matches())
+                {
+                    context.put("foreignCurrency", m.group(2));
+                }
+                
+                // Sets the start and end line of the foreign currency transactions
+                m = pStartForeignCurrency.matcher(lines[i]);
+                if (m.matches())
+                {
+                    context.put("startInForeignCurrency", Integer.toString(i));
+                    ForeignCurrencyAccount = true;
+                }
+                m = pEndForeignCurrency.matcher(lines[i]);
+                if (m.matches() && ForeignCurrencyAccount)
+                {
+                    context.put("endInForeignCurrency", Integer.toString(i));
+                    ForeignCurrencyAccount = false;
                 }
             }
         });
         this.addDocumentTyp(type);
 
-        Block removalblock = new Block("(^|^A)\\d+.\\d+.[\\d]{4} (.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr).* [-]([.,\\d]+)$");
+        Block removalblock = new Block("(^|^A)\\d+.\\d+.[\\d]{4} (Konto.bertrag|.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld-Sparen).* [-]([.,\\d]+)$");
         type.addBlock(removalblock);
+        removalblock.setMaxSize(3);
         removalblock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
@@ -968,20 +1004,36 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date", "amount")
-                        .match("(^|^A)\\d+.\\d+.[\\d]{4} (.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr).* [-](?<amount>[.,\\d]+)$")
+                        .section("date", "amount", "note")
+                        .match("(^|^A)\\d+.\\d+.[\\d]{4} (?<note>Konto.bertrag|.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld-Sparen).* [-](?<amount>[.,\\d]+)$")
                         .match("^(?<date>\\d+.\\d+.[\\d]{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             t.setDateTime(asDate(v.get("date")));     
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(context.get("currency"));
+
+                            /***
+                             * When we recognize a foreign currency account,
+                             * we change from currency to foreign currency
+                             */
+                            if (context.get("startInForeignCurrency") != null 
+                                            && context.get("endInForeignCurrency") != null)
+                                if(removalblock.getStartLineNumber() >= Integer.parseInt(context.get("startInForeignCurrency")) 
+                                                && removalblock.getEndLineNumber() <= Integer.parseInt(context.get("endInForeignCurrency")))
+                                    t.setCurrencyCode(context.get("foreignCurrency"));
+                                else
+                                    t.setCurrencyCode(context.get("currency"));   
+                            else
+                                t.setCurrencyCode(context.get("currency"));
+
+                            t.setNote(v.get("note"));
                         })
 
                         .wrap(TransactionItem::new));
         
-        Block depositblock = new Block("^\\d+.\\d+.\\d+ (Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre).* [+]([.,\\d]+)$");
+        Block depositblock = new Block("(^|^A)\\d+.\\d+.\\d+ (Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre|Korrektur Barauszahlung).* [+]([.,\\d]+)$");
         type.addBlock(depositblock);
+        depositblock.setMaxSize(3);
         depositblock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
@@ -990,14 +1042,29 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date", "amount")
-                        .match("^\\d+.\\d+.[\\d]{4} (Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre).* [+](?<amount>[.,\\d]+)$")
-                        .match("^(?<date>\\d+.\\d+.[\\d]{4}).*$")
+                        .section("date", "amount", "note")
+                        .match("(^|^A)\\d+.\\d+.[\\d]{4} (?<note>Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre|Korrektur Barauszahlung).* [+](?<amount>[.,\\d]+)$")
+                        .match("(^|^A)(?<date>\\d+.\\d+.[\\d]{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(context.get("currency"));
+
+                            /***
+                             * When we recognize a foreign currency account,
+                             * we change from currency to foreign currency
+                             */                            
+                            if (context.get("startInForeignCurrency") != null 
+                                            && context.get("endInForeignCurrency") != null)                           
+                                if(depositblock.getStartLineNumber() >= Integer.parseInt(context.get("startInForeignCurrency")) 
+                                                && depositblock.getEndLineNumber() <= Integer.parseInt(context.get("endInForeignCurrency")))
+                                    t.setCurrencyCode(context.get("foreignCurrency"));
+                                else
+                                    t.setCurrencyCode(context.get("currency"));   
+                            else
+                                t.setCurrencyCode(context.get("currency"));
+
+                            t.setNote(v.get("note"));
                         })
 
                         .wrap(TransactionItem::new));
@@ -1012,14 +1079,15 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date", "amount")
-                        .match("^\\d+.\\d+.\\d{4} (Kontoabschluss Kontof.hrung|Geb.hren\\/Spesen|Geb.hr Barauszahlung|Entgelte|Auslandsentgelt).* [-](?<amount>[.,\\d]+)$")
+                        .section("date", "amount", "note")
+                        .match("^\\d+.\\d+.\\d{4} (?<note>Kontoabschluss Kontof.hrung|Geb.hren\\/Spesen|Geb.hr Barauszahlung|Entgelte|Auslandsentgelt).* [-](?<amount>[.,\\d]+)$")
                         .match("^(?<date>\\d+.\\d+.\\d{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(context.get("currency"));
+                            t.setNote(v.get("note"));
                         })
 
                         .wrap(TransactionItem::new));
@@ -1034,19 +1102,20 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date", "amount")
-                        .match("^\\d+.\\d+.\\d{4} (Kontoabschluss Abschluss Zinsen).* [+](?<amount>[.,\\d]+)$")
+                        .section("date", "amount", "note")
+                        .match("^\\d+.\\d+.\\d{4} (?<note>Kontoabschluss Abschluss Zinsen).* [+](?<amount>[.,\\d]+)$")
                         .match("^(?<date>\\d+.\\d+.\\d{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(context.get("currency"));
+                            t.setNote(v.get("note"));
                         })
-                        
-                        .section("kest", "soli", "kestcur", "solicur").optional()
-                        .match("^Kapitalertragsteuer (?<kest>[.,\\d]+)- (?<kestcur>[\\w]{3})$")
-                        .match("^Solidarit.tszuschlag (?<soli>[.,\\d]+)([-])? (?<solicur>[\\w]{3})$")
+
+                        .section("kest", "soli", "kestcur", "solicur", "note1", "note2").optional()
+                        .match("^(?<note1>Kapitalertragsteuer) (?<kest>[.,\\d]+)- (?<kestcur>[\\w]{3})$")
+                        .match("^(?<note2>Solidarit.tszuschlag) (?<soli>[.,\\d]+)([-])? (?<solicur>[\\w]{3})$")
                         .assign((t, v) -> {
                             Money kest = Money.of(asCurrencyCode(v.get("kestcur")), asAmount(v.get("kest")));
                             if (kest.getCurrencyCode().equals(t.getCurrencyCode()))
@@ -1055,6 +1124,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             Money soli = Money.of(asCurrencyCode(v.get("solicur")), asAmount(v.get("soli")));
                             if (soli.getCurrencyCode().equals(t.getCurrencyCode()))
                                 t.addUnit(new Unit(Unit.Type.TAX, soli));
+
+                            t.setNote(v.get("note1") + "/" + v.get("note2"));
                         })
 
                         .wrap(TransactionItem::new));
@@ -1069,14 +1140,15 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             return entry;
                         })
 
-                        .section("date", "amount")
-                        .match("^\\d+.\\d+.\\d{4} (Kontoabschluss Abschluss Zinsen).* [-](?<amount>[.,\\d]+)$")
+                        .section("date", "amount", "note")
+                        .match("^\\d+.\\d+.\\d{4} (?<note>Kontoabschluss Abschluss Zinsen).* [-](?<amount>[.,\\d]+)$")
                         .match("^(?<date>\\d+.\\d+.\\d+).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(context.get("currency"));
+                            t.setNote(v.get("note"));
                         })
 
                         .wrap(TransactionItem::new));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -108,6 +108,8 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
         private Pattern startsWith;
         private Pattern endsWith;
         private int maxSize = -1;
+        private int startLineNumber = -1;
+        private int endLineNumber = -1;
         private Transaction<?> transaction;
 
         public Block(String startsWith)
@@ -129,6 +131,32 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
         public void setMaxSize(int maxSize)
         {
             this.maxSize = maxSize;
+        }
+
+        /**
+         * Sets the start line number of the block
+         */
+        public void setStartLineNumber(int startLineNumber)
+        {
+            this.startLineNumber = startLineNumber;
+        }
+
+        public int getStartLineNumber()
+        {
+            return startLineNumber;
+        }
+
+        /**
+         * Sets the end line number of the block
+         */
+        public void setEndLineNumber(int endLineNumber)
+        {
+            this.endLineNumber = endLineNumber;
+        }
+
+        public int getEndLineNumber()
+        {
+            return endLineNumber;
         }
 
         public void set(Transaction<?> transaction)
@@ -154,7 +182,6 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 
                 // if an "endsWith" pattern exists, check if the block might end
                 // earlier
-
                 if (endsWith != null)
                 {
                     endLine = findBlockEnd(lines, startLine, endLine);
@@ -168,6 +195,10 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
                     // number
                     endLine = Math.min(endLine, startLine + maxSize - 1);
                 }
+
+                // Sets the start and end line number of the block
+                setStartLineNumber(startLine);
+                setEndLineNumber(endLine);
 
                 transaction.parse(filename, items, lines, startLine, endLine);
             }


### PR DESCRIPTION
This Fixes #2408 and can be closed without merge
Sets in PDFParser.java the start and end line number of a block <-- hope it's Ok

Hallo @grelltrier @buchen 
ich denke das hier wäre die richtige Lösung. Die Korrekte Währung wird nun gesetzt.
![grafik](https://user-images.githubusercontent.com/45203494/135749189-16daa2f3-cd7b-4e0f-8bd2-0bd0d3932f7e.png)