### PR TITLE
PDF-Importer cleanup (Improved textutil.java)

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.MessageFormat;
@@ -25,7 +27,6 @@ import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 /* package */ abstract class BaseCSVExtractor extends CSVExtractor
 {
@@ -76,7 +77,7 @@ import name.abuchen.portfolio.util.TextUtil;
         int lineNo = 1 + skipLines; // +1 because of end user
         for (String[] strings : rawValues)
         {
-            String[] trimmed = TextUtil.strip(strings);
+            String[] trimmed = strip(strings);
 
             try
             {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
+import static name.abuchen.portfolio.util.TextUtil.getListSeparatorChar;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,13 +27,12 @@ import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 /* not thread safe */
 public class CSVExporter
 {
     /* package */ static final CSVFormat STRATEGY = CSVFormat.DEFAULT.builder() //
-                    .setDelimiter(TextUtil.getListSeparatorChar()).setQuote('"').setRecordSeparator("\r\n") //$NON-NLS-1$
+                    .setDelimiter(getListSeparatorChar()).setQuote('"').setRecordSeparator("\r\n") //$NON-NLS-1$
                     .setAllowDuplicateHeaderNames(true).build();
 
     public void exportAccountTransactions(File file, Account account) throws IOException

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
+import static name.abuchen.portfolio.util.TextUtil.stripNonNumberCharacters;
+
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.text.ParseException;
@@ -23,7 +25,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.util.Isin;
-import name.abuchen.portfolio.util.TextUtil;
 
 public abstract class CSVExtractor implements Extractor
 {
@@ -102,7 +103,7 @@ public abstract class CSVExtractor implements Extractor
         try
         {
             Number num = (Number) field2column.get(name).getFormat().getFormat()
-                            .parseObject(TextUtil.stripNonNumberCharacters(value));
+                            .parseObject(stripNonNumberCharacters(value));
             return Long.valueOf((long) Math.round(num.doubleValue() * values.factor()));
         }
         catch (ParseException e)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
@@ -1,5 +1,9 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
+import static name.abuchen.portfolio.util.TextUtil.DECIMAL_SEPARATOR;
+import static name.abuchen.portfolio.util.TextUtil.getListSeparatorChar;
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
@@ -54,7 +58,6 @@ import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.util.Isin;
-import name.abuchen.portfolio.util.TextUtil;
 
 public final class CSVImporter
 {
@@ -371,9 +374,9 @@ public final class CSVImporter
 
             if ("CH".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
                 return FORMATS.get(2);
-            if (TextUtil.DECIMAL_SEPARATOR == ',')
+            if (DECIMAL_SEPARATOR == ',')
                 return FORMATS.get(0);
-            if (TextUtil.DECIMAL_SEPARATOR == '.')
+            if (DECIMAL_SEPARATOR == '.')
                 return FORMATS.get(1);
 
             // fallback
@@ -618,7 +621,7 @@ public final class CSVImporter
 
     private CSVExtractor currentExtractor;
 
-    private char delimiter = TextUtil.getListSeparatorChar();
+    private char delimiter = getListSeparatorChar();
     private Charset encoding = Charset.defaultCharset();
     private int skipLines = 0;
     private boolean isFirstLineHeader = true;
@@ -835,7 +838,7 @@ public final class CSVImporter
         for (Column column : columns)
         {
             column.setField(null);
-            String normalizedColumnName = normalizeColumnName(TextUtil.strip(column.getLabel()));
+            String normalizedColumnName = normalizeColumnName(strip(column.getLabel()));
             Iterator<Field> iter = list.iterator();
             while (iter.hasNext())
             {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
@@ -26,7 +28,6 @@ import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 public abstract class AbstractPDFExtractor implements Extractor
 {
@@ -104,11 +105,11 @@ public abstract class AbstractPDFExtractor implements Extractor
                     ((Transaction) subject).setSource(filename);
                 else if (subject instanceof CrossEntry)
                     ((CrossEntry) subject).setSource(filename);
-                else if (subject.getNote() == null || TextUtil.strip(subject.getNote()).length() == 0)
+                else if (subject.getNote() == null || strip(subject.getNote()).length() == 0)
                     item.getSubject().setNote(filename);
                 else
                     item.getSubject().setNote(
-                                    TextUtil.strip(item.getSubject().getNote()).concat(" | ").concat(filename)); //$NON-NLS-1$
+                                    strip(item.getSubject().getNote()).concat(" | ").concat(filename)); //$NON-NLS-1$
             }
 
             return items;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -15,7 +17,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class BaaderBankPDFExtractor extends AbstractPDFExtractor
@@ -167,12 +168,12 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Verhältnis: 1 : 1 
                 .section("note").optional()
                 .match("^(?<note>Verh.ltnis: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 // Spitzenregulierung KOPIE
                 .section("note").optional()
                 .match("^(?<note>Spitzenregulierung)( .*)?$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -329,7 +330,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Zahlungszeitraum: 01.01.2020 - 31.12.2020 
                 .section("note").optional()
                 .match("^(?<note>Zahlungszeitraum: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> new TransactionItem(t));
     }
@@ -646,7 +647,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Bezugsverhältnis: 16 : 1
                 .section("note").optional()
                 .match("^(?<note>Bezugsverh.ltnis: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> new TransactionItem(t));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -7,7 +9,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
@@ -56,7 +57,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                     t.setDateTime(asDate(v.get("date")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
-                    t.setNote(TextUtil.strip(v.get("note")));
+                    t.setNote(strip(v.get("note")));
 
                     // Switch transactions if ...
                     if (t.getNote() != null)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1,5 +1,9 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
+import static name.abuchen.portfolio.util.TextUtil.stripBlanksAndUnderscores;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
@@ -23,7 +27,6 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.Transaction.Unit.Type;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class ComdirectPDFExtractor extends AbstractPDFExtractor
@@ -278,8 +281,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s_]+)?(?<currency>[\\w\\s_]+)"
                                 + " ([\\s_]+)?-(?<taxRefund>[.,\\d\\s_]+)?$")
                 .assign((t, v) -> {
-                    v.put("taxRefund", TextUtil.stripBlanksAndUnderscores(v.get("taxRefund")));
-                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("taxRefund", stripBlanksAndUnderscores(v.get("taxRefund")));
+                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
 
                     if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                     {
@@ -316,10 +319,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^([\\s]+)?(S([\\s]+)?T([\\s]+)?K) ([\\s]+)?(?<shares>[\\.,\\d\\s]+) (?<nameContinued>.*)[\\s]{3,}(?<isin>.*)$")
                 .match("^(?<currency>[\\w]{3}) [\\.,\\d]+ ([\\s]+)?(Dividende|Aussch.ttung) pro St.ck .*$")
                 .assign((t, v) -> {
-                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
-                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
+                    v.put("wkn", stripBlanks(v.get("wkn")));
+                    v.put("isin", stripBlanks(v.get("isin")));
 
-                    t.setShares(asShares(TextUtil.stripBlanks(v.get("shares"))));
+                    t.setShares(asShares(stripBlanks(v.get("shares"))));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -329,10 +332,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^([\\s]+)?(p([\\s]+)?e([\\s]+)?r) ([\\s]+)?[\\.\\d\\s]+ [\\s\\w]{3,} [\\s]{3,}(?<name>.*)[\\s]{3,}(?<wkn>.*)$")
                 .match("^(?<currency>[A-Z\\s]+) (?<shares>[\\.,\\d\\s]+) ST ([\\s]+)?(?<nameContinued>.*)[\\s]{3,}(?<isin>[\\w\\s]+)$")
                 .assign((t, v) -> {
-                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
-                    v.put("shares", TextUtil.stripBlanks(v.get("shares")));
-                    v.put("currency", TextUtil.stripBlanks(v.get("currency")));
-                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
+                    v.put("wkn", stripBlanks(v.get("wkn")));
+                    v.put("shares", stripBlanks(v.get("shares")));
+                    v.put("currency", stripBlanks(v.get("currency")));
+                    v.put("isin", stripBlanks(v.get("isin")));
 
                     // Workaround for bonds
                     t.setShares((asShares(v.get("shares")) / 100));
@@ -435,7 +438,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // zahlbar ab 19.10.2017                 monatl. Dividende                            
                 .section("note").optional()
                 .match("^zahlbar ab [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)(?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
                 
                 .wrap(TransactionItem::new);
 
@@ -472,7 +475,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<currency>[\\w\\s]+)"
                                 + " ([\\s]+)?[\\.,\\d\\s]+([\\W]+)?$")
                 .assign((t, v) -> {
-                    v.put("currency", TextUtil.stripBlanks(v.get("currency")));
+                    v.put("currency", stripBlanks(v.get("currency")));
 
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -493,8 +496,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<currency>[\\w\\s]+)"
                                 + " ([\\s]+)?(?<amount>[\\.,\\d\\s]+)([\\W]+)?$")
                 .assign((t, v) -> {
-                    t.setCurrencyCode(asCurrencyCode(TextUtil.stripBlanks(v.get("currency"))));
-                    t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
+                    t.setCurrencyCode(asCurrencyCode(stripBlanks(v.get("currency"))));
+                    t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                 })
 
                 //  Zu  Ih r e n G u n s t e n v o r S te u e r n :              E U R             302,5 5   
@@ -516,8 +519,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<gross2>[\\.,\\d\\s]+)([\\W]+)?$")
                 .assign((t, v) -> {
                     long amount = t.getAmount();
-                    long gross1 = asAmount(TextUtil.stripBlanks(v.get("gross1")));
-                    long gross2 = asAmount(TextUtil.stripBlanks(v.get("gross2")));
+                    long gross1 = asAmount(stripBlanks(v.get("gross1")));
+                    long gross2 = asAmount(stripBlanks(v.get("gross2")));
                     long tax = 0;
 
                     if (gross1 > gross2)
@@ -527,7 +530,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         // before taxes < tax base
                         tax = gross2 - amount;
 
-                    t.addUnit(new Unit(Unit.Type.TAX, Money.of(asCurrencyCode(TextUtil.stripBlanks(v.get("currency"))), tax)));
+                    t.addUnit(new Unit(Unit.Type.TAX, Money.of(asCurrencyCode(stripBlanks(v.get("currency"))), tax)));
                 })
 
                 //  Zu  Ih r e n G u n s t e n v o r S te u e r n :              E U R             302,5 5   
@@ -552,11 +555,11 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)?(?<gross2>[\\.,\\d\\s]+)([\\W]+)?$")
                 .match("^([\\s]+)?Umrechnungen zum Devisenkurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
-                    v.put("currency1", TextUtil.stripBlanks(v.get("currency1")));
-                    v.put("gross1", TextUtil.stripBlanks(v.get("gross1")));
-                    v.put("currency2", TextUtil.stripBlanks(v.get("currency2")));
-                    v.put("gross2", TextUtil.stripBlanks(v.get("gross2")));
-                    v.put("exchangeRate", TextUtil.stripBlanks(v.get("exchangeRate")));
+                    v.put("currency1", stripBlanks(v.get("currency1")));
+                    v.put("gross1", stripBlanks(v.get("gross1")));
+                    v.put("currency2", stripBlanks(v.get("currency2")));
+                    v.put("gross2", stripBlanks(v.get("gross2")));
+                    v.put("exchangeRate", stripBlanks(v.get("exchangeRate")));
 
                     long tax = 0;
                     long amount = t.getAmount();
@@ -623,10 +626,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "name", "wkn", "isin")
                 .match("^Stk\\. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
                 .assign((t, v) -> {
-                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
-                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
+                    v.put("wkn", stripBlanks(v.get("wkn")));
+                    v.put("isin", stripBlanks(v.get("isin")));
 
-                    t.setShares(asShares(TextUtil.stripBlanks(v.get("shares"))));
+                    t.setShares(asShares(stripBlanks(v.get("shares"))));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -646,8 +649,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "[\\s]+(?<currency>[\\w\\s]+) "
                                 + "([\\s]+)?(?<amount>[-\\.,\\d\\s]+)$")
                 .assign((t, v) -> {
-                    v.put("amount", TextUtil.stripBlanksAndUnderscores(v.get("amount")));
-                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("amount", stripBlanksAndUnderscores(v.get("amount")));
+                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -849,7 +852,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                     .section("name", "wkn", "date")
                     .match("^.* Verwahrentgelt (?<name>.*), WKN (?<wkn>.*) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                     .assign((t, v) -> {
-                        v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
+                        v.put("wkn", stripBlanks(v.get("wkn")));
 
                         t.setDateTime(asDate(v.get("date")));
                         t.setSecurity(getOrCreateSecurity(v));
@@ -861,7 +864,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                     .match("^.* (Buchung|H.he) von (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                     .assign((t, v) -> {
                         t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
+                        t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                     })
 
                     .wrap(TransactionItem::new);
@@ -936,8 +939,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)?(?<currency>[\\w\\s_]+) "
                                 + "([\\s_]+)?(?<amount>[-\\.,\\d\\s_]+)(.*)?$")
                 .assign((t, v) -> {
-                    v.put("amount", TextUtil.stripBlanksAndUnderscores(v.get("amount")));
-                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("amount", stripBlanksAndUnderscores(v.get("amount")));
+                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -278,8 +278,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s_]+)?(?<currency>[\\w\\s_]+)"
                                 + " ([\\s_]+)?-(?<taxRefund>[.,\\d\\s_]+)?$")
                 .assign((t, v) -> {
-                    v.put("taxRefund", stripBlanksAndUnderscores(v.get("taxRefund")));
-                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("taxRefund", TextUtil.stripBlanksAndUnderscores(v.get("taxRefund")));
+                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
 
                     if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                     {
@@ -316,10 +316,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^([\\s]+)?(S([\\s]+)?T([\\s]+)?K) ([\\s]+)?(?<shares>[\\.,\\d\\s]+) (?<nameContinued>.*)[\\s]{3,}(?<isin>.*)$")
                 .match("^(?<currency>[\\w]{3}) [\\.,\\d]+ ([\\s]+)?(Dividende|Aussch.ttung) pro St.ck .*$")
                 .assign((t, v) -> {
-                    v.put("wkn", stripBlanks(v.get("wkn")));
-                    v.put("isin", stripBlanks(v.get("isin")));
+                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
+                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
 
-                    t.setShares(asShares(stripBlanks(v.get("shares"))));
+                    t.setShares(asShares(TextUtil.stripBlanks(v.get("shares"))));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -329,10 +329,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^([\\s]+)?(p([\\s]+)?e([\\s]+)?r) ([\\s]+)?[\\.\\d\\s]+ [\\s\\w]{3,} [\\s]{3,}(?<name>.*)[\\s]{3,}(?<wkn>.*)$")
                 .match("^(?<currency>[A-Z\\s]+) (?<shares>[\\.,\\d\\s]+) ST ([\\s]+)?(?<nameContinued>.*)[\\s]{3,}(?<isin>[\\w\\s]+)$")
                 .assign((t, v) -> {
-                    v.put("wkn", stripBlanks(v.get("wkn")));
-                    v.put("shares", stripBlanks(v.get("shares")));
-                    v.put("currency", stripBlanks(v.get("currency")));
-                    v.put("isin", stripBlanks(v.get("isin")));
+                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
+                    v.put("shares", TextUtil.stripBlanks(v.get("shares")));
+                    v.put("currency", TextUtil.stripBlanks(v.get("currency")));
+                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
 
                     // Workaround for bonds
                     t.setShares((asShares(v.get("shares")) / 100));
@@ -472,7 +472,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<currency>[\\w\\s]+)"
                                 + " ([\\s]+)?[\\.,\\d\\s]+([\\W]+)?$")
                 .assign((t, v) -> {
-                    v.put("currency", stripBlanks(v.get("currency")));
+                    v.put("currency", TextUtil.stripBlanks(v.get("currency")));
 
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -493,8 +493,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<currency>[\\w\\s]+)"
                                 + " ([\\s]+)?(?<amount>[\\.,\\d\\s]+)([\\W]+)?$")
                 .assign((t, v) -> {
-                    t.setCurrencyCode(asCurrencyCode(stripBlanks(v.get("currency"))));
-                    t.setAmount(asAmount(stripBlanks(v.get("amount"))));
+                    t.setCurrencyCode(asCurrencyCode(TextUtil.stripBlanks(v.get("currency"))));
+                    t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
                 })
 
                 //  Zu  Ih r e n G u n s t e n v o r S te u e r n :              E U R             302,5 5   
@@ -516,8 +516,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + " ([\\s]+)?(?<gross2>[\\.,\\d\\s]+)([\\W]+)?$")
                 .assign((t, v) -> {
                     long amount = t.getAmount();
-                    long gross1 = asAmount(stripBlanks(v.get("gross1")));
-                    long gross2 = asAmount(stripBlanks(v.get("gross2")));
+                    long gross1 = asAmount(TextUtil.stripBlanks(v.get("gross1")));
+                    long gross2 = asAmount(TextUtil.stripBlanks(v.get("gross2")));
                     long tax = 0;
 
                     if (gross1 > gross2)
@@ -527,7 +527,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         // before taxes < tax base
                         tax = gross2 - amount;
 
-                    t.addUnit(new Unit(Unit.Type.TAX, Money.of(asCurrencyCode(stripBlanks(v.get("currency"))), tax)));
+                    t.addUnit(new Unit(Unit.Type.TAX, Money.of(asCurrencyCode(TextUtil.stripBlanks(v.get("currency"))), tax)));
                 })
 
                 //  Zu  Ih r e n G u n s t e n v o r S te u e r n :              E U R             302,5 5   
@@ -552,11 +552,11 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)?(?<gross2>[\\.,\\d\\s]+)([\\W]+)?$")
                 .match("^([\\s]+)?Umrechnungen zum Devisenkurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)(.*)?$")
                 .assign((t, v) -> {
-                    v.put("currency1", stripBlanks(v.get("currency1")));
-                    v.put("gross1", stripBlanks(v.get("gross1")));
-                    v.put("currency2", stripBlanks(v.get("currency2")));
-                    v.put("gross2", stripBlanks(v.get("gross2")));
-                    v.put("exchangeRate", stripBlanks(v.get("exchangeRate")));
+                    v.put("currency1", TextUtil.stripBlanks(v.get("currency1")));
+                    v.put("gross1", TextUtil.stripBlanks(v.get("gross1")));
+                    v.put("currency2", TextUtil.stripBlanks(v.get("currency2")));
+                    v.put("gross2", TextUtil.stripBlanks(v.get("gross2")));
+                    v.put("exchangeRate", TextUtil.stripBlanks(v.get("exchangeRate")));
 
                     long tax = 0;
                     long amount = t.getAmount();
@@ -623,10 +623,10 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "name", "wkn", "isin")
                 .match("^Stk\\. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
                 .assign((t, v) -> {
-                    v.put("wkn", stripBlanks(v.get("wkn")));
-                    v.put("isin", stripBlanks(v.get("isin")));
+                    v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
+                    v.put("isin", TextUtil.stripBlanks(v.get("isin")));
 
-                    t.setShares(asShares(stripBlanks(v.get("shares"))));
+                    t.setShares(asShares(TextUtil.stripBlanks(v.get("shares"))));
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -646,8 +646,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "[\\s]+(?<currency>[\\w\\s]+) "
                                 + "([\\s]+)?(?<amount>[-\\.,\\d\\s]+)$")
                 .assign((t, v) -> {
-                    v.put("amount", stripBlanksAndUnderscores(v.get("amount")));
-                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("amount", TextUtil.stripBlanksAndUnderscores(v.get("amount")));
+                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -849,7 +849,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                     .section("name", "wkn", "date")
                     .match("^.* Verwahrentgelt (?<name>.*), WKN (?<wkn>.*) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                     .assign((t, v) -> {
-                        v.put("wkn", stripBlanks(v.get("wkn")));
+                        v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
 
                         t.setDateTime(asDate(v.get("date")));
                         t.setSecurity(getOrCreateSecurity(v));
@@ -861,7 +861,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                     .match("^.* (Buchung|H.he) von (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                     .assign((t, v) -> {
                         t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        t.setAmount(asAmount(stripBlanks(v.get("amount"))));
+                        t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
                     })
 
                     .wrap(TransactionItem::new);
@@ -936,8 +936,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)?(?<currency>[\\w\\s_]+) "
                                 + "([\\s_]+)?(?<amount>[-\\.,\\d\\s_]+)(.*)?$")
                 .assign((t, v) -> {
-                    v.put("amount", stripBlanksAndUnderscores(v.get("amount")));
-                    v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
+                    v.put("amount", TextUtil.stripBlanksAndUnderscores(v.get("amount")));
+                    v.put("currency", TextUtil.stripBlanksAndUnderscores(v.get("currency")));
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -1460,15 +1460,5 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
             }
         }
         return false;
-    }
-
-    private String stripBlanksAndUnderscores(String input)
-    {
-        return input.replaceAll("[\\s_]", ""); //$NON-NLS-1$ //$NON-NLS-2$
-    }
-
-    private String stripBlanks(String input)
-    {
-        return input.replaceAll("[\\s]", ""); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetFee;
-import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.stripBlanks;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -19,6 +18,7 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class CommerzbankPDFExtractor extends AbstractPDFExtractor
@@ -78,14 +78,14 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("(?<name>.*),? (?<wkn>([\\w]{6}|\\w\\s\\w\\s\\w\\s\\w\\s\\w\\s\\w))$")
                         .match("(?<nameContinued>.*)")
                         .assign((t, v) -> {
-                            v.put("wkn", stripBlanks(v.get("wkn")));
+                            v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
                         // 1 2 : 0 6 S t . 2 3 0 EUR 1 8 4 , 1 6 EUR 4 2 . 3 5 6 , 8 0
                         .section("time").optional()
                         .match("^(?<time>[\\d\\s]+:[\\d\\s]+) (S t .|St.) [\\d\\s,.]* \\w{3} [\\d\\s,.]* \\w{3} [\\d\\s,.]*$")
-                        .assign((t, v) -> type.getCurrentContext().put("time", stripBlanks(v.get("time"))))
+                        .assign((t, v) -> type.getCurrentContext().put("time", TextUtil.stripBlanks(v.get("time"))))
 
                         // G e s c h ä f t s t a g : 1 7 . 0 2 . 2 0 2 1 A b w i c k l u n g : F e s t p r e i s
                         .section("date").optional()
@@ -93,11 +93,11 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             if (type.getCurrentContext().get("time") != null)
                             {
-                                t.setDate(asDate(stripBlanks(v.get("date")), type.getCurrentContext().get("time")));
+                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date")), type.getCurrentContext().get("time")));
                             }
                             else
                             {
-                                t.setDate(asDate(stripBlanks(v.get("date"))));
+                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
                             }
                         })
 
@@ -108,27 +108,27 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("H a n d e l s z e i t : (?<time>[\\d\\s]+:[\\d\\s]+) .*")
                         .assign((t, v) -> {
                             if (v.get("time") != null)
-                                t.setDate(asDate(stripBlanks(v.get("date")), stripBlanks(v.get("time"))));
+                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date")), TextUtil.stripBlanks(v.get("time"))));
                             else
-                                t.setDate(asDate(stripBlanks(v.get("date"))));
+                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
                         })
 
                         // S t . 2 0 0 EUR 2 0 1 , 7 0 
                         .section("shares").optional()
                         .match("(S t .|St.) (?<shares>[\\d\\s,.]*) .*")
-                        .assign((t, v) -> t.setShares(asShares(stripBlanks(v.get("shares")))))
+                        .assign((t, v) -> t.setShares(asShares(TextUtil.stripBlanks(v.get("shares")))))
 
                         // Summe S t . 2 5 0 EUR 1 9 1 , 0 0 8 6 4 EUR 4 7 . 7 5 2 , 1 6
                         .section("shares").optional()
                         .match("^(Summe) (S t .|St.) (?<shares>[\\d\\s,.]*) .*")
-                        .assign((t, v) -> t.setShares(asShares(stripBlanks(v.get("shares")))))
+                        .assign((t, v) -> t.setShares(asShares(TextUtil.stripBlanks(v.get("shares")))))
                         
                         .section("amount", "currency")
                         .match(".*(Zu I h r e n L a s t e n|Zu I h r e n Guns ten).*")
                         .match(".* \\w{3} [\\d\\s]+.[\\d\\s]+.[\\d\\s]+ (?<currency>\\w{3})(?<amount>[\\d\\s,.]*)$")
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setAmount(asAmount(stripBlanks(v.get("amount"))));
+                            t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
                         })
 
                         .wrap(BuySellEntryItem::new);
@@ -173,10 +173,10 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                     .section("currency", "tax", "sign").optional()
                     .match("(abgeführte Steuern|erstattete Steuern) (?<currency>\\w{3})(?<sign>[-\\s]*)?(?<tax>[\\d\\s,.]*)")
                     .assign((t, v) -> {
-                        t.setAmount(asAmount(stripBlanks(v.get("tax"))));
+                        t.setAmount(asAmount(TextUtil.stripBlanks(v.get("tax"))));
                         t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
-                        String sign = stripBlanks(v.get("sign"));
+                        String sign = TextUtil.stripBlanks(v.get("sign"));
                         if ("-".equals(sign))
                         {
                             // change type for withdrawals
@@ -212,10 +212,10 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("(p e r|per) (?<date>[\\d\\s]+.[\\d\\s]+.[\\d\\s]+) (?<name>.*) (?<wkn>([\\w]{6}|\\w\\s\\w\\s\\w\\s\\w\\s\\w\\s\\w))$")
                         .match("STK (?<shares>[\\d\\s,.]+) (?<nameContinued>.*) (?<isin>[\\w]{12})$")
                         .assign((t, v) -> {
-                            v.put("wkn", stripBlanks(v.get("wkn")));
-                            v.put("isin", stripBlanks(v.get("isin")));
-                            t.setDateTime(asDate(stripBlanks(v.get("date"))));
-                            t.setShares(asShares(stripBlanks(v.get("shares"))));
+                            v.put("wkn", TextUtil.stripBlanks(v.get("wkn")));
+                            v.put("isin", TextUtil.stripBlanks(v.get("isin")));
+                            t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
+                            t.setShares(asShares(TextUtil.stripBlanks(v.get("shares"))));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
@@ -224,7 +224,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match(".* \\w{3} [\\d\\s]+.[\\d\\s]+.[\\d\\s]+ (?<currency>\\w{3})(?<amount>[\\d\\s,.]*)$")
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setAmount(asAmount(stripBlanks(v.get("amount"))));
+                            t.setAmount(asAmount(TextUtil.stripBlanks(v.get("amount"))));
                         })
 
                         // USD 7 ,219127 D i v i d e n d e p r o S t ü c k f ü r G e s c h ä f t s j a h r 0 1 . 0 1 . 2 0 b i s 3 1 . 1 2 . 2 0
@@ -234,7 +234,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("Abrechnung (?<note1>.*)")
                         .assign((t, v) -> 
                         {
-                            String note = stripBlanks(v.get("note1")) + " " + stripBlanks(v.get("note2")) + " - " + stripBlanks(v.get("note3"));
+                            String note = TextUtil.stripBlanks(v.get("note1")) + " " + TextUtil.stripBlanks(v.get("note2")) + " - " + TextUtil.stripBlanks(v.get("note3"));
                             t.setNote(note);
                         })
 
@@ -245,7 +245,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^.* [\\d\\s]+\\.[\\d\\s]+\\.[\\d\\s]+ (?<note1>[\\D]+)$")
                         .assign((t, v) -> 
                         {
-                            String note = stripBlanks(v.get("note1")) + " " + stripBlanks(v.get("note2")) + " - " + stripBlanks(v.get("note3"));
+                            String note = TextUtil.stripBlanks(v.get("note1")) + " " + TextUtil.stripBlanks(v.get("note2")) + " - " + TextUtil.stripBlanks(v.get("note3"));
                             t.setNote(note);
                         })
 
@@ -257,7 +257,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("B r u t t o b e t r a g : (?<fxCurrency>\\w{3}) (?<fxAmount>[\\d\\s,.]*)$")
                         .match(".* \\w{3}\\/\\w{3} (?<exchangeRate>[\\d\\s,.]*) (?<currency>\\w{3}) (?<amount>[\\d\\s,.]*)$")                     
                         .assign((t, v) -> {
-                            BigDecimal exchangeRate = asExchangeRate(stripBlanks(v.get("exchangeRate")));
+                            BigDecimal exchangeRate = asExchangeRate(TextUtil.stripBlanks(v.get("exchangeRate")));
                             if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
                             {
                                 exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
@@ -274,18 +274,18 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                                 Unit grossValue;
                                 if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
                                 {
-                                    Money fxAmount = Money.of(asCurrencyCode(stripBlanks(v.get("fxCurrency"))),
+                                    Money fxAmount = Money.of(asCurrencyCode(TextUtil.stripBlanks(v.get("fxCurrency"))),
                                                     asAmount(v.get("fxAmount")));
                                     Money amount = Money.of(asCurrencyCode(v.get("currency")),
-                                                    asAmount(stripBlanks(v.get("amount"))));
+                                                    asAmount(TextUtil.stripBlanks(v.get("amount"))));
                                     grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
                                 }
                                 else
                                 {
                                     Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                                    asAmount(stripBlanks(v.get("fxAmount"))));
+                                                    asAmount(TextUtil.stripBlanks(v.get("fxAmount"))));
                                     Money fxAmount = Money.of(asCurrencyCode(v.get("currency")),
-                                                    asAmount(stripBlanks(v.get("amount"))));
+                                                    asAmount(TextUtil.stripBlanks(v.get("amount"))));
                                     grossValue = new Unit(Unit.Type.GROSS_VALUE, amount, fxAmount, inverseRate);
                                 }
                                 t.addUnit(grossValue);
@@ -321,7 +321,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 if (m.matches())
                 {
                     // Read year
-                    context.put("year", stripBlanks(m.group(3)));
+                    context.put("year", TextUtil.stripBlanks(m.group(3)));
                 }
             }
         });
@@ -341,8 +341,8 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^(.*)(?<day>(0 [1-9])|([1-2] [0-9])|(3 [0-1])) \\. (?<month>((0 [1-9])|(1 [0-2])) )(?<value>((\\. )?(\\d ){1,3})+\\, (\\d \\d))( \\-)$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
-                            t.setDateTime(asDate(stripBlanks(v.get("day"))+"."+stripBlanks(v.get("month"))+"."+context.get("year")));     
-                            t.setAmount(asAmount(stripBlanks(v.get("value"))));
+                            t.setDateTime(asDate(TextUtil.stripBlanks(v.get("day")) + "." + TextUtil.stripBlanks(v.get("month")) + "." + context.get("year")));     
+                            t.setAmount(asAmount(TextUtil.stripBlanks(v.get("value"))));
                             t.setCurrencyCode(context.get("currency"));
                         })
 
@@ -362,8 +362,8 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^(.*)(?<day>(0 [1-9])|([1-2] [0-9])|(3 [0-1])) \\. (?<month>((0 [1-9])|(1 [0-2])) )(?<value>((\\. )?(\\d ){1,3})+\\, (\\d \\d))$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
-                            t.setDateTime(asDate(stripBlanks(v.get("day"))+"."+stripBlanks(v.get("month"))+"."+context.get("year")));     
-                            t.setAmount(asAmount(stripBlanks(v.get("value"))));
+                            t.setDateTime(asDate(TextUtil.stripBlanks(v.get("day")) + "." + TextUtil.stripBlanks(v.get("month")) + "." + context.get("year")));     
+                            t.setAmount(asAmount(TextUtil.stripBlanks(v.get("value"))));
                             t.setCurrencyCode(context.get("currency"));
                         })
 
@@ -386,7 +386,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("withHoldingTax", "currency").optional()
                         .match(".* [\\d\\s,.]* % Q u e l l e n s t e u e r (?<currency>\\w{3}) (?<withHoldingTax>[\\d\\s,.-]*)$")
                         .assign((t, v) -> {
-                            v.put("withHoldingTax", stripBlanks(v.get("withHoldingTax")));
+                            v.put("withHoldingTax", TextUtil.stripBlanks(v.get("withHoldingTax")));
                             processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                         });
     }
@@ -398,7 +398,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match(".* Spesen (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*)$")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -406,7 +406,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match(".* [\\d\\s,.]* % P r o v i s i o n : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -414,7 +414,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match(".* [\\d\\s,.]* % G e s a m t p r o v i s i o n : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -422,7 +422,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match("S o c k e l b e t r a g : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -430,7 +430,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match("U m s c h r e i b e e n t g e l t : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -438,7 +438,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match(".* [\\d\\s,.]* % V a r i a b l e B ö r s e n s p e s e n : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -446,7 +446,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match("T r a n s a k t i o n s e n t g e l t : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -454,7 +454,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match("X e t r a - E n t g e l t : (?<currency>\\w{3}) (?<fee>[\\d\\s,.-]*$)")
                         .assign((t, v) -> {
-                            v.put("fee", stripBlanks(v.get("fee")));
+                            v.put("fee", TextUtil.stripBlanks(v.get("fee")));
                             processFeeEntries(t, v, type);
                         })
 
@@ -462,8 +462,8 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^K u r s w e r t : (?<currency>\\w{3}) (?<amount>[\\d\\s,.]*)$")
                         .match("^I n dem K u r s w e r t s i n d (?<percentage>[\\d\\s,.]*) % A u s g a b e a u f s c h l a g d e r B a n k e n t h a l t e n.*")
                         .assign((t, v) -> {
-                            BigDecimal percentage = asBigDecimal(stripBlanks(v.get("percentage")));
-                            BigDecimal amount = asBigDecimal(stripBlanks(v.get("amount")));
+                            BigDecimal percentage = asBigDecimal(TextUtil.stripBlanks(v.get("percentage")));
+                            BigDecimal amount = asBigDecimal(TextUtil.stripBlanks(v.get("amount")));
                             BigDecimal fee = amount.multiply(percentage, Values.MC);
                             
                             Money f = Money.of(asCurrencyCode(v.get("currency")), fee.setScale(0, Values.MC.getRoundingMode()).longValue());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -18,7 +20,6 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 {
@@ -292,12 +293,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Limitkurs  5,500000 EUR
                 .section("note").optional()
                 .match("^(?<note>Limitkurs .*)")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 // Ursprungs-WKN 549532
                 .section("note").optional()
                 .match("^(?<note>Ursprungs-WKN .*)")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -322,7 +322,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
                                         
-                                        t.setDate(asDate(v.get("date").replaceAll(" ", "")));
+                                        t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -346,7 +346,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                     v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                 }
                                 
-                                t.setDate(asDate(v.get("date").replaceAll(" ", "")));
+                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
                                 t.setShares(asShares(v.get("shares")));
                                 t.setAmount(asAmount(v.get("amount")));
                                 t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -367,7 +367,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
 
-                                        t.setDate(asDate(v.get("date").replaceAll(" ", "")));
+                                        t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -429,7 +429,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -482,7 +482,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -539,7 +539,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -565,7 +565,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(v.get("date").replaceAll(" ", "")));
+                                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -1,5 +1,8 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -16,7 +19,6 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
@@ -84,7 +86,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Kurswert [\\.,\\d]+(\\-)? (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     v.put("name", v.get("name"));
                     t.setShares(asShares(v.get("shares")));
@@ -116,7 +118,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                 // Stoplimit 291,00 EUR Limit 290,00 EUR
                 .section("note").optional()
                 .match("^(?<note>(Limit|Stoplimit) .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -212,7 +214,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 26.02.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 
@@ -267,7 +269,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                      */
                     
                     StringBuilder securityListKey = new StringBuilder("security_");
-                    securityListKey.append(TextUtil.strip(m.group("name"))).append("_");
+                    securityListKey.append(strip(m.group("name"))).append("_");
                     securityListKey.append(baseCurrency).append("_");
                     securityListKey.append(Integer.toString(i)).append("_");
                     securityListKey.append(Integer.toString(endBlock));
@@ -322,7 +324,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
                                         
-                                        t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
+                                        t.setDate(asDate(stripBlanks(v.get("date"))));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -346,7 +348,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                     v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                 }
                                 
-                                t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
+                                t.setDate(asDate(stripBlanks(v.get("date"))));
                                 t.setShares(asShares(v.get("shares")));
                                 t.setAmount(asAmount(v.get("amount")));
                                 t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -367,7 +369,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                             v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                         }
 
-                                        t.setDate(asDate(TextUtil.stripBlanks(v.get("date"))));
+                                        t.setDate(asDate(stripBlanks(v.get("date"))));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
                                         t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -429,7 +431,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
+                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -482,7 +484,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                     }
 
-                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
+                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                     t.setShares(asShares(v.get("shares")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
@@ -539,12 +541,12 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
+                                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
                                     t.setSecurity(getOrCreateSecurity(v));
-                                    t.setNote(v.get("note1") + " " + TextUtil.strip(v.get("note2")));
+                                    t.setNote(v.get("note1") + " " + strip(v.get("note2")));
                                 })
                         ,
                         section -> section
@@ -565,12 +567,12 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                                         v.put("currency", asCurrencyCode(securityData.getCurrency()));
                                     }
 
-                                    t.setDateTime(asDate(TextUtil.stripBlanks(v.get("date"))));
+                                    t.setDateTime(asDate(stripBlanks(v.get("date"))));
                                     t.setShares(asShares(v.get("shares")));
                                     t.setAmount(asAmount(v.get("amount")));
                                     t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
                                     t.setSecurity(getOrCreateSecurity(v));
-                                    t.setNote(v.get("note1") + " " + TextUtil.strip(v.get("note2")));
+                                    t.setNote(v.get("note1") + " " + strip(v.get("note2")));
                                 })
                     )
 
@@ -715,7 +717,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                 // Verrechnete Aktienverluste 112,10- EUR
                 .section("note").optional()
                 .match("^(?<note>Verrechnete Aktienverluste .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> {
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -10,7 +12,6 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class DekaBankPDFExtractor extends AbstractPDFExtractor
@@ -145,7 +146,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                      * EUR Fremdwährung EUR Anteile tag nungstag
                      */
                     StringBuilder securityListKey = new StringBuilder("security_");
-                    securityListKey.append(TextUtil.strip(lines[i - 1])).append("_");
+                    securityListKey.append(strip(lines[i - 1])).append("_");
                     securityListKey.append(lines[i + 3].substring(17, 20)).append("_");
                     securityListKey.append(Integer.toString(i)).append("_");
                     securityListKey.append(Integer.toString(endBlock));
@@ -247,7 +248,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 // Einbuchung w/ Fusion +1,315 31.05.2021 28.05.2021                          
                 .section("note").optional()
                 .match("^(Einbuchung|Ausbuchung) .* (?<note>.*) [-|+][\\.,\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> {
                     if (t.getCurrencyCode() != null)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -15,7 +17,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
@@ -278,10 +279,10 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
                     // Formatting some notes
                     if (!v.get("note1").startsWith("Verwendungszweck"))
-                        v.put("note", TextUtil.strip(v.get("note")) + " " + TextUtil.strip(v.get("note1")));
+                        v.put("note", strip(v.get("note")) + " " + strip(v.get("note1")));
 
                     if (v.get("note").startsWith("Lastschrifteinzug"))
-                        v.put("note", TextUtil.strip(v.get("note1")));
+                        v.put("note", strip(v.get("note1")));
 
                     if (v.get("note").startsWith("Verwendungszweck"))
                         v.put("note", "");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -16,7 +18,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class DkbPDFExtractor extends AbstractPDFExtractor
@@ -829,7 +830,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                                             + v.get("date").substring(6, 8)));
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(context.get("currency"));
-                                            t.setNote(TextUtil.strip(v.get("note")));
+                                            t.setNote(strip(v.get("note")));
                                         })
                                 ,
                                 section -> section
@@ -837,7 +838,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})(?<note>(?! Habenzins).*) [\\w]{3} [\\.,\\d]+ [\\.,\\d]+ (?<amount>[\\.,\\d]+)\\+$")
                                         .assign((t, v) -> {
                                             Map<String, String> context = type.getCurrentContext();
-                                            v.put("note", TextUtil.strip(v.get("note")));
+                                            v.put("note", strip(v.get("note")));
 
                                             t.setDateTime(asDate(v.get("date").substring(0, 6) + context.get("century")
                                                             + v.get("date").substring(6, 8)));
@@ -854,7 +855,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             if (">".equals(v.get("note").substring(v.get("note").length() - 1)))
                                                 v.put("note", v.get("note").substring(0, v.get("note").length() - 1));
 
-                                            t.setNote(TextUtil.strip(v.get("note")));
+                                            t.setNote(strip(v.get("note")));
                                         })
                                 ,
                                 section -> section
@@ -862,7 +863,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})(?<note>(?! Habenzins).*) (?<amount>[\\.,\\d]+)\\+$")
                                         .assign((t, v) -> {
                                             Map<String, String> context = type.getCurrentContext();
-                                            v.put("note", TextUtil.strip(v.get("note")));
+                                            v.put("note", strip(v.get("note")));
 
                                             t.setDateTime(asDate(v.get("date").substring(0, 6) + context.get("century")
                                                             + v.get("date").substring(6, 8)));
@@ -879,7 +880,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             if (">".equals(v.get("note").substring(v.get("note").length() - 1)))
                                                 v.put("note", v.get("note").substring(0, v.get("note").length() - 1));
 
-                                            t.setNote(TextUtil.strip(v.get("note")));
+                                            t.setNote(strip(v.get("note")));
                                         })
                             )
 
@@ -903,7 +904,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                     + v.get("date").substring(6, 8)));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(context.get("currency"));
-                    t.setNote(TextUtil.strip(v.get("note")));
+                    t.setNote(strip(v.get("note")));
                 })
 
                 .wrap(TransactionItem::new));
@@ -926,7 +927,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                     + v.get("date").substring(6, 8)));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(context.get("currency"));
-                    t.setNote(TextUtil.strip(v.get("note")));
+                    t.setNote(strip(v.get("note")));
                 })
 
                 .wrap(TransactionItem::new));
