### PR TITLE
Fix Non-terminating decimal expansion bug + optimization of multiplier calculation

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModelTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModelTest.java
@@ -17,9 +17,20 @@ public class StockSplitModelTest
         // 2 shares for 1
         model.setNewShares(new BigDecimal(2));
         model.setOldShares(new BigDecimal(1));
-
         assertThat(model.calculateNewQuote(4), is(2L)); // quote is halved
         assertThat(model.calculateNewStock(4), is(8L)); // stock is doubled
+        
+        // 1 shares for 3
+        model.setNewShares(new BigDecimal(1));
+        model.setOldShares(new BigDecimal(3));
+        assertThat(model.calculateNewQuote(5), is(15L)); // quote multiplied by 3
+        assertThat(model.calculateNewStock(12), is(4L)); // stock is divided by 3
+        
+        // 3 shares for 1
+        model.setNewShares(new BigDecimal(3));
+        model.setOldShares(new BigDecimal(1));
+        assertThat(model.calculateNewQuote(6), is(2L)); // quote is divided by 3
+        assertThat(model.calculateNewStock(3), is(9L)); // stock is multiplied by 3        
     }
 
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -20,6 +20,8 @@ public class StockSplitModel extends BindingHelper.Model
     private LocalDate exDate = LocalDate.now();
     private BigDecimal newShares = BigDecimal.ONE;
     private BigDecimal oldShares = BigDecimal.ONE;
+    private BigDecimal stockMultiplier = BigDecimal.ONE;
+    private BigDecimal quoteMultiplier = BigDecimal.ONE;
 
     private boolean changeTransactions = true;
     private boolean changeHistoricalQuotes = true;
@@ -57,8 +59,9 @@ public class StockSplitModel extends BindingHelper.Model
     }
 
     public void setNewShares(BigDecimal newShares)
-    {
+    {        
         firePropertyChange("newShares", this.newShares, this.newShares = newShares); //$NON-NLS-1$
+        calculateMultipliers();
     }
 
     public BigDecimal getOldShares()
@@ -69,6 +72,13 @@ public class StockSplitModel extends BindingHelper.Model
     public void setOldShares(BigDecimal oldShares)
     {
         firePropertyChange("oldShares", this.oldShares, this.oldShares = oldShares); //$NON-NLS-1$
+        calculateMultipliers();
+    }
+    
+    private void calculateMultipliers()
+    {
+        stockMultiplier = calculateStockMultiplier();
+        quoteMultiplier = calculateQuoteMultiplier();
     }
 
     public boolean isChangeTransactions()
@@ -93,22 +103,26 @@ public class StockSplitModel extends BindingHelper.Model
                         this.changeHistoricalQuotes = changeHistoricalQuotes);
     }
 
-    // stock multiplier = quote divider
-    private BigDecimal getStockMultiplier()
+    private BigDecimal calculateStockMultiplier()
     {
         return newShares.divide(oldShares, Values.MC);
     }
     
+    private BigDecimal calculateQuoteMultiplier()
+    {
+        return oldShares.divide(newShares, Values.MC);
+    }
+    
     public long calculateNewStock(long oldStock)
     {
-        return BigDecimal.valueOf(oldStock).multiply(getStockMultiplier())
+        return BigDecimal.valueOf(oldStock).multiply(stockMultiplier)
                         .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
     
     public long calculateNewQuote(long oldQuote)
     {
-        return BigDecimal.valueOf(oldQuote).divide(getStockMultiplier()) // when stock is multiplied, quote must be divided
-                        .setScale(0, RoundingMode.HALF_EVEN).longValue();        
+        return BigDecimal.valueOf(oldQuote).multiply(quoteMultiplier)
+                        .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
     
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -21,7 +21,6 @@ public class StockSplitModel extends BindingHelper.Model
     private BigDecimal newShares = BigDecimal.ONE;
     private BigDecimal oldShares = BigDecimal.ONE;
     private BigDecimal stockMultiplier = BigDecimal.ONE;
-    private BigDecimal quoteMultiplier = BigDecimal.ONE;
 
     private boolean changeTransactions = true;
     private boolean changeHistoricalQuotes = true;
@@ -61,7 +60,7 @@ public class StockSplitModel extends BindingHelper.Model
     public void setNewShares(BigDecimal newShares)
     {
         firePropertyChange("newShares", this.newShares, this.newShares = newShares); //$NON-NLS-1$
-        calculateMultipliers();
+        calculateStockMultiplier();
     }
 
     public BigDecimal getOldShares()
@@ -72,13 +71,7 @@ public class StockSplitModel extends BindingHelper.Model
     public void setOldShares(BigDecimal oldShares)
     {
         firePropertyChange("oldShares", this.oldShares, this.oldShares = oldShares); //$NON-NLS-1$
-        calculateMultipliers();
-    }
-    
-    private void calculateMultipliers()
-    {
-        stockMultiplier = calculateStockMultiplier();
-        quoteMultiplier = calculateQuoteMultiplier();
+        calculateStockMultiplier();
     }
 
     public boolean isChangeTransactions()
@@ -103,14 +96,9 @@ public class StockSplitModel extends BindingHelper.Model
                         this.changeHistoricalQuotes = changeHistoricalQuotes);
     }
 
-    private BigDecimal calculateStockMultiplier()
+    private void calculateStockMultiplier()
     {
-        return newShares.divide(oldShares, Values.MC);
-    }
-    
-    private BigDecimal calculateQuoteMultiplier()
-    {
-        return oldShares.divide(newShares, Values.MC);
+        stockMultiplier =  newShares.divide(oldShares, Values.MC);
     }
     
     public long calculateNewStock(long oldStock)
@@ -121,7 +109,7 @@ public class StockSplitModel extends BindingHelper.Model
     
     public long calculateNewQuote(long oldQuote)
     {
-        return BigDecimal.valueOf(oldQuote).multiply(quoteMultiplier)
+        return BigDecimal.valueOf(oldQuote).divide(stockMultiplier, Values.MC) // when stock is multiplied, quote must be divided
                         .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
     

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/StockSplitModel.java
@@ -59,7 +59,7 @@ public class StockSplitModel extends BindingHelper.Model
     }
 
     public void setNewShares(BigDecimal newShares)
-    {        
+    {
         firePropertyChange("newShares", this.newShares, this.newShares = newShares); //$NON-NLS-1$
         calculateMultipliers();
     }


### PR DESCRIPTION
fixes #2581
Reason for issue was missing scale and rounding mode when dividing with stock-multiplier for calculation of new quote.

I changed the calculation the following way:
For both calculations (new stock and new quote) an individual multiplier is used. These multipliers (stockMultiplier and quoteMultipler) were calculated when new shares or old shares are set. In this way the multipliers were only calculated twice and not in every iteration when all new stocks or new quotes were calculated.