### PR TITLE
CSV Import: read time column for all transaction types

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractorTest.java
@@ -217,8 +217,8 @@ public class CSVAccountTransactionExtractorTest
         assertThat(t.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, 100_00)));
         assertThat(t.getNote(), is("Notiz"));
 
-        // asset that time is removed --> not supported for removal
-        assertThat(t.getDateTime(), is(LocalDateTime.parse("2013-01-01T00:00")));
+        // date and time is read 
+        assertThat(t.getDateTime(), is(LocalDateTime.parse("2013-01-01T10:00")));
         assertThat(t.getShares(), is(0L));
         assertThat(t.getSecurity(), is(nullValue()));
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
@@ -101,7 +101,7 @@ import name.abuchen.portfolio.money.Money;
                 AccountTransferEntry entry = new AccountTransferEntry();
                 entry.setAmount(Math.abs(amount.getAmount()));
                 entry.setCurrencyCode(amount.getCurrencyCode());
-                entry.setDate(date.withHour(0).withMinute(0));
+                entry.setDate(date);
                 entry.setNote(note);
                 item = new AccountTransferItem(entry, type == Type.TRANSFER_OUT);
                 break;
@@ -170,7 +170,7 @@ import name.abuchen.portfolio.money.Money;
                 if (type == Type.DIVIDENDS || type == Type.TAXES || type == Type.TAX_REFUND || type == Type.FEES
                                 || type == Type.FEES_REFUND)
                     t.setSecurity(security);
-                t.setDateTime(date.withHour(0).withMinute(0));
+                t.setDateTime(date);
                 t.setNote(note);
 
                 if (type == Type.DIVIDENDS)


### PR DESCRIPTION
When configured, read the time value for all transactions (not only buy and sell transactions)

Fixes #2709