### PR TITLE
Fix implement source attribute

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -53,6 +53,7 @@ public class InsertActionTest
         entry.setDate(transactionDate);
         entry.setSecurity(security);
         entry.setNote("note");
+        entry.setSource("source");
         entry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.TAX, Money.of(CurrencyUnit.EUR, 1_99)));
     }
 
@@ -96,6 +97,7 @@ public class InsertActionTest
         assertThat(t.getSecurity(), is(client.getSecurities().get(0)));
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 9_99)));
         assertThat(t.getNote(), is("note"));
+        assertThat(t.getSource(), is("source"));
         assertThat(t.getDateTime(), is(transactionDate));
         assertThat(t.getShares(), is(99L));
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -2594,6 +2594,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-04T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1500)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -2727,6 +2729,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-21T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2787,6 +2791,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-09-29T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.9)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Gebühr Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -2848,6 +2854,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-30T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.14)));
             assertThat(transaction.getGrossValue().getAmount(), is(Values.Amount.factorize(0.20)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kapitalertragsteuer/Solidaritätszuschlag"));
         }
 
         if (iter.hasNext())
@@ -2873,6 +2881,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-12-31T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.07)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kontoabschluss Abschluss Zinsen"));
         }
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
@@ -2,8 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf.commerzbank;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -530,8 +530,12 @@ public class CommerzbankPDFExtractorTest
         assertThat(t.getSecurity().getCurrencyCode(), is(CurrencyUnit.EUR));
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-03-27T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(12)));
+        assertThat(t.getSource(), is("CommerzbankDividenden01.txt"));
+        assertThat(t.getNote(), is("Zwischendividende 01.01.20 - 31.12.20"));
+
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(61.30))));
         assertThat(t.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.35))));
@@ -570,8 +574,12 @@ public class CommerzbankPDFExtractorTest
         assertThat(t.getSecurity().getCurrencyCode(), is(CurrencyUnit.EUR));
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-02-05T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(500)));
+        assertThat(t.getSource(), is("CommerzbankDividenden02.txt"));
+        assertThat(t.getNote(), is("Dividendengutschrift 01.10.18 - 30.09.19"));
+
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1950.00))));
         assertThat(t.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -67,6 +67,8 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-01-15T08:13:35")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(132.80212)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf01.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5000.00))));
@@ -109,6 +111,8 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-09-21T12:45:38")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(250)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf02.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Limitkurs  5,500000 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1387.85))));
@@ -151,6 +155,8 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-10-16T15:24:22")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.95126)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf03.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));
@@ -193,6 +199,8 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-01-15T12:00:56")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(210)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf04.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Limitkurs  46,200000 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9745.25))));
@@ -235,6 +243,8 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-02-03T08:02:51")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.01514)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf05.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -22,6 +22,7 @@ import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.actions.CheckCurrenciesAction;
 import name.abuchen.portfolio.datatransfer.pdf.ConsorsbankPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
@@ -31,7 +32,6 @@ import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.model.Account;
 
 @SuppressWarnings("nls")
 public class ConsorsbankPDFExtractorTest
@@ -68,7 +68,6 @@ public class ConsorsbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-01-15T08:13:35")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(132.80212)));
         assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf01.txt"));
-        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5000.00))));
@@ -156,7 +155,6 @@ public class ConsorsbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-10-16T15:24:22")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.95126)));
         assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf03.txt"));
-        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));
@@ -244,7 +242,6 @@ public class ConsorsbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-02-03T08:02:51")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.01514)));
         assertThat(entry.getPortfolioTransaction().getSource(), is("ConsorsbankKauf05.txt"));
