### PR TITLE
Automatically show information pane when limit price attribute is selected in attribute settings view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
@@ -69,7 +69,9 @@ public abstract class AbstractFinanceView
     private List<Menu> contextMenus = new ArrayList<>();
 
     protected abstract String getDefaultTitle();
-
+    
+    SashLayout sashLayout;
+    
     protected String getTitle()
     {
         return titleText;
@@ -152,11 +154,12 @@ public abstract class AbstractFinanceView
         Composite sash = new Composite(top, SWT.NONE);
         GridDataFactory.fillDefaults().grab(true, true).applyTo(sash);
 
-        SashLayout sashLayout = new SashLayout(sash, SWT.VERTICAL | SWT.END);
-        sashLayout.setTag(UIConstants.Tag.INFORMATIONPANE);
-        sash.setLayout(sashLayout);
+        SashLayout sl = new SashLayout(sash, SWT.VERTICAL | SWT.END);
+        sl.setTag(UIConstants.Tag.INFORMATIONPANE);
+        sash.setLayout(sl);
 
         createBody(sash);
+        sashLayout = sl;
 
         pane = make(InformationPane.class);
         pane.createViewControl(sash);
@@ -179,6 +182,21 @@ public abstract class AbstractFinanceView
         actionToolBar.update(false);
 
         notifyViewCreationCompleted();
+    }
+    
+    public void flipPane()
+    {
+        if (sashLayout != null)
+            sashLayout.flip();
+    }
+    
+    public boolean isPaneHidden()
+    {
+        if (sashLayout == null)
+            return false;
+            
+        return sashLayout.isHidden();
+        
     }
 
     protected abstract Control createBody(Composite parent);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeListTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeListTab.java
@@ -162,19 +162,19 @@ public class AttributeListTab implements AbstractTabbedView.Tab, ModificationLis
         tableViewer.setInput(client.getSettings().getAttributeTypes().filter(t -> t.getTarget() == mode.getType())
                         .toArray());
 
-        tableViewer.addSelectionChangedListener(
-                        event -> {
-                            Object selectedElement = event.getStructuredSelection().getFirstElement();
-                            view.setInformationPaneInput(selectedElement);
-                            // when selected element provides additional information (settings) in information pane: display it automatically
-                            if (selectedElement instanceof AttributeType
-                                && ((AttributeType)selectedElement).getType() == LimitPrice.class
-                                && view.isPaneHidden())
-                            {
-                                view.flipPane();
-                            }
-                            
-                        });
+        tableViewer.addSelectionChangedListener(event ->
+        {
+            Object selectedElement = event.getStructuredSelection().getFirstElement();
+            view.setInformationPaneInput(selectedElement);
+            // when selected element provides additional information (e.g. settings)
+            // in information pane: display it automatically
+            if (selectedElement instanceof AttributeType
+                && ((AttributeType)selectedElement).getType() == LimitPrice.class
+                && view.isPaneHidden())
+            {
+                view.flipPane();
+            }                            
+        });
 
         new ContextMenu(tableViewer.getTable(), this::fillContextMenu).hook();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeListTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/settings/AttributeListTab.java
@@ -26,6 +26,7 @@ import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientSettings;
 import name.abuchen.portfolio.model.InvestmentPlan;
+import name.abuchen.portfolio.model.LimitPrice;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.ui.Images;
@@ -162,7 +163,18 @@ public class AttributeListTab implements AbstractTabbedView.Tab, ModificationLis
                         .toArray());
 
         tableViewer.addSelectionChangedListener(
-                        event -> view.setInformationPaneInput(event.getStructuredSelection().getFirstElement()));
+                        event -> {
+                            Object selectedElement = event.getStructuredSelection().getFirstElement();
+                            view.setInformationPaneInput(selectedElement);
+                            // when selected element provides additional information (settings) in information pane: display it automatically
+                            if (selectedElement instanceof AttributeType
+                                && ((AttributeType)selectedElement).getType() == LimitPrice.class
+                                && view.isPaneHidden())
+                            {
+                                view.flipPane();
+                            }
+                            
+                        });
 
         new ContextMenu(tableViewer.getTable(), this::fillContextMenu).hook();
 


### PR DESCRIPTION
The limit price settings are not that easy to find without any information: 
- https://forum.portfolio-performance.info/t/benutzerspezifische-farben-fur-attribute-vom-typ-limit/18485/2
- https://forum.portfolio-performance.info/t/prozentualer-absoluter-abstand-zum-limit-darstellen/8366/7

Therefore I added an automatism to show the information pane when user clicks on a limit price attribute in the settings view:

https://user-images.githubusercontent.com/90478568/142628347-5c72c10c-dc24-43be-b9de-5b3bd661029f.mov


