### PR TITLE
Improved some PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/commerzbank/CommerzbankPDFExtractorTest.java
@@ -188,7 +188,7 @@ public class CommerzbankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.92))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.53))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.19))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -89,7 +89,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
 
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -1730,7 +1730,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
 
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
@@ -1760,7 +1760,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
 
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
@@ -1790,7 +1790,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll(" ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
 
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -120,19 +120,19 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d'ex.cution)(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 26/P11/2021L10:05:13 CETDate et heure d'exécution: 26/11/2021 13:25:24 CETDate de comptabilisation: 26/11/2021Date valeur: 30/11/2021Lieu d'exécution: EURONEXT - EURONEXT BRUSS
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^Ordre cr.. .(\\s)?: .*Date et heure d'ex.cution(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 05/11/2020 11:25:43 CET
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^Ordre cr.. .(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                         )
 
                 // Lastschrift 1.994,39 EUR Valutadatum 17/03/2021
@@ -257,14 +257,14 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date")
                                         .match("^(Nettoguthaben|Net CREDIT) [\\.,\\d]+ [\\w]{3} (Datum|Date) (\\s)?(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})$")
-                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("/", "."))))
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("\\/", "."))))
                                 ,
                                 // Date valeur: 11/01/2021
                                 // Date valeur: 17/11/2021 C
                                 section -> section
                                         .attributes("date")
                                         .match("^Date valeur(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})(.*)?$")
-                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("/", "."))))
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("\\/", "."))))
                         )
 
                 .oneOf(

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -42,7 +42,9 @@ class PDFExtractorUtils
                     DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", Locale.GERMANY) }; //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("dd.MM.yyyy HH.mm.ss", Locale.GERMANY) }; //$NON-NLS-1$
 
     public static void checkAndSetTax(Money tax, Object transaction, DocumentType type)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -618,7 +618,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("AUFTRAG");
-                        v.put("note", "Auftrag " + parts[1].replaceAll(" ", "").replace("BASISLASTSCHRIFT", "Basislastschrift"));
+                        v.put("note", "Auftrag " + parts[1].replaceAll("\\s", "").replace("BASISLASTSCHRIFT", "Basislastschrift"));
                     }
 
                     if ("LASTSCHRIFT".equals(v.get("note")))
@@ -654,7 +654,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Online Shopping vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Kauf/Online Shopping vom " + parts[1].replaceAll("\\s", ""));
                         }
                         else
                         {
@@ -668,7 +668,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Bargeldbezug vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Bargeldbezug vom " + parts[1].replaceAll("\\s", ""));
                         }
                         else
                         {
@@ -690,7 +690,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Dienstleistung vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Kauf/Dienstleistung vom " + parts[1].replaceAll("\\s", ""));
                         }
                         else
                         {
@@ -862,7 +862,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("FÜR");
-                        v.put("note", "Guthabengebühr für " + parts[1].replaceAll(" ", ""));
+                        v.put("note", "Guthabengebühr für " + parts[1].replaceAll("\\s", ""));
                     }
 
                     t.setNote(v.get("note"));
@@ -981,21 +981,21 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
     }
 
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -500,17 +502,30 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 // Kurswert 509,71- EUR
                 // Kundenbonifikation 40 % vom Ausgabeaufschlag 9,71 EUR
                 // Ausgabeaufschlag pro Anteil 5,00 %
