### PR TITLE
Update PostbankPDFExtractor.java

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
@@ -190,6 +190,114 @@ public class PostbankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf02()
+    {
+        PostbankPDFExtractor extractor = new PostbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "postbank_verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("US64110L1061"));
+        assertThat(security.getWkn(), is("552484"));
+        assertThat(security.getName(), is("NETFLIX INC. REGISTERED SHARES DL -,001"));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(1094.73)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-13T10:35:11")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
+                        is(Money.of("EUR", Values.Amount.factorize(8.60))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("EUR", Values.Amount.factorize(48.17))));
+    }
+    
+    @Test
+    public void testWertpapierVerkauf03()
+    {
+        PostbankPDFExtractor extractor = new PostbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "postbank_verkauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("US53578A1088"));
+        assertThat(security.getWkn(), is("A1H82D"));
+        assertThat(security.getName(), is("LINKEDIN CORP. REGISTERED SHS CL.A DL-,0001"));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(1279.69)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-13T00:00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(7)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
+                        is(Money.of("EUR", Values.Amount.factorize(9.95))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+    }
+    
+    @Test
+    public void testWertpapierVerkauf04()
+    {
+        PostbankPDFExtractor extractor = new PostbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "postbank_verkauf04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        // check security
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("LU0274208692"));
+        assertThat(security.getWkn(), is("DBX1MW"));
+        assertThat(security.getName(), is("XTRACKERS MSCI WORLD SWAP INHABER-ANTEILE 1C O.N."));
+
+        // check buy sell transaction
+        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
+        assertThat(item.orElseThrow(IllegalArgumentException::new).getSubject(), instanceOf(BuySellEntry.class));
+        BuySellEntry entry = (BuySellEntry) item.orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(Values.Amount.factorize(49.01)));
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-01-10T00:00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.7918)));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE), 
+                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of("EUR", Values.Amount.factorize(0.18))));
+    }
+
+    @Test
     public void testDividende01()
     {
         Client client = new Client();
@@ -287,6 +395,39 @@ public class PostbankPDFExtractorTest
 
         assertThat(t.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(68.40))));
         assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        assertThat(t.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+    }
