### PR TITLE
Add Note column to the Trades view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -238,6 +238,19 @@ public class TradesTableViewer
         column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getReturn()));
         column.setVisible(false);
         support.addColumn(column);
+        
+        column = new Column("note", Messages.ColumnNote, SWT.LEFT, 80); //$NON-NLS-1$
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                Trade t = (Trade) e;
+                return t.getLastTransaction().getTransaction().getNote();
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getLastTransaction().getTransaction().getNote()));
+        support.addColumn(column);
 
         column = new Column("portfolio", Messages.ColumnPortfolio, SWT.LEFT, 100); //$NON-NLS-1$
         column.setMenuLabel(Messages.ColumnPortfolio);


### PR DESCRIPTION
Add the ability to show a Notes column on the Trades view, which will show the note of the final (closing) transaction of the trade.

Why: PP is very useful for doing taxes - in particular, you can use the CSV export from the Trades view to see all closing trades, & help calculate taxes due.  However, in crypto, most transactions need context - thus, they're tagged with i.e. a link to the etherscan transaction for an ethereum gas fee, a mention of which exchange it was sold on, etc.  Without this context, it isn't really possible to use the CSV to reconcile taxes, as different "closing" transactions may be treated differently.  This lets that context be included in CSV exports, so it can be used for calculating crypto taxes.