### PR TITLE
Added: "unixtime" as possible <format> for TODAY

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.online.impl.variableurl.macros;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAmount;
@@ -16,6 +18,7 @@ public class Today implements Macro
 
     private final DateTimeFormatter formatter;
     private final TemporalAmount delta;
+    private final boolean ut;
 
     public Today(CharSequence input)
     {
@@ -25,7 +28,8 @@ public class Today implements Macro
             throw new IllegalArgumentException();
 
         String p = matcher.group(2);
-        if (p == null || p.isEmpty())
+        ut = (p.equals("unixtime")) ? true : false;
+        if (p == null || p.isEmpty() || ut)
             formatter = DateTimeFormatter.ISO_DATE;
         else
             formatter = DateTimeFormatter.ofPattern(p);
@@ -46,6 +50,10 @@ public class Today implements Macro
     @Override
     public CharSequence resolve(Security security)
     {
-        return formatter.format(LocalDate.now().plus(delta));
+        LocalDate ld = LocalDate.now().plus(delta);
+        if (ut == true)
+            return String.valueOf(ld.toEpochSecond(LocalTime.parse("00:00:00"),ZoneOffset.of("Z")));
+        else
+            return formatter.format(ld);
     }
 }


### PR DESCRIPTION
Hi!

As discuessed in the Portfolio Performance Forum [here](https://forum.portfolio-performance.info/t/dynamische-kursdaten-urls/2929/78), I needed to generate a dynamic url which contained the current date as unix time. Since `DateTimeFormatter` does not contain a `<format>` that represents the date in unix time, I added the possibility to simply use `unixtime` as `<format>` for the `TODAY` Macro.

So with this pull request the users will not only be allowed to write `{TODAY:dd.MM.yyyy:-P3M}` in their dynamic urls which will create `15.09.2021`, but they will also be allowed to write `{TODAY:unixtime:-P3M}` which will create `1631664000`.

Hopefully one of the maintainers of thie project will merge this little request into the next update because I have litterally just created a github account and learned how to work with all that stuff here only to make this request.


