### PR TITLE
Reorder rebalancing model update and view redraw to avoid NPE

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -880,8 +880,8 @@ import name.abuchen.portfolio.util.TextUtil;
                 public void run()
                 {
                     assignment.moveTo(targetNode);
-                    nodeViewer.setExpandedState(targetNode, true);
                     onTaxnomyNodeEdited(targetNode);
+                    nodeViewer.setExpandedState(targetNode, true);
                 }
             });
         }


### PR DESCRIPTION
When assigning a security to an asset class, the rebalancing view is now redrawn after the recalculation of the model.
Fixes #2594