### PR TITLE
Reverse column order fix

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthMatrixTab.java
@@ -77,7 +77,7 @@ public class PaymentsPerMonthMatrixTab implements PaymentsTab
     protected IPreferenceStore preferences;
 
     private boolean showOnlyOneYear = false;
-    protected boolean columnsInReverseOrder = false;
+    private boolean columnsInReverseOrder = false;
 
     protected Font boldFont;
     private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM yy"); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterMatrixTab.java
@@ -45,17 +45,14 @@ public class PaymentsPerQuarterMatrixTab extends PaymentsPerMonthMatrixTab
 
         createSumColumn(records, layout);
 
-        if (columnsInReverseOrder)
-        {
-            reverseColumnOrder();
-        }
+        sortColumnOrder();
     }
 
     @Override
-    protected void reverseColumnOrder()
+    protected void sortColumnOrder()
     {
         // Keep first column in same position
-        reverseColumnOrder(1, 0);
+        sortColumnOrder(1, 0);
     }
 
     private void createQuarterColumns(TableViewer records, TableColumnLayout layout)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearMatrixTab.java
@@ -52,15 +52,15 @@ public class PaymentsPerYearMatrixTab extends PaymentsPerMonthMatrixTab
 
         if (columnsInReverseOrder)
         {
-            reverseColumnOrder();
+            sortColumnOrder();
         }
     }
     
     @Override
-    protected void reverseColumnOrder()
+    protected void sortColumnOrder()
     {
         // Keep first column in same position
-        reverseColumnOrder(1, 0);
+        sortColumnOrder(1, 0);
     }
 
     private void createYearColumn(TableViewer records, TableColumnLayout layout, LocalDate start, int index)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearMatrixTab.java
@@ -50,10 +50,7 @@ public class PaymentsPerYearMatrixTab extends PaymentsPerMonthMatrixTab
 
         createSumColumn(records, layout);
 
-        if (columnsInReverseOrder)
-        {
-            sortColumnOrder();
-        }
+        sortColumnOrder();
     }
     
     @Override


### PR DESCRIPTION
Context: When updating the table model, new columns are added in a first step and then old columns are remove. 
Fix: The reorder must take place **after** the removal of the old columns. Beside this, `sortColumnOrder` now enforces the natural order of the columns and don't relay on the current state of the column order.

Fixes: #2640 