### PR TITLE
Refactored new processWithHoldingTaxEntries methods into AbstractPDFExtractor

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -2018,9 +2018,9 @@ public class DABPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.59))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.85))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.84))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.73 + (2 / 127.99) + 0.48 + 0.03))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(((95 / 127.99) + 0.48 + 0.03)))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -1142,9 +1142,9 @@ public class DkbPDFExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(53)));
 
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.79))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.79))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.53))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.85 / 1.1426))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
@@ -1180,9 +1180,9 @@ public class DkbPDFExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(10.6841)));
 
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.09))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.09))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.48))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.46 / 1.1780))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/onvista/OnvistaPDFExtractorTest.java
@@ -1610,9 +1610,9 @@ public class OnvistaPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.02))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.14))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.64))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((4.64 + 3.71) / 7.483))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.64 / 7.483))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
@@ -1850,9 +1850,9 @@ public class OnvistaPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.91))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.80))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.73))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(((414 + 9) / 121.06) + 2.28 + 0.12))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(((414 / 121.06) + 2.28 + 0.12)))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -288,10 +288,8 @@ public abstract class AbstractPDFExtractor implements Extractor
     protected void processWithHoldingTaxEntries(Object t, Map<String, String> v, String taxType, DocumentType type)
     {
         /***
-         * If there is "withholding tax", do not take into account the other
-         * types of withholding tax. The calculation of the total withholding
-         * tax based on the "creditable withholding tax" and the "repatriable
-         * withholding tax" may otherwise lead to rounding errors.
+         * If it is a "withholding tax", the other types of "creditable
+         * withholding tax" are not to be considered.
          */
         if (checkWithHoldingTax(taxType, type))
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -29,7 +29,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public abstract class AbstractPDFExtractor implements Extractor
 {
-    protected static final String FLAG_WITHHOLDING_TAX_FOUND = "isHoldingTax"; //$NON-NLS-1$
+    protected static final String FLAG_WITHHOLDING_TAX_FOUND = Boolean.FALSE.toString();
 
     private final NumberFormat numberFormat = NumberFormat.getInstance(Locale.GERMANY);
 
@@ -285,7 +285,7 @@ public abstract class AbstractPDFExtractor implements Extractor
         }
     }
 
-    protected void processWithHoldingTaxEntries(Object t, Map<String, String> v, String taxtype, DocumentType type)
+    protected void processWithHoldingTaxEntries(Object t, Map<String, String> v, String taxType, DocumentType type)
     {
         /***
          * If there is "withholding tax", do not take into account the other
@@ -293,28 +293,28 @@ public abstract class AbstractPDFExtractor implements Extractor
          * tax based on the "creditable withholding tax" and the "repatriable
          * withholding tax" may otherwise lead to rounding errors.
          */
-        if (checkWithHoldingTax(type, taxtype))
+        if (checkWithHoldingTax(taxType, type))
         {
             if (t instanceof name.abuchen.portfolio.model.Transaction)
             {
-                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get(taxtype))); //$NON-NLS-1$
+                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get(taxType))); //$NON-NLS-1$
                 PDFExtractorUtils.checkAndSetTax(tax, (name.abuchen.portfolio.model.Transaction) t, type);
             }
             else
             {
-                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get(taxtype))); //$NON-NLS-1$
+                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get(taxType))); //$NON-NLS-1$
                 PDFExtractorUtils.checkAndSetTax(tax,
                                 ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction(), type);
             }
         }
     }
 
