### PR TITLE
Fixes "null" caption as currency in LimitExceededWidget when no currency assigned to security

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/Values.java
@@ -92,7 +92,7 @@ public abstract class Values<E>
 
         public String format(String currencyCode, long quote)
         {
-            return currencyCode + " " + format(quote); //$NON-NLS-1$
+            return currencyCode != null ? currencyCode + " " + format(quote) : format(quote); //$NON-NLS-1$
         }
 
         public String format(Quote quote)


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/90478568/156052302-02fc0009-a093-4329-a515-5bad7e699f6f.png)

After:
![grafik](https://user-images.githubusercontent.com/90478568/156052321-671dad6f-14e2-49cd-94bd-d173b72f3705.png)