-        assertThat(entry.getPortfolioTransaction().getNote(), is(""));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/DADATBankenhausPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/DADATBankenhausPDFExtractorTest.java
@@ -464,6 +464,8 @@ public class DADATBankenhausPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-03-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug09.txt"));
+        assertThat(transaction.getNote(), is("Kontoführungsgebühr"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.50))));
@@ -494,6 +496,8 @@ public class DADATBankenhausPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-07T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug10.txt"));
+        assertThat(transaction.getNote(), is("Depotgebührenabrechnung per 31.12.2020"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(63.68))));
@@ -729,6 +733,8 @@ public class DADATBankenhausPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-12-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug14.txt"));
+        assertThat(transaction.getNote(), is("Kontoführungsgebühr"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.50))));
@@ -760,6 +766,8 @@ public class DADATBankenhausPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug15.txt"));
+        assertThat(transaction.getNote(), is("Kontoführungsgebühr"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.50))));
@@ -791,6 +799,8 @@ public class DADATBankenhausPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-06-30T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug16.txt"));
+        assertThat(transaction.getNote(), is("Spesen"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.53))));
@@ -822,6 +832,8 @@ public class DADATBankenhausPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-10-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug17.txt"));
+        assertThat(transaction.getNote(), is("Werbebonus"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(75.00))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/DegiroPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/DegiroPDFExtractorTest.java
@@ -1,8 +1,8 @@
 package name.abuchen.portfolio.datatransfer.pdf.degiro;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -60,6 +60,8 @@ public class DegiroPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-08-02T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Einzahlung"));
             assertThat(transaction.getMonetaryAmount(),
                             is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(350.00))));
         }
@@ -129,6 +131,8 @@ public class DegiroPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-03-01T13:21")));
+            assertThat(transaction.getSource(), is("Kontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Gebühr für Ausübung/Zuteilung"));
             assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
         }
 
@@ -153,6 +157,8 @@ public class DegiroPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES_REFUND));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-03-05T15:37")));
+            assertThat(transaction.getSource(), is("Kontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Gutschrift für die Neukundenaktion"));
             assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(18.00))));
         }
     }
@@ -237,12 +243,16 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-07-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug03.txt"));
+        assertThat(transaction.getNote(), is("Zinsen"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.07))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
                         .collect(Collectors.toList()).get(11).getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(transaction.getSource(), is("Kontoauszug03.txt"));
+        assertThat(transaction.getNote(), is("Einrichtung von Handelsmodalitäten 2017"));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.50))));
     }
@@ -265,6 +275,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-08-31T00:00")));
+        assertThat(transaction.getSource(), is("Kontoauszug04.txt"));
+        assertThat(transaction.getNote(), is("Einrichtung von Handelsmodalitäten 2017"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.89))));
 
     }
@@ -294,6 +306,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-02-22T18:40")));
+        assertThat(transaction.getSource(), is("Kontoauszug05.txt"));
+        assertThat(transaction.getNote(), is("SOFORT Einzahlung"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(27.00))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -301,6 +315,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-02-22T18:40")));
+        assertThat(transaction.getSource(), is("Kontoauszug05.txt"));
+        assertThat(transaction.getNote(), is("SOFORT Zahlungsgebühr"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -374,6 +390,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-07-25T13:06")));
+        assertThat(transaction.getSource(), is("Kontoauszug06.txt"));
+        assertThat(transaction.getNote(), is("Einzahlung"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -381,6 +399,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-08-05T00:09")));
+        assertThat(transaction.getSource(), is("Kontoauszug06.txt"));
+        assertThat(transaction.getNote(), is("Auszahlung"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -928,6 +948,8 @@ public class DegiroPDFExtractorTest
                         .collect(Collectors.toList()).get(0).getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-08-26T08:41")));
+        assertThat(transaction.getSource(), is("Rekeningoverzicht02.txt"));
+        assertThat(transaction.getNote(), is("iDEAL Deposit"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.00))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -949,6 +971,8 @@ public class DegiroPDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
         assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-08-27T10:16")));
+        assertThat(transaction.getSource(), is("Rekeningoverzicht02.txt"));
+        assertThat(transaction.getNote(), is("Overboeking"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.41))));
 
         transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -1072,6 +1096,8 @@ public class DegiroPDFExtractorTest
                         .collect(Collectors.toList()).get(4).getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-03-01T18:47")));
+        assertThat(transaction.getSource(), is("AccountStatement01.txt"));
+        assertThat(transaction.getNote(), is("Interest"));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.88))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -1924,6 +1924,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-29T00:00")));
+            assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Steuerausgleich"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.23)));
         }
     }
@@ -2054,6 +2056,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-04-23T00:00")));
+            assertThat(transaction.getSource(), is("GiroKontoauszug04.txt"));
+            assertThat(transaction.getNote(), is("Rechnung"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(15.00)));
         }
     }
