### PR TITLE
Show totals at the top & bottom of Statement of Assets

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -166,17 +166,19 @@ public class StatementOfAssetsViewer
         {
             // when flattening, assign sortOrder to keep the tree structure for
             // sorting (only positions within a category are sorted)
-            int sortOrder = 0;
-
+            int sortOrder = 1;
             List<Element> answer = new ArrayList<>();
 
-            Element root = new Element(groupByTaxonomy, Integer.MAX_VALUE);
+            // Show the grand total at both the top & bottom
+            Element totalTop = new Element(groupByTaxonomy, 0);
+            Element totalBottom = new Element(groupByTaxonomy, Integer.MAX_VALUE);
 
             for (AssetCategory cat : groupByTaxonomy.asList())
             {
                 Element category = new Element(groupByTaxonomy, cat, sortOrder);
                 answer.add(category);
-                root.addChild(category);
+                totalTop.addChild(category);
+                totalBottom.addChild(category);
                 sortOrder++;
 
                 for (AssetPosition p : cat.getPositions())
@@ -188,7 +190,8 @@ public class StatementOfAssetsViewer
                 sortOrder++;
             }
 
-            answer.add(root);
+            answer.add(totalTop);
+            answer.add(totalBottom);
             return answer;
         }
 


### PR DESCRIPTION
Statement of Assets is one of the most commonly-used screens. However, as soon as you have a decent number of positions, it requires scrolling all the way to the bottom to check your total.  Not only is this a bit cumbersome to do each time you visit that view, but it's inconsistent with how all the other categories are listed (for which the totals are at the top). This PR will let you view your totals either at the top or bottom of the page, eliminating the need to scroll down each time.

https://github.com/buchen/portfolio/issues/2409

