### PR TITLE
Add Locale hints when parsing dates

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -244,9 +244,9 @@ public abstract class AbstractPDFExtractor implements Extractor
         }
     }
 
-    protected LocalDateTime asDate(String value)
+    protected LocalDateTime asDate(String value, Locale... hints)
     {
-        return PDFExtractorUtils.asDate(value);
+        return PDFExtractorUtils.asDate(value, hints);
     }
 
     protected LocalTime asTime(String value)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.stripBlanks;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -322,7 +324,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
                                         
-                                        t.setDate(asDate(v.get("date").replaceAll(" ", "")));
+                                        t.setDate(asDate(stripBlanks(v.get("date"))));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -346,7 +348,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                     v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                 }
                                 
-                                t.setDate(asDate(v.get("date").replaceAll(" ", "")));
+                                t.setDate(asDate(stripBlanks(v.get("date"))));
                                 t.setShares(asShares(v.get("shares")));
                                 t.setAmount(asAmount(v.get("amount")));
                                 t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -367,8 +369,8 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
 
-                                        t.setDate(asDate(v.get("date").replaceAll(" ", "")));
-                                        t.setShares(asShares(v.get("shares")));
+                                        t.setDate(asDate(stripBlanks(v.get("date"))));
+                                        t.setShares(asShares(stripBlanks(v.get("shares"))));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
                                         t.setSecurity(getOrCreateSecurity(v));
@@ -429,7 +431,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -482,7 +484,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -539,7 +541,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -565,7 +567,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,19 +121,19 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d'ex.cution)(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 26/P11/2021L10:05:13 CETDate et heure d'exécution: 26/11/2021 13:25:24 CETDate de comptabilisation: 26/11/2021Date valeur: 30/11/2021Lieu d'exécution: EURONEXT - EURONEXT BRUSS
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^Ordre cr.. .(\\s)?: .*Date et heure d'ex.cution(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 05/11/2020 11:25:43 CET
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^Ordre cr.. .(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
-                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replaceAll("/", "."), v.get("time"))))
+                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                         )
 
                 // Lastschrift 1.994,39 EUR Valutadatum 17/03/2021
@@ -257,14 +258,14 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date")
                                         .match("^(Nettoguthaben|Net CREDIT) [\\.,\\d]+ [\\w]{3} (Datum|Date) (\\s)?(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})$")
-                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("/", "."))))
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"), Locale.GERMANY)))
                                 ,
                                 // Date valeur: 11/01/2021
                                 // Date valeur: 17/11/2021 C
                                 section -> section
                                         .attributes("date")
                                         .match("^Date valeur(\\s)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})(.*)?$")
-                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replaceAll("/", "."))))
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"), Locale.GERMANY)))
                         )
 
                 .oneOf(

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -12,6 +12,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
@@ -23,7 +24,7 @@ import name.abuchen.portfolio.money.Values;
 
 class PDFExtractorUtils
 {
-    private static final DateTimeFormatter[] DATE_FORMATTER = { //
+    private static final DateTimeFormatter[] DATE_FORMATTER_GERMANY = { //
                     DateTimeFormatter.ofPattern("d.M.yyyy", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d.M.yy", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("yyyy-M-d", Locale.GERMANY), //$NON-NLS-1$
@@ -32,18 +33,27 @@ class PDFExtractorUtils
                     DateTimeFormatter.ofPattern("dd-MM-yyyy", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d. MMMM yyyy", Locale.GERMANY), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.UK), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("LL/dd/yyyy", Locale.UK), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.US), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("d MMM yyyy", Locale.US), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.GERMANY) }; //$NON-NLS-1$
+
+    private static final DateTimeFormatter[] DATE_FORMATTER_US = { //
+                    DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.US), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("d MMM yyyy", Locale.US) }; //$NON-NLS-1$
+
+    private static final DateTimeFormatter[] DATE_FORMATTER_UK = { //
+                    DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.UK), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("LL/dd/yyyy", Locale.UK) }; //$NON-NLS-1$
+
+    private static final Map<Locale, DateTimeFormatter[]> LOCALE2DATE = Map.of(Locale.GERMANY, DATE_FORMATTER_GERMANY,
+                    Locale.US, DATE_FORMATTER_US, Locale.UK, DATE_FORMATTER_UK);
 
     private static final DateTimeFormatter[] DATE_TIME_FORMATTER = { //
                     DateTimeFormatter.ofPattern("d.M.yyyy HH:mm", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
-                    DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", Locale.GERMANY) }; //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("dd.MM.yyyy HH.mm.ss", Locale.GERMANY) }; //$NON-NLS-1$
 
     private static final Pattern PATTERN_BLANKS = Pattern.compile("\\s"); //$NON-NLS-1$
 
@@ -86,7 +96,7 @@ class PDFExtractorUtils
                 t.addUnit(new Unit(Unit.Type.TAX, txTax, tax, inverseRate));
         }
     }
-    
+
     public static void checkAndSetFee(Money tax, Object transaction, DocumentType type)
     {
         if (transaction instanceof name.abuchen.portfolio.model.Transaction)
@@ -184,17 +194,22 @@ class PDFExtractorUtils
         }
     }
 
-    public static LocalDateTime asDate(String value)
+    public static LocalDateTime asDate(String value, Locale... hints)
     {
-        for (DateTimeFormatter formatter : DATE_FORMATTER)
+        Locale[] locales = hints.length > 0 ? hints : new Locale[] { Locale.GERMANY, Locale.US, Locale.UK };
+        
+        for (Locale l : locales)
         {
-            try
+            for (DateTimeFormatter formatter : LOCALE2DATE.get(l))
             {
-                return LocalDate.parse(value, formatter).atStartOfDay();
-            }
-            catch (DateTimeParseException ignore)
-            {
-                // continue with next formatter
+                try
+                {
+                    return LocalDate.parse(value, formatter).atStartOfDay();
+                }
+                catch (DateTimeParseException ignore)
+                {
+                    // continue with next formatter
+                }
             }
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -71,7 +72,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     v.put("currency", CurrencyUnit.USD);
                     t.setShares(asShares(v.get("shares")));
-                    t.setDate(asDate(v.get("date")));
+                    t.setDate(asDate(v.get("date"), Locale.UK));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -121,7 +122,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                         .section("date", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) [\\d]{2}\\/[\\d]{2}\\/[\\d]{4} (?<currency>[\\w]{3}) .* Cash Disbursement \\- Wallet \\([\\w]{3}\\) (?<amount>[\\.,\\d]+)$")
                         .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
+                            t.setDateTime(asDate(v.get("date"), Locale.UK));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(v.get("currency"));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -101,13 +101,8 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                         // EUR 192,14 20.04.2021 03.53.15 WP-Rechnung GS
                         .section("date", "time").optional() //
                         .find("^Zum Kurs von .*$")
-                        .match("^[\\w]{3} [.,\\d]+ (?<date>\\d+.\\d+.\\d{4}) ([\\s]+)?(?<time>\\d+.\\d+.\\d+).*$")
-                        .assign((t, v) -> {
-                            if (v.get("time") != null)
-                                t.setDate(asDate(v.get("date"), v.get("time").replace(".", ":")));
-                            else
-                                t.setDate(asDate(v.get("date")));
-                        })
+                        .match("^[\\w]{3} [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<time>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}) .*$")
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                         // Belastung (vor Steuern) EUR 1.560,83
                         // Gutschrift (vor Steuern) EUR 8.175,91


### PR DESCRIPTION
Remove all string manipulations of strings (except the removing of
spurious blanks). Instead, provide hints to the asDate method as to
which locale to use.

Issue: #2682