### PR TITLE
Always show 'Export All'; add 'Export Selected (CSV)'

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -19,10 +19,17 @@ import name.abuchen.portfolio.ui.util.viewers.SharesLabelProvider;
 public class TableViewerCSVExporter extends AbstractCSVExporter
 {
     private final TableViewer viewer;
+    private final boolean selectionOnly;
 
     public TableViewerCSVExporter(TableViewer viewer)
     {
+        this(viewer, false);
+    }
+
+    public TableViewerCSVExporter(TableViewer viewer, boolean selectionOnly)
+    {
         this.viewer = viewer;
+        this.selectionOnly = selectionOnly;
     }
 
     @Override
@@ -54,7 +61,8 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
             }
 
             // write body
-            for (TableItem item : viewer.getTable().getItems())
+            TableItem[] items = selectionOnly ? viewer.getTable().getSelection() : viewer.getTable().getItems();
+            for (TableItem item : items)
             {
                 for (int ii = 0; ii < columnCount; ii++)
                 {


### PR DESCRIPTION
The "All Transactions" view currently has the following export options:

_All Transactions (CSV)_
_All Transactions (JSON)_ or _Selected Transactions (JSON)_, depending on whether something is selected

This has the following issues:
- It's not possible to export a subset as CSV
- When something is selected, it is impossible to unselect everything without switching to a different view and back. Therefore, _All Transactions (JSON)_ is gone, which is very unintuitive.

Let's change that by
- always showing both _All Transactions (CSV)_ and _All Transactions (JSON)_, regardless of selection
- showing both _Selected Transactions (CSV)_ and _Selected Transactions (JSON)_ whenever something is selected