### PR TITLE
Modify Comdirect PDF-Importer to support new transaction format and small fixes

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -65,6 +65,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        assertThat(entry.getSource(), is("Kauf01.txt"));
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2000-01-01T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
@@ -109,6 +110,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-01-01T09:04")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(42)));
+        assertThat(entry.getSource(), is("Kauf02.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1413.46))));
@@ -150,6 +152,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-06-27T17:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(12)));
+        assertThat(entry.getSource(), is("Kauf03.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(822.66))));
@@ -191,6 +194,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-11-22T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(20)));
+        assertThat(entry.getSource(), is("Kauf04.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1431.40))));
@@ -232,6 +236,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-07-18T17:02")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(160)));
+        assertThat(entry.getSource(), is("Kauf05.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(19359.18))));
@@ -273,6 +278,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-03-14T12:09")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1437)));
+        assertThat(entry.getSource(), is("Kauf06.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16312.80))));
@@ -314,6 +320,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2008-10-16T09:54")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
+        assertThat(entry.getSource(), is("Kauf07.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7586.80))));
@@ -355,6 +362,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-11-08T11:51")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getSource(), is("Kauf08.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1469.55))));
@@ -396,6 +404,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-04-03T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.805)));
+        assertThat(entry.getSource(), is("Kauf09.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.96))));
@@ -437,6 +446,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-02-21T15:43")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(34)));
+        assertThat(entry.getSource(), is("Kauf10.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1686.80))));
@@ -478,6 +488,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-04-16T18:33")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
+        assertThat(entry.getSource(), is("Kauf11.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4444.15))));
@@ -519,6 +530,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-12-28T16:50")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(150)));
+        assertThat(entry.getSource(), is("Kauf12.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1430.30))));
@@ -560,6 +572,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-10-05T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1303)));
+        assertThat(entry.getSource(), is("Kauf13.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4682.25))));
@@ -569,6 +582,52 @@ public class ComdirectPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.56 + 0.95))));
+    }
+
+    @Test
+    public void testWertpapierKauf14()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf14.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("LU0048580855"));
+        assertThat(security.getWkn(), is("973265"));
+        assertThat(security.getName(), is("Fidelity Fds-Greater China Fd. Reg.Shares A (Glob.Cert.) o.N."));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+
+        // check buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance)
+                        .collect(Collectors.toList()).get(0).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-05-07T00:00")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.165)));
+        assertThat(entry.getSource(), is("Kauf14.txt"));
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(),
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(60.80))));
     }
 
     @Test
@@ -601,6 +660,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-01-01T10:57")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
+        assertThat(entry.getSource(), is("Verkauf01.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10100.00))));
@@ -642,6 +702,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-08T17:03")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1140)));
+        assertThat(entry.getSource(), is("Verkauf02.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20413.33))));
@@ -683,6 +744,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-02-25T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(570)));
+        assertThat(entry.getSource(), is("Verkauf03.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(21239.83))));
@@ -736,6 +798,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-08-25T14:34")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
+        assertThat(entry.getSource(), is("Verkauf04.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.54))));
@@ -789,6 +852,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-12-15T20:37")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
+        assertThat(entry.getSource(), is("Verkauf05.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1263.05))));
@@ -842,6 +906,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2008-06-11T18:54")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2000)));
+        assertThat(entry.getSource(), is("Verkauf06.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(906.85))));
@@ -883,6 +948,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2003-12-08T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(550)));
+        assertThat(entry.getSource(), is("Verkauf07.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1086.72))));
@@ -924,6 +990,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2004-03-10T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(300)));
+        assertThat(entry.getSource(), is("Verkauf08.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(136.85))));
@@ -965,6 +1032,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-08-25T14:34")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
+        assertThat(entry.getSource(), is("Verkauf09.txt"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.54))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -2637,7 +2637,7 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-03-26T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.00)));
             assertThat(transaction.getSource(), is("Finanzreport01.txt"));
-            assertThat(transaction.getNote(), is("Kartenzahlung"));
+            assertThat(transaction.getNote(), is("Kartenverfügung Kartenzahlung"));
         }
 
         if (iter.hasNext())

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -2593,7 +2593,7 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-04T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(1500)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(1500.00)));
             assertThat(transaction.getSource(), is("Finanzreport01.txt"));
             assertThat(transaction.getNote(), is("Lastschrift"));
         }
@@ -2607,7 +2607,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-05T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(300)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(300.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2619,7 +2621,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-10-30T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(50)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(50.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Auszahlung"));
         }
 
         if (iter.hasNext())
@@ -2631,7 +2635,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-03-26T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(9)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kartenzahlung"));
         }
 
         if (iter.hasNext())
@@ -2644,6 +2650,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-17T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(68.88)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
         
 
@@ -2656,7 +2664,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-14T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(10000)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(10000.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Girokonto"));
         }
 
         if (iter.hasNext())
@@ -2668,7 +2678,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-03-26T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(100)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(100.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Girokonto"));
         }
 
         if (iter.hasNext())
@@ -2681,6 +2693,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-17T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(2.18)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Visa-Umsatz"));
         }
 
         if (iter.hasNext())
@@ -2693,6 +2707,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-09-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(3.94)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Visa-Umsatz"));
         }
 
         if (iter.hasNext())
@@ -2705,6 +2721,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-10-24T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(19.21)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -2716,7 +2734,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-14T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(10000)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(10000.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Girokonto"));
         }
 
         if (iter.hasNext())
@@ -2728,7 +2748,7 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-21T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20.00)));
             assertThat(transaction.getSource(), is("Finanzreport01.txt"));
             assertThat(transaction.getNote(), is("Übertrag"));
         }
