### PR TITLE
Transactions with identical date and time are ordered by updatedAt.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/ClientTestUtilities.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/ClientTestUtilities.java
@@ -59,11 +59,11 @@ public class ClientTestUtilities
         client.getSecurities().forEach(Security::getAttributes);
 
         client.getAccounts().forEach(a -> {
-            a.getTransactions().sort(new AccountTransaction.ByDateAmountTypeAndHashCode());
+            a.getTransactions().sort(Transaction.BY_DATE);
             a.getAttributes();
         });
         client.getPortfolios().forEach(p -> {
-            p.getTransactions().sort(new Transaction.ByDate());
+            p.getTransactions().sort(Transaction.BY_DATE);
             p.getAttributes();
         });
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
@@ -51,7 +51,7 @@ public class AccountBalanceChart extends TimelineChart // NOSONAR
 
             CurrencyConverter converter = new CurrencyConverterImpl(exchangeRateProviderFactory,
                             account.getCurrencyCode());
-            Collections.sort(tx, new Transaction.ByDate());
+            Collections.sort(tx, Transaction.BY_DATE);
 
             if (now.isAfter(end))
                 end = now;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
 import name.abuchen.portfolio.money.Values;
@@ -338,7 +339,7 @@ public class AccountListView extends AbstractFinanceView implements Modification
             return;
 
         List<AccountTransaction> tx = new ArrayList<>(account.getTransactions());
-        Collections.sort(tx, new AccountTransaction.ByDateAmountTypeAndHashCode());
+        Collections.sort(tx, Transaction.BY_DATE);
 
         MutableMoney balance = MutableMoney.of(account.getCurrencyCode());
         for (AccountTransaction t : tx)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -438,8 +438,7 @@ public class PerformanceView extends AbstractHistoricView
                                 return colorFor(element);
                             }
                         });
-        column.setSorter(ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getDateTime()),
-                        SWT.UP);
+        column.setSorter(ColumnViewerSorter.create(TransactionPair.BY_DATE), SWT.UP);
         support.addColumn(column);
 
         column = new Column(Messages.ColumnTransactionType, SWT.LEFT, 100);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -182,7 +182,7 @@ public class SecuritiesChart
                     if (tx.isEmpty())
                         return new ChartInterval(now, now);
 
-                    Collections.sort(tx, new TransactionPair.ByDate());
+                    Collections.sort(tx, TransactionPair.BY_DATE);
                     boolean hasHoldings = ClientSnapshot.create(client, converter, LocalDate.now())
                                     .getPositionsByVehicle().containsKey(security);
 
@@ -1038,7 +1038,7 @@ public class SecuritiesChart
                         .filter(t -> t.getType() == PortfolioTransaction.Type.BUY
                                         || t.getType() == PortfolioTransaction.Type.DELIVERY_INBOUND)
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
-                        .sorted(new Transaction.ByDate()).collect(Collectors.toList());
+                        .sorted(Transaction.BY_DATE).collect(Collectors.toList());
 
         addInvestmentMarkers(purchase, Messages.SecurityMenuBuy, colorEventPurchase);
 
@@ -1047,7 +1047,7 @@ public class SecuritiesChart
                         .filter(t -> t.getType() == PortfolioTransaction.Type.SELL
                                         || t.getType() == PortfolioTransaction.Type.DELIVERY_OUTBOUND)
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
-                        .sorted(new Transaction.ByDate()).collect(Collectors.toList());
+                        .sorted(Transaction.BY_DATE).collect(Collectors.toList());
 
         addInvestmentMarkers(sales, Messages.SecurityMenuSell, colorEventSale);
     }
@@ -1130,7 +1130,7 @@ public class SecuritiesChart
         List<AccountTransaction> dividends = client.getAccounts().stream().flatMap(a -> a.getTransactions().stream())
                         .filter(t -> t.getSecurity() == security)
                         .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS)
-                        .filter(t -> chartInterval.contains(t.getDateTime())).sorted(new Transaction.ByDate())
+                        .filter(t -> chartInterval.contains(t.getDateTime())).sorted(Transaction.BY_DATE)
                         .collect(Collectors.toList());
 
         if (dividends.isEmpty())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionsViewer.java
@@ -266,8 +266,7 @@ public final class TransactionsViewer implements ModificationListener
             }
         });
         