@@ -2083,6 +2087,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-04-01T00:00")));
+            assertThat(transaction.getSource(), is("GiroKontoauszug05.txt"));
+            assertThat(transaction.getNote(), is("Abrechnungszeitraum vom 01.01.2021 bis 31.03.2021"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.24)));
         }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -65,7 +65,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-11-25T11:02:54")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(20)));
-        assertThat(entry.getNote(), is("Limit 97,50 % | Kauf01.txt"));
+        assertThat(entry.getSource(), is("Kauf01.txt"));
+        assertThat(entry.getNote(), is("Limit 97,50 %"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2030.66))));
@@ -107,7 +108,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-25T09:33:06")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
-        assertThat(entry.getNote(), is("Limit 1,75 EUR | Kauf02.txt"));
+        assertThat(entry.getSource(), is("Kauf02.txt"));
+        assertThat(entry.getNote(), is("Limit 1,75 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1760.91))));
@@ -354,7 +356,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-10-27T09:05:33")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(60)));
-        assertThat(entry.getNote(), is("Limit 85,00 % | Verkauf01.txt"));
+        assertThat(entry.getSource(), is("Verkauf01.txt"));
+        assertThat(entry.getNote(), is("Limit 85,00 %"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4937.19))));
@@ -407,7 +410,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-02-10T10:58:02")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(200)));
-        assertThat(entry.getNote(), is("Limit 15,05 EUR | Verkauf02.txt"));
+        assertThat(entry.getSource(), is("Verkauf02.txt"));
+        assertThat(entry.getNote(), is("Limit 15,05 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3000.00))));
@@ -490,7 +494,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-22T20:56:04")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(20)));
-        assertThat(entry.getNote(), is("Limit 5,44 EUR | Verkauf04.txt"));
+        assertThat(entry.getSource(), is("Verkauf04.txt"));
+        assertThat(entry.getNote(), is("Limit 5,44 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(99.00))));
@@ -584,7 +589,8 @@ public class DkbPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-07-06T14:49:39")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(75)));
-        assertThat(entry.getNote(), is("Limit 27,80 EUR | Verkauf06.txt"));
+        assertThat(entry.getSource(), is("Verkauf06.txt"));
+        assertThat(entry.getNote(), is("Limit 27,80 EUR"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2051.02))));
@@ -1743,6 +1749,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-06T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1000)));
+            assertThat(transaction.getSource(), is("GiroKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
         }
 
         if (iter.hasNext())
@@ -2548,6 +2556,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-09T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(100)));
+            assertThat(transaction.getSource(), is("KreditKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Einzahlung"));
         }
 
         if (iter.hasNext())
@@ -2572,6 +2582,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-21T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.01)));
+            assertThat(transaction.getSource(), is("KreditKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Habenzins auf 28 Tage"));
         }
 
         if (iter.hasNext())
@@ -2584,6 +2596,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-10-23T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.01)));
+            assertThat(transaction.getSource(), is("KreditKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Abgeltungsteuer"));
         }
 
         if (iter.hasNext())