@@ -2742,7 +2762,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-30T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(2000)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(2000.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Tagesgeld PLUS-Konto"));
         }
 
         if (iter.hasNext())
@@ -2754,7 +2776,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-05T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(300)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(300.00)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Visa-Karte"));
         }
 
         if (iter.hasNext())
@@ -2767,6 +2791,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-07-22T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(71.93)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Gutschrift"));
         }
 
         if (iter.hasNext())
@@ -2778,7 +2804,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-01T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5432.1)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5432.10)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Bargeldeinzahlung Karte"));
         }
 
         if (iter.hasNext())
@@ -2790,7 +2818,7 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-09-29T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.9)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.90)));
             assertThat(transaction.getSource(), is("Finanzreport01.txt"));
             assertThat(transaction.getNote(), is("Gebühr Barauszahlung"));
         }
@@ -2804,7 +2832,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-05T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.9)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.90)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Entgelte"));
         }
 
         if (iter.hasNext())
@@ -2816,7 +2846,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-10-22T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.9)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.90)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Gebühren/Spesen"));
         }
 
         if (iter.hasNext())
@@ -2829,6 +2861,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-27T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.45)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Auslandsentgelt"));
         }
 
         if (iter.hasNext())
@@ -2839,8 +2873,10 @@ public class ComdirectPDFExtractorTest
             AccountTransaction transaction = (AccountTransaction) item.getSubject();
             assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-03-31T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.7)));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-28T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.70)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Versandpauschale"));
         }
 
         if (iter.hasNext())
@@ -2849,40 +2885,54 @@ public class ComdirectPDFExtractorTest
 
             // assert transaction22
             AccountTransaction transaction = (AccountTransaction) item.getSubject();
-            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-30T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.14)));
-            assertThat(transaction.getGrossValue().getAmount(), is(Values.Amount.factorize(0.20)));
-            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
-            assertThat(transaction.getNote(), is("Kapitalertragsteuer/Solidaritätszuschlag"));
-        }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction23
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
-            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-30T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.14)));
-            assertThat(transaction.getGrossValue().getAmount(), is(Values.Amount.factorize(0.19)));
-        }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction23
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
             assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-12-31T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.07)));
             assertThat(transaction.getSource(), is("Finanzreport01.txt"));
             assertThat(transaction.getNote(), is("Kontoabschluss Abschluss Zinsen"));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction23
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-28T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.14)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kontoabschluss Abschluss Zinsen"));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction23
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-28T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.05)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kapitalertragsteuer"));
+        }
+
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction23
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
+            assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-09-30T00:00")));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.05)));
+            assertThat(transaction.getSource(), is("Finanzreport01.txt"));
+            assertThat(transaction.getNote(), is("Kapitalertragsteuer"));
         }
     }
 
@@ -2912,7 +2962,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-18T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20.00)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2925,6 +2977,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2937,6 +2991,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-12-02T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(500)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2949,6 +3005,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-30T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(12.31)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Visa-Umsatz"));
         }
 
         if (iter.hasNext())
@@ -2961,6 +3019,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-05T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(30)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2973,6 +3033,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-26T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(810)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2985,6 +3047,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-27T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(200)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -2996,7 +3060,9 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-18T00:00")));
-            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getAmount(), is(Values.Amount.factorize(20.00)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Visa-Karte"));
         }
 
         if (iter.hasNext())
@@ -3009,6 +3075,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-11-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(20)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Visa-Karte"));
         }
 
         if (iter.hasNext())
@@ -3021,6 +3089,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-12-02T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(500)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Visa-Karte"));
         }
 
         if (iter.hasNext())