-        ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getDateTime()).attachTo(column,
-                        SWT.UP);
+        ColumnViewerSorter.create(TransactionPair.BY_DATE).attachTo(column, SWT.UP);
         new DateTimeEditingSupport(Transaction.class, "dateTime").addListener(this).attachTo(column); //$NON-NLS-1$
         support.addColumn(column);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
@@ -37,6 +37,7 @@ import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
 import name.abuchen.portfolio.money.Quote;
@@ -140,7 +141,7 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
                 return colorFor((AccountTransaction) element);
             }
         });
-        ColumnViewerSorter.create(new AccountTransaction.ByDateAmountTypeAndHashCode()).attachTo(column, SWT.DOWN);
+        ColumnViewerSorter.create(Transaction.BY_DATE).attachTo(column, SWT.DOWN);
         new DateTimeEditingSupport(AccountTransaction.class, "dateTime").addListener(this).attachTo(column); //$NON-NLS-1$
         transactionsColumns.addColumn(column);
 
@@ -543,7 +544,7 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
             return;
 
         List<AccountTransaction> tx = new ArrayList<>(account.getTransactions());
-        Collections.sort(tx, new AccountTransaction.ByDateAmountTypeAndHashCode());
+        Collections.sort(tx, Transaction.BY_DATE);
 
         MutableMoney balance = MutableMoney.of(account.getCurrencyCode());
         for (AccountTransaction t : tx)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/CalculationLineItemPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/CalculationLineItemPane.java
@@ -99,13 +99,7 @@ public class CalculationLineItemPane implements InformationPanePage
         // date
         Column column = new Column(Messages.ColumnDate, SWT.None, 80);
         column.setLabelProvider(new DateTimeLabelProvider(e -> ((CalculationLineItem) e).getDateTime()));
-        column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
-
-            CalculationLineItem c1 = (CalculationLineItem) o1;
-            CalculationLineItem c2 = (CalculationLineItem) o2;
-
-            return c1.getDateTime().compareTo(c2.getDateTime());
-        }));
+        column.setSorter(ColumnViewerSorter.create(CalculationLineItem.BY_DATE));
         support.addColumn(column);
 
         // transaction type

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/TransactionsTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/TransactionsTab.java
@@ -127,8 +127,7 @@ public class TransactionsTab implements PaymentsTab
         Column column = new Column(Messages.ColumnDate, SWT.None, 80);
         column.setLabelProvider(new DateTimeLabelProvider(
                         element -> ((TransactionPair<?>) element).getTransaction().getDateTime()));
-        ColumnViewerSorter.create(e -> ((TransactionPair<?>) e).getTransaction().getDateTime()).attachTo(column,
-                        SWT.UP);
+        ColumnViewerSorter.create(TransactionPair.BY_DATE).attachTo(column, SWT.UP);
         support.addColumn(column);
 
         Function<Object, Comparable<?>> tx2type = element -> ((TransactionPair<?>) element)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewTransactionsPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/PreviewTransactionsPage.java
