### PR TITLE
Fix  statement of assets data were not updated after edit filter

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -221,7 +221,7 @@ public final class ClientFilterMenu implements IMenuListener
             return;
         }
 
-        boolean isCustomItemSelected = customItems.contains(selectedItem);
+        final boolean isCustomItemSelected = customItems.contains(selectedItem);
 
         EditClientFilterDialog dialog = new EditClientFilterDialog(Display.getDefault().getActiveShell(), client,
                         preferences);
@@ -230,9 +230,14 @@ public final class ClientFilterMenu implements IMenuListener
 
         preferences.putValue(PREF_KEY, new Gson().toJson(customItems));
 
-        if (isCustomItemSelected && !customItems.contains(selectedItem))
+        if (isCustomItemSelected)
         {
-            selectedItem = defaultItems.get(0);
+            // previously selected custom filter was deleted in dialog --> select default filter item
+            if(!customItems.contains(selectedItem))
+                selectedItem = defaultItems.get(0);
+
+            // always update listeners (when custom filter selected) because filter may have been changed in edit filter dialog
+            // or default filter was set because selected filter was deleted 
             listeners.forEach(l -> l.accept(selectedItem.filter));
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -233,7 +233,7 @@ public final class ClientFilterMenu implements IMenuListener
         if (isCustomItemSelected)
         {
             // previously selected custom filter was deleted in dialog --> select default filter item
-            if(!customItems.contains(selectedItem))
+            if (!customItems.contains(selectedItem))
                 selectedItem = defaultItems.get(0);
 
             // always update listeners (when custom filter selected) because filter may have been changed in edit filter dialog


### PR DESCRIPTION
Aktuell gibt es den Bug, dass sich die Ansicht "Vermögensaufstellung" nicht entsprechend des Filters aktualisiert, wenn man den aktivierten nutzerdefinierten Filter verändert (Konto/Depot hinzufügen/entfernen). Man musste als workaound immer erneut den Filter nochmal anklicken:

https://user-images.githubusercontent.com/90478568/143441088-59beeb41-3d5b-4305-8656-8e502acf8c26.mov



