### PR TITLE
fixes calculation of historical prices when applying split

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModelTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModelTest.java
@@ -1,0 +1,27 @@
+package name.abuchen.portfolio.ui.wizards.splits;
+
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+@SuppressWarnings("nls")
+public class StockSplitModelTest
+{
+
+    @Test
+    public void testCalculateNewQuoteAndStock()
+    {
+        StockSplitModel model = new StockSplitModel(null, null);
+        // 2 shares for 1
+        model.setNewShares(new BigDecimal(2));
+        model.setOldShares(new BigDecimal(1));        
+        
+        assertThat(model.calculateNewQuote(4), is(2L)); // quote is halved
+        assertThat(model.calculateNewStock(4), is(8L)); // stock is doubled
+    }
+    
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewQuotesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewQuotesPage.java
@@ -1,8 +1,5 @@
 package name.abuchen.portfolio.ui.wizards.splits;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
@@ -53,11 +50,8 @@ public class PreviewQuotesPage extends AbstractWizardPage
                     return Values.Quote.format(p.getValue());
                 case 2:
                     if (model.isChangeHistoricalQuotes() && p.getDate().isBefore(model.getExDate()))
-                    {
-                        long quote = BigDecimal.valueOf(p.getValue()).multiply(model.getNewShares())
-                                        .divide(model.getOldShares(), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
-                                        .longValue();
-                        return Values.Quote.format(quote);
+                    {                    
+                        return Values.Quote.format(model.calculateNewQuote(p.getValue()));
                     }
                     return null;
                 default:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewTransactionsPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewTransactionsPage.java
@@ -1,7 +1,5 @@
 package name.abuchen.portfolio.ui.wizards.splits;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Collections;
 import java.util.List;
 
@@ -76,11 +74,8 @@ public class PreviewTransactionsPage extends AbstractWizardPage
                     return Values.Share.format(t.getShares());
                 case 3:
                     if (model.isChangeTransactions() && t.getDateTime().toLocalDate().isBefore(model.getExDate()))
-                    {
-                        long shares = BigDecimal.valueOf(t.getShares()).multiply(model.getNewShares())
-                                        .divide(model.getOldShares(), Values.MC).setScale(0, RoundingMode.HALF_EVEN)
-                                        .longValue();
-                        return Values.Share.format(shares);
+                    {                     
+                        return Values.Share.format(model.calculateNewStock(t.getShares()));
                     }
                     return null;
                 case 4:

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -93,6 +93,24 @@ public class StockSplitModel extends BindingHelper.Model
                         this.changeHistoricalQuotes = changeHistoricalQuotes);
     }
 
+    // stock multiplier = quote divider
+    private BigDecimal getStockMultiplier()
+    {
+        return newShares.divide(oldShares, Values.MC);
+    }
+    
+    public long calculateNewStock(long oldStock)
+    {
+        return BigDecimal.valueOf(oldStock).multiply(getStockMultiplier())
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
+    }
+    
+    public long calculateNewQuote(long oldQuote)
+    {
+        return BigDecimal.valueOf(oldQuote).divide(getStockMultiplier()) // when stock is multiplied, quote must be divided
+        .setScale(0, RoundingMode.HALF_EVEN).longValue();        
+    }
+    
     @Override
     public void applyChanges()
     {
@@ -101,8 +119,6 @@ public class StockSplitModel extends BindingHelper.Model
         SecurityEvent event = new SecurityEvent(exDate, SecurityEvent.Type.STOCK_SPLIT, newShares + ":" + oldShares); //$NON-NLS-1$
         security.addEvent(event);
 
-        BigDecimal multiplier = newShares.divide(oldShares, Values.MC);
-
         if (isChangeTransactions())
         {
             List<TransactionPair<?>> transactions = security.getTransactions(getClient());
@@ -110,8 +126,7 @@ public class StockSplitModel extends BindingHelper.Model
             {
                 Transaction t = pair.getTransaction();
                 if (t.getDateTime().toLocalDate().isBefore(exDate))
-                    t.setShares(BigDecimal.valueOf(t.getShares()).multiply(multiplier)
-                                    .setScale(0, RoundingMode.HALF_EVEN).longValue());
+                    t.setShares(calculateNewStock(t.getShares()));
             }
         }
 
@@ -121,8 +136,7 @@ public class StockSplitModel extends BindingHelper.Model
             for (SecurityPrice p : quotes)
             {
                 if (p.getDate().isBefore(exDate))
-                    p.setValue(BigDecimal.valueOf(p.getValue()).multiply(multiplier).setScale(0, RoundingMode.HALF_EVEN)
-                                    .longValue());
+                    p.setValue(calculateNewQuote(p.getValue()));
             }
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -108,7 +108,7 @@ public class StockSplitModel extends BindingHelper.Model
     public long calculateNewQuote(long oldQuote)
     {
         return BigDecimal.valueOf(oldQuote).divide(getStockMultiplier()) // when stock is multiplied, quote must be divided
-        .setScale(0, RoundingMode.HALF_EVEN).longValue();        
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();        
     }
     
     @Override


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/verbuchung-eines-aktiensplits-passt-kurse-falsch-herum-an/18581
https://forum.portfolio-performance.info/t/aktiensplit-buchen/11758/71

<details>
  <summary>Before Fix (wrong prices are marked red in screenshots)</summary>

![grafik](https://user-images.githubusercontent.com/90478568/141533144-01ccfa67-25a6-4367-9f78-84cb747c08d7.png)  
![grafik](https://user-images.githubusercontent.com/90478568/141533527-4373d16d-17a9-404c-8293-88cce4538163.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533537-2c0ff7a3-2c0c-409d-a8cf-b1e7fd87370a.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533541-ea019045-138c-4f00-8413-2a5cd8d44264.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533551-d05b08ab-3d1e-46b2-b111-7c566d25a9a4.png)

</details>
<details>
  <summary>With/After Fix</summary>

![grafik](https://user-images.githubusercontent.com/90478568/141533597-cdc097fe-bf3e-453f-970e-6acaba09d637.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533604-fb846f9a-3c3a-4737-a220-fe26d40b6982.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533610-3f37483f-1f24-490d-b4a9-d05e408dc6b0.png)
![grafik](https://user-images.githubusercontent.com/90478568/141533620-99eb5880-acd1-4285-9200-2ccc43b03486.png)
![grafik](https://user-images.githubusercontent.com/90478568/141653741-32de4f16-5b15-4afe-ab47-b221866cb0c4.png)

</details>