+    
+    @Test
+    public void testDividende04()
+    {
+        Client client = new Client();
+
+        PostbankPDFExtractor extractor = new PostbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "postbank_dividende04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst().get().getSecurity();
+        assertThat(security.getIsin(), is("DE000A0Q4R36"));
+        assertThat(security.getWkn(), is("A0Q4R3"));
+        assertThat(security.getName(), is("ISH.ST.EU.600 HEALT.C.U.ETF DE INHABER-ANLAGEAKTIEN"));
+
+        AccountTransaction t = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(t.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(t.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(19.25))));
+        assertThat(t.getShares(), is(Values.Share.factorize(20)));
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2016-04-15T00:00")));
+
+        assertThat(t.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(19.54)))); // Why not 19.25? See https://github.com/buchen/portfolio/pull/2533
+        assertThat(t.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.29))));
         assertThat(t.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_dividende04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_dividende04.txt
@@ -1,0 +1,60 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postbank Köln · 51222 Köln    Seite 1
+Depotnummer
+ 123456789
+ Kundennummer 1234567899
+Dr. Max Mustermann
+ Abrechnungsnr. 64628421310
+Herrn Datum 14.04.2016
+Dr. Max Mustermann
+Musterstraße 1
+12345 Musterstadt
+                                                        
+                                                        
+                                                        
+Gutschrift von Investmenterträgen
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 20 ISH.ST.EU.600 HEALT.C.U.ETF DE DE000A0Q4R36 (A0Q4R3)
+INHABER-ANLAGEAKTIEN
+Zahlbarkeitstag 15.04.2016 Ertrag pro St. 0,962472000 EUR
+Bestandsstichtag 14.04.2016 Inländischer Dividenden-
+Ex-Tag 15.04.2016 anteil pro St. 0,007344000 EUR
+Geschäftsjahr 01.03.2015 - 29.02.2016 Zinsanteil pro St. 0,016649700 EUR
+Ausländischer Dividenden- und Veräußerungs-
+gewinnanteil pro St. 0,972318100 EUR
+Ausschüttung 19,25+ EUR
+Anrechenbare Quellensteuer pro Stück 0,0144878 EUR 0,29 EUR
+Kapitalertragsteuerpflichtiger inländischer
+Dividendenanteil gesamt 0,15 EUR
+Verrechneter Sparer-Pauschbetrag 0,15 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Kapitalertragsteuerpflichtiger Zinsanteil gesamt 0,33 EUR
+Verrechneter Sparer-Pauschbetrag 0,33 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Kapitalertragsteuerpflichtiger ausländischer Dividenden- 
+und Veräußerungsgewinnanteil gesamt 19,45 EUR
+Verrechneter Sparer-Pauschbetrag 19,45 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Ausmachender Betrag 19,25+ EUR
+Bitte ggf. Rückseite beachten.
+0860.04150100.0002925ER03
+
+Seite 2
+Depotnummer 123456789
+Kundennummer 1234567899
+Abrechnungsnr. 64628421310
+Datum 14.04.2016
++ anrechenbare Quellensteuer pro Stück 0,014487800 EUR
+= anrechenbare Quellensteuer pro Stück gesamt 0,014487800 EUR
+Lagerstelle Clearstream Banking FFM (849000 / 4003)
+Den Betrag buchen wir mit Wertstellung 15.04.2016 zu Gunsten des Kontos 12345678, BLZ 370 110 00. 
+Keine Steuerbescheinigung. 
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2016 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien Sonstige
+Pauschbetrag Quellensteuer
+Nachher 0,00 0,00 473,88 0,98 0,00 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0860.04150100.0002926ER03

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf02.txt
@@ -1,0 +1,56 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postbank Köln · 51222 Köln    Seite 1 von 2
+Depotnummer
+ 123456789
+ Kundennummer 1234567899
+Dr. Max Mustermann
+ Auftragsnummer 12345678999/50.00
+Herrn Datum 13.12.2016
+Dr. Max Mustermann Rechnungsnummer W00860-0123456789/16
+Musterweg 1 Umsatzsteuer-ID DE123456789   
+12345 Musterstadt
+ 
+Wertpapier Abrechnung Verkauf 
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 10 NETFLIX INC.                       US64110L1061 (552484)
+REGISTERED SHARES DL -,001         
+Börse Tradegate (Best Execution)
+Market-Order
+Limit bestens
+Schlusstag/-Zeit 13.12.2016 10:35:11
+Ausführungskurs 115,15 EUR
+Girosammelverw. mehrere Sammelurkunden - kein Stückeausdruck -
+Kurswert 1.151,50 EUR
+Provision 7,95- EUR
+Übertragungs-/Liefergebühr 0,65- EUR
+Ermittlung steuerrelevante Erträge
+Veräußerungsgewinn 173,20 EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 173,20 EUR
+ 
+Steuerberechnung
+Kapitalertragsteuer 24,51% auf 173,20 EUR 42,45- EUR
+Solidaritätszuschlag 5,50% auf 42,45 EUR 2,33- EUR
+Kirchensteuer 8,00% auf 42,45 EUR 3,39- EUR
+Ausmachender Betrag 1.094,73 EUR
+ 
+Den Gegenwert buchen wir mit Valuta  15.12.2016 zu Gunsten des Kontos  123456789, BLZ  37011000. 
+Die Wertpapiere entnehmen wir Ihrem Depotkonto.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+0800.12130011.0004005OR07                                                             
+Seite 2 von 2
+Depotnummer 123456789
+Kundennummer 1234567899
+Auftragsnummer 123456/50.00
+Datum 13.12.2016
+ 
+Für das Geschäft wurde keine Anlageberatung erbracht.
+ 
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2016 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien Sonstige
+Pauschbetrag Quellensteuer
+Nachher 0,00 0,00 0,00 0,00 504,04 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0860.12131911.0004536OR07                                                             

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf03.txt
@@ -1,0 +1,47 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postbank Köln · 51222 Köln    Seite 1 von 2
+Depotnummer
+ 123456789
+ Kundennummer 1234567899
+Dr. Max Mustermann
+ Auftragsnummer 12345678/32.00
+Herrn Datum 13.12.2016
+Dr. Max Mustermann Rechnungsnummer W00860-0001400141/16
+Musterstraße 1 Umsatzsteuer-ID DE123456789   
+12345 Musterstadt
+ 
+Wertpapier Abrechnung Verkauf-Festpreisgeschäft 
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 7 LINKEDIN CORP.                     US53578A1088 (A1H82D)
+REGISTERED SHS CL.A DL-,0001       
+Börse Außerbörslich
+Abrech.-Preis 196,00 USD
+Wertpapierrechnung Lagerland USA
+Devisenkurs (EUR/USD) 1,06386 vom 12.12.2016
+Kurswert 1.289,64 EUR
+Provision 9,95- EUR
+Ermittlung steuerrelevante Erträge
+Veräußerungsverlust 15,88- EUR
+Eingebuchte Aktienverluste 15,88 EUR
+Ausmachender Betrag 1.279,69 EUR
+ 
+Den Gegenwert buchen wir mit Valuta  14.12.2016 zu Gunsten des Kontos  12345678, BLZ  37011000. 
+Die Wertpapiere entnehmen wir Ihrem Depotkonto.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+ 
+Barabfindung wegen Fusion
+0860.12132252.0000128OR07                                                             
+Seite 2 von 2
+Depotnummer 123456789
+Kundennummer 1234567899
+Auftragsnummer 12345678/32.00
+Datum 13.12.2016
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2016 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien Sonstige
+Pauschbetrag Quellensteuer
+Nachher 15,88 0,00 379,00 4,90 0,00 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0860.12132252.0000129OR07                                                             

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/postbank_verkauf04.txt
@@ -1,0 +1,53 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Postbank Köln · 51222 Köln    Seite 1 von 2
+Depotnummer
+ 123456789
+ Kundennummer 1234567899
+Dr. Max Mustermann
+ Auftragsnummer 123456/37.00
+Herr Doktor Datum 10.01.2020
+Max Mustermann Rechnungsnummer W00860-0123456789/20
+Musterstraße 1 Umsatzsteuer-ID DE123456789   
+12345 Musterstadt
+ 
+Wertpapier Abrechnung Rücknahme Investmentfonds
+Auftrag vom 09.01.2020 15:24:25 Uhr
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 0,7918 XTRACKERS MSCI WORLD SWAP          LU0274208692 (DBX1MW)
+INHABER-ANTEILE 1C O.N.            
+Handels-/Ausführungsplatz Außerbörslich (gemäß Weisung)
+Schlusstag 10.01.2020 Auftragserteilung/ -ort Online-Banking
+Ausführungskurs 62,12 EUR
+Girosammelverw. mehrere Sammelurkunden - kein Stückeausdruck -
+Kurswert 49,19 EUR
+Ermittlung steuerrelevante Erträge
+Veräußerungsgewinn (nach Teilfreistellung) 0,71 EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,71 EUR
+ 
+Steuerberechnung
+Kapitalertragsteuer 24,51% auf 0,71 EUR 0,17- EUR
+Kirchensteuer 8,00% auf 0,17 EUR 0,01- EUR
+Ausmachender Betrag 49,01 EUR
+ 
+Den Gegenwert buchen wir mit Valuta 14.01.2020 zu Gunsten des Kontos 012345678
+(IBAN DE12 3456 7890 0123 4567 89), BLZ 37011000 (BIC PBNKDEFFXXX).
+Die Wertpapiere entnehmen wir Ihrem Depotkonto.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+ 
+Für das Geschäft wurde keine Anlageberatung erbracht.
+ 
+0860.01101923.0007596OR07                                                             
+Seite 2 von 2
+Depotnummer 123456789
+Kundennummer 1234567899
+Auftragsnummer 123456/37.00
+Datum 10.01.2020
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verlustverrechnungstöpfe 2020 ohne Vorjahressaldo Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien Sonstige
+Pauschbetrag Quellensteuer
+Nachher 0,00 0,00 0,00 0,00 0,00 12.562,07
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0860.01101923.0007597OR07                                                             


### PR DESCRIPTION
Fixed issues with PostbankPDFExtractor and added compatibility for more postbank document types.

Considered Cases:
- "Rücknahme Investmentfonds" (Opposit of existing A"usgabe Investmentfonds")
- "Date" Section parsing (some, especially older documents have no "Schlusstag" but only a "Datum" section)
- "Schlusstag/-Zeit" in some documents has no "Auftragserteilung" behind the date. Existing pattern did not match because it required a space after the date
- Added "Gutschrift von Investmenterträgen" as Header for dividends (older documents used that heading).