### PR TITLE
Fix sorting arrow in tables heads

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
@@ -369,7 +369,7 @@ public final class ColumnViewerSorter
             {
                 setupSortingContext();
 
-                int dir = direction == SWT.DOWN ? 1 : -1;
+                int dir = direction == SWT.UP ? 1 : -1;
 
                 if (element1 == null && element2 == null)
                     return 0;


### PR DESCRIPTION
Fixes #2576

Hallo @buchen 
Der Sortierungspfeil in den Tabellenköpfen ist beim sortieren immer verkehrt herum.
Ich bin mir nicht ganz sicher, ob diese Änderung ausreicht um den Sortierungpfeil in allen 
Tabellenköpfen richtigrum darzustellen.

Gruß
Alex