### PR TITLE
Time widget always wide enough for five character

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -201,7 +201,7 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
                     // drop down is available
                 }
             };
-            time.setFormat(CDT.TIME_SHORT);
+            time.setPattern("HH:mm"); //$NON-NLS-1$
             time.setButtonImage(Images.CLOCK.image());
 
             button = new ImageHyperlink(editArea, SWT.NONE);


### PR DESCRIPTION
When CLOCK_24_HOUR is used for CDateTime, the pattern "HH:mm" should be used. Otherwise in some languages the pattern "H:mm" is used and the initial value "0:00" results in a too narrow widget.

Fixes #2680 