### PR TITLE
PerformanceHeatmapWidget calculates wrong excess return for current month regarding HVPI benchmark 

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexHeatmapCalculationsTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexHeatmapCalculationsTest.java
@@ -1,0 +1,172 @@
+package name.abuchen.portfolio.snapshot;
+
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import name.abuchen.portfolio.AccountBuilder;
+import name.abuchen.portfolio.SecurityBuilder;
+import name.abuchen.portfolio.TestCurrencyConverter;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.util.Interval;
+
+@SuppressWarnings("nls")
+public class PerformanceIndexHeatmapCalculationsTest
+{
+    private LocalDate startDate;
+    private String endDateString;
+    private String startDateString;
+    private LocalDate endDate;
+    private Client client;
+
+    @Before
+    public void setUp() {
+        this.client = new Client();
+    
+        this.startDateString = "2021-12-01";
+        this.endDateString = "2022-01-01";
+        this.startDate = LocalDate.parse(startDateString);
+        this.endDate = LocalDate.parse(endDateString);
+        
+        new AccountBuilder() //
+            .deposit_(startDate.atStartOfDay(), 100)
+            .addTo(client);
+    }
+    
+    private PerformanceIndex getClientIndex() {
+        List<Exception> warnings = new ArrayList<Exception>();
+        Interval reportInterval = Interval.of(startDate, endDate);
+        CurrencyConverter converter = new TestCurrencyConverter();
+        
+        return PerformanceIndex.forClient(client, converter, reportInterval, warnings);
+    }
+    
+    @Test
+    public void testThatClientIndexPerformanceCorectWhenDataPointsForBothDatesAreAvailableNoPerformance()
+    {
+        Interval interval = Interval.of(startDate,
+                                        endDate);
+        
+        assertThat(getClientIndex().getPerformance(interval), closeTo(0.0, 0.1e-10));
+    }
+    
+    @Test
+    public void testThatClientIndexPerformanceWithInterestZeroWhenDataPointsForNoDatesAreAvailable()
+    {
+        new AccountBuilder() //
+          .interest(startDate.plusDays(1).atStartOfDay(), 1)
+          .addTo(client);
+        
+        Interval interval = Interval.of(startDate.minusDays(1),
+                                        endDate.plusDays(1));
+        
+        assertThat(getClientIndex().getPerformance(interval), closeTo(0.0, 0.1e-10));
+    }
+    
+    @Test
+    public void testThatClientPerformanceIsCalculatedCorrectlyWithInterest()
+    {      
+        new AccountBuilder() //
+            .interest(startDate.plusDays(1).atStartOfDay(), 1)
+            .addTo(client);
+        
+        Interval interval = Interval.of(startDate,
+                                        endDate);
+        
+        assertThat(getClientIndex().getPerformance(interval), closeTo(0.01, 0.1e-10));
+    }
+    
+    
+    @Test
+    public void testThatSecurityPerformanceCorectWhenDataPointsForBothDatesAreAvailableNoPerformance()
+    {   
+        Interval interval = Interval.of(startDate,
+                                        endDate);
+        
+        Security security = new SecurityBuilder()
+                                  .addPrice(startDateString,100)
+                                  .addTo(client);
+                                    
+        PerformanceIndex securityIndex = PerformanceIndex.forSecurity(getClientIndex(), security);
+
+        
+        assertThat(securityIndex.getPerformance(interval), closeTo(0.00, 0.1e-10));
+    }
+    
+    @Test
+    public void testThatSecurityPerformanceCorectWhenDataPointsForBothDatesAreAvailableSomePerformance()
+    {
+        Interval interval = Interval.of(startDate,
+                                        endDate);
+
+        Security security = new SecurityBuilder()
+                                  .addPrice(startDateString,100)
+                                  .addPrice(endDateString, 101)
+                                  .addTo(client);
+                                    
+        PerformanceIndex securityIndex = PerformanceIndex.forSecurity(getClientIndex(), security);
+
+        
+        assertThat(securityIndex.getPerformance(interval), closeTo(0.01, 0.1e-10));
+    }
+    
+    
+    @Test
+    public void testThatSecurityPerformanceCorrectWhenLastDataPointIsNotAvailable()
+    {      
+        Security security = new SecurityBuilder()
+                                  .addPrice(startDateString, 100)
+                                  .addPrice(endDateString, 101)
+                                  .addTo(client);
+                                    
+        PerformanceIndex securityIndex = PerformanceIndex.forSecurity(getClientIndex(), security);
+        
+        Interval interval = Interval.of(startDate,
+                                        endDate.plusDays(1));
+
+        
+        assertThat(securityIndex.getPerformance(interval), closeTo(0.01, 0.1e-10));
+    }
+    
+    @Test
+    public void testThatSecurityPerformanceCorrectWhenFirstDataPointIsNotAvailable()
+    {      
+        Security security = new SecurityBuilder()
+                                  .addPrice(startDateString, 100)
+                                  .addPrice(endDateString, 101)
+                                  .addTo(client);
+                                    
+        PerformanceIndex securityIndex = PerformanceIndex.forSecurity(getClientIndex(), security);
+        
+        Interval interval = Interval.of(startDate.minusDays(1),
+                                        endDate);
+
+        
+        assertThat(securityIndex.getPerformance(interval), closeTo(0.01, 0.1e-10));
+    }
+    
+    @Test
+    public void testThatSecurityPerformanceZeroWhenNoDataPointIsNotAvailable()
+    {      
+        Security security = new SecurityBuilder()
+                                  .addPrice(startDateString, 100)
+                                  .addPrice(endDateString, 101)
+                                  .addTo(client);
+                                    
+        PerformanceIndex securityIndex = PerformanceIndex.forSecurity(getClientIndex(), security);
+        
+        Interval interval = Interval.of(startDate.minusDays(1),
+                                        endDate.plusDays(1));
+
+        
+        assertThat(securityIndex.getPerformance(interval), closeTo(0.0, 0.1e-10));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.Year;
 import java.time.YearMonth;
 import java.time.temporal.TemporalAdjusters;
-import java.util.Arrays;
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.ToDoubleFunction;
 
@@ -124,34 +123,13 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
 
     private double getPerformanceFor(PerformanceIndex index, YearMonth month)
     {
-        int start = Arrays.binarySearch(index.getDates(), month.atDay(1).minusDays(1));
-        // should not happen, but let's be defensive this time
-        if (start < 0)
-            start = 0;
-
-        int end = Arrays.binarySearch(index.getDates(), month.atEndOfMonth());
-        // make sure there is an end index if the binary search returns a
-        // negative value (i.e. if the current month is not finished)
-        if (end < 0)
-        {
-            // take the last available date
-            end = index.getDates().length - 1;
-        }
-
-        return ((index.getAccumulatedPercentage()[end] + 1) / (index.getAccumulatedPercentage()[start] + 1)) - 1;
+        return index.getPerformance(Interval.of(month.atDay(1).minusDays(1),
+                                                month.atEndOfMonth()));
     }
 
     private double getSumPerformance(PerformanceIndex index, Year year)
     {
-        int start = Arrays.binarySearch(index.getDates(), year.atDay(1).minusDays(1));
-        if (start < 0)
-            start = 0;
-
-        int end = Arrays.binarySearch(index.getDates(), year.atDay(1).with(TemporalAdjusters.lastDayOfYear()));
-        if (end < 0)
-            end = index.getDates().length - 1;
-
-        return ((index.getAccumulatedPercentage()[end] + 1) / (index.getAccumulatedPercentage()[start] + 1)) - 1;
+        return index.getPerformance(Interval.of(year.atDay(1).minusDays(1),
+                                                year.atDay(1).with(TemporalAdjusters.lastDayOfYear())));
     }
-
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -441,4 +441,34 @@ public class PerformanceIndex
             }
         }
     }
