### PR TITLE
Small improvement of the display in the security chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -429,7 +429,7 @@ public class TimelineChart extends Chart // NOSONAR
             setRedraw(false);
 
             getAxisSet().adjustRange();
-            ChartUtil.addYMargins(this, 0.03);
+            ChartUtil.addYMargins(this, 0.08);
         }
         finally
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -1150,7 +1150,7 @@ public class SecuritiesChart
                             .collect(Collectors.toList()).toArray(new Date[0]);
 
             IAxis yAxis1st = chart.getAxisSet().getYAxis(0);
-            double yAxis1stAxisPrice = yAxis1st.getRange().lower;
+            double yAxis1stAxisPrice = yAxis1st.getRange().lower * (1 - 2 * 0.08);
 
             double[] values = new double[dates.length];
             Arrays.fill(values, yAxis1stAxisPrice);


### PR DESCRIPTION
The maximum quote and the minimum quote overlap with other texts in the chart
Maybe this is so useful... 🤔 

Before -> After
![bottom_before](https://user-images.githubusercontent.com/45203494/138600767-9eb01907-cda8-485e-8448-93108931e1cd.JPG) ![bottom_after](https://user-images.githubusercontent.com/45203494/138600772-4d384aff-1c72-4ed7-94a0-19af08aa8529.JPG)

Before -> After
![top_before](https://user-images.githubusercontent.com/45203494/138600812-c1c42458-7bf1-41a5-b228-97817f69c12c.JPG) ![top_after](https://user-images.githubusercontent.com/45203494/138600816-923856de-92ba-4467-a25a-6b919a9cca44.JPG)