@@ -2596,6 +2610,8 @@ public class DkbPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-25T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(62.32)));
+            assertThat(transaction.getSource(), is("KreditKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Laden Ort 220,"));
         }
 
         if (iter.hasNext())

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ebase/EbasePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ebase/EbasePDFExtractorTest.java
@@ -198,6 +198,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-24T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung02.txt"));
+        assertThat(transaction.getNote(), is("Vorabpauschale zum Stichtag 31.12.2019"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.14))));
@@ -250,6 +252,8 @@ public class EbasePDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-01-27T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.001162)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("Umsatzabrechnung03.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Verkauf wegen Vorabpauschale"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.13))));
@@ -403,6 +407,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-22T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0.100548)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung05.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.00))));
@@ -616,6 +622,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-23T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0.414447)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung08.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.70))));
@@ -847,6 +855,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-04-06T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(9.999999)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung11.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.00))));
@@ -878,6 +888,8 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-04-01T00:00")));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung12.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.00))));
@@ -936,6 +948,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-05T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0.024859)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung13.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.00))));
@@ -993,6 +1007,8 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-02T00:00")));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung14.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.00))));
@@ -1909,6 +1925,8 @@ public class EbasePDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-22T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0L)));
+        assertThat(transaction.getSource(), is("Umsatzabrechnung16.txt"));
+        assertThat(transaction.getNote(), is("Vorabpauschale zum Stichtag 31.12.2020"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.94))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
@@ -2,8 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf.filfondbank;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -63,6 +63,8 @@ public class FILFondbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-04-16T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.045)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("Fondabrechnung01.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Splitkauf"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.77))));
@@ -1262,6 +1264,8 @@ public class FILFondbankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-02T00:00")));
+        assertThat(transaction.getSource(), is("Fondabrechnung12.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt 2018"));
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));
     }
@@ -1391,6 +1395,8 @@ public class FILFondbankPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-04T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.634)));
+        assertThat(entry.getSource(), is("Fondabrechnung13.txt"));
+        assertThat(entry.getNote(), is("Entgeltbelastung"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));
@@ -1411,6 +1417,8 @@ public class FILFondbankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-04T00:00")));
+        assertThat(transaction.getSource(), is("Fondabrechnung13.txt"));
+        assertThat(transaction.getNote(), is("Depotführungsentgelt"));
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(25.00))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -740,6 +740,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-11-12T00:00")));
+        assertThat(transaction.getSource(), is("biwAGKontoauszug01.txt"));
+        assertThat(transaction.getNote(), is("Gebühr Kapitaltransaktion Ausland"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.56))));
 
@@ -2337,6 +2339,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-26T00:00")));
+        assertThat(transaction.getSource(), is("FinTechKontoauszug02.txt"));
+        assertThat(transaction.getNote(), is("Überweisung"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15000.00))));
     }
@@ -2361,6 +2365,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
+        assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
+        assertThat(transaction.getNote(), is("Steuertopfoptimierung 2016"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.94))));
     }
@@ -2385,6 +2391,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
+        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
+        assertThat(transaction.getNote(), is("EINZAHLUNG"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000.00))));
 
@@ -2394,6 +2402,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
+        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
+        assertThat(transaction.getNote(), is("Zinsabschluss   01.10.2010 - 31.12.2010"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
     }
@@ -3192,6 +3202,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-20T00:00")));
+        assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
+        assertThat(transaction.getNote(), is("Depotgebühren 01.04.2020 - 30.04.2020"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.26))));
 
@@ -3230,6 +3242,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-18T00:00")));
+        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+        assertThat(transaction.getNote(), is("Überweisung"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
 
@@ -3284,6 +3298,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+        assertThat(transaction.getNote(), is("R-Transaktion"));
         assertThat(transaction.getMonetaryAmount(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justtrade/JustTradePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/justtrade/JustTradePDFExtractorTest.java
@@ -1,9 +1,9 @@
 package name.abuchen.portfolio.datatransfer.pdf.justtrade;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -18,8 +18,8 @@ import org.junit.Test;
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
-import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.JustTradePDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.model.AccountTransaction;
@@ -776,6 +776,8 @@ public class JustTradePDFExtractorTest
 
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-03-15T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(30)));
+        assertThat(t.getSource(), is("Dividende01.txt"));
+        assertThat(t.getNote(), is("Vierteljährlich"));
 
         assertThat(t.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.15))));
