### PR TITLE
Automatic file extensions for chart export

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -21,12 +21,14 @@ import name.abuchen.portfolio.util.TextUtil;
 
 /* package */class ChartContextMenu
 {
+    private static final int DEFAULT_FILE_EXTENSION = 2;
+
     private static final String[] EXTENSIONS = new String[] { "*.jpeg", "*.jpg", "*.png" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
     private Chart chart;
     private Menu contextMenu;
-    
-    private static int lastUsedFileExtension = 2;
+
+    private static int lastUsedFileExtension = DEFAULT_FILE_EXTENSION;
 
     public ChartContextMenu(Chart chart)
     {
@@ -205,38 +207,46 @@ import name.abuchen.portfolio.util.TextUtil;
                         if (filename == null)
                             return;
 
+                        lastUsedFileExtension = dialog.getFilterIndex();
+                        if (lastUsedFileExtension == -1)
+                            lastUsedFileExtension = DEFAULT_FILE_EXTENSION;
+
                         int format;
                         if (filename.endsWith(".jpg") || filename.endsWith(".jpeg")) //$NON-NLS-1$ //$NON-NLS-2$
                             format = SWT.IMAGE_JPEG;
                         else if (filename.endsWith(".png")) //$NON-NLS-1$
                             format = SWT.IMAGE_PNG;
                         else
-                            format = SWT.IMAGE_UNDEFINED;
-                        
-                        lastUsedFileExtension = dialog.getFilterIndex();
-                        if(lastUsedFileExtension == -1)
-                            lastUsedFileExtension = 0;
-
-                        if (format != SWT.IMAGE_UNDEFINED)
                         {
-                            boolean isChartTitleVisible = chart.getTitle().isVisible(); 
-                            boolean isChartLegendVisible = chart.getLegend().isVisible();
-                            try
+                            if (lastUsedFileExtension == 0 || lastUsedFileExtension == 1)
                             {
-                                chart.suspendUpdate(true);
-                                chart.getTitle().setVisible(true);
-                                chart.getLegend().setVisible(true);
-                                chart.getLegend().setPosition(SWT.BOTTOM);
-                                chart.suspendUpdate(false);
-                                chart.save(filename, format);
+                                filename = filename + ".jpg"; //$NON-NLS-1$
+                                format = SWT.IMAGE_JPEG;
                             }
-                            finally
+                            else
                             {
-                                chart.suspendUpdate(true);
-                                chart.getTitle().setVisible(isChartTitleVisible);
-                                chart.getLegend().setVisible(isChartLegendVisible);
-                                chart.suspendUpdate(false);
+                                filename = filename + ".png"; //$NON-NLS-1$
+                                format = SWT.IMAGE_PNG;
                             }
+                        }
+
+                        boolean isChartTitleVisible = chart.getTitle().isVisible();
+                        boolean isChartLegendVisible = chart.getLegend().isVisible();
+                        try
+                        {
+                            chart.suspendUpdate(true);
+                            chart.getTitle().setVisible(true);
+                            chart.getLegend().setVisible(true);
+                            chart.getLegend().setPosition(SWT.BOTTOM);
+                            chart.suspendUpdate(false);
+                            chart.save(filename, format);
+                        }
+                        finally
+                        {
+                            chart.suspendUpdate(true);
+                            chart.getTitle().setVisible(isChartTitleVisible);
+                            chart.getLegend().setVisible(isChartLegendVisible);
+                            chart.suspendUpdate(false);
                         }
                     }
 
@@ -249,8 +259,7 @@ import name.abuchen.portfolio.util.TextUtil;
                 {
                     PortfolioPlugin.log(e);
                 }
-                
-                
+
             }
         });
     }


### PR DESCRIPTION
When no file extension is given, an extension is automatically added (depending on the chosen extension filter or '.png' as last fallback)

Fixes #2723