-    protected boolean checkWithHoldingTax(DocumentType type, String taxtype)
+    protected boolean checkWithHoldingTax(String taxType, DocumentType type)
     {
         if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
         {
-            if ("creditableWithHoldingTax".equalsIgnoreCase(taxtype) //$NON-NLS-1$
-                            || ("repatriableWithHoldingTax".equalsIgnoreCase(taxtype))) //$NON-NLS-1$
+            if ("creditableWithHoldingTax".equalsIgnoreCase(taxType) //$NON-NLS-1$
+                            || ("repatriableWithHoldingTax".equalsIgnoreCase(taxType))) //$NON-NLS-1$
                 return false;
         }
         return true;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -313,8 +313,7 @@ public abstract class AbstractPDFExtractor implements Extractor
     {
         if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
         {
-            if ("creditableWithHoldingTax".equalsIgnoreCase(taxType) //$NON-NLS-1$
-                            || ("repatriableWithHoldingTax".equalsIgnoreCase(taxType))) //$NON-NLS-1$
+            if ("creditableWithHoldingTax".equalsIgnoreCase(taxType)) //$NON-NLS-1$
                 return false;
         }
         return true;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -676,9 +676,12 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Quellensteuer EUR 30,21 -
                 // US-Quellensteuer EUR 0,17 -
-                .section("tax", "currency").optional()
-                .match("^(US-)?Quellensteuer (?<currency>[\\w]{3}) (?<tax>[\\.\\d]+,[\\d]{2}) \\-$")
-                .assign((t, v) -> processTaxEntries(t, v, type));
+                .section("withHoldingTax", "currency").optional()
+                .match("^(US-)?Quellensteuer (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.\\d]+,[\\d]{2}) \\-$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -235,9 +235,12 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // 20% Quellensteuer EUR -884.00
-                .section("currency", "tax").optional()
-                .match("^[\\d]+% Quellensteuer (?<currency>[\\w]{3}) -(?<tax>[.,'\\d]+)$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("currency", "withHoldingTax").optional()
+                .match("^[\\d]+% Quellensteuer (?<currency>[\\w]{3}) -(?<withHoldingTax>[.,'\\d]+)$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // 10% Nicht r�ckforderbare Steuern EUR -442.00
                 .section("currency", "tax").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -379,11 +379,11 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
     {
         transaction
                         // 2 2 , 0 0 0 % Q u e l l e n s t e u e r USD 1 9 , 0 6 -
-                        .section("tax", "currency").optional()
-                        .match(".* [\\d\\s,.]* % Q u e l l e n s t e u e r (?<currency>\\w{3}) (?<tax>[\\d\\s,.-]*)$")
+                        .section("withHoldingTax", "currency").optional()
+                        .match(".* [\\d\\s,.]* % Q u e l l e n s t e u e r (?<currency>\\w{3}) (?<withHoldingTax>[\\d\\s,.-]*)$")
                         .assign((t, v) -> {
-                            v.put("tax", stripBlanks(v.get("tax")));
-                            processTaxEntries(t, v, type);
+                            v.put("withHoldingTax", stripBlanks(v.get("withHoldingTax")));
+                            processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                         });
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -669,14 +669,20 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // QUST 15,00000  %   EUR                 24,45  USD                 27,00
-                .section("tax", "currency").optional()
-                .match("^QUST [\\.,\\d]+ ([\\s]+)?% ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+) .*$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^QUST [\\.,\\d]+ ([\\s]+)?% ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) .*$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Quellensteuer in EUR 1,88 EUR
-                .section("tax", "currency").optional()
-                .match("^Quellensteuer in [\\w]{3} (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^Quellensteuer in [\\w]{3} (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Kapitalertragsteuer (Account)
                 // KAPST                                 25,00 % EUR                111,00 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -264,9 +264,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer USD - 167.00
-                .section("tax", "currency").optional()
-                .match("^Quellensteuer (?<currency>[\\w]{3}) - (?<tax>[.,\\d]+)$")
-                .assign((t, v) -> processTaxEntries(t, v, type));
+                .section("withHoldingTax", "currency").optional()
+                .match("^Quellensteuer (?<currency>[\\w]{3}) - (?<withHoldingTax>[.,\\d]+)$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -826,32 +826,32 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // davon anrechenbare Quellensteuer 15% ZAR 1.560,00
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 1,62
                 // davon anrechenbare US-Quellensteuer  15% USD             2,430     
-                .section("tax", "currency").optional()
-                .match("^(.*)?davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[\\.,\\d]+)(\\-|[\\s]+)?$")
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^(.*)?davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        processTaxEntries(t, v, type);
+                        processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                     }
                 })
 
                 // erstattungsfähige Quellensteuer 0,315% JPY 2
-                .section("tax", "currency").optional()
-                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
+                .section("repatriableWithHoldingTax", "currency").optional()
+                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<repatriableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        processTaxEntries(t, v, type);
+                        processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type);
                     }
                 })
 
                 // anrechenbare Quellensteuer 15% EUR 0,73
-                .section("tax", "currency").optional()
-                .match("^anrechenbare Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<tax>[\\.,\\d]+)(\\-)?$")
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^anrechenbare Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        processTaxEntries(t, v, type);
+                        processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                     }
                 })
 
@@ -918,10 +918,11 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     }
                 })
 
-                .section("tax", "currency").optional()
-                .match("^abzgl\\. Quellensteuer .* [\\w]{3} (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^abzgl\\. Quellensteuer .* [\\w]{3} (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // abzgl. Kapitalertragsteuer 25,00 % von 90,02 EUR 22,51 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -822,32 +822,31 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 });
 
         transaction
+                // ausländische Quellensteuer 15,315% JPY 95
+                .section("withHoldingTax", "currency").optional()
+                .match("^ausländische Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<withHoldingTax>[\\.,\\d]+)(\\-)?$")
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                        processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                    }
+                })
+
+                // abzgl. Quellensteuer 15,00 % von 281,25 USD 42,19 USD
+                .section("withHoldingTax", "currency").optional()
+                .match("^abzgl\\. Quellensteuer .* [\\w]{3} (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
+
                 // davon anrechenbare US-Quellensteuer 15% EUR 0,79
                 // davon anrechenbare Quellensteuer 15% ZAR 1.560,00
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 1,62
                 // davon anrechenbare US-Quellensteuer  15% USD             2,430     
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("^(.*)?davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
-                .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
-                        processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
-                    }
-                })
-
-                // erstattungsfähige Quellensteuer 0,315% JPY 2
-                .section("repatriableWithHoldingTax", "currency").optional()
-                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<repatriableWithHoldingTax>[\\.,\\d]+)$")
-                .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
-                        processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type);
-                    }
-                })
-
-                // anrechenbare Quellensteuer 15% EUR 0,73
-                .section("creditableWithHoldingTax", "currency").optional()
-                .match("^anrechenbare Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -916,13 +915,6 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     {
                         processTaxEntries(t, v, type);
                     }