@@ -3033,6 +3103,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2013-12-08T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.9)));
+            assertThat(transaction.getSource(), is("Finanzreport02.txt"));
+            assertThat(transaction.getNote(), is("Gebühren/Spesen"));
         }
     }
 
@@ -3063,6 +3135,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-05T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(49.66)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3075,6 +3149,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-27T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(22.89)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3087,6 +3163,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(264.99)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3099,6 +3177,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-29T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(199.00)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3111,6 +3191,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-07-03T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(29.90)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3123,6 +3205,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-07-03T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.14)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3135,6 +3219,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-07-03T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(8.65)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3147,6 +3233,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-21T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(8.98)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Visa-Umsatz"));
         }
 
         if (iter.hasNext())
@@ -3159,6 +3247,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(816.00)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3171,6 +3261,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(816.00)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3183,6 +3275,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(250.00)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3195,6 +3289,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.14)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Visa-Kartenabrechnung"));
         }
 
         if (iter.hasNext())
@@ -3207,6 +3303,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-22T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.16)));
+            assertThat(transaction.getSource(), is("Finanzreport03.txt"));
+            assertThat(transaction.getNote(), is("Auslandsentgelt"));
         }
     }
 
@@ -3237,6 +3335,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-14T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(501.00)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Kontoübertrag"));
         }
 
         if (iter.hasNext())
@@ -3249,6 +3349,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(2450.87)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Girokonto"));
         }
 
         if (iter.hasNext())
@@ -3261,6 +3363,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(2450.87)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Übertrag auf Girokonto"));
         }
 
         if (iter.hasNext())
@@ -3273,6 +3377,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-13T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(9.07)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Gutschrift aus Bonus-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3285,6 +3391,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-09T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1200)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3297,6 +3405,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.USD));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-14T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(554.83)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Kontoübertrag"));
         }
 
         if (iter.hasNext())
@@ -3309,6 +3419,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-30T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.02)));
+            assertThat(transaction.getSource(), is("Finanzreport04.txt"));
+            assertThat(transaction.getNote(), is("Kontoabschluss Abschluss Zinsen"));
         }
     }
 
@@ -3339,6 +3451,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-08-01T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(894.30)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3351,6 +3465,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-04T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.42)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3363,6 +3479,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-04T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(188.58)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3375,6 +3493,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-08T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.36)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3387,6 +3507,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-08T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(124.64)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3399,6 +3521,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-13T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.30)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3411,6 +3535,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.30)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3423,6 +3549,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-13T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3435,6 +3563,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3447,6 +3577,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-22T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.89)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3459,6 +3591,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-22T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(129.11)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3471,6 +3605,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.70)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3483,6 +3619,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-28T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(257.30)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3495,6 +3633,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-11T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(1000)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Übertrag"));
         }
 
         if (iter.hasNext())
@@ -3507,6 +3647,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-08-01T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(2.97)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Gutschrift Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3519,6 +3661,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-12T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(191.70)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Korrektur Barauszahlung"));
         }
 
         if (iter.hasNext())
@@ -3531,6 +3675,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-29T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(894.30)));
+            assertThat(transaction.getSource(), is("Finanzreport05.txt"));
+            assertThat(transaction.getNote(), is("Visa-Kartenabrechnung"));
         }
     }
     
@@ -3561,6 +3707,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-08-01T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(30.00)));
+            assertThat(transaction.getSource(), is("Finanzreport06.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
         }
 
         if (iter.hasNext())
@@ -3573,6 +3721,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-23T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.86)));
+            assertThat(transaction.getSource(), is("Finanzreport06.txt"));
+            assertThat(transaction.getNote(), is("Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3585,6 +3735,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-23T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(29.14)));
+            assertThat(transaction.getSource(), is("Finanzreport06.txt"));
+            assertThat(transaction.getNote(), is("Visa-Umsatz"));
         }
 
         if (iter.hasNext())
@@ -3597,6 +3749,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-08-01T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.86)));
+            assertThat(transaction.getSource(), is("Finanzreport06.txt"));
+            assertThat(transaction.getNote(), is("Gutschrift Wechselgeld-Sparen"));
         }
 
         if (iter.hasNext())
@@ -3609,6 +3763,8 @@ public class ComdirectPDFExtractorTest
             assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
             assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-31T00:00")));
             assertThat(transaction.getAmount(), is(Values.Amount.factorize(30.00)));