@@ -105,7 +105,7 @@ public class PreviewTransactionsPage extends AbstractWizardPage
     {
         Security security = model.getSecurity();
         List<TransactionPair<?>> transactions = security.getTransactions(model.getClient());
-        Collections.sort(transactions, new TransactionPair.ByDate());
+        Collections.sort(transactions, TransactionPair.BY_DATE);
         tableViewer.setInput(transactions);
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/AktienfreundeNetExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/AktienfreundeNetExporter.java
@@ -35,7 +35,7 @@ public class AktienfreundeNetExporter
         List<? extends Transaction> transactions = Stream
                         .concat(client.getAccounts().stream(), client.getPortfolios().stream())
                         .flatMap(l -> l.getTransactions().stream()) //
-                        .sorted(new Transaction.ByDate()) //
+                        .sorted(Transaction.BY_DATE) //
                         .collect(Collectors.toList());
 
         // write to file

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
@@ -1,9 +1,7 @@
 package name.abuchen.portfolio.model;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.ResourceBundle;
 
 import name.abuchen.portfolio.money.Money;
@@ -44,33 +42,6 @@ public class AccountTransaction extends Transaction
         public String toString()
         {
             return RESOURCES.getString("account." + name()); //$NON-NLS-1$
-        }
-    }
-
-    /**
-     * Comparator to sort by date, amount, type, and hash code in order to have
-     * a stable enough sort order to calculate the balance per transaction.
-     */
-    public static final class ByDateAmountTypeAndHashCode implements Comparator<AccountTransaction>, Serializable
-    {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public int compare(AccountTransaction t1, AccountTransaction t2)
-        {
-            int compare = t1.getDateTime().compareTo(t2.getDateTime());
-            if (compare != 0)
-                return compare;
-
-            compare = Long.compare(t1.getAmount(), t2.getAmount());
-            if (compare != 0)
-                return compare;
-
-            compare = t1.getType().compareTo(t2.getType());
-            if (compare != 0)
-                return compare;
-
-            return Integer.compare(t1.hashCode(), t2.hashCode());
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -622,14 +622,14 @@ public class Client
         for (Portfolio portfolio : portfolios)
         {
             answer.append(portfolio.getName()).append('\n');
-            portfolio.getTransactions().stream().sorted(new Transaction.ByDate())
+            portfolio.getTransactions().stream().sorted(Transaction.BY_DATE)
                             .forEach(t -> answer.append(t).append('\n'));
         }
 
         for (Account account : accounts)
         {
             answer.append(account.getName()).append('\n');
-            account.getTransactions().stream().sorted(new Transaction.ByDate())
+            account.getTransactions().stream().sorted(Transaction.BY_DATE)
                             .forEach(t -> answer.append(t).append('\n'));
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -1007,8 +1007,7 @@ public class ClientFactory
             List<TransactionPair<?>> transactions = security.getTransactions(client);
 
             // sort by date of transaction
-            Collections.sort(transactions, (one, two) -> one.getTransaction().getDateTime()
-                            .compareTo(two.getTransaction().getDateTime()));
+            Collections.sort(transactions, TransactionPair.BY_DATE);
 
             // count and assign number of shares by account
             Map<Account, Long> account2shares = new HashMap<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -137,14 +137,34 @@ public abstract class Transaction implements Annotated, Adaptable
         }
     }
 
-    public static final class ByDate implements Comparator<Transaction>, Serializable
+    /**
+     * Date comparator for transactions. Guarantees a stable sorting.
+     */
+    public static final Comparator<Transaction> BY_DATE = new ByDate();
+
+    private static final class ByDate implements Comparator<Transaction>, Serializable
     {
         private static final long serialVersionUID = 1L;
 
         @Override
         public int compare(Transaction t1, Transaction t2)
         {
-            return t1.getDateTime().compareTo(t2.getDateTime());
+            int compareTo = t1.getDateTime().compareTo(t2.getDateTime());
+            if (compareTo != 0)
+                return compareTo;
+
+            // Fallback to updateAt
+            compareTo = t1.getUpdatedAt().compareTo(t2.getUpdatedAt());
+            if (compareTo != 0)
+                return compareTo;
+
+            // Fallback to uuid
+            compareTo = t1.getUUID().compareTo(t2.getUUID());
+            if (compareTo != 0)
+                return compareTo;
+
+            // Final fallback to guarantee stable sorting
+            return Integer.compare(t1.hashCode(), t2.hashCode());
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TransactionPair.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TransactionPair.java
@@ -12,14 +12,19 @@ import name.abuchen.portfolio.money.Values;
  */
 public class TransactionPair<T extends Transaction> implements Adaptable
 {
-    public static final class ByDate implements Comparator<TransactionPair<?>>, Serializable
+    /**
+     * Date comparator for transaction pairs. Guarantees a stable sorting. 
+     */
+    public static final Comparator<TransactionPair<?>> BY_DATE = new ByDate();
+
+    private static final class ByDate implements Comparator<TransactionPair<?>>, Serializable
     {
         private static final long serialVersionUID = 1L;
 
         @Override
         public int compare(TransactionPair<?> t1, TransactionPair<?> t2)
         {
-            return t1.getTransaction().getDateTime().compareTo(t2.getTransaction().getDateTime());
+            return Transaction.BY_DATE.compare(t1.getTransaction(), t2.getTransaction());
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIRRYield.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIRRYield.java
@@ -26,7 +26,7 @@ public class ClientIRRYield
         List<Transaction> transactions = new ArrayList<>();
         collectAccountTransactions(client, interval, transactions);
         collectPortfolioTransactions(client, interval, transactions);
-        Collections.sort(transactions, new Transaction.ByDate());
+        Collections.sort(transactions, Transaction.BY_DATE);
 
         List<LocalDate> dates = new ArrayList<>();
         List<Double> values = new ArrayList<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioSnapshot.java
@@ -44,7 +44,7 @@ public class PortfolioSnapshot
                                 List<PortfolioTransaction> tx = e.getValue();
 
                                 Optional<PortfolioTransaction> last = tx.stream()
-                                                .sorted(new Transaction.ByDate().reversed()).findFirst();
+                                                .sorted(Transaction.BY_DATE.reversed()).findFirst();
 
                                 if (last.isPresent())
                                 {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.snapshot.security;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.Optional;
 
 import name.abuchen.portfolio.Messages;
@@ -54,6 +55,12 @@ public interface CalculationLineItem
         }
 
         @Override
+        public long getOrderingHint()
+        {
+            return txPair.getTransaction().getUpdatedAt().getEpochSecond();
+        }
+
+        @Override
         public Money getValue()
         {
             return txPair.getTransaction().getMonetaryAmount();
@@ -69,6 +76,7 @@ public interface CalculationLineItem
         {
             return txPair.getTransaction();
         }
+
     }
 
     public static class DividendPayment extends TransactionItem
@@ -227,6 +235,13 @@ public interface CalculationLineItem
         {
             super(portfolio, position, date);
         }
+
+        @Override
+        public long getOrderingHint()
+        {
+            return 0;
+        }
+
     }
 
     public static class ValuationAtEnd extends Valuation
@@ -235,7 +250,27 @@ public interface CalculationLineItem
         {
             super(portfolio, position, date);
         }
+
+        @Override
+        public long getOrderingHint()
+        {
+            return Long.MAX_VALUE;
+        }
     }
+
+    public static final Comparator<CalculationLineItem> BY_DATE = new Comparator<CalculationLineItem>()
+    {
+        @Override
+        public int compare(CalculationLineItem l1, CalculationLineItem l2)
+        {
+            int compareTo = l1.getDateTime().compareTo(l2.getDateTime());
+            if (compareTo != 0)
+                return compareTo;
+
+            // Fallback
+            return Long.compare(l1.getOrderingHint(), l2.getOrderingHint());
+        }
+    };
 
     public static CalculationLineItem of(TransactionPair<?> transaction)
     {
@@ -271,6 +306,8 @@ public interface CalculationLineItem
     String getLabel();
 
     LocalDateTime getDateTime();
+
+    long getOrderingHint();
 
     Money getValue();
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -102,7 +101,7 @@ public class Trade implements Adaptable
 
         // let's sort again because the list might not be sorted anymore due to
         // transfers
-        Collections.sort(transactions, Comparator.comparing(p -> p.getTransaction().getDateTime()));
+        Collections.sort(transactions, TransactionPair.BY_DATE);
 
         // re-set start date from first entry after sorting
         this.setStart(transactions.get(0).getTransaction().getDateTime());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
@@ -34,8 +34,7 @@ public class TradeCollector
     {
         List<TransactionPair<?>> transactions = security.getTransactions(client);
 
-        Collections.sort(transactions,
-                        (p1, p2) -> p1.getTransaction().getDateTime().compareTo(p2.getTransaction().getDateTime()));
+        Collections.sort(transactions, TransactionPair.BY_DATE);
 
         List<Trade> trades = new ArrayList<>();
         Map<Portfolio, List<TransactionPair<PortfolioTransaction>>> openTransactions = new HashMap<>();
@@ -115,8 +114,7 @@ public class TradeCollector
         long sharesToDistribute = pair.getTransaction().getShares();
         
         // sort open to get fifo
-        Collections.sort(open,
-                        (p1, p2) -> p1.getTransaction().getDateTime().compareTo(p2.getTransaction().getDateTime()));
+        Collections.sort(open, TransactionPair.BY_DATE);
 
         for (TransactionPair<PortfolioTransaction> candidate : new ArrayList<>(open))
         {


### PR DESCRIPTION
When adding multiple transactions with the same date and time (usually 00:00h), now the sorting takes 'updatedAt' into account. This is a more understandable behavior than using 'amount' and 'type' for sorting. Now the transactions are listed in the order of creation (as long as they are not changed afterwards).

Related to #1874 