### PR TITLE
Allow removing and adding sub/child filter elements, fixes #1375

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -838,6 +838,7 @@ public class Messages extends NLS
     public static String MenuRenameDashboard;
     public static String MenuRenameLabel;
     public static String MenuReportingPeriodDelete;
+    public static String MenuReportingPeriodInsert;
     public static String MenuReportingPeriodManage;
     public static String MenuResetChartSeries;
     public static String MenuResetColumns;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -838,6 +838,7 @@ public class Messages extends NLS
     public static String MenuRenameDashboard;
     public static String MenuRenameLabel;
     public static String MenuReportingPeriodDelete;
+    public static String MenuReportingPeriodDeleteConfirm;
     public static String MenuReportingPeriodInsert;
     public static String MenuReportingPeriodManage;
     public static String MenuResetChartSeries;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientFilterDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientFilterDialog.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.dialogs;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,6 +12,7 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.TreeColumnLayout;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -276,7 +278,10 @@ public class EditClientFilterDialog extends Dialog
                     {
                         if(p.getSegmentCount() == 1)
                         { // parent node clicked (filter itself)
-                            items.remove(p.getFirstSegment());
+                            ClientFilterMenu.Item parentFilter = (ClientFilterMenu.Item)p.getFirstSegment();
+                            String message =  MessageFormat.format(Messages.MenuReportingPeriodDeleteConfirm, parentFilter.getLabel());
+                            if (MessageDialog.openConfirm(Display.getDefault().getActiveShell(), getText(), message))
+                                items.remove(p.getFirstSegment());
                         }
                         else if(p.getSegmentCount() == 2)
                         { // child node clicked (portfolio or account)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ListSelectionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ListSelectionDialog.java
@@ -145,6 +145,7 @@ public class ListSelectionDialog extends Dialog
             input.addFocusListener(FocusListener.focusGainedAdapter(e -> input.selectAll()));
             input.addModifyListener(e -> property = input.getText());
             GridDataFactory.fillDefaults().grab(true, false).applyTo(input);
+            input.setFocus(); // when textinput visible, set focus
         }
 
         Label label = new Label(container, SWT.None);
@@ -153,7 +154,8 @@ public class ListSelectionDialog extends Dialog
 
         searchText = new Text(container, SWT.SEARCH | SWT.ICON_SEARCH | SWT.ICON_CANCEL);
         GridDataFactory.fillDefaults().span(2, 1).grab(true, false).applyTo(searchText);
-        searchText.setFocus();
+        if(propertyLabel == null)
+            searchText.setFocus(); // only set focus if textinput invisible
 
         Composite tableArea = new Composite(container, SWT.NONE);
         GridDataFactory.fillDefaults().span(2, 1).grab(false, true).applyTo(tableArea);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1696,6 +1696,8 @@ MenuRenameLabel = Edit label...
 
 MenuReportingPeriodDelete = Delete
 
+MenuReportingPeriodDeleteConfirm = Really delete filter ''{0}''?
+
 MenuReportingPeriodInsert = Add
 
 MenuReportingPeriodManage = Manage...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1698,7 +1698,7 @@ MenuReportingPeriodDelete = Delete
 
 MenuReportingPeriodDeleteConfirm = Really delete filter ''{0}''?
 
-MenuReportingPeriodInsert = Add
+MenuReportingPeriodInsert = Add elements
 
 MenuReportingPeriodManage = Manage...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1696,6 +1696,8 @@ MenuRenameLabel = Edit label...
 
 MenuReportingPeriodDelete = Delete
 
+MenuReportingPeriodInsert = Add
+
 MenuReportingPeriodManage = Manage...
 
 MenuResetChartSeries = Reset data series

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1689,6 +1689,8 @@ MenuRenameLabel = Bezeichnung editieren...
 
 MenuReportingPeriodDelete = L\u00F6schen
 
+MenuReportingPeriodDeleteConfirm = Filter ''{0}'' wirklich l\u00F6schen?
+
 MenuReportingPeriodInsert = Hinzuf\u00FCgen
 
 MenuReportingPeriodManage = Verwalten...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1689,6 +1689,8 @@ MenuRenameLabel = Bezeichnung editieren...
 
 MenuReportingPeriodDelete = L\u00F6schen
 
+MenuReportingPeriodInsert = Hinzuf\u00FCgen
+
 MenuReportingPeriodManage = Verwalten...
 
 MenuResetChartSeries = Datenreihen zur\u00FCcksetzen

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1691,7 +1691,7 @@ MenuReportingPeriodDelete = L\u00F6schen
 
 MenuReportingPeriodDeleteConfirm = Filter ''{0}'' wirklich l\u00F6schen?
 
-MenuReportingPeriodInsert = Hinzuf\u00FCgen
+MenuReportingPeriodInsert = Elemente Hinzuf\u00FCgen
 
 MenuReportingPeriodManage = Verwalten...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Editar etiqueta...
 
 MenuReportingPeriodDelete = Eliminar
 
+MenuReportingPeriodInsert = A\u00F1adir
+
 MenuReportingPeriodManage = Gestionar...
 
 MenuResetChartSeries = Reiniciar series de datos

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1685,7 +1685,7 @@ MenuReportingPeriodDelete = Eliminar
 
 MenuReportingPeriodDeleteConfirm = ¿Realmente quieres eliminar el filtro ''{0}''?
 
-MenuReportingPeriodInsert = A\u00F1adir
+MenuReportingPeriodInsert = A\u00F1adir elementos
 
 MenuReportingPeriodManage = Gestionar...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Editar etiqueta...
 
 MenuReportingPeriodDelete = Eliminar
 
+MenuReportingPeriodDeleteConfirm = ¿Realmente quieres eliminar el filtro ''{0}''?
+
 MenuReportingPeriodInsert = A\u00F1adir
 
 MenuReportingPeriodManage = Gestionar...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1684,6 +1684,8 @@ MenuRenameLabel = \u00C9diter libell\u00E9...
 
 MenuReportingPeriodDelete = Supprimer
 
+MenuReportingPeriodInsert = Ajouter
+
 MenuReportingPeriodManage = G\u00E9rer...
 
 MenuResetChartSeries = R\u00E9initialiser s\u00E9rie de donn\u00E9es

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1686,7 +1686,7 @@ MenuReportingPeriodDelete = Supprimer
 
 MenuReportingPeriodDeleteConfirm = Voulez-vous vraiment supprimer le filtre ''{0}'' ?
 
-MenuReportingPeriodInsert = Ajouter
+MenuReportingPeriodInsert = Ajouter des \u00E9l\u00E9ments
 
 MenuReportingPeriodManage = G\u00E9rer...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1684,6 +1684,8 @@ MenuRenameLabel = \u00C9diter libell\u00E9...
 
 MenuReportingPeriodDelete = Supprimer
 
+MenuReportingPeriodDeleteConfirm = Voulez-vous vraiment supprimer le filtre ''{0}'' ?
+
 MenuReportingPeriodInsert = Ajouter
 
 MenuReportingPeriodManage = G\u00E9rer...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1691,7 +1691,7 @@ MenuReportingPeriodDelete = Elimina
 
 MenuReportingPeriodDeleteConfirm = Vuoi davvero cancellare il filtro ''{0}''?
 
-MenuReportingPeriodInsert = Aggiungi
+MenuReportingPeriodInsert = Aggiungere elementi
 
 MenuReportingPeriodManage = Gestisci...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1689,6 +1689,8 @@ MenuRenameLabel = Modifica etichetta...
 
 MenuReportingPeriodDelete = Elimina
 
+MenuReportingPeriodDeleteConfirm = Vuoi davvero cancellare il filtro ''{0}''?
+
 MenuReportingPeriodInsert = Aggiungi
 
 MenuReportingPeriodManage = Gestisci...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1689,6 +1689,8 @@ MenuRenameLabel = Modifica etichetta...
 
 MenuReportingPeriodDelete = Elimina
 
+MenuReportingPeriodInsert = Aggiungi
+
 MenuReportingPeriodManage = Gestisci...
 
 MenuResetChartSeries = Reset serie dati

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Label bewerken...
 
 MenuReportingPeriodDelete = Verwijderen
 
+MenuReportingPeriodInsert = Toevoegen
+
 MenuReportingPeriodManage = Beheer...
 
 MenuResetChartSeries = Gegevensseries resetten

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Label bewerken...
 
 MenuReportingPeriodDelete = Verwijderen
 
+MenuReportingPeriodDeleteConfirm = Wil je echt het filter ''{0}'' verwijderen?
+
 MenuReportingPeriodInsert = Toevoegen
 
 MenuReportingPeriodManage = Beheer...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1685,7 +1685,7 @@ MenuReportingPeriodDelete = Verwijderen
 
 MenuReportingPeriodDeleteConfirm = Wil je echt het filter ''{0}'' verwijderen?
 
-MenuReportingPeriodInsert = Toevoegen
+MenuReportingPeriodInsert = Elementen toevoegen
 
 MenuReportingPeriodManage = Beheer...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Editar r\u00F3tulo...
 
 MenuReportingPeriodDelete = Excluir
 
+MenuReportingPeriodDeleteConfirm = Quer mesmo apagar o filtro ''{0}''?
+
 MenuReportingPeriodInsert = Adicionar
 
 MenuReportingPeriodManage = Gerenciar...

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1685,7 +1685,7 @@ MenuReportingPeriodDelete = Excluir
 
 MenuReportingPeriodDeleteConfirm = Quer mesmo apagar o filtro ''{0}''?
 
-MenuReportingPeriodInsert = Adicionar
+MenuReportingPeriodInsert = Adicionar elementos
 
 MenuReportingPeriodManage = Gerenciar...
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1683,6 +1683,8 @@ MenuRenameLabel = Editar r\u00F3tulo...
 
 MenuReportingPeriodDelete = Excluir
 
+MenuReportingPeriodInsert = Adicionar
+
 MenuReportingPeriodManage = Gerenciar...
 
 MenuResetChartSeries = Repor s\u00E9rie de dados

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -196,7 +196,10 @@ public final class ClientFilterMenu implements IMenuListener
         manager.add(new SimpleAction(Messages.LabelClientFilterNew, a -> createCustomFilter()));
         manager.add(new SimpleAction(Messages.LabelClientFilterManage, a -> editCustomFilter()));
 
-        manager.add(new SimpleAction(Messages.LabelClientClearCustomItems, a -> {
+        manager.add(new SimpleAction(Messages.LabelClientClearCustomItems, a -> {           
+            if (!MessageDialog.openConfirm(Display.getDefault().getActiveShell(), Messages.LabelClientClearCustomItems, Messages.LabelClientClearCustomItems + "?")) //$NON-NLS-1$
+                return;
+            
             if (customItems.contains(selectedItem))
             {
                 selectedItem = defaultItems.get(0);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -66,6 +66,11 @@ public final class ClientFilterMenu implements IMenuListener
         {
             return uuids;
         }
+        
+        public void setUUIDs(String uuids)
+        {
+            this.uuids = uuids;
+        }
 
         public ClientFilter getFilter()
         {
@@ -276,12 +281,10 @@ public final class ClientFilterMenu implements IMenuListener
 
     private Optional<Item> buildItem(String uuids)
     {
-        if (uuids == null || uuids.isEmpty())
+        if (uuids == null)
             return Optional.empty();
 
         String[] ids = uuids.split(","); //$NON-NLS-1$
-        if (ids.length == 0)
-            return Optional.empty();
 
         Map<String, Object> uuid2object = new HashMap<>();
         client.getPortfolios().forEach(p -> uuid2object.put(p.getUUID(), p));
@@ -299,11 +302,16 @@ public final class ClientFilterMenu implements IMenuListener
 
         String label = Arrays.stream(selected).map(String::valueOf).collect(Collectors.joining(", ")); //$NON-NLS-1$
 
-        String uuids = Arrays.stream(selected)
-                        .map(o -> o instanceof Account ? ((Account) o).getUUID() : ((Portfolio) o).getUUID())
-                        .collect(Collectors.joining(",")); //$NON-NLS-1$
+        String uuids = buildUUIDs(selected);
 
         return new Item(label, uuids, new PortfolioClientFilter(portfolios, accounts));
+    }
+    
+    public static String buildUUIDs(Object[] selected) 
+    {
+        return Arrays.stream(selected)
+                        .map(o -> o instanceof Account ? ((Account) o).getUUID() : ((Portfolio) o).getUUID())
+                        .collect(Collectors.joining(",")); //$NON-NLS-1$
     }
 
     public boolean hasActiveFilter()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
@@ -43,6 +44,21 @@ public class PortfolioClientFilter implements ClientFilter
     public PortfolioClientFilter(Portfolio portfolio, Account account)
     {
         this(Arrays.asList(portfolio), Arrays.asList(account));
+    }
+    
+    public void removePortfolio(Portfolio portfolio)
+    {
+        portfolios.remove(portfolio);
+    }
+    
+    public void removeAccount(Account account)
+    {
+        accounts.remove(account);
+    }
+    
+    public Object[] getAllElements()
+    {
+        return Stream.concat(portfolios.stream(), accounts.stream()).toArray();
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -46,16 +46,21 @@ public class PortfolioClientFilter implements ClientFilter
         this(Arrays.asList(portfolio), Arrays.asList(account));
     }
     
-    public void removePortfolio(Portfolio portfolio)
+    public void removeElement(Object element)
     {
-        portfolios.remove(portfolio);
+        portfolios.remove(element);
+        accounts.remove(element);
     }
     
-    public void removeAccount(Account account)
+    public void addElement(Object element)
     {
-        accounts.remove(account);
+        if(element instanceof Portfolio)
+            portfolios.add((Portfolio)element);
+        
+        if(element instanceof Account)
+            accounts.add((Account)element);
     }
-    
+       
     public Object[] getAllElements()
     {
         return Stream.concat(portfolios.stream(), accounts.stream()).toArray();


### PR DESCRIPTION
fixes #1375
- https://forum.portfolio-performance.info/t/bestehende-filter-erweitern/7355
- https://forum.portfolio-performance.info/t/filter-aendern-in-der-vermoegensaufstellung/9233

new with this PR:

* sub filter can now be added to main filter (see video in https://github.com/buchen/portfolio/pull/2495#issuecomment-962196719)
![grafik](https://user-images.githubusercontent.com/90478568/140185113-28523404-9caf-490f-85bf-3cc713218dd7.png)
* subfilters can be deleted by context menu
* when deleting main/parent filter a confirmation message is shown
* confirmation message before deleting all user filters