@@ -893,6 +895,8 @@ public class JustTradePDFExtractorTest
 
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-09-23T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(40)));
+        assertThat(t.getSource(), is("Dividende04.txt"));
+        assertThat(t.getNote(), is("Vierteljährlich"));
 
         assertThat(t.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.90))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBankExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/KeytradeBankExtractorTest.java
@@ -61,7 +61,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-15T12:31:50")));
         assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(168)));
-        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(1994.39)));
+        assertThat(t.getPortfolioTransaction().getSource(), is("KeytradeBank_Kauf01.txt"));
+        assertThat(t.getPortfolioTransaction().getNote(), is("Limit (11,79 EUR)"));
+        
+        assertThat(t.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1994.39))));
+        assertThat(t.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1979.44))));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.95))));
     }
@@ -94,7 +102,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-10-19T11:53:02")));
         assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
-        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(4963.99)));
+        assertThat(t.getPortfolioTransaction().getSource(), is("KeytradeBank_Kauf02.txt"));
+        assertThat(t.getPortfolioTransaction().getNote(), is("Limit (16 EUR)"));
+        
+        assertThat(t.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4963.99))));
+        assertThat(t.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4939.04))));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
     }
@@ -127,7 +143,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-10-19T11:53:03")));
         assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
-        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(4963.99)));
+        assertThat(t.getPortfolioTransaction().getSource(), is("KeytradeBank_Kauf03.txt"));
+        assertThat(t.getPortfolioTransaction().getNote(), is("Limit (16 EUR)"));
+        
+        assertThat(t.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4963.99))));
+        assertThat(t.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4939.04))));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
     }
@@ -160,7 +184,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(t.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-05-13T09:56:05")));
         assertThat(t.getPortfolioTransaction().getShares(), is(Values.Share.factorize(22)));
-        assertThat(t.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(6118.95)));
+        assertThat(t.getPortfolioTransaction().getSource(), is("KeytradeBank_Kauf04.txt"));
+        assertThat(t.getPortfolioTransaction().getNote(), is("Limit (277 EUR)"));
+        
+        assertThat(t.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6118.95))));
+        assertThat(t.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6094.00))));
+        assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(t.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
     }
@@ -191,17 +223,17 @@ public class KeytradeBankExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-06-16T09:45:18")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("KeytradeBank_Kauf05.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Limit (37,45 USD)"));
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(953.95))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(924.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(29.95))));
-
-//        Unit gross = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-//                        .orElseThrow(IllegalArgumentException::new);
-//        assertThat(gross.getAmount(), is( Values.Amount.factorize(0.00)));
-//        assertThat(gross.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(953.95))));
     }
 
     @Test
@@ -234,8 +266,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-10T15:23:42")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("KeytradeBank_Verkauf01.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Market"));
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10499.55))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10524.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
     }
@@ -270,8 +309,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-07-01T12:34:24")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(22)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("KeytradeBank_Verkauf02.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Market"));
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5409.05))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5434.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(24.95))));
     }
@@ -306,8 +352,15 @@ public class KeytradeBankExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-09-11T11:09:35")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getPortfolioTransaction().getSource(), is("KeytradeBank_Verkauf03.txt"));
+        assertThat(entry.getPortfolioTransaction().getNote(), is("Limit (38,60 USD)"));
+
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(938.83))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(968.78))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(29.95))));
     }
@@ -335,10 +388,12 @@ public class KeytradeBankExtractorTest
                         .orElseThrow(IllegalArgumentException::new).getSubject();
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.67))));
+
         assertThat(t.getShares(), is(Values.Share.factorize(22)));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-06-29T00:00")));
 
+        assertThat(t.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.67))));
         assertThat(t.getGrossValue(), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.70))));
         assertThat(t.getUnitSum(Unit.Type.TAX), 
@@ -370,10 +425,12 @@ public class KeytradeBankExtractorTest
                         .orElseThrow(IllegalArgumentException::new).getSubject();
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(45.65))));
+
         assertThat(t.getShares(), is(Values.Share.factorize(310)));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-02-01T00:00")));
 
