### PR TITLE
fix sorting of limit price column

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
@@ -90,7 +90,7 @@ public class LimitPrice implements Comparable<LimitPrice>
         int compare = operator.getOperatorString().compareTo(other.getRelationalOperator().getOperatorString());
         if (compare != 0)
             return compare;
-        return (int) (value - other.getValue());
+        return Long.compare(value, other.getValue());
     }
 
     @Override


### PR DESCRIPTION
**Reason for sorting error:**
Compare value (neg/0/pos) was calculated by
````
return (int) (value - other.getValue());
````
Where values were of datatype long. But casting long to int results in loss of information and leads to wrong order.

**Before Fix:**
![grafik](https://user-images.githubusercontent.com/90478568/141657710-065bb0f2-dedf-4880-a8a5-f53a07dd2700.png)

**After Fix:**
![grafik](https://user-images.githubusercontent.com/90478568/141657715-5aa8790a-bdd1-42bb-aa18-bdd682d926b9.png)

EDIT: Also reported here: 
https://forum.portfolio-performance.info/t/formatting-of-limit-prevents-opening-of-all-securities-view/14334/8