+    
+    public double getPerformance(Interval interval)
+    {
+        double startValue, endValue;
+        startValue = endValue = 0;
+        
+        int startIndex = Arrays.binarySearch(this.getDates(), interval.getStart());
+        boolean startFound = (startIndex >= 0);
+        if (startFound)
+            startValue = this.getAccumulatedPercentage()[startIndex];
+        
+        int endIndex = Arrays.binarySearch(this.getDates(), interval.getEnd());
+        boolean endFound = (endIndex >= 0);
+        if (endFound)
+        {
+            endValue = this.getAccumulatedPercentage()[endIndex];
+        }
+        else if (startFound)
+        {
+            // make sure there is an end index if the binary search returns a
+            // negative value (i.e. if the current month is not finished)
+            // But be sure to only do so if a start date was found at all.
+            // If both are not found, no data is available and everything stays
+            // zero.
+            int lastIndex = this.getDates().length - 1;
+            endValue = this.getAccumulatedPercentage()[lastIndex];
+        }
+
+        return ((endValue + 1) / (startValue + 1)) - 1;
+    }
 }


### PR DESCRIPTION
I always had issues with the displayed excess return rate in the monthly heatmap when using an inflation index (in my case DE HVPI). The values were just not true for the current month and jumped around when adjusting the Dashboard interval. The problem is as well described here in the forum: https://forum.portfolio-performance.info/t/falsche-berechnung-normalisierte-monatsrenditen-heatmap-bei-fehlenden-benchmark-werten/17481/2

I have debugged the issue and found that the performance computation in the heatmap UI class does not cover the case when neither the start, nor the end date have values inside the benchmark index. For me this is always the case for the most recent month since the HVPI has only monthly entries for the first of the month and gets published delayed. The current behavior of the code is to simply grab the first and last value from the benchmark regarding the Dashboard interval and calculate the cumulative performance. This is certainly not what you would expect for the current month so I assume this is a bug and not a voluntary heuristic. This also explains why the values differ if the interval is adjusted.

As a remedy I added a special code path to return zero performance in this case where no data is available yet, since neither start, nor end date of the interval are included in the performance index.

I refactored the content of the getPerformanceFor function out into a method of the PerformanceIndex to reduce duplicate code. I furthermore added several tests. I tried to cover all edge cases for the calculations fired from the heatmap UI class. I was unable to successfully run the whole project's tests since I am obviously missing resources some of them expect. Maybe you could add the necessary steps to the Readme? Feel free to relocate or adjust the code to your style.