+            assertThat(transaction.getSource(), is("Finanzreport06.txt"));
+            assertThat(transaction.getNote(), is("Visa-Kartenabrechnung"));
         }
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Dividende17.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Dividende17.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    1234123412 
+     10288 010 BLZ:        200 411 33 
+Herrn                              
+                             
+Felix Möller                 
+                             
+                             
+                                   
+Dorfstraße                                                         
+                             
+12345 Entenhausen                                                
+31.12.2021
+USt-ID-Nr.:      DE812279461     
+Rechnungsnummer: 567996058551DCD2         
+ G u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Ertragsgutschrift                                                                  
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+p e  r 1  5. 1  2 .2 0 2 1                          i Sh s - E  O C  o rp   Bd   La  r . Ca  p U  . ET F            77 8  92  8
+ S TK                81 , 9  2 1                R e g i s te r e  d  S ha r e  s  o . N.            I E 0 0  3 2 52 3  47  8
+                                      Emissionsland: IRLAND                        
+EUR 0,2245     Ausschüttung pro Stück für Geschäftsjahr     01.03.21 bis 28.02.22  
+zahlbar ab 31.12.2021                                                              
+                         Abrechnung Ertragsgutschrift                              
+Bruttobetrag:                                              EUR              18,39  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+DE04 1234 4567 1234 1234 40   EUR       31.12.2021         EUR              18,39  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 1RIHIHNKLPV001JQ).                                                   
+Ihre comdirect                                                                     
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport01.txt
@@ -124,19 +124,12 @@ Valuta Referenz IBAN/BIC Eingang
 0,010% ab 30.06. 0,19 EUR
 vom 30.06.2018 bis 30.09.2018
 Kapitalertragsteuer 0,05- EUR
-Solidaritätszuschlag 0,01- EUR
-Abschlussrechnung 0,14 EUR
-Saldo nach Abschluss 0,14 EUR
-28.09.2018 Kontoabschluss Abschluss Zinsen Kto 000000005EUR +0,14
-30.09.2018 1PF18271L0000 von 30.06.2018 bis 30.09.2018
-052/2794 Habenzinsen
-0,010% ab 30.06. 0,19 EUR
-vom 30.06.2018 bis 30.09.2018
-Kapitalertragsteuer 0,05- EUR
 Solidaritätszuschlag 0,00 EUR
-Abschlussrechnung 0,14 EUR
-Saldo nach Abschluss 0,14 EUR
-Neuer Saldo 01.10.2018 +0,14
+Sonderentgelte
+Versandpauschale 0,70- EUR
+Abschlussrechnung 0,56- EUR
+Saldo nach Abschluss 0,56- EUR
+Neuer Saldo 01.10.2018 +0,56-
 Visa Prepaid-Karte 0000 Visa Limit Verfügungslimit am GeldautomatEUR 0/Monat EUR 600/Tag
 Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
 Valuta Referenz IBAN/BIC Eingang
@@ -155,14 +148,6 @@ Alter Saldo 03.09.2018 +120,33
 27.07.2018 Auslandsentgelt 1.75 PROZ.AUSLANDSENTGELT -0,45
 27.07.2018 0000000000000
 01
-31.03.2016 Kontoabschluss Kontoführung -0,70
-31.03.2016 5DF00000J0453148/00000 Konto 00000000 EUR
-vom 01.01.2016 bis 31.03.2016
-Kontoführung 0,00 EUR
-Sonderentgelte
-Versandpauschale 0,70- EUR
-Abschlussrechnung 0,70- EUR
-Saldo nach Abschluss 192,17 EUR
 23.07.2019 Gutschrift Firma Ort 9 007 +71,93
 22.07.2019 1190723500000
 01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Kauf14.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Kauf14.txt
