### PR TITLE
Remove wrong space in regex for Keytrade Bank PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/Kauf06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/Kauf06.txt
@@ -1,0 +1,24 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Disponible depuis le : 13/12/2021 Téléchargé le : 29/12/2021
+Bordereau
+Compte titres: 7634568
+Numéro de réf. : 7763C9846/01
+Achat 20 KBC (BE0003565737) à 74,5 EUR
+Type d' instrument: Actions
+Type d'ordre: Limit (74,50 EUR)
+Validité: GTC
+Ordre créé à: 13/12/2021 08:48:02 CET
+Date et heure d'exécution: 13/12/2021 16:24:15 CET
+Date de comptabilisation: 13/12/2021
+Date valeur: 15/12/2021
+Lieu d'exécution: Equiduct
+Montant brut - 1.490,00 EUR
+- 1.490,00 EUR
+Taxe boursière - 0,35% - 5,22 EUR
+Courtage - 7,50 EUR
+Débit 1.502,72 EUR
+Keytrade Bank, succursale belge d'Arkéa Direct Bank SA (France)
+Boulevard du Souverain 100 - 1170 Bruxelles, RPM Bruxelles - TVA BE 0879 257 191
+Intermédiaire en assurance autorisé à exercer en Belgique (ORIAS 07008441)
+T +32 2 679 90 00 - F +32 2 679 90 01 - info@keytradebank.com - keytradebank.be 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/Verkauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/keytradebank/Verkauf04.txt
@@ -1,0 +1,24 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Disponible depuis le : 27/01/2021 Téléchargé le : 29/12/2021
+Bordereau
+Compte titres: 7634568
+Numéro de réf. : 7763C9846/01
+Vente 40 ORANGE BELGIUM (BE0003735496) à 22,45 EUR
+Type d' instrument: Actions
+Type d'ordre: Market
+Validité: GTC
+Ordre créé à: 27/01/2021 14:37:13 CET
+Date et heure d'exécution: 27/01/2021 14:37:13 CET
+Date de comptabilisation: 27/01/2021
+Date valeur: 29/01/2021
+Lieu d'exécution: Equiduct
+Montant brut + 898,00 EUR
++ 898,00 EUR
+Taxe boursière - 0,35% - 3,14 EUR
+Courtage - 7,50 EUR
+Crédit 908,64 EUR
+Keytrade Bank, succursale belge d'Arkéa Direct Bank SA (France)
+Boulevard du Souverain 100 - 1170 Bruxelles, RPM Bruxelles - TVA BE 0879 257 191
+Intermédiaire en assurance autorisé à exercer en Belgique (ORIAS 07008441)
+T +32 2 679 90 00 - F +32 2 679 90 01 - info@keytradebank.com - keytradebank.be 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -64,17 +64,19 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Achat 310 HOME24 SE  INH O.N. (DE000A14KEB5) à 15,9324 EUR
                 // Vente 310 VERBIO VER.BIOENERGIE ON (DE000A0JL9W6) à 33,95 EUR
                 // Verkauf 22 SARTORIUS AG O.N. (DE0007165607) für 247 EUR
-                .section("isin", "name", "shares", "currency")
-                .match("^(Kauf|Achat|Verkauf|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* (?<currency>[\\w]{3})$")
+                .section("isin", "name", "shares", "amount", "currency")
+                .match("^(Kauf|Achat|Verkauf|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(v.get("currency"));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
                 // Ausführungsdatum und -zeit : 15/03/2021 12:31:50 CET
-                // Ordre créé à : 10/02/2021 15:23:42 CET
+                // Ordre créé à: 10/02/2021 15:23:42 CET
                 .section("date", "time")
-                .match("^(Ausf.hrungsdatum und \\-zeit|Ordre cr.. .) : (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}) .*$")
+                .match("^(Ausf.hrungsdatum und \\-zeit|Ordre cr.. .)\\s?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}) .*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
 
                 // Lastschrift 1.994,39 EUR Valutadatum 17/03/2021
@@ -111,8 +113,9 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Auftragstyp : Limit (16 EUR)
+                // Type d'ordre: Limit (46,3 EUR
                 .section("note").optional()
-                .match("^(Auftragstyp|Type d' ordre) : (?<note>.*)$")
+                .match("^(Auftragstyp|Type d' ordre)\\s?: (?<note>.*)$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(BuySellEntryItem::new);


### PR DESCRIPTION
Keytrade Bank PDF Importer:
There was some space character that induced some regex to not be matched.