+        assertThat(t.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(45.65))));        
         assertThat(t.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(62.00))));
         assertThat(t.getUnitSum(Unit.Type.TAX),
@@ -405,8 +462,10 @@ public class KeytradeBankExtractorTest
                         .orElseThrow(IllegalArgumentException::new).getSubject();
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2016-12-08T00:00")));
         assertThat(t.getShares(), is(Values.Share.factorize(25)));
+
         assertThat(t.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.06))));
         assertThat(t.getGrossValue(), 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
@@ -1780,6 +1780,8 @@ public class OnvistaPDFExtractorTest
 
         assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-05-25T00:00")));
         assertThat(entry.getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getSource(), is("EinbuchungVonRechten01.txt"));
+        assertThat(entry.getNote(), is("Einbuchung der Rechte zur Dividende wahlweise."));
 
         assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
@@ -2295,6 +2297,8 @@ public class OnvistaPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-04-04T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Überweisungseingang SEPA"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(200)));
         }
 
@@ -2384,6 +2388,8 @@ public class OnvistaPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-04-07T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Portogebühren"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.62)));
         }
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
@@ -2,8 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf.postbank;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -216,6 +216,8 @@ public class PostbankPDFExtractorTest
         assertThat(t.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(8.64))));
         assertThat(t.getShares(), is(Values.Share.factorize(12)));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2021-02-22T00:00")));
+        assertThat(t.getSource(), is("postbank_dividende01.txt"));
+        assertThat(t.getNote(), is("Quartalsdividende"));
 
         assertThat(t.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(10.17))));
         assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(1.53))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/raiffeisenbankgruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/raiffeisenbankgruppePDFExtractorTest.java
@@ -175,6 +175,8 @@ public class raiffeisenbankgruppePDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-01T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("BASISLASTSCHRIFT"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(42.13)));
         }
 
@@ -307,6 +309,8 @@ public class raiffeisenbankgruppePDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-23T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("GUTSCHRIFT"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(85.65)));
         }
 
@@ -355,6 +359,8 @@ public class raiffeisenbankgruppePDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-31T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Entgelte vom 01.12.2020 - 31.12.2020"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.00 + 1.00)));
         }
 
@@ -367,6 +373,8 @@ public class raiffeisenbankgruppePDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-31T00:00")));
+            assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Abschluss vom 01.10.2020 bis 31.12.2020"));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.95)));
         }
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/WeberbankExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/WeberbankExtractorTest.java
@@ -17,8 +17,8 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
 import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
-import name.abuchen.portfolio.datatransfer.pdf.WeberbankPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.WeberbankPDFExtractor;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
@@ -60,9 +60,13 @@ public class WeberbankExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
 
-        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(9657.00)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-26T15:14:29")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4440)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9657.00))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9657.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
@@ -97,9 +101,13 @@ public class WeberbankExtractorTest
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
-        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(2335.30)));
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-26T15:12:58")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(193)));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2335.30))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2335.30))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
@@ -130,12 +138,19 @@ public class WeberbankExtractorTest
                         .orElseThrow(IllegalArgumentException::new).getSubject();
         
         assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.14))));
+
         assertThat(t.getShares(), is(Values.Share.factorize(107)));
         assertThat(t.getDateTime(), is(LocalDateTime.parse("2020-08-07T00:00")));
+        assertThat(t.getSource(), is("WeberbankDividend01.txt"));
+        assertThat(t.getNote(), is("Quartalsdividende"));
 
-        assertThat(t.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(74.05))));
+        assertThat(t.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.14))));
+        assertThat(t.getGrossValue(), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(74.05))));
         assertThat(t.getUnitSum(Unit.Type.TAX), 
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.11 + 7.40 + 0.40))));
+        assertThat(t.getUnitSum(Unit.Type.FEE), 
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -489,7 +489,6 @@ public class PerformanceView extends AbstractHistoricView
             }
         });
         column.setSorter(ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getSource()));