@@ -1,0 +1,157 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Ihren Auftrag haben wir gemäß unseren produktbezogenen
+Geschäftsbedingungen "Trading" wie nachstehend ausgeführt.
+Die Wertpapiere haben wir der Abrechnung entsprechend gebucht.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und
+Vollständigkeit zu überprüfen und etwaige Einwendungen
+25449 Quickborn unverzüglich zu erheben.
+fon   : 04106-708 25 00                                                  Tele   
+                                                                              
+                             
+                                       
+                             
+    97757 010
+Depotnr.:        1234567 00 
+            BLZ:             200 411 44
+Max Mustermann                  
+                             
+                             
+Musterstrasse 45                                          
+12345 Musterhausen                                         
+                             
+                             
+                             
+                                                  
+                                                  
+GESCHÄFTSABRECHNUNG VOM 10.05.2021                                                   
+                                                                                                                                    
+*
+Wertpapierkauf                                                                                                                      
+Geschäftsnummer   : 91 053052                                                                                                       
+                    1123456789560      Rechnungsnummer   : 123456784001DF35                                                          
+Geschäftstag      : 07.05.2021        Ausführung          comdirect                                                                 
+                                                          (Festpreisgeschäft)                                                       
+                                                                                                                                    
+Wertpapier-Bezeichnung                                               WPKNR/ISIN                                                     
+Fidelity Fds-Greater China Fd.                                           973265                                                     
+Reg.Shares A (Glob.Cert.) o.N.                                     LU0048580855                                                     
+                                                                                                                                    
+                                                                                                                                    
+Nennwert                  Zum comdirect Preis von                                                                                   
+St.  0,165                USD  387,84625                                                                                            
+                          Kurswert                    : USD               63,99                                                     
+                                                                                                                                    
+                          Ausmachender Betrag         : USD               60,80                                                     
+           Umrechnung zum Devisenkurs 1,216500        : EUR               49,98                                                     
+                 4,98812% Reduktion Kaufaufschlag     : USD                3,19-                                                    
+                                                                                                                                    
+                                                                                                                                    
+IBAN                                  Valuta         Zu Ihren Lasten vor Steuern                                                    
+DE12 1234 1234 1234 1234 00   EUR     12.05.2021        EUR               49,98                                                     
+                                                                                                                                    
+Verwahrungs-Art: WERTPAPIERRECHNUNG LUXEMBURG (AKV)                                                                                 
+                                                                                                                                    
+                                                                                                                                    
+                                                                                                                                    
+Informationen zur steuerlichen Behandlung dieses Geschäftsvorgangs und den auf                                                      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung.                                                      
+                                                                                                                                    
+                                                                                                                                    
+Ihre comdirect                                                                                                                      
+                                                                                                                                    
+Diese Abrechnung wird von der Bank nicht unterschrieben                                                                             
+Die Leistung ist gemäß §4 Nr.8 UStG umsatzsteuerfrei. USt-Id-Nr.: DE 114 103 514                                                    
+A113
+DO15DD/16/04/2010
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+1234567  Max Mustermann                                 
+                                                  
+            
+200 411 44 Musterstrasse 45                                  12345 Musterhausen                                     
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+ c o  m   d  i r e  c  t                                    
+               
+ 2  5  4  5  1   Q  u  i c  k  b  o  r n                   
+0  1   0  9  7757
+                                                  
+ T  e  le  f o  n  :              0  4  1  0  6   -  7  0 8 25 00
+                              
+Herrn                          D  a  t u  m   :                        1  0  . 0  5  .2021         
+M a x M u s t e r m a n n                     D   e  p  o  t  n  u  m   m  er:         1 2  3  4 5  6 7 00  
+M u s t e r s t r a s s e   4  5               
+1 23 R  e  f e  r e  n  z  - N   u mmer:    2 C   I H   2  Z  Q   9  7GI002GX       4 5    M u s t e r h a u s e n                         
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Wertpapierkauf Nr. 91053052 vom 07.05.2021                                                                
+Stk.               0,165 FID.FDS-GREAT.CHINA A GL. , WKN / ISIN: 973265  / LU0048580855                                           
+ Zu  Ih r e n L a s te n  v o r  S te u e r n:                                                                                                       E U R             -49,9 8   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  0 , 0 0                          
+                                                                                                                                
+                                                                                                                                
+ K ap i ta le r tr a gs t e ue r                                                                        E  U   R                                  0 , 0 0                          
+S  ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0                          
+ K irc h e n s te u e r                                                                              E_  _U   R_  _  _  _   _  _  _   _  _  _  _   _  _  _   _  _0 ,_ _0 0_                          
+a b g e f ü h rt e S t e u er n                                                                                                                    E_ U_ R_ _ _ _ _ _ _ _ _  __  _ __ _ 0_,_0_ 0_   
+                                                                                                                                
+Z u  Ih r e n L a s te n  n a ch  S te u e r n :                                                                                                    E U R             -49,9 8   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Belastung erfolgt mit Valuta 12.05.2021 auf Konto EUR mit der IBAN DE12 1234 1234 1234 1234 00                                                    
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+Ihre comdirect                                                                                                                                        
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/SteuermitteilungDividende16.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/SteuermitteilungDividende16.txt
@@ -1,0 +1,114 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+12312312  Felix  Möller                                      
+                                                  
+            
+200 411 33 Dorfstraße                                      12345 Entenhausen                                  
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+c  o  m   d  i r e  c  t                                    
+               
+2   5  4  5  1   Q  u  i c  k  b  o  r n                   
+ 0 1   0  1  0288
+                                                  
+ T  e  le  f o  n  :             0   4  1  0  6   -  7  0 8 25 00
+                              
+ H  e  r r n                            D  a  t u  m   :                       3   1  . 1  2  .2021
+ F  e  li x    M   ö  l l e  r                              D   e  p  o  t  n  u  m   m  er:         4  4  4  4  4  4 4 44  
+Dorfstraße                   
+12345 Musterdorf              R   e  f e  r e  n  z  - N   u mmer:    1 R   I H   I H  N   K  L PV001JQ                             
+                                      
+                                                  
+                                                  
+                                                  
+Steuerliche Behandlung: Ausländische Investment-Ausschüttung vom 31.12.2021                                                       
+Stk.              81,921 ISHS-EO C.BD L.C.U.ETFEOD , WKN / ISIN: 778928  / IE0032523478                                           
+Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R              18,3 9   
+                                                                                             
+                                                                                             
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e ( 1 )                                                     E  U   R                                1  8 , 3 9                          
+                                                                                                                                
+                                                                                                                                
+ K ap i ta le r tr a gs t e ue r  ( 2 )                                                                   E  U   R                                -  4 , 4 9                          
+ S ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                -  0 , 2 4                          
+ K irc h e n s te u e r                                                                              _E  _U   _R  _  _  _   _  _  _   _  _  _  _   _  _  _   -_  _0 ,_ _4 _1                          
+ ab g e f ü h rt e S t e u er n                                                                                                                    _E _U _R _ _ _ _ _ _ _  __  __ _ _ -__5,_1_ 4_   
+                                                                                                                                
+ Zu  Ih r e n G u n s t e n n a c h S t e u er n :                                                                                                   E U R              13,2 5   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Gutschrift erfolgt mit Valuta 31.12.2021 auf Konto EUR mit der IBAN DE04 1234 1234 1234 1234 12                                                   
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(1) siehe "Hinweise zur Ermittlung der Steuerbemessungsgrundlage" auf der Folgeseite                                                                  
+(2) Durch die Berücksichtigung der Kirchensteuer (8% bzw. 9%) als Sonderausgabe reduziert sich der Kapitalertragsteuersatz auf 24,51% bzw. 24,45%.    
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2021 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+              388,41                21,36
+               34,95                34,22
+nach Ermittlung
+              392,90 21,60                35,36                34,22               
+Verrechnungssalden in EUR (4)
+2021 Gewinne / Verluste sonstige anrechenbare verfügbarerin aus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+           -1.234,56             1.234,56                 0,00                 0,00
+nach Ermittlung
+           -1.234,56             1.234,56
+                0,00                 0,00
+Hinweise zur Ermittlung der Steuerbemessungsgrundlage:                                                                                                             
+                                                                                                                                                                                    
+I n v e st m e n t -A u s s c h ü tt un g                                                                                                              E  U   R                                1  8  ,  3   9                                                       
+T  ei lf re is t e llu n g  (0 %  )                                                                                                                  _E  _U   R_  _  _  _  _  _  _   _  _  _  _  _  _   _  _  _  0_  _,  _0   _0                                                       
+S  te u e r b e m e s s u n g s g r u n d la g e  v o r  V  er l u s tv e r re c h n u n g                                                                 E  U   R                                1  8  ,  3   9                                                       
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+Ihre comdirect                                                                                                                                        
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -101,7 +101,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^Wertpapier-Bezeichnung .*$")
                 .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
                 .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -124,7 +124,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 .section("exchangeRate").optional()
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -138,7 +138,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                  * Fees are processed in a separate transaction
                  */
                 .section("negative").optional()
