### PR TITLE
Securities Notes Usability Issues

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/NoteColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/NoteColumn.java
@@ -32,7 +32,14 @@ public class NoteColumn extends Column
             {
                 Annotated n = Adaptor.adapt(Annotated.class, e);
                 if (n != null)
-                    return n.getNote();
+                {
+                    String note = n.getNote();
+                    if(note != null)
+                    {
+                        note = note.replace("\n", " "); 
+                    }
+                    return note; 
+                }
 
                 Named n2 = Adaptor.adapt(Named.class, e);
                 return n2 != null ? n2.getNote() : null;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -146,8 +146,8 @@ public class SecurityMasterDataPage extends AbstractPage
         deco.show();
 
         Text valueNote = bindings.bindStringInput(container, Messages.ColumnNote, "note", //$NON-NLS-1$
-                        SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL, SWT.DEFAULT);
-        GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, SWTHelper.lineHeight(valueNote) * 4)
+                        SWT.BORDER | SWT.MULTI | SWT.V_SCROLL | SWT.H_SCROLL | SWT.WRAP, SWT.DEFAULT);
+        GridDataFactory.fillDefaults().grab(true, true).hint(SWT.DEFAULT, SWTHelper.lineHeight(valueNote) * 4)
                         .applyTo(valueNote);
     }
 }


### PR DESCRIPTION
This PR fixes 3 usability issues related to Notes, when editing a Security:

1) When expanding the Edit Security dialog, the "notes" textbox does not expand to fill empty space (instead, a tiny notes textbox remains, & the expanded dialog area remains as empty background). Fixes: https://github.com/buchen/portfolio/issues/2051)

2) For very long notes, the text doesn't wrap, requiring the user to keep scrolling left & right to read it (or trying to manually manage the newlines). This fixes line wrapping, so that it's no longer necessary to scroll back & forth to read longer notes.

3) For multi-line notes, the main grid view itself actually shows newlines (rather than having one line per entry) - which results in the vast majority o vertical space being consumed by just the "notes" cell, & an impossible amount of vertical scrolling for those with very large Securities lists. This fix will show multi-line notes as a single line in the grid, making it possible to use multi-line notes, without blowing up the vertical space in the securities list :)

Screenshots:

Items 1 & 2, Before:
![Peek 2022-01-02 21-41](https://user-images.githubusercontent.com/1877409/147902948-ebf92c91-0019-48d5-9c5a-ca0876559d22.gif)

Items 1 & 2, After:
![Peek 2022-01-02 21-42](https://user-images.githubusercontent.com/1877409/147902953-3c17f6b4-881a-4a88-9273-cf78a2a028bd.gif)

Item 3, Before:
![2022-01-02 21 48 59](https://user-images.githubusercontent.com/1877409/147902677-c52d748b-495f-4a78-91c9-ef0069476569.png)

Item 3, After:
![2022-01-02 21 51 33](https://user-images.githubusercontent.com/1877409/147902715-6e8c22a6-3a25-4d50-b819-c4c9d81c41b0.png)