-        column.setVisible(false);
         support.addColumn(column);
 
         support.createColumns();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/TransactionsTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/TransactionsTab.java
@@ -363,7 +363,6 @@ public class TransactionsTab implements PaymentsTab
             }
         });
         ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getSource()).attachTo(column);
-        column.setVisible(false);
         support.addColumn(column);
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -22,10 +22,12 @@ import name.abuchen.portfolio.datatransfer.SecurityCache;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.model.Annotated;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CrossEntry;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.util.TextUtil;
 
 public abstract class AbstractPDFExtractor implements Extractor
 {
@@ -112,10 +114,12 @@ public abstract class AbstractPDFExtractor implements Extractor
 
                 if (subject instanceof Transaction)
                     ((Transaction) subject).setSource(filename);
-                else if (subject.getNote() == null || subject.getNote().trim().length() == 0)
+                else if (subject instanceof CrossEntry)
+                    ((CrossEntry) subject).setSource(filename);
+                else if (subject.getNote() == null || TextUtil.strip(subject.getNote()).length() == 0)
                     item.getSubject().setNote(filename);
                 else
-                    item.getSubject().setNote(item.getSubject().getNote().trim().concat(" | ").concat(filename)); //$NON-NLS-1$
+                    item.getSubject().setNote(TextUtil.strip(item.getSubject().getNote()).concat(" | ").concat(filename)); //$NON-NLS-1$
             }
 
             return items;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -223,10 +223,22 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                         })
 
+                        // USD 7 ,219127 D i v i d e n d e p r o S t ü c k f ü r G e s c h ä f t s j a h r 0 1 . 0 1 . 2 0 b i s 3 1 . 1 2 . 2 0
+                        // z a h l b a r ab 2 6 . 0 5 . 2 0 2 0 Z w i s c h e n d i v i d e n d e
                         .section("note1", "note2", "note3").optional()
-                        .match("^\\w{3} [\\d\\s,.]* .* (?<note2>[\\d\\s]+.[\\d\\s]+.[\\d\\s]+) .* (?<note3>[\\d\\s]+.[\\d\\s]+.[\\d\\s]+)$")
-                        .match(".*")
+                        .match("^[\\w]{3} [\\d\\s,.]* [\\D]+ (?<note2>[\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+) [\\D]+ (?<note3>[\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+)$")
                         .match("Abrechnung (?<note1>.*)")
+                        .assign((t, v) -> 
+                        {
+                            String note = stripBlanks(v.get("note1")) + " " + stripBlanks(v.get("note2")) + " - " + stripBlanks(v.get("note3"));
+                            t.setNote(note);
+                        })
+
+                        // USD 7 ,219127 D i v i d e n d e p r o S t ü c k f ü r G e s c h ä f t s j a h r 0 1 . 0 1 . 2 0 b i s 3 1 . 1 2 . 2 0
+                        // z a h l b a r ab 2 6 . 0 5 . 2 0 2 0 Z w i s c h e n d i v i d e n d e
+                        .section("note1", "note2", "note3").optional()
+                        .match("^[\\w]{3} [\\d\\s,.]* [\\D]+ (?<note2>[\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+) [\\D]+ (?<note3>[\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+)$")
+                        .match("^.* [\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+ (?<note1>[\\D]+)$")
                         .assign((t, v) -> 
                         {
                             String note = stripBlanks(v.get("note1")) + " " + stripBlanks(v.get("note2")) + " - " + stripBlanks(v.get("note3"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -16,6 +16,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class DkbPDFExtractor extends AbstractPDFExtractor
@@ -777,7 +778,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                     + v.get("date").substring(6, 8)));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(context.get("currency"));
-                    t.setNote(v.get("note"));
+                    t.setNote(TextUtil.strip(v.get("note")));
                 })
 
                 .wrap(TransactionItem::new));