-                })
-
-                .section("withHoldingTax", "currency").optional()
-                .match("^abzgl\\. Quellensteuer .* [\\w]{3} (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> {
-                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
-                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // abzgl. Kapitalertragsteuer 25,00 % von 90,02 EUR 22,51 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -744,17 +744,19 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
     {
         transaction
                 // QUELLENSTEUER: -1,86 USD
-                .section("tax", "currency").optional()
-                .match("^QUELLENSTEUER: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^QUELLENSTEUER: \\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // QUELLENSTEUER           -15,60 USD  Auslands-KESt           -13,00 USD
-                .section("tax", "currency").optional()
-                .match("^QUELLENSTEUER [\\s]+\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}) .*$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^QUELLENSTEUER [\\s]+\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}) .*$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Auslands-KESt: -1,54 USD

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -762,11 +762,6 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Anrechenbare Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
 
-                // 4 % rückforderbare Quellensteuer 3,40 PLN
-                .section("repatriableWithHoldingTax", "currency").optional()
-                .match("^.* r.ckforderbare Quellensteuer (?<repatriableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type))
-
                 // abgeführte Kapitalertragsteuer 0,00
                 .section("tax").optional()
                 .match("^abgef.hrte Kapitalertragsteuer (?<tax>[\\.,\\d]+)$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -392,9 +392,9 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Anrechenbare ausländische Quellensteuer 13,07 EUR
-                .section("tax", "currency").optional()
-                .match("^Anrechenbare ausl.ndische Quellensteuer (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processTaxEntries(t, v, type));
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare ausl.ndische Quellensteuer (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -17,9 +16,6 @@ import name.abuchen.portfolio.money.Money;
 @SuppressWarnings("nls")
 public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String FLAG_WITHHOLDING_TAX_FOUND = "exchangeRate"; //$NON-NLS-1$
-    private static final String EXCHANGE_RATE = "exchangeRate"; //$NON-NLS-1$
-
     public Direkt1822BankPDFExtractor(Client client)
     {
         super(client);
@@ -215,17 +211,17 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
                 // Einbehaltene Quellensteuer 15 % auf 5,22 USD 0,66-
                 // EUR
-                .section("quellensteinbeh", "currency").optional()
-                .match("^Einbehaltende Quellensteuer [\\.,\\d]+ .* (?<quellensteinbeh>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^Einbehaltende Quellensteuer [\\.,\\d]+ .* (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
-                    addTax(t, v, type, "quellensteinbeh");
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Anrechenbare Quellensteuer 15 % auf 4,38 EUR 0,66 EUR
-                .section("quellenstanr", "currency").optional()
-                .match("^Anrechenbare Quellensteuer [\\.,\\d]+ .* (?<quellenstanr>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(t, v, type, "quellenstanr"));
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare Quellensteuer [\\.,\\d]+ .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -274,47 +270,5 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
                     processFeeEntries(t, v, type);
                 });
-    }
-
-    private void addTax(Object t, Map<String, String> v, DocumentType type, String taxtype)
-    {
-        // Wenn es 'Einbehaltene Quellensteuer' gibt, dann die weiteren
-        // Quellensteuer-Arten nicht berücksichtigen.
-        if (checkWithholdingTax(type, taxtype))
-        {
-            name.abuchen.portfolio.model.Transaction tx = getTransaction(t);
-
-            String currency = asCurrencyCode(v.get("currency"));
-            long amount = asAmount(v.get(taxtype));
-
-            if (!currency.equals(tx.getCurrencyCode()) && type.getCurrentContext().containsKey(EXCHANGE_RATE))
-            {
-                BigDecimal rate = BigDecimal.ONE.divide(asExchangeRate(type.getCurrentContext().get(EXCHANGE_RATE)), 10,
-                                RoundingMode.HALF_DOWN);
-
-                currency = tx.getCurrencyCode();
-                amount = rate.multiply(BigDecimal.valueOf(amount)).setScale(0, RoundingMode.HALF_DOWN).longValue();
-            }
-
-            tx.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, amount)));
-        }
-    }
-
-    private boolean checkWithholdingTax(DocumentType type, String taxtype)
-    {
-        if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
-        {
-            if ("quellenstanr".equalsIgnoreCase(taxtype))
-                return false;
-        }
-        return true;
-    }
-
-    private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-            return ((name.abuchen.portfolio.model.Transaction) t);
-        return ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction();
-
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -1148,12 +1148,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 // Anrechenbare Quellensteuer 15 % auf 42,65 EUR 6,40 EUR
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("^Anrechenbare Quellensteuer .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
-
-                // 20 % rückforderbare Quellensteuer 10,20 CHF
-                .section("repatriableWithHoldingTax", "currency").optional()
-                .match("^.* r.ckforderbare Quellensteuer (?<repatriableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type));
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -22,8 +22,6 @@ import name.abuchen.portfolio.util.TextUtil;
 public class DkbPDFExtractor extends AbstractPDFExtractor
 {
     private static final String IS_JOINT_ACCOUNT = "isJointAccount"; //$NON-NLS-1$
-    private static final String EXCHANGE_RATE = "exchangeRate"; //$NON-NLS-1$
-    private static final String FLAG_WITHHOLDING_TAX_FOUND  = "isHoldingTax"; //$NON-NLS-1$
 
     BiConsumer<Map<String, String>, String[]> isJointAccount = (context, lines) -> {
         Pattern pJointAccount = Pattern.compile("^Anteilige Berechnungsgrundlage für \\(50,00([\\s]+)?%\\).*$"); //$NON-NLS-1$
@@ -1134,28 +1132,28 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     }
                 })
 
+                // Finanztransaktionssteuer 5,71- EUR
+                .section("tax", "currency").optional()
+                .match("^Finanztransaktionssteuer (?<tax>[\\.,\\d]+)- (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processTaxEntries(t, v, type))
+
                 // Einbehaltene Quellensteuer 35 % auf 51,00 CHF 14,93- EUR
-                .section("quellensteinbeh", "currency").optional()
-                .match("^Einbehaltene Quellensteuer .* (?<quellensteinbeh>[\\.,\\d]+)- (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^Einbehaltene Quellensteuer .* (?<withHoldingTax>[\\.,\\d]+)- (?<currency>[\\w]{3})$")
                 .assign((t, v) ->  {
                     type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
-                    addTax(t, v, type, "quellensteinbeh");
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Anrechenbare Quellensteuer 15 % auf 42,65 EUR 6,40 EUR
-                .section("quellenstanr", "currency").optional()
-                .match("^Anrechenbare Quellensteuer .* (?<quellenstanr>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(t, v, type, "quellenstanr"))
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare Quellensteuer .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
 
                 // 20 % rückforderbare Quellensteuer 10,20 CHF
-                .section("quellenstrueck", "currency").optional()
-                .match("^.* r.ckforderbare Quellensteuer (?<quellenstrueck>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(t, v, type, "quellenstrueck"))
-
-                // Finanztransaktionssteuer 5,71- EUR
-                .section("quellenstrueck", "currency").optional()
-                .match("^Finanztransaktionssteuer (?<quellenstrueck>[\\.,\\d]+)- (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(t, v, type, "quellenstrueck"));
+                .section("repatriableWithHoldingTax", "currency").optional()
+                .match("^.* r.ckforderbare Quellensteuer (?<repatriableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -1190,56 +1188,5 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^Maklercourtage .* (?<fee>[\\.,\\d]+)- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
-    }
-
-    private void addTax(Object t, Map<String, String> v, DocumentType type, String taxtype)
-    {
-        // Wenn es 'Einbehaltene Quellensteuer' gibt, dann die weiteren
-        // Quellensteuer-Arten nicht berücksichtigen.
-        // Die Berechnung der Gesamt-Quellensteuer anhand der anrechenbaren- und
-        // der rückforderbaren Steuer kann ansonsten zu Rundungsfehlern führen.
-        if (checkWithholdingTax(type, taxtype))
-        {
-            name.abuchen.portfolio.model.Transaction tx = getTransaction(t);
-
-            String currency = asCurrencyCode(v.get("currency"));
-            long amount = asAmount(v.get(taxtype));
-
-            if (!currency.equals(tx.getCurrencyCode()) && type.getCurrentContext().containsKey(EXCHANGE_RATE))
-            {
-                BigDecimal rate = BigDecimal.ONE.divide(
-                                asExchangeRate(type.getCurrentContext().get(EXCHANGE_RATE)), 10,
-                                RoundingMode.HALF_DOWN);
-
-                currency = tx.getCurrencyCode();
-                amount = rate.multiply(BigDecimal.valueOf(amount)).setScale(0, RoundingMode.HALF_DOWN).longValue();
-            }
-
-            tx.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, amount)));
-        }
-    }
-
-    private boolean checkWithholdingTax(DocumentType type, String taxtype)
-    {
-        if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
-        {
-            if ("quellenstanr".equalsIgnoreCase(taxtype) || ("quellenstrueck".equalsIgnoreCase(taxtype)))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            return ((name.abuchen.portfolio.model.Transaction) t);
-        }
-        else
-        {
-            return ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction();
-        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
@@ -247,11 +247,13 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
                 .match(".*KESt-Neu.*(?<currency>[\\w]{3}).*-(?<tax>[\\d.]+,\\d+).*")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
-                // Ertrag 0,68 USD Kurswert USD 2,04Quellensteuer USD
-                // -0,31
-                .section("tax", "currency").optional()
-                .match(".*Quellensteuer.*(?<currency>[\\w]{3}).*-(?<tax>[\\d.]+,\\d+).*")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                // Ertrag 0,68 USD Kurswert USD 2,04Quellensteuer USD -0,31
+                .section("withHoldingTax", "currency").optional()
+                .match(".*Quellensteuer.*(?<currency>[\\w]{3}).*-(?<withHoldingTax>[\\d.]+,\\d+).*")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Kursgewinn-KESt EUR -3,37
                 .section("tax", "currency").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -420,10 +420,13 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Steuer : Quellensteuer
                 // Steuern : USD 0.18
-                .section("currency", "tax").optional()
+                .section("currency", "withHoldingTax").optional()
                 .match("^Steuer : Quellensteuer")
-                .match("^Steuern : (?<currency>[\\w]{3}) (?<tax>['\\.,\\d]+)")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .match("^Steuern : (?<currency>[\\w]{3}) (?<withHoldingTax>['\\.,\\d]+)")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Steuer : KESt1
                 // Steuern : USD 0.18

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -1522,19 +1522,28 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Quellenst.-satz :           15,00 %    Gez. Quellenst. :            1,15 USD
-                .section("tax", "currency").optional()
-                .match("^.* Gez\\. Quellenst\\.([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^.* Gez\\. Quellenst\\.([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Quellenst.-satz :            15,00 %  Gez. Quellensteuer :           18,28 USD
-                .section("tax", "currency").optional()
-                .match("^.* Gez\\. Quellensteuer([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^.* Gez\\. Quellensteuer([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:            382,12 EUR
-                .section("tax", "currency").optional()
-                .match("^.* Einbeh\\. Steuer\\*([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processTaxEntries(t, v, type));
+                .section("withHoldingTax", "currency").optional()
+                .match("^.* Einbeh\\. Steuer\\*([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -305,14 +305,20 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer US-Emittent: -3,05 USD 
-                .section("tax", "currency").optional()
-                .match("^Quellensteuer US\\-Emittent: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Quellensteuer: -8,81 EUR 
-                .section("tax", "currency").optional()
-                .match("^Quellensteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Umsatzsteuer: -0,19 EUR 
                 .section("tax", "currency").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -121,7 +121,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 // Orderausführung Datum/Zeit: 31 Jul 2020 21:00:15
                 .section("date", "time").optional()
                 .match("Orderausführung Datum\\/Zeit: (?<date>\\d+ .* \\d{4}) (?<time>\\d+:\\d+:\\d+).*")
-                .assign((t, v) -> t.setDate(asDate(v.get("date").replace("Mrz", "Mär"), v.get("time"))))
+                .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                 // Schlusstag/-Zeit 02.01.2020 10:49:34 Auftragserteilung/ -ort sonstige
                 .section("date", "time").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -148,9 +148,12 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer 28 % EUR -77.14
-                .section("tax", "currency").optional()
-                .match("^(Quellensteuer) .* (?<currency>[\\w]{3}) (?<tax>-['.,\\d]+)$")
-                .assign((t, v) -> processTaxEntries(t, v, type));
+                .section("withHoldingTax", "currency").optional()
+                .match("^(Quellensteuer) .* (?<currency>[\\w]{3}) (?<withHoldingTax>-['.,\\d]+)$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
@@ -18,9 +18,6 @@ import name.abuchen.portfolio.util.TextUtil;
 @SuppressWarnings("nls")
 public class NIBCBankPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String EXCHANGE_RATE = "exchangeRate"; //$NON-NLS-1$
-    private static final String FLAG_WITHHOLDING_TAX_FOUND = "exchangeRate"; //$NON-NLS-1$
-
     public NIBCBankPDFExtractor(Client client)
     {
         super(client);
@@ -277,22 +274,22 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Einbehaltene Quellensteuer 19 % auf 85,00 PLN 3,59- EUR
-                .section("quellensteinbeh", "currency").optional()
-                .match("^Einbehaltene Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<quellensteinbeh>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^Einbehaltene Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
-                    addTax(type, t, v, "quellensteinbeh");
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Anrechenbare Quellensteuer 15 % auf 18,87 EUR 2,83 EUR
-                .section("quellenstanr", "currency").optional()
-                .match("^Anrechenbare Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<quellenstanr>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(type, t, v, "quellenstanr"))
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
 
                 // 4 % rückforderbare Quellensteuer 3,40 PLN
-                .section("quellenstrueck", "currency").optional()
-                .match("^.* r.ckforderbare Quellensteuer (?<quellenstrueck>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(type, t, v, "quellenstrueck"))
+                .section("repatriableWithHoldingTax", "currency").optional()
+                .match("^.* r.ckforderbare Quellensteuer (?<repatriableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type))
 
                 // abgeführte Kapitalertragsteuer 0,00
                 .section("tax").optional()
@@ -337,55 +334,5 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.bertragungs-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
-    }
-
-    private void addTax(DocumentType type, Object t, Map<String, String> v, String taxtype)
-    {
-        // Wenn es 'Einbehaltene Quellensteuer' gibt, dann die weiteren
-        // Quellensteuer-Arten nicht berücksichtigen.
-        // Die Berechnung der Gesamt-Quellensteuer anhand der anrechenbaren- und
-        // der rückforderbaren Steuer kann ansonsten zu Rundungsfehlern führen.
-        if (checkWithholdingTax(type, taxtype))
-        {
-            name.abuchen.portfolio.model.Transaction tx = getTransaction(t);
-
-            String currency = asCurrencyCode(v.get("currency"));
-            long amount = asAmount(v.get(taxtype));
-
-            if (!currency.equals(tx.getCurrencyCode()) && type.getCurrentContext().containsKey(EXCHANGE_RATE))
-            {
-                BigDecimal rate = BigDecimal.ONE.divide(asExchangeRate(type.getCurrentContext().get(EXCHANGE_RATE)), 10,
-                                RoundingMode.HALF_DOWN);
-
-                currency = tx.getCurrencyCode();
-                amount = rate.multiply(BigDecimal.valueOf(amount)).setScale(0, RoundingMode.HALF_DOWN).longValue();
-            }
-
-            tx.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, amount)));
-        }
-    }
-
-    private boolean checkWithholdingTax(DocumentType documentType, String taxtype)
-    {
-        if (Boolean.valueOf(documentType.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
-        {
-            if ("quellenstanr".equalsIgnoreCase(taxtype) || ("quellenstrueck".equalsIgnoreCase(taxtype)))
-            { 
-                return false; 
-            }
-        }
-        return true;
-    }
-
-    private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-        {
-            return ((name.abuchen.portfolio.model.Transaction) t);
-        }
-        else
-        {
-            return ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction();
-        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
@@ -286,11 +286,6 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 .match("^Anrechenbare Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
 
-                // 4 % rückforderbare Quellensteuer 3,40 PLN
-                .section("repatriableWithHoldingTax", "currency").optional()
-                .match("^.* r.ckforderbare Quellensteuer (?<repatriableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type))
-
                 // abgeführte Kapitalertragsteuer 0,00
                 .section("tax").optional()
                 .match("^abgef.hrte Kapitalertragsteuer (?<tax>[\\.,\\d]+)$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -1352,16 +1352,6 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     }
                 })
 
-                // erstattungsfähige Quellensteuer 12% DKK 3,71
-                .section("repatriableWithHoldingTax", "currency").optional()
-                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<repatriableWithHoldingTax>[\\.,\\d]+)$")
-                .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
-                        processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type);
-                    }
-                })
-
                 // einbehaltene Kapitalertragsteuer EUR 1,81
                 // einbehaltene Kapitalertragsteuer EUR              0,39     
                 .section("tax", "currency").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -1343,22 +1343,22 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // davon anrechenbare US-Quellensteuer EUR 4,74
                 // davon anrechenbare US-Quellensteuer 15% EUR 2,72
                 //    davon anrechenbare Quellensteuer Fondseingangsseite EUR 0,03
-                .section("tax", "currency").optional()
-                .match("(^|^.* davon |^davon )anrechenbare (US-)?Quellensteuer( [\\.,\\d]+%|.*)? (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("(^|^.* davon |^davon )anrechenbare (US-)?Quellensteuer( [\\.,\\d]+%|.*)? (?<currency>[\\w]{3}) (?<creditableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        processTaxEntries(t, v, type);
+                        processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                     }
                 })
 
                 // erstattungsfähige Quellensteuer 12% DKK 3,71
-                .section("tax", "currency").optional()
-                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
+                .section("repatriableWithHoldingTax", "currency").optional()
+                .match("^erstattungsf.hige Quellensteuer .* (?<currency>[\\w]{3}) (?<repatriableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        processTaxEntries(t, v, type);
+                        processWithHoldingTaxEntries(t, v, "repatriableWithHoldingTax", type);
                     }
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -31,12 +31,12 @@ class PDFExtractorUtils
                     DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.UK), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("MM/dd/yyyy", Locale.UK), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("LL/dd/yyyy", Locale.UK), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.US), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("d MMM yyyy", Locale.ENGLISH), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("d MMM yyyy", Locale.US), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.GERMANY) }; //$NON-NLS-1$
 
-    private static final DateTimeFormatter[] DATE_TIME_FORMATTER = {
+    private static final DateTimeFormatter[] DATE_TIME_FORMATTER = { //
                     DateTimeFormatter.ofPattern("d.M.yyyy HH:mm", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
@@ -58,16 +58,14 @@ class PDFExtractorUtils
             Money txTax = Money.of(t.getCurrencyCode(), BigDecimal.valueOf(tax.getAmount()).multiply(inverseRate)
                             .setScale(0, RoundingMode.HALF_UP).longValue());
 
-            // store tax value in both currencies, if security's currency
-            // is different to transaction currency
+            /**
+             * Store tax value in both currencies, if security's currency is
+             * different to transaction currency
+             */
             if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-            {
                 t.addUnit(new Unit(Unit.Type.TAX, txTax));
-            }
             else
-            {
                 t.addUnit(new Unit(Unit.Type.TAX, txTax, tax, inverseRate));
-            }
         }
     }
 
@@ -86,16 +84,14 @@ class PDFExtractorUtils
             Money fxFee = Money.of(t.getCurrencyCode(), BigDecimal.valueOf(fee.getAmount()).multiply(inverseRate)
                             .setScale(0, RoundingMode.HALF_UP).longValue());
 
-            // store fee value in both currencies, if security's currency
-            // is different to transaction currency
+            /**
+             * Store tax value in both currencies, if security's currency is
+             * different to transaction currency
+             */
             if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-            {
                 t.addUnit(new Unit(Unit.Type.FEE, fxFee));
-            }
             else
-            {
                 t.addUnit(new Unit(Unit.Type.FEE, fxFee, fee, inverseRate));
-            }
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -158,6 +158,10 @@ class PDFExtractorUtils
 
     public static LocalDateTime asDate(String value)
     {
+        // https://bugs.openjdk.java.net/browse/JDK-8198491
+        // From Java 7 to Java 8 and to Java 9 the month names were adjusted.
+        value = value.replace("Mrz", "Mär"); //$NON-NLS-1$//$NON-NLS-2$
+
         for (DateTimeFormatter formatter : DATE_FORMATTER)
         {
             try
@@ -192,6 +196,10 @@ class PDFExtractorUtils
 
     public static LocalDateTime asDate(String date, String time)
     {
+        // https://bugs.openjdk.java.net/browse/JDK-8198491
+        // From Java 7 to Java 8 and to Java 9 the month names were adjusted.
+        date = date.replace("Mrz", "Mär"); //$NON-NLS-1$//$NON-NLS-2$
+
         String value = String.format("%s %s", date, time); //$NON-NLS-1$
 
         for (DateTimeFormatter formatter : DATE_TIME_FORMATTER)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -944,9 +944,12 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer 15.00% (NL) EUR 3.69
-                .section("tax", "currency").optional()
-                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+)(.*)?$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("withHoldingTax", "currency").optional()
+                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,'\\d\\s]+)(.*)?$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Verrechnungssteuer 35% (CH) CHF 19.75
                 .section("tax", "currency").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -18,9 +17,6 @@ import name.abuchen.portfolio.util.TextUtil;
 @SuppressWarnings("nls")
 public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String FLAG_WITHHOLDING_TAX_FOUND = "exchangeRate"; //$NON-NLS-1$
-    private static final String EXCHANGE_RATE = "exchangeRate"; //$NON-NLS-1$
-
     public SantanderConsumerBankAGPDFExtractor(Client client)
     {
         super(client);
@@ -194,17 +190,17 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
     {
         transaction
                 // Einbehaltene Quellensteuer 15 % auf 2,96 USD 0,37- EUR
-                .section("currency", "quellensteinbeh").optional()
-                .match("^Einbehaltene Quellensteuer [\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<quellensteinbeh>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
+                .section("withHoldingTax", "currency").optional()
+                .match("^Einbehaltene Quellensteuer [\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
                 .assign((t, v) -> {
                     type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
-                    addTax(t, v, type, "quellensteinbeh");
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Anrechenbare Quellensteuer 15 % auf 2,44 EUR 0,37 EUR
-                .section("currency", "quellenstanr").optional()
-                .match("^Anrechenbare Quellensteuer [\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<quellensteinbeh>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
-                .assign((t, v) -> addTax(t, v, type, "quellenstanr"));
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare Quellensteuer [\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<creditableWithHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -219,47 +215,5 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^Fremde Abwicklungsgeb.hr .* (?<fee>[.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
-    }
-
-    private void addTax(Object t, Map<String, String> v, DocumentType type, String taxtype)
-    {
-        // Wenn es 'Einbehaltene Quellensteuer' gibt, dann die weiteren
-        // Quellensteuer-Arten nicht berücksichtigen.
-        if (checkWithholdingTax(type, taxtype))
-        {
-            name.abuchen.portfolio.model.Transaction tx = getTransaction(t);
-
-            String currency = asCurrencyCode(v.get("currency"));
-            long amount = asAmount(v.get(taxtype));
-
-            if (!currency.equals(tx.getCurrencyCode()) && type.getCurrentContext().containsKey(EXCHANGE_RATE))
-            {
-                BigDecimal rate = BigDecimal.ONE.divide(asExchangeRate(type.getCurrentContext().get(EXCHANGE_RATE)), 10,
-                                RoundingMode.HALF_DOWN);
-
-                currency = tx.getCurrencyCode();
-                amount = rate.multiply(BigDecimal.valueOf(amount)).setScale(0, RoundingMode.HALF_DOWN).longValue();
-            }
-
-            tx.addUnit(new Unit(Unit.Type.TAX, Money.of(currency, amount)));
-        }
-    }
-
-    private boolean checkWithholdingTax(DocumentType type, String taxtype)
-    {
-        if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
-        {
-            if ("quellenstanr".equalsIgnoreCase(taxtype))
-                return false;
-        }
-        return true;
-    }
-
-    private name.abuchen.portfolio.model.Transaction getTransaction(Object t)
-    {
-        if (t instanceof name.abuchen.portfolio.model.Transaction)
-            return ((name.abuchen.portfolio.model.Transaction) t);
-        return ((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction();
-
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
@@ -267,9 +267,12 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer 15.00% (US) USD 4.20
-                .section("currency", "tax").optional()
-                .match("^Quellensteuer ['.,\\d]+% \\(.*\\) (?<currency>[\\w]{3}) (?<tax>['.,\\d]+)$")
-                .assign((t, v) -> processTaxEntries(t, v, type))
+                .section("currency", "withHoldingTax").optional()
+                .match("^Quellensteuer ['.,\\d]+% \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>['.,\\d]+)$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                })
 
                 // Zusätzlicher Steuerrückbehalt 15% USD 4.20
                 .section("currency", "tax").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -32,8 +32,8 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
     private static final String regexShares = "St.ck (?<shares>(\\d+.)?\\d+(,\\d+)?)"; //$NON-NLS-1$
     private static final String regexFees = "Provision (?<fee>(\\d+\\.)?\\d+(,\\d+)?) (?<currency>\\w{3}+)"; //$NON-NLS-1$
     private static final String regexTaxes = "Gesamtsumme Steuern (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$"; //$NON-NLS-1$
-    private static final String regexWithholdingTaxDivDoc = ".*Ausl.ndische Quellensteuer .* (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$"; //$NON-NLS-1$
-    private static final String regexWithholdingTaxTaxDoc = "Anrechenbare ausl.ndische Quellensteuer (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$"; //$NON-NLS-1$
+    private static final String regexwithHoldingTaxDivDoc = ".*Ausl.ndische Quellensteuer .* (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$"; //$NON-NLS-1$
+    private static final String regexwithHoldingTaxTaxDoc = "Anrechenbare ausl.ndische Quellensteuer (?<tax>[\\d.]+,\\d+) (?<currency>\\w{3}+)$"; //$NON-NLS-1$
 
     private static final String TO_BE_DELETED = "to_be_deleted"; //$NON-NLS-1$
     private static final String ATTRIBUTE_PAY_DATE = "pay_date"; //$NON-NLS-1$
@@ -248,7 +248,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                         })
                         
                         .section("tax", "currency").optional() //
-                        .match(regexWithholdingTaxDivDoc) //
+                        .match(regexwithHoldingTaxDivDoc) //
                         .assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
@@ -328,7 +328,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                         })
                         
                         .section("tax", "currency").optional() //
-                        .match(regexWithholdingTaxTaxDoc) //
+                        .match(regexwithHoldingTaxTaxDoc) //
                         .assign((t, v) -> {
                             Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1219,17 +1219,19 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     {
         transaction
                 // Quellensteuer DE für US-Emittent -7,56 USD
-                .section("tax", "currency").optional()
-                .match("^([\\d] )?Quellensteuer .* -(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^([\\d] )?Quellensteuer .* -(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Quellensteuer -12,00 USD
-                .section("tax", "currency").optional()
-                .match("^([\\d] )?Quellensteuer -(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .section("withHoldingTax", "currency").optional()
+                .match("^([\\d] )?Quellensteuer -(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
                 // Kapitalertragssteuer -30,63 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -211,7 +211,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .section("withHoldingTax", "currency").optional()
                 .match("^Einbehaltende Quellensteuer [\\.,\\d]+ % .* (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
+                    type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, Boolean.TRUE.toString());
                     processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -17,8 +16,6 @@ import name.abuchen.portfolio.money.Money;
 @SuppressWarnings("nls")
 public class WeberbankPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String FLAG_WITHHOLDING_TAX_FOUND = "exchangeRate"; //$NON-NLS-1$
-
     public WeberbankPDFExtractor(Client client)
     {
         super(client);
@@ -210,37 +207,17 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .match("^Solidaritätszuschlag [\\.,\\d]+ % .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
-                // Einbehaltene Quellensteuer 15 % auf 87,74 USD 11,11-
-                // EUR
-                .section("quellensteinbeh", "currency").optional()
-                .match("^Einbehaltende Quellensteuer [\\.,\\d]+ % .* (?<quellensteinbeh>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
+                // Einbehaltene Quellensteuer 15 % auf 87,74 USD 11,11- EUR
+                .section("withHoldingTax", "currency").optional()
+                .match("^Einbehaltende Quellensteuer [\\.,\\d]+ % .* (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     type.getCurrentContext().put(FLAG_WITHHOLDING_TAX_FOUND, "true");
-                    addTax(type, t, v, "quellensteinbeh");
+                    processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
-                // Anrechenbare Quellensteuer 15 % auf 74,05 EUR 11,11
-                // EUR
-                .section("quellenstanr", "currency").optional()
-                .match("^Anrechenbare Quellensteuer [\\.,\\d]+ % .* (?<quellenstanr>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> addTax(type, t, v, "quellenstanr"));
-    }
-
-    private void addTax(DocumentType type, Object t, Map<String, String> v, String taxtype)
-    {
-        // Wenn es 'Einbehaltene Quellensteuer' gibt, dann die weiteren
-        // Quellensteuer-Arten nicht berücksichtigen.
-        if (checkWithholdingTax(type, taxtype))
-        {
-            ((name.abuchen.portfolio.model.Transaction) t).addUnit(new Unit(Unit.Type.TAX,
-                            Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get(taxtype)))));
-        }
-    }
-
-    private boolean checkWithholdingTax(DocumentType type, String taxtype)
-    {
-        if (Boolean.valueOf(type.getCurrentContext().get(FLAG_WITHHOLDING_TAX_FOUND)))
-            return !"quellenstanr".equalsIgnoreCase(taxtype);
-        return true;
+                // Anrechenbare Quellensteuer 15 % auf 74,05 EUR 11,11 EUR
+                .section("creditableWithHoldingTax", "currency").optional()
+                .match("^Anrechenbare Quellensteuer [\\.,\\d]+ % .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 }


### PR DESCRIPTION
Refactored new processWithHoldingTaxEntries methods into AbstractPDFExtractor
Fix DKB PDF-Importer withHoldingTax
Fix parse changes in date format (months) from Java7 to Java11

Hallo @buchen 
dieser PR verfrachtet alle "Quellensteuerarten" in die `PDFExtractorUtils.java`
Dabei wird in die `AbstractPDFExtractor.java` die `checkWithHoldingTax()` und 
`processWithHoldingTaxEntries()` eingeschoben.

Es geht hier um die
- Einbehaltenen Quellensteuern
- Anrechenbaren Quellensteuern
- rückforderbaren Quellensteuern
- erstattungsfähigen Quellensteuern

Somit werden die PDF-Importer etwas übersichtlicher und vieles wird zusammengefasst.

Des Weiteren werden die Parse-Änderungen im Datumsformat Java7 -> Java11 behoben.

Gruß
Alex
