### PR TITLE
Preset time for new transactions

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1029,6 +1029,11 @@ public class Messages extends NLS
     public static String PrefTitleDivvyDiary;
     public static String PrefTitleFinnhub;
     public static String PrefTitleQuandl;
+    public static String PresetsPrefPageDescription;
+    public static String PresetsPrefPageNow;
+    public static String PresetsPrefPageStartOfDay;
+    public static String PresetsPrefPageTime;
+    public static String PresetsPrefPageTitle;
     public static String SecurityFilter;
     public static String SecurityFilterSharesHeldEqualZero;
     public static String SecurityFilterSharesHeldNotZero;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
@@ -169,6 +169,11 @@ public interface UIConstants
          * Preference key whether to store settings (standard calendar)
          */
         String CALENDAR = "CALENDAR"; //$NON-NLS-1$
+        
+        /**
+         * Preference key for preset time in new transactions.
+         */
+        String PRESET_VALUE_TIME = "PRESET_VALUE_TIME"; //$NON-NLS-1$
     }
 
     interface CSS // NOSONAR

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
@@ -12,6 +12,7 @@ import name.abuchen.portfolio.online.impl.EODHistoricalDataQuoteFeed;
 import name.abuchen.portfolio.online.impl.FinnhubQuoteFeed;
 import name.abuchen.portfolio.online.impl.QuandlQuoteFeed;
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.dialogs.transactions.PresetValues;
 import name.abuchen.portfolio.util.FormatHelper;
 import name.abuchen.portfolio.util.TradeCalendarManager;
 
@@ -87,5 +88,11 @@ public class Preference2EnvAddon
                     @Preference(value = UIConstants.Preferences.FORMAT_CALCULATED_QUOTE_DIGITS) int quotePrecision)
     {
         FormatHelper.setCalculatedQuoteDisplayPrecision(quotePrecision);
+    }
+
+    @Inject
+    public void setTimePreset(@Preference(value = UIConstants.Preferences.PRESET_VALUE_TIME) String timePresetValue)
+    {
+        PresetValues.setTimePreset(timePresetValue);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -45,7 +45,7 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
     protected Portfolio portfolio;
     protected Security security;
     protected LocalDate date = LocalDate.now();
-    protected LocalTime time = LocalTime.MIDNIGHT;
+    protected LocalTime time = PresetValues.getTime();
     protected long shares;
     protected BigDecimal quote = BigDecimal.ONE;
     protected long grossValue;
@@ -89,6 +89,7 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
         setForexFees(0);
         setForexTaxes(0);
         setNote(null);
+        setTime(PresetValues.getTime());
     }
 
     protected void fillFromTransaction(PortfolioTransaction transaction)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransactionModel.java
@@ -46,7 +46,7 @@ public class AccountTransactionModel extends AbstractModel
     private Security security;
     private Account account;
     private LocalDate date = LocalDate.now();
-    private LocalTime time = LocalTime.MIDNIGHT;
+    private LocalTime time = PresetValues.getTime();
     private long shares;
 
     private long fxGrossAmount;
@@ -182,6 +182,7 @@ public class AccountTransactionModel extends AbstractModel
         setTaxes(0);
         setFxTaxes(0);
         setNote(null);
+        setTime(PresetValues.getTime());
     }
 
     public boolean supportsShares()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AccountTransferModel.java
@@ -39,7 +39,7 @@ public class AccountTransferModel extends AbstractModel
     private Account sourceAccount;
     private Account targetAccount;
     private LocalDate date = LocalDate.now();
-    private LocalTime time = LocalTime.MIDNIGHT;
+    private LocalTime time = PresetValues.getTime();
 
     private long fxAmount;
     private BigDecimal exchangeRate = BigDecimal.ONE;
@@ -132,6 +132,7 @@ public class AccountTransferModel extends AbstractModel
         setFxAmount(0);
         setAmount(0);
         setNote(null);