@@ -948,7 +949,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})(?<note>(?! Abgeltungsteuer).*) [\\w]{3} [\\.,\\d]+ [\\.,\\d]+ (?<amount>[\\.,\\d]+) \\-$")
                                         .assign((t, v) -> {
                                             Map<String, String> context = type.getCurrentContext();
-                                            v.put("note", TextUtil.strip(v.get("note")));
+                                            v.put("note", strip(v.get("note")));
 
                                             t.setDateTime(asDate(v.get("date").substring(0, 6) + context.get("century")
                                                             + v.get("date").substring(6, 8)));
@@ -965,7 +966,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             if (">".equals(v.get("note").substring(v.get("note").length() - 1)))
                                                 v.put("note", v.get("note").substring(0, v.get("note").length() - 1));
 
-                                            t.setNote(TextUtil.strip(v.get("note")));
+                                            t.setNote(strip(v.get("note")));
                                         })
                                 ,
                                 section -> section
@@ -973,7 +974,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})(?<note>(?! Abgeltungsteuer).*) (?<amount>[\\.,\\d]+) \\-$")
                                         .assign((t, v) -> {
                                             Map<String, String> context = type.getCurrentContext();
-                                            v.put("note", TextUtil.strip(v.get("note")));
+                                            v.put("note", strip(v.get("note")));
 
                                             t.setDateTime(asDate(v.get("date").substring(0, 6) + context.get("century")
                                                             + v.get("date").substring(6, 8)));
@@ -990,7 +991,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             if (">".equals(v.get("note").substring(v.get("note").length() - 1)))
                                                 v.put("note", v.get("note").substring(0, v.get("note").length() - 1));
 
-                                            t.setNote(TextUtil.strip(v.get("note")));
+                                            t.setNote(strip(v.get("note")));
                                         })
                             )
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -17,7 +19,6 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
@@ -508,7 +509,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr.: 132465978
                 .section("note").optional()
                 .match("^.* (?<note>Transaktion-Nr\\.: [\\d]+)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -12,7 +14,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 public class HelloBankPDFExtractor extends AbstractPDFExtractor
 {
@@ -70,7 +71,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .match("^Kurs: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -172,7 +173,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .match("^(Dividende|Ertrag): [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -264,7 +265,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .match("^steuerlicher Anschaffungswert: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs")|| !v.get("name1").startsWith("Verwahrart"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
                     
                     t.setSecurity(getOrCreateSecurity(v));
                 })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -16,7 +18,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class INGDiBaPDFExtractor extends AbstractPDFExtractor
@@ -178,7 +179,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .section("note1", "note2").optional()
                 .match("^Diese Order wurde mit folgendem (?<note1>Limit) .*: (?<note2>[\\.,\\d]+ [\\w]{3})( .*)?$")
                 .assign((t, v) -> {
-                    t.setNote(TextUtil.strip(v.get("note1")) + ": " + TextUtil.strip(v.get("note2")));   
+                    t.setNote(strip(v.get("note1")) + ": " + strip(v.get("note2")));   
                 })
 
                 .wrap(BuySellEntryItem::new);
@@ -362,7 +363,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("tax")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
-                    String sign = TextUtil.strip(v.get("sign"));
+                    String sign = strip(v.get("sign"));
                     if ("".equals(sign))
                     {
                         // change type for withdrawals

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JSONPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JSONPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
@@ -41,7 +43,6 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 public class JSONPDFExtractor extends AbstractPDFExtractor
 {
@@ -168,10 +169,10 @@ public class JSONPDFExtractor extends AbstractPDFExtractor
     {
         JSecurity security = new JSecurity();
         
-        if (TextUtil.strip(v.get("nameContinued")) != null) //$NON-NLS-1$
-            security.setName(TextUtil.strip(v.get("name") + " " + TextUtil.strip(v.get("nameContinued")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        if (strip(v.get("nameContinued")) != null) //$NON-NLS-1$
+            security.setName(strip(v.get("name") + " " + strip(v.get("nameContinued")))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         else
-            security.setName(TextUtil.strip(v.get("name"))); //$NON-NLS-1$
+            security.setName(strip(v.get("name"))); //$NON-NLS-1$
 
         security.setIsin(v.get("isin")); //$NON-NLS-1$
         security.setTicker(v.get("ticker")); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -13,7 +15,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class NIBCBankPDFExtractor extends AbstractPDFExtractor
@@ -75,7 +76,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 .match("^Kurswert [\\.,\\d]+([\\-])? (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     v.put("name", v.get("name"));
                     t.setShares(asShares(v.get("shares")));
@@ -104,7 +105,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 // Limit 79,23 EUR
                 .section("note").optional()
                 .match("^(?<note>(Limit|Stoplimit) .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -200,7 +201,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 26.02.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 
@@ -239,7 +240,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 // Verrechnete Aktienverluste 112,10- EUR
                 .section("note").optional()
                 .match("^(?<note>Verrechnete Aktienverluste .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> {
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -12,7 +12,6 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -44,8 +43,6 @@ class PDFExtractorUtils
                     DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //$NON-NLS-1$
                     DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", Locale.GERMANY) }; //$NON-NLS-1$
-
-    private static final Pattern PATTERN_BLANKS = Pattern.compile("\\s"); //$NON-NLS-1$
 
     private PDFExtractorUtils()
     {
@@ -235,10 +232,5 @@ class PDFExtractorUtils
         }
 
         throw new DateTimeParseException(Messages.MsgErrorNotAValidDate, value, 0);
-    }
-
-    public static String stripBlanks(String input)
-    {
-        return input == null ? null : PATTERN_BLANKS.matcher(input).replaceAll(""); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -12,7 +14,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class PostbankPDFExtractor extends AbstractPDFExtractor
@@ -73,7 +74,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<name1>.*)$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -114,7 +115,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                 // Limit 43,00 EUR 
                 .section("note").optional()
                 .match("^(?<note>Limit .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -149,7 +150,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* (Aussch.ttung|Dividende|Ertrag) ([\\s]+)?pro (St\\.|St.ck) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Zahlbarkeitstag"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -217,7 +218,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 22.02.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -1,5 +1,8 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -16,7 +19,6 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class PostfinancePDFExtractor extends AbstractPDFExtractor
@@ -147,7 +149,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Börsentransaktion: Kauf Unsere Referenz: 153557048
                 .section("note").optional()
                 .match("^B.rsentransaktion: (Kauf|Verkauf) Unsere (?<note>Referenz: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -240,7 +242,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Auftrag 10111111 
                 .section("note").optional()
                 .match("^(?<note>Auftrag .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -309,7 +311,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Kapitalgewinn Unsere Referenz: 149619136
                 .section("note").optional()
                 .match("^(Dividende|Kapitalgewinn) Unsere (?<note>Referenz: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 
@@ -352,7 +354,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Jahresgebühr Unsere Referenz: 161333839
                 .section("note1", "note2")
                 .match("^(?<note1>Jahresgeb.hr) Unsere (?<note2>Referenz: .*)$")
-                .assign((t, v) -> t.setNote(v.get("note1") + " - " + TextUtil.strip(v.get("note2"))))
+                .assign((t, v) -> t.setNote(v.get("note1") + " - " + strip(v.get("note2"))))
 
                 .wrap(t -> {
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)
@@ -578,7 +580,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    v.put("note", TextUtil.strip(v.get("note")));
+                    v.put("note", strip(v.get("note")));
 
                     if ("ÜBERTRAG".equals(v.get("note")))
                         v.put("note", "Übertrag auf Konto");
@@ -612,13 +614,13 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    v.put("note", TextUtil.strip(v.get("note")));
+                    v.put("note", strip(v.get("note")));
 
                     if (v.get("note").contains("AUFTRAG") && v.get("note").contains("LASTSCHRIFT"))
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("AUFTRAG");
-                        v.put("note", "Auftrag " + TextUtil.stripBlanks(parts[1]).replace("BASISLASTSCHRIFT", "Basislastschrift"));
+                        v.put("note", "Auftrag " + stripBlanks(parts[1]).replace("BASISLASTSCHRIFT", "Basislastschrift"));
                     }
 
                     if ("LASTSCHRIFT".equals(v.get("note")))
@@ -654,7 +656,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Online Shopping vom " + TextUtil.stripBlanks(parts[1]));
+                            v.put("note", "Kauf/Online Shopping vom " + stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -668,7 +670,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Bargeldbezug vom " + TextUtil.stripBlanks(parts[1]));
+                            v.put("note", "Bargeldbezug vom " + stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -690,7 +692,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Dienstleistung vom " + TextUtil.stripBlanks(parts[1]));
+                            v.put("note", "Kauf/Dienstleistung vom " + stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -732,7 +734,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    v.put("note", TextUtil.strip(v.get("note")));
+                    v.put("note", strip(v.get("note")));
 
                     if ("ÜBERTRAG".equals(v.get("note")))
                         v.put("note", "Übertrag aus Konto");
@@ -761,7 +763,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    v.put("note", TextUtil.strip(v.get("note")));
+                    v.put("note", strip(v.get("note")));
 
                     if (v.get("note").contains("TWINT"))
                         v.put("note", "TWINT Geld empfangen");
@@ -834,7 +836,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    v.put("note", TextUtil.strip(v.get("note")));
+                    v.put("note", strip(v.get("note")));
 
                     if ("JAHRESPREIS LOGIN".equals(v.get("note")))
                         v.put("note", "Jahrespreis Login");
@@ -862,7 +864,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("FÜR");
-                        v.put("note", "Guthabengebühr für " + TextUtil.stripBlanks(parts[1]));
+                        v.put("note", "Guthabengebühr für " + stripBlanks(parts[1]));
                     }
 
                     t.setNote(v.get("note"));
@@ -899,7 +901,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(context.get("currency"));
 
                     // Formatting some notes
-                    t.setNote("Zinsabschluss " + TextUtil.strip(v.get("note")));
+                    t.setNote("Zinsabschluss " + strip(v.get("note")));
                 })
 
                 .section("date1", "date2", "amount").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -618,7 +618,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("AUFTRAG");
-                        v.put("note", "Auftrag " + parts[1].replaceAll(" ", "").replace("BASISLASTSCHRIFT", "Basislastschrift"));
+                        v.put("note", "Auftrag " + TextUtil.stripBlanks(parts[1]).replace("BASISLASTSCHRIFT", "Basislastschrift"));
                     }
 
                     if ("LASTSCHRIFT".equals(v.get("note")))
@@ -654,7 +654,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Online Shopping vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Kauf/Online Shopping vom " + TextUtil.stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -668,7 +668,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Bargeldbezug vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Bargeldbezug vom " + TextUtil.stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -690,7 +690,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                         {
                             String splitNote = v.get("note");
                             String[] parts = splitNote.split("OM");
-                            v.put("note", "Kauf/Dienstleistung vom " + parts[1].replaceAll(" ", ""));
+                            v.put("note", "Kauf/Dienstleistung vom " + TextUtil.stripBlanks(parts[1]));
                         }
                         else
                         {
@@ -862,7 +862,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     {
                         String splitNote = v.get("note");
                         String[] parts = splitNote.split("FÜR");
-                        v.put("note", "Guthabengebühr für " + parts[1].replaceAll(" ", ""));
+                        v.put("note", "Guthabengebühr für " + TextUtil.stripBlanks(parts[1]));
                     }
 
                     t.setNote(v.get("note"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Map;
@@ -15,7 +17,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
@@ -75,7 +76,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Kurs: ([\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs:") || !v.get("name1").startsWith("Fondsgesellschaft:"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -89,7 +90,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Ausf.hrungskurs [\\.,\\d]+ (?<currency>[\\w]{3}) .*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -164,7 +165,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Limit bestens
                 .section("note").optional()
                 .match("^(?<note>Limit .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -196,7 +197,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Dividende: [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Dividende:"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -210,7 +211,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Dividende pro St.ck [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Zahlbarkeitstag"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
@@ -296,7 +297,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 01.12.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -12,7 +14,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class SBrokerPDFExtractor extends AbstractPDFExtractor
@@ -83,7 +84,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<name1>.*)$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -135,7 +136,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 // Limit 189,40 EUR
                 .section("note").optional()
                 .match("(?<note>Limit [\\.,\\d]+ [\\w]{3})$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -185,7 +186,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .match("^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Aussch.ttung|Dividende) pro (St\\.|St.ck) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Zahlbarkeitstag"))
-                        v.put("name", TextUtil.strip(v.get("name")) + " " + TextUtil.strip(v.get("name1")));
+                        v.put("name", strip(v.get("name")) + " " + strip(v.get("name1")));
 
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -306,7 +307,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 22.12.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(t -> new TransactionItem(t));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -12,7 +14,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
@@ -80,7 +81,7 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
                 // Limit billigst
                 .section("note").optional()
                 .match("^(?<note>Limit .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -176,7 +177,7 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
                 // Ex-Tag 20.05.2021 Art der Dividende Quartalsdividende
                 .section("note").optional()
                 .match("^.* Art der Dividende (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -7,7 +9,6 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class SelfWealthPDFExtractor extends AbstractPDFExtractor
@@ -79,7 +80,7 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
                 // JOHN DOE A/C Reference No: T20210701123456­-1
                 .section("note").optional()
                 .match("^.* Reference No: (?<note>.*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.util.TextUtil.strip;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -12,7 +14,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.util.TextUtil;
 
 @SuppressWarnings("nls")
 public class SimpelPDFExtractor extends AbstractPDFExtractor
@@ -98,7 +99,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                 // Auftrags-Nummer: 20220106123456789000000612345
                 .section("note").optional()
                 .match("^(?<note>Auftrags-Nummer: [\\d]+)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(BuySellEntryItem::new);
 
@@ -165,7 +166,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                 // WKN / ISIN: AT0000A1Z882 Turnus: jährlich
                 .section("note").optional()
                 .match("^.* (?<note>Turnus: .*)$")
-                .assign((t, v) -> t.setNote(TextUtil.strip(v.get("note"))))
+                .assign((t, v) -> t.setNote(strip(v.get("note"))))
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
@@ -126,6 +126,23 @@ public final class TextUtil
     }
 
     /**
+     * Strip blanks in String
+     * It is not the same function as TextUtil.strip()
+     */
+    public static String stripBlanks(String input)
+    {
+        return input == null ? null : Pattern.compile("\\s").matcher(input).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * Remove blanks followed by underscores in the string
+     */
+    public static String stripBlanksAndUnderscores(String input)
+    {
+        return input == null ? null : Pattern.compile("[\\s_]").matcher(input).replaceAll(""); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
      * Removes unwanted characters before and after any number characters. Used
      * when importing data from CSV files.
      */


### PR DESCRIPTION
Move stripBlanks() from PDFExtractorUtils.java to TextUtil.java
Extension TextUtil.java with stripBlanksAndUnderscores()
Cleanup from Comdirect PDF importer by extending TextUtil.java
Cleanup from Commerzbank PDF importer by extending TextUtil.java
Cleanup from DZBankGruppe PDF importer by extending TextUtil.java
Cleanup of Postfinance PDF importer by extension of TextUtil.java

Hallo @buchen 
ja, der draft-pull-request #2682 war gehörig misslungen.
Ich muss mich da einfach besser konzentieren und strickt eins nach dem anderen pushen.
Das hat dich eine Menge deiner kostbaren Zeit gekostet, welche du in anderes hättest investieren können.
Entschuldigung.
Dafür bin ich weiterhin hoch motiviert das Projekt PP weiter voran zu treiben 💯 

In diesem PR:
Wir sollten die Stringbearbeitung zentral in der TextUtil.java behalten.
Daher schlage ich dir diese Lösung vor. 

Gruß Alex