-                .match("^.* \\d+.\\d+.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>[-])(.*)?$")
+                .match("^.* \\d{2}\\.\\d{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>\\-)(.*)?$")
                 .assign((t, v) -> {
                     if (t.getPortfolioTransaction().getType().isLiquidation())
                     {
@@ -165,7 +165,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
                 .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -236,7 +236,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR               10,12- 
                 .section("amount", "currency", "exchangeRate", "fxCurrency").optional()
                 .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+(.*)?$")
                 .assign((t, v) -> {
                     if ("X".equals(type.getCurrentContext().get("negative")))
@@ -449,7 +449,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // EUR           5.000 SANHA ANL 13/26 STZ , WKN / ISIN: A1TNA7  / DE000A1TNA70
                 // Z u  Ih r e n G u n s t e n n a c h S t e u er n :       U S D             126,3 2 
                 .section("shares", "name", "wkn", "isin", "currency")
-                .match("^[\\w]{3}. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*), WKN \\/ ISIN: (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
+                .match("^[\\w]{3}([\\.])? ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*), WKN \\/ ISIN: (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
                 .match("^([\\s]+)?Z([\\s]+)?u"
                                 + "([\\s]+)?I([\\s]+)?h([\\s]+)?r([\\s]+)?e([\\s]+)?n"
                                 + "([\\s]+)?G([\\s]+)?u([\\s]+)?n([\\s]+)?s([\\s]+)?t([\\s]+)?e([\\s]+)?n"
@@ -613,7 +613,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Stk.              11,486 ISIV-MSCI FRAN. U.ETF EOA , WKN / ISIN: A12ATD  / IE00BP3QZJ36   
                 .section("shares", "name", "wkn", "isin")
-                .match("^Stk. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
+                .match("^Stk\\. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
                 .assign((t, v) -> {
                     v.put("wkn", stripBlanks(v.get("wkn")));
                     v.put("isin", stripBlanks(v.get("isin")));
@@ -679,7 +679,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^Wertpapier-Bezeichnung .*$")
                 .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
                 .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -702,7 +702,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 .section("negative").optional()
                 .match("^.* Zu Ihren Lasten( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>[-])(.*)?$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>[\\-])(.*)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -712,7 +712,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 .section("exchangeRate").optional()
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -721,18 +721,6 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //                           Kurswert                    : EUR                3,54 
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern                                                    
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR                9,61- 
-                .section("fxCurrency", "fxAmount", "currency", "amount").optional()
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Zu Ihren Lasten( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
-                .assign((t, v) -> {                            
-                    if ("X".equals(type.getCurrentContext().get("negative")))
-                    {
-                        t.setAmount(asAmount(v.get("fxAmount")) + asAmount(v.get("amount")));
-                        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    }
-                })
-
                 //  Summe        St.  20                 EUR  71,00        EUR            1.420,00  
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern 
                 // DExx xxxx xxxx xxxx xxxx xx   EUR     24.11.2016        EUR            1.431,40  
@@ -754,7 +742,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR               10,12- 
                 .section("amount", "currency", "exchangeRate", "fxCurrency", "amount2").optional()
                 .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount2>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
                     if ("X".equals(type.getCurrentContext().get("negative")))
@@ -813,7 +801,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                     // Abrechnung Verwahrentgelt Xetra Gold, WKN A0S9GB 06.01.2020
                     .section("name", "wkn", "date")
-                    .match("^.*Verwahrentgelt (?<name>.*), WKN (?<wkn>.*) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
+                    .match("^.* Verwahrentgelt (?<name>.*), WKN (?<wkn>.*) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                     .assign((t, v) -> {
                         v.put("wkn", stripBlanks(v.get("wkn")));
 
@@ -861,7 +849,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^Wertpapier-Bezeichnung .*$")
                 .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
                 .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}).*$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -884,7 +872,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 .section("exchangeRate").optional()
-                .match("^.* Umrechn. zum Dev. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {                   
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -998,7 +986,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block removalBlock = new Block("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Konto.bertrag|.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld-).* \\-[\\.,\\d]+$");
+        Block removalBlock = new Block("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Konto.bertrag|.bertrag|Lastschrift|Visa\\-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld\\-).* \\-[\\.,\\d]+$");
         type.addBlock(removalBlock);
         removalBlock.setMaxSize(3);
         removalBlock.set(new Transaction<AccountTransaction>()
@@ -1010,7 +998,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("note1", "note2", "amount", "date")
-                        .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note1>Konto.bertrag|.bertrag|Lastschrift|Visa-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld-)(?<note2>.*) \\-(?<amount>[\\.,\\d]+)$")
+                        .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note1>Konto.bertrag|.bertrag|Lastschrift|Visa\\-Umsatz|Auszahlung|Barauszahlung|Kartenverf.gun|Guthaben.bertr|Wechselgeld\\-)(?<note2>.*) \\-(?<amount>[\\.,\\d]+)$")
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
@@ -1035,14 +1023,14 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             
                             // Formatting some notes
                             if (v.get("note1").startsWith("Kartenverfügun"))
-                                v.put("note", "Kartenzahlung");
-                            else if (v.get("note2").matches("(?i)(.* )?Wechselgeld\\-.*"))
+                                v.put("note", "Kartenverfügung Kartenzahlung");
+                            else if (v.get("note2").matches("^(?i:(.* )?Wechselgeld\\-.*)$"))
                                 v.put("note", "Wechselgeld-Sparen");
-                            else if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Girokonto"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Girokonto)$"))
                                 v.put("note", "Übertrag auf Girokonto");
-                            else if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Tagesgeld PLUS-Konto"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Tagesgeld PLUS\\-Konto)$"))
                                 v.put("note", "Übertrag auf Tagesgeld PLUS-Konto");
-                            else if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Visa-Karte"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Visa\\-Karte)$"))
                                 v.put("note", "Übertrag auf auf Visa-Karte");
                             else
                                 v.put("note", v.get("note1"));
@@ -1052,7 +1040,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
         
-        Block depositBlock = new Block("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre|Korrektur Barauszahlung).* \\+[\\.,\\d]+$");
+        Block depositBlock = new Block("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa\\-Kartenabre|Korrektur Barauszahlung).* \\+[\\.,\\d]+$");
         type.addBlock(depositBlock);
         depositBlock.setMaxSize(3);
         depositBlock.set(new Transaction<AccountTransaction>()
@@ -1064,7 +1052,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("note1", "note2", "amount", "date")
-                        .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note1>Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa-Kartenabre|Korrektur Barauszahlung)(?<note2>.*) \\+(?<amount>[\\.,\\d]+)$")
+                        .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note1>Konto.bertrag|.bertrag|Guthaben.bertr|Gutschrift|Bar|Visa\\-Kartenabre|Korrektur Barauszahlung)(?<note2>.*) \\+(?<amount>[\\.,\\d]+)$")
                         .match("(^|^A)(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
@@ -1088,19 +1076,19 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             }
 
                             // Formatting some notes
-                            if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Girokonto"))
+                            if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Girokonto)$"))
                                 v.put("note", "Übertrag auf Girokonto");
-                            else if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Tagesgeld PLUS-Konto"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Tagesgeld PLUS\\-Konto)$"))
                                 v.put("note", "Übertrag auf Tagesgeld PLUS-Konto");
-                            else if (v.get("note2").matches("(?i)(.* )?Uebertrag auf Visa-Karte"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Visa\\-Karte)$"))
                                 v.put("note", "Übertrag auf Visa-Karte");
-                            else if (v.get("note2").matches("(?i)(.* )?Bargeldeinzahlung Karte .*"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Bargeldeinzahlung Karte .*)$"))
                                 v.put("note", "Bargeldeinzahlung Karte");
-                            else if (v.get("note2").matches("(?i)(.* )?Gutschrift aus Bonus-Sparen"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Gutschrift aus Bonus\\-Sparen)$"))
                                 v.put("note", "Gutschrift aus Bonus-Sparen");
-                            else if (v.get("note2").matches("(?i)(.* )?Gutschr\\. Wechselgeld-Sparen"))
+                            else if (v.get("note2").matches("^(?i:(.* )?Gutschr\\. Wechselgeld\\-Sparen)$"))
                                 v.put("note", "Gutschrift Wechselgeld-Sparen");
-                            else if (v.get("note1").matches("(?i)Visa-Kartenabre.*"))
+                            else if (v.get("note1").matches("^(?i:Visa\\-Kartenabre.*)$"))
                                 v.put("note", "Visa-Kartenabrechnung");
                             else
                                 v.put("note", v.get("note1"));
@@ -1272,7 +1260,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Börsenplatzabhäng. Entgelt  : EUR                1,50 
                 .section("currency", "fee").optional()
-                .match("^.* B.rsenplatzabh.ng. Entgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* B.rsenplatzabh.ng\\. Entgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1300,7 +1288,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                     }
                 }) 
 
-                //                           Abwickl.entgelt Clearstream : EUR                2,90
+                //                           Variable Börsenspesen       : EUR                3,00
                 .section("currency", "fee").optional()
                 .match("^.* Variable B.rsenspesen ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1031,7 +1031,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                             else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Tagesgeld PLUS\\-Konto)$"))
                                 v.put("note", "Übertrag auf Tagesgeld PLUS-Konto");
                             else if (v.get("note2").matches("^(?i:(.* )?Uebertrag auf Visa\\-Karte)$"))
-                                v.put("note", "Übertrag auf auf Visa-Karte");
+                                v.put("note", "Übertrag auf Visa-Karte");
                             else
                                 v.put("note", v.get("note1"));
 


### PR DESCRIPTION
Fix accountbill transactions (interest's, fee's, tax's)
Fix some notes
https://forum.portfolio-performance.info/t/pdf-import-von-comdirect/1647/185
Fixes #2611
Add tests for dividends with tax treatment (files reversed)

Hallo
irgendwie wurde vom Finanzreport01 mehrere Inhalte aus unbekannten PDF-Debugs hineinkopiert.
Das sieht man recht gut an den Datumsangaben die durcheinander sind. (mal 2018, 2015, 2017 etc.). 
Dadurch wurde u.a. auch doppeltes hineinkopiert. (siehe gelöschte Zeilen) 
Ich habe versucht diese in Einklang zu bekommen.
Darauf sollten wir in Zukunft achten, dass vorhanden PDF-Debugs nicht missbräuchlich verändert 
werden in dem irgendwelche Daten hinzugefügt werden.