-                .section("feeFx", "feeFy", "amountFx", "currency").optional()
-                .match("^Kurswert (?<amountFx>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
-                .match("^Kundenbonifikation (?<feeFy>[\\.,\\d]+) % vom Ausgabeaufschlag [\\.,\\d]+ [\\w]{3}")
-                .match("^Ausgabeaufschlag pro Anteil (?<feeFx>[\\.,\\d]+) %")
+                .section("fxFee", "fyFee", "fxAmount", "currency").optional()
+                .match("^Kurswert (?<fxAmount>[\\.,\\d]+)\\- (?<currency>[\\w]{3})")
+                .match("^Kundenbonifikation (?<fyFee>[\\.,\\d]+) % vom Ausgabeaufschlag [\\.,\\d]+ [\\w]{3}")
+                .match("^Ausgabeaufschlag pro Anteil (?<fxFee>[\\.,\\d]+) %")
                 .assign((t, v) -> {
-                    // Fee in percent
-                    double amountFx = Double.parseDouble(v.get("amountFx").replace(',', '.'));
-                    double feeFy = Double.parseDouble(v.get("feeFy").replace(',', '.'));
-                    double feeFx = Double.parseDouble(v.get("feeFx").replace(',', '.'));
-                    feeFy = (amountFx / (1 + feeFx / 100)) * (feeFx / 100) * (feeFy / 100);
-                    String fee =  Double.toString((amountFx / (1 + feeFx / 100)) * (feeFx / 100) - feeFy).replace('.', ',');
+                    BigDecimal fxFeeDivisor1 = asExchangeRate(v.get("fxFee")).divide(new BigDecimal(100));
+                    BigDecimal fxFeeDivisor2 = fxFeeDivisor1.add(BigDecimal.ONE);
+                    BigDecimal fyFeeDivisor = asExchangeRate(v.get("fyFee")).divide(new BigDecimal(100));
+
+                    // fxFee = (fxAmount / (1 + fxFee / 100)) * (fxFee / 100)
+                    BigDecimal fxFee = asExchangeRate(v.get("fxAmount")).divide(fxFeeDivisor2, 10,
+                                    RoundingMode.HALF_DOWN);
+                    fxFee = fxFee.multiply(fxFeeDivisor1).setScale(2, RoundingMode.HALF_UP);
+
+                    // fyFee = (fxAmount / (1 + fxFee / 100)) * (fxFee / 100) * (fyFee / 100)
+                    BigDecimal fyFee = asExchangeRate(v.get("fxAmount")).divide(fxFeeDivisor2, 10,
+                                    RoundingMode.HALF_DOWN);
+                    fyFee = fyFee.multiply(fxFeeDivisor1);
+                    fyFee = fyFee.multiply(fyFeeDivisor).setScale(2, RoundingMode.HALF_UP);
+
+                    // fee = fxFee - fyFee
+                    String fee = (String) NumberFormat.getNumberInstance(Locale.GERMANY)
+                                    .format(fxFee.subtract(fyFee));
+
                     v.put("fee", fee);
 
                     processFeeEntries(t, v, type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -101,13 +101,8 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                         // EUR 192,14 20.04.2021 03.53.15 WP-Rechnung GS
                         .section("date", "time").optional() //
                         .find("^Zum Kurs von .*$")
-                        .match("^[\\w]{3} [.,\\d]+ (?<date>\\d+.\\d+.\\d{4}) ([\\s]+)?(?<time>\\d+.\\d+.\\d+).*$")
-                        .assign((t, v) -> {
-                            if (v.get("time") != null)
-                                t.setDate(asDate(v.get("date"), v.get("time").replace(".", ":")));
-                            else
-                                t.setDate(asDate(v.get("date")));
-                        })
+                        .match("^[\\w]{3} [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<time>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}) .*$")
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                         // Belastung (vor Steuern) EUR 1.560,83
                         // Gutschrift (vor Steuern) EUR 8.175,91


### PR DESCRIPTION
Change calculation type from "double" to "BigDecimal"
Fix Commerzbank fee calculation
Fix some replaceAll function to pattern
Remove some unuset replace functions

Hallo @buchen 
ursprünglich wollte ich die `.replace(',', '.')` teile in den PDF-Importern entfernen.
Bei denen im Screenshot bin ich mir noch nicht sicher, wie und ob es sich lohnt diese zu entfernen.
(DAB und FinTechGroupBank)
![grafik](https://user-images.githubusercontent.com/45203494/152538089-5bfdadb0-3bbb-43f3-8fd6-e63766ab6d0e.png)

Schau es dir bitte mal an, ob das soweit für dich passt. :see_no_evil: :see_no_evil: :see_no_evil:

So richtig zufrieden bin ich innerlich aber irgendwie nicht. 
Eigentlich nervt mich an den Importer gesamt der Aufbau der einzelnen sections und die Vereinheitlichung (Standardisierung).
Der Ansatz "Enums" dafür zu verwenden find ich eigentlich ganz cool.

```
    public enum RecordField
    {
        // If switch the transaction e.g. from buy to sell
        TYPE("type"), //$NON-NLS-1$

        // Security name
        NAME("name"), //$NON-NLS-1$

        // ISIN
        ISIN("isin"), //$NON-NLS-1$

        // WKN
        WKN("wkn"), //$NON-NLS-1$

        // Valuta date
        DATE("date"), //$NON-NLS-1$

        // Currency amount
        AMOUNT("amount"), //$NON-NLS-1$

        // Foreign currency amount
        fxAMOUNT("fxAmount"), //$NON-NLS-1$

        // Currency or Currency of security
        CURRENCY("currency"), //$NON-NLS-1$

        // Foreign currency
        fxCURRENCY("fxCurrency"), //$NON-NLS-1$

        // Shares
        SHARES("shares"), //$NON-NLS-1$

        // Taxes
        TAX("tax"), //$NON-NLS-1$

        // Tax refund
        TAXREFUND("taxRefund"), //$NON-NLS-1$

        // Fees
        FEE("fee"), //$NON-NLS-1$

        // Fee refund
        FEEREFUND("feeRefund"), //$NON-NLS-1$

        // Currency exchange rate
        EXCHANGERATE("exchangeRate"), //$NON-NLS-1$

        // Withholding tax
        WITHHOLDINGTAX("withholdingTax"), //$NON-NLS-1$

        // Creditable withholding tax
        creditableWITHHOLDINGTAX("creditableWithholdingTax"); //$NON-NLS-1$

        private static final Map<String, RecordField> LOOKUP = new HashMap<String, RecordField>();

        static
        {
            for (RecordField m : EnumSet.allOf(RecordField.class))
                LOOKUP.put(m.getRecordField(), m);
        }

        private String RecordField;

        RecordField(String envRecordField)
        {
            this.RecordField = envRecordField;
        }

        public String getRecordField()
        {
            return RecordField;
        }

        public String getRegEx(String pattern)
        {
            return "(?<" + RecordField + ">" + pattern + ")"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
        }

        public static RecordField get(String RecordField)
        {
            return LOOKUP.get(RecordField);
        }
    }
```
Man müsste nun die .section irgendwie aufbohren, dass dies noch irgendwie "fluffig" funktioniert und geschmeidig aussieht.
Im Kopf habe ich dazu folgende Idee.
```
.section(RecordField.NAME.getRecordField(), RecordField.ISIN.getRecordField(), RecordField.SHARES.getRecordField(), RecordField.CURRENCY.getRecordField())
.find("Gattungsbezeichnung ISIN")
.match("^" + RecordField.NAME.getRegEx(".*") + " " + RecordField.ISIN.getRegEx("[\\w]{12}") + "$")
.match("^STK " + RecordField.SHARES.getRegEx("[\\.,\\d]+") + " " + RecordField.CURRENCY.getRegEx("[\\w]{3}") + "$")
.assign((t, v) -> {
    t.setShares(asShares(v.get(RecordField.SHARES.getRecordField())));
    t.setSecurity(getOrCreateSecurity(v)); <--- noch kein Plan... :-)
})
```
Dadurch wir irgendwie alles lang, also fehlt mir hier noch die Idee wie man dass auch shorten kann, dass das ganze so aussieht...
```
.section(NAME, ISIN, SHARES, CURRENCY)
.find("Gattungsbezeichnung ISIN")
.match("^" + NAME.getRegEx(".*") + " " + ISIN.getRegEx("[\\w]{12}") + "$")
.match("^STK " + SHARES.getRegEx("[\\.,\\d]+") + " " + CURRENCY.getRegEx("[\\w]{3}") + "$")
.assign((t, v) -> {
    t.setShares(asShares(v.get(SHARES)));
    t.setSecurity(getOrCreateSecurity(v)); <--- immernoch kein Plan... :-P
})
```
oder noch smarter... und wie die .find()-funktion gleich auch noch `"^"` und `"$"` mit integrieren.
```
.section(NAME, ISIN, SHARES, CURRENCY)
.find("Gattungsbezeichnung ISIN")
.match("NAME.(".*") + " " + ISIN.("[\\w]{12}"))
.match("STK " + SHARES.("[\\.,\\d]+") + " " + CURRENCY.("[\\w]{3}") )
.assign((t, v) -> {
    t.setShares(asShares(SHARES));
    t.setSecurity(getOrCreateSecurity(v)); <--- immernoch kein Plan... :-P
})
```
Gruß
Alex
