### PR TITLE
Fix inconsistent date format in CSV exports

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -96,7 +96,7 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
                                                 .toFormatter();
                                 
                                 LocalDateTime dateTime = LocalDateTime.parse(columnValue, formatter);
-                                columnValue = dateTime.toString();
+                                columnValue = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
                             }
                             catch(Exception e)
                             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -85,7 +85,8 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
                         boolean isDateColumn = columnHeader.equals(Messages.ColumnStartDate) || columnHeader.equals(Messages.ColumnEndDate);
                         if(isDateColumn)
                         {
-                            try {
+                            try 
+                            {
                                 DateTimeFormatter formatter =  
                                                 new DateTimeFormatterBuilder().appendPattern("MMM d, uuuu[, h:m a]")
                                                 .parseDefaulting(ChronoField.CLOCK_HOUR_OF_AMPM, 12)


### PR DESCRIPTION
Fixes https://github.com/buchen/portfolio/issues/2077

Appearance of CSV export before (inconsistent date format, cannot be sorted chronologically):

![2022-01-02 20 16 19](https://user-images.githubusercontent.com/1877409/147899367-3caecfa9-4908-44a3-805f-7fb3a1f1aa02.png)

With this fix (date format is consistent & sortable):

![2022-01-02 20 15 54](https://user-images.githubusercontent.com/1877409/147899346-72fdc6a3-a6e8-498a-8549-9db9aac38d9a.png)