+        setTime(PresetValues.getTime());
     }
 
     public void setSource(AccountTransferEntry entry)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValues.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValues.java
@@ -1,0 +1,28 @@
+package name.abuchen.portfolio.ui.dialogs.transactions;
+
+import java.time.LocalTime;
+
+public class PresetValues
+{
+    public enum TimePreset
+    {
+        MIDNIGHT, NOW
+    }
+
+    private static TimePreset timePreset = TimePreset.MIDNIGHT;
+
+    public static void setTimePreset(String timePresetValue)
+    {
+        PresetValues.timePreset = TimePreset.valueOf(timePresetValue);
+    }
+
+    /**
+     * Preset time value initially shown in dialogs for new transactions.
+     */
+    public static LocalTime getTime()
+    {
+        if (timePreset == TimePreset.NOW)
+            return LocalTime.now();
+        return LocalTime.MIDNIGHT;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransferModel.java
@@ -39,7 +39,7 @@ public class SecurityTransferModel extends AbstractModel
     private Portfolio sourcePortfolio;
     private Portfolio targetPortfolio;
     private LocalDate date = LocalDate.now();
-    private LocalTime time = LocalTime.MIDNIGHT;
+    private LocalTime time = PresetValues.getTime();
 
     private long shares;
     private BigDecimal quote = BigDecimal.ONE;
@@ -108,6 +108,7 @@ public class SecurityTransferModel extends AbstractModel
         setShares(0);
         setAmount(0);
         setNote(null);
+        setTime(PresetValues.getTime());
     }
 
     private IStatus calculateStatus()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/OpenPreferenceDialogHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/OpenPreferenceDialogHandler.java
@@ -20,6 +20,7 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.preferences.AlphaVantagePreferencePage;
 import name.abuchen.portfolio.ui.preferences.CalendarPreferencePage;
+import name.abuchen.portfolio.ui.preferences.PresetsPreferencePage;
 import name.abuchen.portfolio.ui.preferences.DivvyDiaryPreferencePage;
 import name.abuchen.portfolio.ui.preferences.EODHistoricalDataPreferencePage;
 import name.abuchen.portfolio.ui.preferences.FinnhubPreferencePage;
@@ -57,10 +58,13 @@ public class OpenPreferenceDialogHandler
     {
         PreferenceManager pm = new PreferenceManager('/');
         pm.addToRoot(new PreferenceNode("general", new GeneralPreferencePage())); //$NON-NLS-1$
+        pm.addTo("general", new PreferenceNode("presets", new PresetsPreferencePage())); //$NON-NLS-1$ //$NON-NLS-2$
+        
         pm.addToRoot(new PreferenceNode("presentation", new PresentationPreferencePage())); //$NON-NLS-1$
         pm.addTo("presentation", new PreferenceNode("language", new LanguagePreferencePage())); //$NON-NLS-1$ //$NON-NLS-2$
         pm.addTo("presentation", new PreferenceNode("theme", new ThemePreferencePage(themeEngine))); //$NON-NLS-1$ //$NON-NLS-2$
         pm.addTo("presentation", new PreferenceNode("formatting", new FormattingPreferencePage())); //$NON-NLS-1$ //$NON-NLS-2$
+        
         pm.addToRoot(new PreferenceNode("calendar", new CalendarPreferencePage())); //$NON-NLS-1$
 
         pm.addToRoot(new PreferenceNode("api", new APIKeyPreferencePage())); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2082,6 +2082,16 @@ PrefUpdateQuotesAfterFileOpen = Automatically update quotes after opening a file
 
 PrefUpdateSite = &Update URL:
 
+PresetsPrefPageDescription = Preset values for new data.
+
+PresetsPrefPageNow = Current time
+
+PresetsPrefPageStartOfDay = Start of day
+
+PresetsPrefPageTime = Time
+
+PresetsPrefPageTitle = Presets
+
 RebalanceAmbiguousTooltip = The rebalancing result is ambiguous.\n\nYou can refine the taxonomy or exclude some securities from the rebalancing to resolve the ambiguity.
 
 RebalanceInexactTooltip = The rebalancing result is not exact, because there is no exact solution.\n\nThis solution minimizes the mean square error while respecting that the results have to add up to 0.\n\nYou can coarsen the taxonomy or include more securities in the rebalancing to get an exact solution.

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2067,6 +2067,16 @@ PrefUpdateQuotesAfterFileOpen = Wertpapierkurse nach dem \u00D6ffnen der Datei a
 
 PrefUpdateSite = &Update URL:
 
+PresetsPrefPageDescription = Vorgabewerte f\u00FCr neue Eingaben.
+
+PresetsPrefPageNow = Aktuelle Uhrzeit
+
+PresetsPrefPageStartOfDay = Tagesbeginn
+
+PresetsPrefPageTime = Uhrzeit
+
+PresetsPrefPageTitle = Voreinstellungen
+
 RebalanceAmbiguousTooltip = Dieses Rebalancing Ergebnis ist mehrdeutig.\n\nDurch Verfeinern der Taxonomie oder durch Ausschlie\u00DFen von Wertpapieren vom Rebalancing kann die Mehrdeutigkeit behoben werden.
 
 RebalanceInexactTooltip = Dieses Rebalancing Ergebnis ist nicht exakt, weil es keine exakte L\u00F6sung gibt.\n\nDiese L\u00F6sung minimiert den mittleren quadratischen Fehler unter der Nebenbedingung, dass die Rebalancing Werte sich zu 0 addieren m\u00FCssen.\n\nDurch vergr\u00F6bern der Taxonomie oder durch Einschlie\u00DFen von weiteren Wertpapieren beim Rebalancing kann eine genaue L\u00F6sung erm\u00F6glicht werden.

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
@@ -6,6 +6,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.dialogs.transactions.PresetValues;
 
 public class PreferencesInitializer extends AbstractPreferenceInitializer
 {
@@ -30,5 +31,6 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer
         store.setDefault(UIConstants.Preferences.ALPHAVANTAGE_CALL_FREQUENCY_LIMIT, 5);
         store.setDefault(UIConstants.Preferences.CALENDAR, "default"); //$NON-NLS-1$
         store.setDefault(UIConstants.Preferences.PORTFOLIO_REPORT_API_URL, "https://api.portfolio-report.net"); //$NON-NLS-1$
+        store.setDefault(UIConstants.Preferences.PRESET_VALUE_TIME, PresetValues.TimePreset.MIDNIGHT.name());
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PresetsPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PresetsPreferencePage.java
@@ -1,0 +1,31 @@
+package name.abuchen.portfolio.ui.preferences;
+
+import org.eclipse.jface.preference.ComboFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.dialogs.transactions.PresetValues;
+
+public class PresetsPreferencePage extends FieldEditorPreferencePage
+{
+    public PresetsPreferencePage()
+    {
+        super(GRID);
+
+        setTitle(Messages.PresetsPrefPageTitle);
+        setDescription(Messages.PresetsPrefPageDescription);
+    }
+
+    @Override
+    protected void createFieldEditors()
+    {
+        String[][] entryNamesAndValues = new String[2][2];
+        entryNamesAndValues[0] = new String[] { Messages.PresetsPrefPageStartOfDay,
+                        PresetValues.TimePreset.MIDNIGHT.name() };
+        entryNamesAndValues[1] = new String[] { Messages.PresetsPrefPageNow, PresetValues.TimePreset.NOW.name() };
+
+        addField(new ComboFieldEditor(UIConstants.Preferences.PRESET_VALUE_TIME, Messages.PresetsPrefPageTime,
+                        entryNamesAndValues, getFieldEditorParent()));
+    }
+}


### PR DESCRIPTION
The time value for new transactions can be preset with either 0:00h (the old standard) or the current time. The behavior can be configured in the preference.

Fixes #1874 