### PR TITLE
Write backup files to a subdir

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -328,9 +328,18 @@ public class ClientInput
             // keep original extension in order to be able to open the backup
             // file directly from within PP
             String backupName = constructFilename(file, suffix);
-
+            
             Path sourceFile = file.toPath();
-            Path backupFile = sourceFile.resolveSibling(backupName);
+            
+            // Write backups to a subdir, so it can be symlinked to a different location
+            // than the main db if desired
+            Path backupSubdir = sourceFile.resolveSibling("backup"); //$NON-NLS-1$
+            File directory = backupSubdir.toFile();
+            if (!directory.exists()){
+                directory.mkdir();
+            }
+            
+            Path backupFile = backupSubdir.resolve(backupName);
             Files.copy(sourceFile, backupFile, StandardCopyOption.REPLACE_EXISTING);
         }
         catch (IOException e)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -335,7 +335,8 @@ public class ClientInput
             // than the main db if desired
             Path backupSubdir = sourceFile.resolveSibling("backup"); //$NON-NLS-1$
             File directory = backupSubdir.toFile();
-            if (!directory.exists()){
+            if (!directory.exists())
+            {
                 directory.mkdir();
             }
             


### PR DESCRIPTION
Write backup xml files to a subdir next to the main db file, rather than into to the same dir itself.  Addresses this issue (https://github.com/buchen/portfolio/issues/1329) by allowing the backups to be relocated by then symlinking that /backup dir elsewhere.