### PR TITLE
Fix DAB Bank PDF importer regarding foreign exchange transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -1172,23 +1172,6 @@ public class DABPDFExtractorTest
         // check tax-refund transaction
         item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
         assertThat(item.isPresent(), is(false));
-        /*
-        assertThat(item.get().getSubject(), instanceOf(AccountTransaction.class));
-        AccountTransaction transaction = (AccountTransaction) item.get().getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-18T00:00")));
-        assertThat(transaction.getSource(), is("Verkauf12.txt"));
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.08))));
-        assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.08))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-                        */
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/Verkauf12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/Verkauf12.txt
@@ -1,0 +1,46 @@
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+DEPOTNUMMER=1234567890
+Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
+VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+Verkauf Limitauftrag ADRESSZEILE2=Max Mustermann
+Kommissionsgeschäft ADRESSZEILE3=Musterstraße 123
+ADRESSZEILE4=54321 Musterstadt
+Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
+1234567890 99887755 / 18.02.2022 ADRESSZEILE6=
+Herr BELEGNUMMER=1234
+Max Mustermann SEITENNUMMER=1
+Musterstraße 123 STEUERERSTATTUNG=N
+54321 Musterstadt Depotinhaber
+Max Mustermann
+München, 18.02.2022
+Wir haben für Sie verkauft
+Gattungsbezeichnung ISIN
+First Majestic Silver Corp. Registered Shares o.N. CA32076V1031
+Nominal Kurs
+STK 100,000 CAD 14,9900
+Handelstag 18.02.2022 Kurswert CAD 1.499,00 
+Handelszeit 16:56* Provision CAD 13,06-
+Börse Kanada/NCT Handelsplatzentgelt CAD 15,00-
+Verwahrart Wertpapierrechnung Ausmachender Betrag CAD 1.470,94 
+Lagerland Kanada
+Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten
+23.02.2022 1234567890 EUR/CAD 1,451293 EUR 1.013,54
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Aktien EUR 76,24
+Aktienverlusttopf EUR 2.053,85 1.977,61
+allgemeiner Verlusttopf EUR 1.996,95 1.996,95
+Freistellungsauftrag (eingereicht: EUR 1.500,00) EUR 1.500,00 1.500,00
+Quellensteuertopf EUR 0,00 0,00
+zu versteuern EUR 0,00
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 0,00
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,00
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
+Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/Verkauf12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/Verkauf12.txt
@@ -7,40 +7,40 @@ Wertpapierabrechnung DEPOTUNTERBEZEICHNUNG=
 VERSANDARTENSCHLUESSEL=DRUCK
 ADRESSZEILE1=Herr
 Verkauf Limitauftrag ADRESSZEILE2=Max Mustermann
-Kommissionsgeschäft ADRESSZEILE3=Musterstraße 123
+KommissionsgeschÃ¤ft ADRESSZEILE3=MusterstraÃŸe 123
 ADRESSZEILE4=54321 Musterstadt
 Depot-Nr. Abrechnungs-Nr. ADRESSZEILE5=
 1234567890 99887755 / 18.02.2022 ADRESSZEILE6=
 Herr BELEGNUMMER=1234
 Max Mustermann SEITENNUMMER=1
-Musterstraße 123 STEUERERSTATTUNG=N
+MusterstraÃŸe 123 STEUERERSTATTUNG=N
 54321 Musterstadt Depotinhaber
 Max Mustermann
-München, 18.02.2022
-Wir haben für Sie verkauft
+MÃ¼nchen, 18.02.2022
+Wir haben fÃ¼r Sie verkauft
 Gattungsbezeichnung ISIN
 First Majestic Silver Corp. Registered Shares o.N. CA32076V1031
 Nominal Kurs
 STK 100,000 CAD 14,9900
 Handelstag 18.02.2022 Kurswert CAD 1.499,00 
 Handelszeit 16:56* Provision CAD 13,06-
-Börse Kanada/NCT Handelsplatzentgelt CAD 15,00-
+BÃ¶rse Kanada/NCT Handelsplatzentgelt CAD 15,00-
 Verwahrart Wertpapierrechnung Ausmachender Betrag CAD 1.470,94 
 Lagerland Kanada
 Wert Konto-Nr. Devisenkurs Betrag zu Ihren Gunsten
 23.02.2022 1234567890 EUR/CAD 1,451293 EUR 1.013,54
 Hinweise zur steuerlichen Verrechnung: vorher aktuell
-Veräußerungsgewinn Aktien EUR 76,24
+VerÃ¤uÃŸerungsgewinn Aktien EUR 76,24
 Aktienverlusttopf EUR 2.053,85 1.977,61
 allgemeiner Verlusttopf EUR 1.996,95 1.996,95
 Freistellungsauftrag (eingereicht: EUR 1.500,00) EUR 1.500,00 1.500,00
 Quellensteuertopf EUR 0,00 0,00
 zu versteuern EUR 0,00
 im laufenden Jahr einbehaltene Kapitalertragsteuer EUR 0,00
-im laufenden Jahr einbehaltener Solidaritätszuschlag EUR 0,00
-* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland
-  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+im laufenden Jahr einbehaltener SolidaritÃ¤tszuschlag EUR 0,00
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemÃ¤ÃŸ der lokalen Zeit in Deutschland
+  (MitteleuropÃ¤ische Zeit bzw. MitteleuropÃ¤ische Sommerzeit).
 Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
-BNP Paribas S.A. Niederlassung Deutschland > Standort: München > Landsberger Straße 300 > 80687 München > Sitz: Nürnberg HRB Nürnberg 31129 > USt.-Ident-Nr.: DE 
-191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > Président du 
-Conseil d‘Administration: Jean Lemierre, Directeur Général: Jean-Laurent Bonnafé
+BNP Paribas S.A. Niederlassung Deutschland > Standort: MÃ¼nchen > Landsberger StraÃŸe 300 > 80687 MÃ¼nchen > Sitz: NÃ¼rnberg HRB NÃ¼rnberg 31129 > USt.-Ident-Nr.: DE 
+191528929 > Sitz der Hauptniederlassung der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449 > PrÃ©sident du 
+Conseil dâ€˜Administration: Jean Lemierre, Directeur GÃ©nÃ©ral: Jean-Laurent BonnafÃ©

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -215,7 +215,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // Börse USA/NAN Ausmachender Betrag USD 5.280,17-
                 // 03.08.2015 0000000000 EUR/USD 1,100297 EUR 4.798,86
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
-                .match("^.* (Ausmachender Betrag|Kurswert) (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)(\\-)?$")
+                .match("^.* (Ausmachender Betrag|Kurswert) (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)(\\-)?\\s?$")
                 .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\.,\\d]+$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross


### PR DESCRIPTION
Sometimes PDFbox leaves trailing whitespace in some of the lines. This commit adds support for trailing whitespace in one of the affected sections.