@@ -859,7 +860,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     if (">".equals(v.get("note").substring(v.get("note").length() - 1)))
                         v.put("note", v.get("note").substring(0, v.get("note").length() - 1));
 
-                    t.setNote(v.get("note"));
+                    t.setNote(TextUtil.strip(v.get("note")));
                 })
 
                 .wrap(TransactionItem::new));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -748,6 +748,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setDateTime(asDate(v.get("date") + type.getCurrentContext().get("year")));
                     t.setCurrencyCode(asCurrencyCode(type.getCurrentContext().get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
+                    t.setNote(v.get("note"));
                 })
 
                 // 31.10. 31.10. REF: 000017304356 37,66
@@ -759,6 +760,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setDateTime(asDate(v.get("date") + type.getCurrentContext().get("year")));
                     t.setCurrencyCode(asCurrencyCode(type.getCurrentContext().get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
+                    t.setNote(v.get("note"));
                 })
 
                 // 07.04. 03.04. REF: 000033640646 0,62-
@@ -774,6 +776,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setDateTime(asDate(v.get("date") + type.getCurrentContext().get("year")));
                     t.setCurrencyCode(asCurrencyCode(type.getCurrentContext().get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
+                    t.setNote(v.get("note"));
                 })
 
                 .wrap(t -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransferEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransferEntry.java
@@ -106,6 +106,19 @@ public class AccountTransferEntry implements CrossEntry, Annotated
     }
 
     @Override
+    public String getSource()
+    {
+        return this.transactionFrom.getSource();
+    }
+
+    @Override
+    public void setSource(String source)
+    {
+        this.transactionFrom.setSource(source);
+        this.transactionTo.setSource(source);
+    }
+
+    @Override
     public void insert()
     {
         accountFrom.addTransaction(transactionFrom);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
@@ -108,11 +108,13 @@ public class BuySellEntry implements CrossEntry, Annotated
         this.accountTransaction.setNote(note);
     }
 
+    @Override
     public String getSource()
     {
         return this.portfolioTransaction.getSource();
     }
 
+    @Override
     public void setSource(String source)
     {
         this.portfolioTransaction.setSource(source);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -1336,7 +1336,7 @@ public class ClientFactory
         client.getAccounts().forEach(a -> allTransactions.addAll(a.getTransactions()));
         client.getPortfolios().forEach(p -> allTransactions.addAll(p.getTransactions()));
 
-        Pattern pattern = Pattern.compile("^((?<note>.*) \\| )?(?<file>[^ ]*\\.(pdf|csv))$"); //$NON-NLS-1$
+        Pattern pattern = Pattern.compile("^((?<note>.*) \\| )?(?<file>[^ ]*\\.(pdf|csv))$", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
 
         for (Transaction tx : allTransactions)
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CrossEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CrossEntry.java
@@ -13,4 +13,8 @@ public interface CrossEntry
     TransactionOwner<? extends Transaction> getCrossOwner(Transaction t);
 
     void insert();
+
+    String getSource();
+
+    void setSource(String source);
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransferEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransferEntry.java
@@ -118,6 +118,19 @@ public class PortfolioTransferEntry implements CrossEntry, Annotated
     }
 
     @Override
+    public String getSource()
+    {
+        return this.transactionFrom.getSource();
+    }
+
+    @Override
+    public void setSource(String source)
+    {
+        this.transactionFrom.setSource(source);
+        this.transactionTo.setSource(source);
+    }
+
+    @Override
     public void insert()
     {
         portfolioFrom.addTransaction(transactionFrom);


### PR DESCRIPTION
Hallo @buchen,

hier wie besprochen der pull request mit den TestCases, welche fehlschlagen.
Ich bin mir nicht ganz sicher, aber die `InsertActionTest.java` müsste dementsprechend angepasst werden.

Das `Pattern.CASE_INSENSITIVE` wird glaube ich benötigt, weil die Dateiendungen nicht immer klein geschrieben werden.
Bei z.B. *.PDF oder *.Pdf wird dies nicht erkannt.