### PR TITLE
Fix Onvista PDF-Importer with missing blank and older issues

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/DividendeWithReinvest02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/DividendeWithReinvest02.txt
@@ -1,0 +1,49 @@
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Erträgnisgutschrift aus Wertpapieren ADRESSZEILE1=Herr
+ADRESSZEILE2=Hans Mustermann
+ADRESSZEILE3=Beispielstr 12
+ADRESSZEILE4=12345 Stadt
+Ausschüttung für
+Herr ADRESSZEILE5=01.04.2017 - 06.10.2017
+Hans Mustermann ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+Beispielstr 12 BELEGNUMMER=123
+12345 Stadt 123456789 12345678 / 19.10.2017 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+Hans Mustermann
+Ertragsthesaurierung Frankfurt am Main, 19.10.2017
+Gattungsbezeichnung ISIN
+iS.EO Go.B.C.2.5-5.5y.U.ETF DE Inhaber-Anteile DE000A0H08A8
+Nominal Ex-Tag Zahltag Ausschüttungsbetrag pro Stück
+STK 0,4512 06.10.2017 20.10.2017 EUR 0,169895
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+20.10.2017 123456789 EUR 0,00
+Ertrag für 2017 EUR 0,08
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Zinsanteil (Thesaurierung) EUR 0,08
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+Steuerliquidität EUR 0,02
+zu versteuern EUR 0,08
+einbehaltene Kapitalertragsteuer EUR 0,02
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 2,65
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,14
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Itzehoe, Steuernummer 18/297/13562.
+Steuerlicher Stichtag 06.10.2017
+Die KAG entnimmt KESt, SolZ und ggf. KiSt dem Sondervermögen und stellt den auszahlenden Stellen diesen Betrag in
+Form der Steuerliquidität zur Verfügung. Abhängig von der tatsächlich abzuführenden Steuer wird ein möglicher
+Differenzbetrag dem Kundenkonto erstattet.
+Jahressteuerbescheinigung folgt
+Verwahrart: Girosammelverwahrung      
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+3.20/ABREEREIERTR/GDBERTRG/000123/102027/004465

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Kauf09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Kauf09.txt
@@ -1,0 +1,41 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=405259000
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Max Muster
+ADRESSZEILE2=Mini Muster
+Kauf ADRESSZEILE3=Kauffmannstr 111A
+Kommissionsgeschäft ADRESSZEILE4=70195 Stuttgart Botnang
+Max Muster ADRESSZEILE5=
+Mini Muster ADRESSZEILE6=Depot-Nr. Abrechnungs-Nr.
+Kaufstr 78A BELEGNUMMER=1111
+70195 Stuttgart Botnang 11111111 11111111 / 08.11.2021 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+Max und Mini Muster
+Frankfurt am Main, 08.11.2021
+Wir haben für Sie gekauft
+Gattungsbezeichnung Fälligkeit näch. Zinstermin ISIN
+HSBC Trinkaus & Burkhardt AG DIZ 23.06.23 23.06.2023 DE000TT9F809
+RoyalD. 19
+Nominal Kurs
+STK 670,000 EUR 16,5000
+Handelstag 08.11.2021 Kurswert EUR 11.055,00-
+Handelszeit 09:46 Orderprovision EUR 5,00-
+Handelsplatz außerbörslich HSBC Trinkaus Handelsplatzgebühr EUR 2,00-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Lasten
+10.11.2021 111111111 EUR 11.062,00
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+onvist a bank - eine M arke der Com merzbank AG · Wildunger S t raße 6a · 6 0 487 Frankfur t a m M ain
+Kundenservice: +49 ( 0 )69-710 7-53 0 · T: +49 ( 0 )69-710 7- 0 · F: +49 ( 0 )69-710 7-10 0 · E: in fo@onvist a -bank.de · W: w w w.onvist a -bank.de
+Commerzbank AG · 60261 Frankfur t am Main · AG Frankfur t am Main HRB 32000 · Vorstand: Manf red Knof (Vorsitzender),
+Marcus Chromik, Michael Kotzbauer, Bet t ina Orlopp, Sabine Schmit t roth · Vorsitzender des Aufsichtsrates: Helmut Got tschalk
+3.18/1111111/1111111/111111/111111/111111

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Kauf10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Kauf10.txt
@@ -1,0 +1,38 @@
+`PDF Autor: ''
+PDFBox Version: 1.8.16
+
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=Nummer
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=Name Vorname
+Kauf Limitauftrag ADRESSZEILE3=Straße Nummer
+Kommissionsgeschäft ADRESSZEILE4=PLZ ORT
+Herr ADRESSZEILE5=
+Name Vorname ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+Straße Nummer BELEGNUMMER=27332
+PLZ Ort Nummer 1Nummer2/ 15.10.2018 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+Name Nachname
+Frankfurt am Main, 15.10.2018
+Wir haben für Sie gekauft
+Gattungsbezeichnung ISIN
+Synchrony Financial Registered Shares DL -,001 US87165B1035
+Nominal Kurs
+STK 3,000 USD 30,1699
+Handelstag 12.10.2018 Kurswert USD 90,51-
+Handelszeit 16:04 Orderprovision USD 11,54-
+Handelsplatz Börse New York/NAY Handelsplatzgebühr USD 2,88-
+Verwahrart Wertpapierrechnung Ausmachender Betrag USD 104,93-
+Lagerland USA
+Wert Konto-Nr. Devisenkurs Betrag zu Ihren Lasten
+16.10.2018 290261041 EUR/USD 1,1536 EUR 90,96
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+3.18/ABREABHNHANDKFDI/GAAASAFG/027332/161018/011407

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
@@ -309,9 +309,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-15T16:11")));
+        assertThat(transaction.getSource(), is("Kauf05.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.10))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.10))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 3rd buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).collect(Collectors.toList())
@@ -420,9 +430,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-07-17T09:04")));
+        assertThat(transaction.getSource(), is("Kauf07.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -504,6 +524,47 @@ public class OnvistaPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 2.00))));
+    }
+
+    @Test
+    public void testWertpapierKauf10()
+    {
+        OnvistaPDFExtractor extractor = new OnvistaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf10.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("US87165B1035"));
+        assertThat(security.getName(), is("Synchrony Financial Registered Shares DL -,001"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+
+        // check buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(0).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-10-12T16:04")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
+        assertThat(entry.getSource(), is("Kauf10.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(90.96))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(78.46))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((11.54 + 2.88) / 1.1536))));
     }
 
     @Test
@@ -618,9 +679,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-09-14T09:02")));
+        assertThat(transaction.getSource(), is("Verkauf02.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.18))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.18))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 2nd buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).collect(Collectors.toList())
@@ -689,9 +760,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-04-08T12:30")));
+        assertThat(transaction.getSource(), is("Verkauf03.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.28))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.28))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -781,9 +862,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-05-06T12:00")));
+        assertThat(transaction.getSource(), is("Verkauf05.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.05))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.05))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -833,9 +924,19 @@ public class OnvistaPDFExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-09-25T00:00")));
+        assertThat(transaction.getSource(), is("Verkauf06.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(74.63))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(74.63))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -875,6 +976,257 @@ public class OnvistaPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.22 + 0.23))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf08()
+    {
+        OnvistaPDFExtractor extractor = new OnvistaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf08.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(10));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security1 = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security1.getIsin(), is("DE000GD8RHG7"));
+        assertThat(security1.getName(), is("Goldman Sachs Wertpapier GmbH TuBear 24.11.17 DAX 13410"));
+        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security2 = results.stream().filter(i -> i instanceof SecurityItem).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security2.getIsin(), is("DE000LS27QS5"));
+        assertThat(security2.getName(), is("Lang & Schwarz AG Turbo 31.01.18 DAX"));
+        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security3 = results.stream().filter(i -> i instanceof SecurityItem).skip(2).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security3.getIsin(), is("DE000PP09P16"));
+        assertThat(security3.getName(), is("BNP Paribas Em.-u.Handelsg.mbH TurboL 30.11.17 S&P500 2550"));
+        assertThat(security3.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security4 = results.stream().filter(i -> i instanceof SecurityItem).skip(3).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security4.getIsin(), is("DE000PP1BEF0"));
+        assertThat(security4.getName(), is("BNP Paribas Em.-u.Handelsg.mbH TurboL 18.12.17 DAX 13170"));
+        assertThat(security4.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security5 = results.stream().filter(i -> i instanceof SecurityItem).skip(4).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security5.getIsin(), is("FR0010959676"));
+        assertThat(security5.getName(), is("Amundi ETF MSCI Emerging Mkts Actions au Porteur o.N."));
+        assertThat(security5.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check 1st buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(0).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-10T09:56")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(200)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(482.66))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(524.60))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.22 + 1.72 + 2.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 2nd buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(1).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-10T10:54")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(200)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(424.50))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(418.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 3rd buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(2).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-09T12:55")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(303.50))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(310.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 4th buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(3).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-09T12:56")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(139.50))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(146.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 5th buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(4).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-09T13:43")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(700)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2946.50))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2940.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf09()
+    {
+        OnvistaPDFExtractor extractor = new OnvistaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf09.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(6));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security1 = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security1.getIsin(), is("DE000ZAL1111"));
+        assertThat(security1.getName(), is("Zalando SE Inhaber-Aktien o.N."));
+        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security2 = results.stream().filter(i -> i instanceof SecurityItem).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security2.getIsin(), is("DE0006632003"));
+        assertThat(security2.getName(), is("MorphoSys AG Inhaber-Aktien o.N."));
+        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check 1st buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(0).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-08-08T15:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
+        assertThat(entry.getSource(), is("Verkauf09.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4361.00))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4354.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 2nd buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(1).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-08-08T17:27")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
+        assertThat(entry.getSource(), is("Verkauf09.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4293.60))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4300.10))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        // check 3rd buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(2).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-08-08T17:28")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(40)));
+        assertThat(entry.getSource(), is("Verkauf09.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4234.10))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4227.60))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 1.50))));
+
+        Item item = results.stream().filter(i -> i.getSubject() instanceof AccountTransaction).findFirst().get();
+        AccountTransaction transaction = (AccountTransaction) item.getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+        
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-08-08T17:27")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
+        assertThat(transaction.getSource(), is("Verkauf09.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.78))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.78))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -1487,15 +1839,21 @@ public class OnvistaPDFExtractorTest
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DividendeWithReinvest01.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(3));
+        assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security1 = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("DE0005557508"));
-        assertThat(security.getName(), is("Deutsche Telekom AG Namens-Aktien o.N."));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security1.getIsin(), is("DE000A1TNRX5"));
+        assertThat(security1.getName(), is("Deutsche Telekom AG Dividend in Kind-Cash Line"));
+        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        Security security2 = results.stream().filter(i -> i instanceof SecurityItem).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security2.getIsin(), is("DE0005557508"));
+        assertThat(security2.getName(), is("Deutsche Telekom AG Namens-Aktien o.N."));
+        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
         AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
@@ -1505,6 +1863,8 @@ public class OnvistaPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-05-17T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(25)));
+        assertThat(transaction.getSource(), is("DividendeWithReinvest01.txt"));
+        assertThat(transaction.getNote(), is("neue Aktien reinvestiert: DE000A1TNRX5"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.50))));
@@ -1524,11 +1884,74 @@ public class OnvistaPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-05-17T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getSource(), is("DividendeWithReinvest01.txt"));
+        assertThat(entry.getNote(), is("Reinvestierung: DE0005557508"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.50))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.50))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testDividendeWithReinvest02()
+    {
+        OnvistaPDFExtractor extractor = new OnvistaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DividendeWithReinvest02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE000A0H08A8"));
+        assertThat(security.getName(), is("iS.EO Go.B.C.2.5-5.5y.U.ETF DE Inhaber-Anteile"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-10-20T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.4512)));
+        assertThat(transaction.getSource(), is("DividendeWithReinvest02.txt"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.08))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.02))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        // check reinvest transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(0).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-10-20T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.4512)));
+        assertThat(entry.getSource(), is("DividendeWithReinvest02.txt"));
+        assertThat(entry.getNote(), is("Ertragsthesaurierung"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
@@ -2105,9 +2528,17 @@ public class OnvistaPDFExtractorTest
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-11-26T00:00")));
+        assertThat(transaction.getSource(), is("Umtausch02.txt"));
+        assertThat(transaction.getNote(), is("Steuerausgleich"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.90))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.90))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 2nd transaction
         entry = (PortfolioTransaction) results.stream().filter(i -> i instanceof TransactionItem)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Verkauf08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Verkauf08.txt
@@ -1,0 +1,224 @@
+PDF Author: '' 
+PDFBox Version: 1.8.13
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=XXXXXX
+Verkauf ADRESSZEILE3=XXXXXX
+Kommissionsgeschäft ADRESSZEILE4=XXXXXX
+Herr ADRESSZEILE5=
+XXXXXX ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+XXXXXX BELEGNUMMER=9114
+Depotinhaber
+XXXXXX
+Frankfurt am Main, 10.11.2017
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+Goldman Sachs Wertpapier GmbH TuBear 24.11.17 DAX 13410 DE000GD8RHG7
+Nominal Kurs
+STK 200,000 EUR 2,6230
+Handelstag 10.11.2017 Kurswert EUR 524,60 
+Handelszeit 09:56 Orderprovision EUR 5,00-
+Börse außerbörslich Goldman Sachs Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung Kapitalertragsteuer EUR 31,22-
+Solidaritätszuschlag EUR 1,72-
+Kirchensteuer EUR 2,50-
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+13.11.2017 237584042 EUR 482,66
+Es folgt Seite 2
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Herr
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=XXXXXX
+XXXXXX 12108319 2 ADRESSZEILE3=XXXXXX
+ADRESSZEILE4=XXXXXX
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=9114
+Jahressteuerbescheinigung folgt SEITENNUMMER=2
+STEUERERSTATTUNG=N
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=XXXXXX
+Kauf ADRESSZEILE3=XXXXXX
+Kommissionsgeschäft ADRESSZEILE4=XXXXXX
+Herr ADRESSZEILE5=
+XXXXXX ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+XXXXXX BELEGNUMMER=XXXX
+XXXXXX XXXXXX XXXXXX / 10.11.2017 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+XXXXXX
+Frankfurt am Main, 10.11.2017
+Wir haben für Sie gekauft
+Gattungsbezeichnung ISIN
+Lang & Schwarz AG Turbo 31.01.18 DAX DE000LS27QS5
+Nominal Kurs
+STK 200,000 EUR 2,0900
+Handelstag 10.11.2017 Kurswert EUR 418,00-
+Handelszeit 10:54 Orderprovision EUR 5,00-
+Börse außerbörslich Lang & Schwarz Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Lasten
+13.11.2017 237584042 EUR 424,50
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=XXXXXX
+Verkauf ADRESSZEILE3=XXXXXX
+Kommissionsgeschäft ADRESSZEILE4=XXXXXX
+Herr ADRESSZEILE5=
+XXXXXX ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+XXXXXX BELEGNUMMER=9116
+XXXXXX XXXXXX XXXXXX / 10.11.2017 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+XXXXXX
+Frankfurt am Main, 10.11.2017
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+BNP Paribas Em.-u.Handelsg.mbH TurboL 30.11.17 S&P500 2550 DE000PP09P16
+Nominal Kurs
+STK 1.000,000 EUR 0,3100
+Handelstag 09.11.2017 Kurswert EUR 310,00 
+Handelszeit 12:55 Orderprovision EUR 5,00-
+Börse außerbörslich BNP Paribas Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+13.11.2017 237584042 EUR 303,50
+Es folgt Seite 2
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Herr
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=XXXXXX
+XXXXXX XXXXXX 2 ADRESSZEILE3=XXXXXX
+ADRESSZEILE4=XXXXXX
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=XXXX
+Jahressteuerbescheinigung folgt
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=XXXXXX
+Verkauf ADRESSZEILE3=XXXXXX
+Kommissionsgeschäft ADRESSZEILE4=XXXXXX
+Herr ADRESSZEILE5=
+XXXXXX ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+XXXXXX BELEGNUMMER=9117
+XXXXXX XXXXXX XXXXXX / 10.11.2017 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+XXXXXX
+Frankfurt am Main, 10.11.2017
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+BNP Paribas Em.-u.Handelsg.mbH TurboL 18.12.17 DAX 13170 DE000PP1BEF0
+Nominal Kurs
+STK 100,000 EUR 1,4600
+Handelstag 09.11.2017 Kurswert EUR 146,00 
+Handelszeit 12:56 Orderprovision EUR 5,00-
+Börse außerbörslich BNP Paribas Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+13.11.2017 237584042 EUR 139,50
+Es folgt Seite 2
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Herr
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=XXXXXX
+XXXXXX XXXXXX 2 ADRESSZEILE3=XXXXXX
+ADRESSZEILE4=XXXXXX
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=XXXX
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=XXXXXX
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Herr
+ADRESSZEILE2=XXXXXX
+Kauf ADRESSZEILE3=XXXXXX
+Kommissionsgeschäft ADRESSZEILE4=XXXXXX
+Herr ADRESSZEILE5=
+XXXXXX ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+XXXXXX BELEGNUMMER=XXXX
+XXXXXX XXXXXX XXXXXX / 10.11.2017 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+XXXXXX
+Frankfurt am Main, 10.11.2017
+Wir haben für Sie gekauft
+Gattungsbezeichnung ISIN
+Amundi ETF MSCI Emerging Mkts Actions au Porteur o.N. FR0010959676
+Nominal Kurs
+STK 700,000 EUR 4,2000
+Handelstag 09.11.2017 Kurswert EUR 2.940,00-
+Handelszeit 13:43 Orderprovision EUR 5,00-
+Börse außerbörslich Baader Bank Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Lasten
+13.11.2017 237584042 EUR 2.946,50
+Die jährlich zu zahlende Verwaltungsvergütung und die Gesamtkostenquote sind dem Verkaufsprospekt bzw. den
+Vertragsbedingungen zu entnehmen.
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Verkauf09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/Verkauf09.txt
@@ -1,0 +1,140 @@
+PDF Author: ''
+PDFBox Version: 1.8.13
+
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Person
+ADRESSZEILE2=VORNAME NACHNAME
+Kauf ADRESSZEILE3=STRASSESTRASSE
+Kommissionsgeschäft ADRESSZEILE4=77777 WoAuchImmerDorf
+Person ADRESSZEILE5=
+VORNAME NACHNAME ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+STRASSESTRASSE BELEGNUMMER=11421
+77777 WoAuchImmerDorf 123456789 98765432 / 08.08.2018 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+VORNAME NACHNAME
+Frankfurt am Main, 08.08.2018
+Wir haben für Sie gekauft
+Gattungsbezeichnung ISIN
+Zalando SE Inhaber-Aktien o.N. DE000ZAL1111
+Nominal Kurs
+STK 100,000 EUR 43,5450
+Handelstag 08.08.2018 Kurswert EUR 4.354,50-
+Handelszeit 15:00 Orderprovision EUR 5,00-
+Handelsplatz außerbörslich Baader Bank Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Lasten
+10.08.2018 330247043 EUR 4.361,00
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+3.18/ABREABHNHANDKFDI/GAAASAFG/011421/090818/002343
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Person
+ADRESSZEILE2=VORNAME NACHNAME
+Verkauf ADRESSZEILE3=STRASSESTRASSE
+Kommissionsgeschäft ADRESSZEILE4=77777 WoAuchImmerDorf
+Person ADRESSZEILE5=
+VORNAME NACHNAME ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+STRASSESTRASSE BELEGNUMMER=11422
+77777 WoAuchImmerDorf 123456789 68411850 / 08.08.2018 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+VORNAME NACHNAME
+Frankfurt am Main, 08.08.2018
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+Zalando SE Inhaber-Aktien o.N. DE000ZAL1111
+Nominal Kurs
+STK 100,000 EUR 43,0010
+Handelstag 08.08.2018 Kurswert EUR 4.300,10
+Handelszeit 17:27 Orderprovision EUR 5,00-
+Handelsplatz außerbörslich Lang & Schwarz Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Gunsten
+10.08.2018 330247043 EUR 4.293,60
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsverlust Aktien EUR 67,40
+Aktienverlusttopf EUR 0,00 0,00
+allgemeiner Verlusttopf EUR 0,00 0,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern (negativ) EUR 67,40
+Steuerausgleich nach § 43a EStG:
+Kapitalertragsteuer EUR 16,85
+Solidaritätszuschlag EUR 0,93
+Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
+08.08.2018 330247043 80817950 EUR 17,78
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 4.762,62
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 261,94
+Es folgt Seite 2
+3.18/ABREABHNHANDVFDI/GAAASAFG/011422/090818/002343
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+ADRESSZEILE1=Person
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. ADRESSZEILE2=VORNAME NACHNAME
+123456789 68411850 2 ADRESSZEILE3=STRASSESTRASSE
+ADRESSZEILE4=77777 WoAuchImmerDorf
+ADRESSZEILE5=
+ADRESSZEILE6=
+BELEGNUMMER=11422
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem SEITENNUMMER=2
+Finanzamt Itzehoe, Steuernummer 18/297/13562. STEUERERSTATTUNG=N
+Jahressteuerbescheinigung folgt
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+3.18/ABREABHNHANDVFDI/GAAASAFG/011422/090818/002343
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=123456789
+DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=EBOX
+Wertpapierabrechnung ADRESSZEILE1=Person
+ADRESSZEILE2=VORNAME NACHNAME
+Kauf ADRESSZEILE3=STRASSESTRASSE
+Kommissionsgeschäft ADRESSZEILE4=77777 WoAuchImmerDorf
+Person ADRESSZEILE5=
+VORNAME NACHNAME ADRESSZEILE6=
+Depot-Nr. Abrechnungs-Nr.
+STRASSESTRASSE BELEGNUMMER=11423
+77777 WoAuchImmerDorf 123456789 80926283 / 08.08.2018 SEITENNUMMER=1STEUERERSTATTUNG=N
+Depotinhaber
+VORNAME NACHNAME
+Frankfurt am Main, 08.08.2018
+Wir haben für Sie gekauft
+Gattungsbezeichnung ISIN
+MorphoSys AG Inhaber-Aktien o.N. DE0006632003
+Nominal Kurs
+STK 40,000 EUR 105,6900
+Handelstag 08.08.2018 Kurswert EUR 4.227,60-
+Handelszeit 17:28 Orderprovision EUR 5,00-
+Handelsplatz außerbörslich Lang & Schwarz Handelsplatzgebühr EUR 1,50-
+Verwahrart Girosammelverwahrung
+Wert Konto-Nr. Betrag zu Ihren Lasten
+10.08.2018 330247043 EUR 4.234,10
+Wir werden in Ihrem Depot wie angegeben buchen.
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+3.18/ABREABHNHANDKFDI/GAAASAFG/011423/090818/002343

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -63,7 +63,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Reinvestierung|Ausbuchung:) .*$");
+        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Reinvestierung|Ausbuchung:)( .*)?$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -29,6 +29,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("Frankfurt am Main"); //$NON-NLS-1$
 
         addBuySellTransaction();
+        addReinvestTransaction();
         addDividendeTransaction();
         addAdvanceTaxTransaction();
         addDeliveryInOutBoundTransaction();
@@ -45,7 +46,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("(Kauf|Verkauf|Gesamtfälligkeit|Reinvestierung|Zwangsabfindung|Dividende)");
+        DocumentType type = new DocumentType("(Kauf|Verkauf|Gesamtfälligkeit|Zwangsabfindung|Dividende)");
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
@@ -63,7 +64,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Reinvestierung|Ausbuchung:)( .*)?$");
+        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Ausbuchung:)( .*)?$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -147,12 +148,10 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // STK 65,000 EUR 39,4400
                 // Nominal Kurs
                 // STK 0,7445 EUR 200,1500
-                // Nominal Reinvestierungspreis
-                // STK 25,000 EUR 0,700000
                 // Nominal Ex-Tag
                 // STK 25,000 22.09.2015
                 .section("notation", "shares")
-                .find("Nominal (Kurs|Einl.sung zu:|Reinvestierungspreis|Ex-Tag)")
+                .find("Nominal (Kurs|Einl.sung zu:|Ex-Tag)")
                 .match("^(?<notation>[\\w]{3}) (?<shares>[\\.,\\d]+) ([\\w]{3} [\\.,\\d]+|[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                 .assign((t, v) -> {
                     // Workaround for bonds
@@ -196,9 +195,6 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                         .match("^[\\w]{3} [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2,4})$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
                                 ,
-                                /***
-                                 * This is for the reinvestment of dividends
-                                 */
                                 // STK 25,000 17.05.2013 17.05.2013 EUR 0,700000
                                 section -> section
                                         .attributes("date")
@@ -209,17 +205,6 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // 19.08.2019 123450042 EUR 150,01
                 .section("amount", "currency").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
-                .assign((t, v) -> {
-                    t.setAmount(asAmount(v.get("amount")));
-                    t.setCurrencyCode(v.get("currency"));
-                })
-
-                /***
-                 * This is for the reinvestment of dividends
-                 */
-                // Leistungen aus dem steuerlichen Einlagenkonto (§27 KStG) EUR 17,50
-                .section("amount", "currency").optional()
-                .match("^Leistungen aus dem steuerlichen Einlagenkonto .* (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -275,6 +260,137 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
         addTaxReturnBlock(type);
+    }
+
+    private void addReinvestTransaction()
+    {
+        DocumentType type = new DocumentType("(Reinvestierung|Ertragsthesaurierung)");
+        this.addDocumentTyp(type);
+
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        pdfTransaction.subject(() -> {
+            BuySellEntry entry = new BuySellEntry();
+            entry.setType(PortfolioTransaction.Type.BUY);
+
+            /***
+             * If we have multiple entries in the document,
+             * with taxes and tax refunds,
+             * then the "negative" flag must be removed.
+             */
+            type.getCurrentContext().remove("negative");
+
+            return entry;
+        });
+
+        Block firstRelevantLine = new Block("^(Reinvestierung|Ertragsthesaurierung) .*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction
+                // Gattungsbezeichnung ISIN
+                // iS.EO Go.B.C.2.5-5.5y.U.ETF DE Inhaber-Anteile DE000A0H08A8
+                // Nominal Ex-Tag Zahltag Ausschüttungsbetrag pro Stück
+                // STK 0,4512 06.10.2017 20.10.2017 EUR 0,169895
+                .section("name", "isin", "name1", "date", "currency").optional()
+                .find("Gattungsbezeichnung ISIN")
+                .match("^(?<name>.*) (?<isin>[\\w]{12})$")
+                .match("^(?<name1>.*)$")
+                .match("^[\\w]{3} [\\.,\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Nominal"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+
+                    t.setDate(asDate(v.get("date")));
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
+
+                /***
+                 * If we have a reinvest
+                 * we pick the second
+                 */
+                // Gattungsbezeichnung ISIN
+                // Deutsche Telekom AG Namens-Aktien o.N. DE0005557508
+                // Die Dividende wurde wie folgt in neue Aktien reinvestiert:
+                // Gattungsbezeichnung ISIN
+                // Deutsche Telekom AG Dividend in Kind-Cash Line DE000A1TNRX5
+                .section("name", "isin", "name1", "currency").optional()
+                .find("Gattungsbezeichnung ISIN")
+                .find("Gattungsbezeichnung ISIN")
+                .match("^(?<name>.*) (?<isin>[\\w]{12})$")
+                .match("^(?<name1>.*)")
+                .match("^[\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                .assign((t, v) -> {
+                    if (!v.get("name1").startsWith("Nominal"))
+                        v.put("name", v.get("name") + " " + v.get("name1"));
+
+                    t.setSecurity(getOrCreateSecurity(v));
+                })
+
+                // Gattungsbezeichnung ISIN
+                // Deutsche Telekom AG Namens-Aktien o.N. DE0005557508
+                // Gattungsbezeichnung ISIN
+                // Deutsche Telekom AG Dividend in Kind-Cash Line DE000A1TNRX5
+                .section("isin").optional()
+                .find("Gattungsbezeichnung .*").optional()
+                .match("^.* (?<isin>[\\w]{12})$")
+                .assign((t, v) -> {
+                    // if we have a new isin for reinvest, we grab the old for note
+                    Map<String, String> context = type.getCurrentContext();
+                    context.put("isin", v.get("isin"));
+                })
+
+                // Nominal Reinvestierungspreis
+                // STK 25,000 EUR 0,700000
+                // Nominal Ex-Tag Zahltag Ausschüttungsbetrag pro Stück
+                // STK 0,4512 06.10.2017 20.10.2017 EUR 0,169895
+                .section("notation", "shares")
+                .find("Nominal (Ex-Tag|Reinvestierungspreis)( .*)")
+                .match("^(?<notation>[\\w]{3}) (?<shares>[\\.,\\d]+) ([\\w]{3} [\\.,\\d]+"
+                                + "|[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\w]{3} [\\.,\\d]+)$")
+                .assign((t, v) -> {
+                    // Workaround for bonds
+                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("STK"))
+                        t.setShares((asShares(v.get("shares")) / 100));
+                    else
+                        t.setShares(asShares(v.get("shares")));
+                })
+
+                // Zahlungstag 17.05.2013
+                .section("date").optional()
+                .match("^Zahlungstag (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
+                .assign((t, v) -> t.setDate(asDate(v.get("date"))))
+
+                // Leistungen aus dem steuerlichen Einlagenkonto (§27 KStG) EUR 17,50
+                .section("amount", "currency").optional()
+                .match("^Leistungen aus dem steuerlichen Einlagenkonto .* (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
+
+                // Steuerliquidität EUR 0,02
+                // zu versteuern EUR 0,08
+                .section("tax", "amount", "currency").optional()
+                .match("Ertragsthesaurierung .*")
+                .match("Steuerliquidität [\\w]{3} (?<tax>[\\.,\\d]+)")
+                .match("^zu versteuern (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")) - asAmount(v.get("tax")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
+
+                .section("note").optional()
+                .match("^(?<note>Reinvestierung) .*$")
+                .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+                    t.setNote(v.get("note") + ": " + context.get("isin"));
+                })
+
+                .section("note").optional()
+                .match("^(?<note>Ertragsthesaurierung) .*$")
+                .assign((t, v) -> t.setNote(v.get("note")))
+
+                .wrap(BuySellEntryItem::new);
     }
 
     private void addDividendeTransaction()
@@ -345,6 +461,21 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
+                /***
+                 * This is for the reinvestment of dividends
+                 */
+                // Gattungsbezeichnung ISIN
+                // Gattungsbezeichnung ISIN
+                .section("isin").optional()
+                .find("Gattungsbezeichnung .*")
+                .find("Gattungsbezeichnung .*")
+                .match("^.* (?<isin>[\\w]{12})$")
+                .assign((t, v) -> {
+                    // if we have a new isin for reinvest, we grab it
+                    Map<String, String> context = type.getCurrentContext();
+                    context.put("isin", v.get("isin"));
+                })
+
                 .oneOf(
                             // STK 50,000 21.04.2016 21.04.2016 EUR 0,200000
                             // STK 1,000 17.11.2010 EUR 1,548250
@@ -400,6 +531,20 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(v.get("currency"));
                 })
 
+                /***
+                 * This is for the "Ertragsthesaurierung"
+                 */
+                // Steuerliquidität EUR 0,02
+                // zu versteuern EUR 0,08
+                .section("tax", "amount", "currency").optional()
+                .match("Ertragsthesaurierung .*")
+                .match("Steuerliquidität [\\w]{3} (?<tax>[\\.,\\d]+)")
+                .match("^zu versteuern (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")) - asAmount(v.get("tax")));
+                    t.setCurrencyCode(v.get("currency"));
+                })
+
                 // 15.07.2019 123456789 EUR/USD 1,1327 EUR 13,47
                 .section("amount", "currency", "fxCurrency", "exchangeRate").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/(?<fxCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
@@ -419,6 +564,14 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
                     if (unit.getForex().getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                         t.addUnit(unit);
+                })
+
+                // Die Dividende wurde wie folgt in neue Aktien reinvestiert:
+                .section("note").optional()
+                .match("^.* (?<note>neue Aktien reinvestiert:)$")
+                .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+                    t.setNote(v.get("note") + " " + context.get("isin"));
                 })
 
                 .wrap(TransactionItem::new);
@@ -981,6 +1134,11 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         t.addUnit(new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate));
                     }
                 })
+
+                // Steuerausgleich nach § 43a EStG:
+                .section("note").optional()
+                .match("^(?<note>Steuerausgleich) .*$")
+                .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(t -> {
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -63,7 +63,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Reinvestierung|Ausbuchung:).*$");
+        Block firstRelevantLine = new Block("^(Spitze )?(Kauf|Verkauf|Gesamtf.lligkeit|Reinvestierung|Ausbuchung:) .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 


### PR DESCRIPTION
Fix blank in search pattern

Im Straßenname des PDF-Debugs wurde ein pattern gefunden, welcher nicht gefunden werden sollte , daher lief dieser auf error.
Ein Leerzeichen eingefügt. :roll_eyes::roll_eyes::roll_eyes:

Und selbst für den Fix hab ich einen zweiten Anlauf heute benötigt. :roll_eyes:

Edit:
Fix reinvest transaction
Add Ertragsthesaurierung
Fixes #851
Fixes #861
Fixes #1025
Fixes #1475
Fixes #1735