### PR TITLE
Modify and Improve FlatEx PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechDividende06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechDividende06.txt
@@ -1,0 +1,38 @@
+FinTech Group Bank AG
+Hausbroicher Str. 222
+47877 Willich
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 (0)9221 - 7035898
+E-Mail: kunden@flatex.de
+FinTech Group Bank AG -  Rotfeder-Ring 7 - 60327 Frankfurt am Main
+01022620000005000000000
+Herrn
+M Frankfurt,          15.01.2014ax Mustermann
+Musterstra�e. 2
+12345 Stadt
+Zinsgutschrift
+Ihre Depotnummer : 1111111111
+Depotinhaber     : Mustermann, Max
+Nr.111111111                   ISH.FOOBAR 12345666 x.EFT (DE1234567890/AB1234)
+St./Nominale    :       1.000 EUR
+Zinstage        :         365          Ertrag p.a.     :       7,3750 %
+Extag           :  28.04.2016          Ertrag          :       7,3750 %
+Zinstermin      :  28.04.2016          Zinsbetrag      :        73,75 EUR
+Zahlungstag     :  28.04.2016          Faktor          :     1,000000
+Valuta          :  28.04.2016         *Einbeh. Steuer  :         0,00 EUR
+                                       Endbetrag       :        73,75 EUR
+* Einbehaltene Kapitalertragsteuer, ggf. ausl�ndische Quellensteuer zuz�glich
+  Solidarit�tszuschlag und ggf. Kirchensteuer. Evtl. Details dazu finden Sie im
+  Steuerreport unter der Transaktion-Nr.: 111111111
+Die Verrechnung des Endbetrages erfolgt �ber Ihr Konto Nr.:  111111111
+Die  Gutschrift erfolgt  unter Vorbehalt  des  Eingangs.  Einwendungen  m�ssen
+unverz�glich  nach  Zugang  erhoben  werden.  Die  Unterlassung  rechtzeitiger
+Einwendung gilt als Genehmigung.
+Dieser   Beleg   ist    keine   Steuerbescheinigung.    Kapitalertr�ge   sind
+einkommensteuerpflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+F�r weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Willich  -  Amtsgericht Krefeld  (HRB 10867)
+Vorsitzender des Aufsichtsrats: Frank Niehage   -  Vorstand: Lars Lankes, Bernd W�rfel
+2000000000000000 0000000000000000

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -1,20 +1,20 @@
 package name.abuchen.portfolio.datatransfer.pdf.fintechgroupbank;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertNull;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
 import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.datatransfer.Extractor;
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
@@ -45,26 +45,24 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(6));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0005194062"));
         assertThat(security.getWkn(), is("519406"));
         assertThat(security.getName(), is("BAYWA AG VINK.NA. O.N."));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-
-        // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        // check buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -72,6 +70,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-01-28T12:50")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(150)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5893.10))));
@@ -83,8 +82,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.90 + 1.00 + 1.00))));
 
         // check 2st buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -92,6 +91,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-01-28T12:58")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5954.80))));
@@ -103,8 +103,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(2).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -112,6 +112,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-01-28T12:58")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5943.00))));
@@ -123,13 +124,15 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check tax-refund in 3rd buy sell transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-01-28T12:58")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
         assertThat(transaction.getSource(), is("FinTechSammelabrechnung01.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(100.00))));
@@ -148,14 +151,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung02.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(20));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000CQ0U7Z4"));
         assertThat(security.getWkn(), is("CQ0U7Z"));
@@ -163,8 +167,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -172,6 +176,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:41")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4550.00)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3008.90))));
@@ -183,8 +188,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 2st buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -192,6 +197,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:46")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(745)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3000.80))));
@@ -203,8 +209,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(2).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -212,6 +218,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:46")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4100)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3039.90))));
@@ -223,8 +230,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 4rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(3).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -232,6 +239,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:48")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2870)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3019.40))));
@@ -243,8 +251,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(4).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -252,6 +260,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:51")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4300)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3015.90))));
@@ -263,8 +272,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(5).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -272,6 +281,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T14:53")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2050)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3019.40))));
@@ -283,8 +293,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(6).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -292,6 +302,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T15:09")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2470)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2992.60))));
@@ -303,8 +314,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.90))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(7).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -312,6 +323,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T15:30")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2280)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3015.50))));
@@ -323,8 +335,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(8).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -332,6 +344,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T15:31")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1145)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3017.25))));
@@ -343,8 +356,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(9).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -352,6 +365,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-11-01T15:52")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1247)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5417.88))));
@@ -370,14 +384,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung03.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung03.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000A1MECS1"));
         assertThat(security.getWkn(), is("A1MECS"));
@@ -385,8 +400,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -394,6 +409,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-01-09T15:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.025361)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.72))));
@@ -412,14 +428,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung04.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung04.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0001234567"));
         assertThat(security.getWkn(), is("DS5WKN"));
@@ -427,8 +444,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -436,6 +453,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-08-13T16:20")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2000)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung04.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1023.90))));
@@ -454,26 +472,24 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung05.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung05.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(7));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000VN4LAU4"));
         assertThat(security.getWkn(), is("VN4LAU"));
         assertThat(security.getName(), is("VONT.FINL PR CALL17 DAX"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof BuySellEntryItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-
         // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -481,6 +497,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-01-02T13:15")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1750)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1036.40))));
@@ -492,8 +509,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.90))));
 
         // check 2st buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -501,6 +518,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-01-02T14:55")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1250)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1003.90))));
@@ -512,8 +530,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.90))));
 
         // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(2).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -521,6 +539,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-01-02T16:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1750)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1232.40))));
@@ -532,8 +551,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.90))));
 
         // check 4rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(3).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -541,6 +560,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-01-02T16:07")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1250)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(844.10))));
@@ -552,13 +572,15 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90))));
 
         // check tax-refund in 4rd buy sell transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-01-02T16:07")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(1250)));
         assertThat(transaction.getSource(), is("FinTechSammelabrechnung05.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(44.72))));
@@ -577,14 +599,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung06.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechSammelabrechnung06.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000SKWM021"));
         assertThat(security.getWkn(), is("SKWM02"));
@@ -592,8 +615,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -601,6 +624,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-09-08T08:32")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(460)));
         assertThat(entry.getSource(), is("FinTechSammelabrechnung06.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1253.15))));
@@ -612,13 +636,15 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00 + 6.85))));
 
         // check tax-refund buy sell transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-09-08T08:32")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(460)));
         assertThat(transaction.getSource(), is("FinTechSammelabrechnung06.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(463.04))));
@@ -644,7 +670,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0392495023"));
         assertThat(security.getWkn(), is("ETF114"));
@@ -652,8 +678,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -661,6 +687,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-12-03T13:59")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(10)));
         assertThat(entry.getSource(), is("biwAGKauf01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.30))));
@@ -686,7 +713,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0378438732"));
         assertThat(security.getWkn(), is("ETF001"));
@@ -694,8 +721,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -703,6 +730,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-08-01T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2.460378)));
         assertThat(entry.getSource(), is("biwAGKauf02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(250.00))));
@@ -721,93 +749,70 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "biwAGWertpapierEingang01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "biwAGWertpapierEingang01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000US9RGR9"));
         assertThat(security.getName(), is("UBS AG LONDON 14/16 RWE"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check delivery inbound (Einlieferung) transaction
-        PortfolioTransaction transaction = (PortfolioTransaction) results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        PortfolioTransaction entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(transaction.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-11-24T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(250)));
-        assertThat(transaction.getSource(), is("biwAGWertpapierEingang01.txt"));
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-11-24T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(250)));
+        assertThat(entry.getSource(), is("biwAGWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
 
-        assertThat(transaction.getMonetaryAmount(),
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7517.50))));
-        assertThat(transaction.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7517.50))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
     public void testbiwAGKontoauszug01()
     {
-        Client client = new Client();
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
-
-        Security existingSecurity = new Security("Ohne Name AG", CurrencyUnit.EUR);
-        existingSecurity.setIsin("ISIN12345678");
-        client.addSecurity(existingSecurity);
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "biwAGKontoauszug01.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(2));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check 1st transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-11-12T00:00")));
-        assertThat(transaction.getSource(), is("biwAGKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Gebühr Kapitaltransaktion Ausland"));
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.56))));
-        assertThat(transaction.getGrossValue(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.56))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-12-31T00:00")));
-        assertThat(transaction.getSource(), is("biwAGKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss   01.10.2014 - 31.12.2014"));
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.89))));
-        assertThat(transaction.getGrossValue(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.89))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-12-31T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.89))));
+            assertThat(transaction.getSource(), is("biwAGKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Zinsabschluss   01.10.2014 - 31.12.2014"));
+        }
     }
 
     @Test
@@ -824,7 +829,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B2QWCY14"));
         assertThat(security.getWkn(), is("A0Q1YY"));
@@ -832,8 +837,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -841,6 +846,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-12-15T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(19.334524)));
         assertThat(entry.getSource(), is("FinTechKauf01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1050.00))));
@@ -866,7 +872,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0392494992"));
         assertThat(security.getWkn(), is("ETF113"));
@@ -874,8 +880,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -883,6 +889,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-06-16T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(13.268957)));
         assertThat(entry.getSource(), is("FinTechKauf02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(800.00))));
@@ -908,7 +915,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0328475792"));
         assertThat(security.getWkn(), is("DBX1A7"));
@@ -916,8 +923,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -925,6 +932,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-06-15T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(5.082011)));
         assertThat(entry.getSource(), is("FinTechKauf03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
@@ -950,7 +958,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B2NPKV68"));
         assertThat(security.getWkn(), is("A0NECU"));
@@ -958,8 +966,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -967,6 +975,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-06-15T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(9.703363)));
         assertThat(entry.getSource(), is("FinTechKauf04.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
@@ -992,7 +1001,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B3S5XW04"));
         assertThat(security.getWkn(), is("A1JJTP"));
@@ -1000,8 +1009,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1009,6 +1018,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-01-09T15:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.099044)));
         assertThat(entry.getSource(), is("FinTechKauf05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.16))));
@@ -1034,7 +1044,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0274211480"));
         assertThat(security.getWkn(), is("DBX1DA"));
@@ -1042,8 +1052,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1051,6 +1061,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-01-02T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(7.979324)));
         assertThat(entry.getSource(), is("FinTechKauf06.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
@@ -1076,7 +1087,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B6YX5D40"));
         assertThat(security.getWkn(), is("A1JKS0"));
@@ -1084,8 +1095,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1093,6 +1104,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-01-02T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(22.973458)));
         assertThat(entry.getSource(), is("FinTechKauf07.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
@@ -1118,7 +1130,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0635178014"));
         assertThat(security.getWkn(), is("ETF127"));
@@ -1126,8 +1138,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1135,6 +1147,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-03T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1.43414)));
         assertThat(entry.getSource(), is("FinTechKauf08.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(52.50))));
@@ -1160,7 +1173,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00BF2B0K52"));
         assertThat(security.getWkn(), is("A2DTF1"));
@@ -1168,8 +1181,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1177,6 +1190,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-01-17T17:52")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(61)));
         assertThat(entry.getSource(), is("FinTechKauf09.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1279.55))));
@@ -1187,7 +1201,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90 + 2.71))));
     }
-    
+
     @Test
     public void testFinTechKauf10()
     {
@@ -1202,7 +1216,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0392494562"));
         assertThat(security.getWkn(), is("ETF110"));
@@ -1210,8 +1224,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -1219,29 +1233,29 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-04T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(8.205431)));
         assertThat(entry.getSource(), is("FinTechKauf10.txt"));
+        assertNull(entry.getNote());
 
-        // Stock bought for EUR 400, EUR 0.01 Tax refund.
-        // Total on reference account: EUR 399.99
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
-        // No tax, since tax refund is reported separately.
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // check tax-refund transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+        // check tax refund transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-04T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(8.205431)));
         assertThat(transaction.getSource(), is("FinTechKauf10.txt"));
+        assertNull(transaction.getNote());
 
-        assertThat(transaction.getMonetaryAmount(), 
+        assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.01))));
         assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.01))));
@@ -1258,7 +1272,8 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKaufStorno01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKaufStorno01.txt"),
+                        errors);
 
         assertThat(errors.size(), is(1));
         assertThat(errors.get(0).getMessage(), containsString(Messages.MsgErrorOrderCancellationUnsupported));
@@ -1279,7 +1294,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000US9RGR9"));
         assertThat(security.getWkn(), is("US9RGR"));
@@ -1287,8 +1302,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1296,6 +1311,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-01-22T16:14")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(250)));
         assertThat(entry.getSource(), is("FinTechVerkauf01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16508.16))));
@@ -1321,7 +1337,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0009807008"));
         assertThat(security.getWkn(), is("980700"));
@@ -1329,8 +1345,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1338,6 +1354,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-07-04T14:23")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(121)));
         assertThat(entry.getSource(), is("FinTechVerkauf02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4840.15))));
@@ -1363,7 +1380,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B53HP851"));
         assertThat(security.getWkn(), is("A0YEDM"));
@@ -1371,8 +1388,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1380,6 +1397,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-01-09T15:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.007229)));
         assertThat(entry.getSource(), is("FinTechVerkauf03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.95))));
@@ -1405,7 +1423,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00BKWQ0D84"));
         assertThat(security.getWkn(), is("A1191N"));
@@ -1413,8 +1431,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1422,6 +1440,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-02-06T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.089051)));
         assertThat(entry.getSource(), is("FinTechVerkauf04.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9.48))));
@@ -1447,7 +1466,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0008402215"));
         assertThat(security.getWkn(), is("840221"));
@@ -1455,22 +1474,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-05-08T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(360)));
         assertThat(transaction.getSource(), is("FinTechDividende01.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 716759781"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(795.15))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1080.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(284.85))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -1488,7 +1508,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE1234567890"));
         assertThat(security.getWkn(), is("AB1234"));
@@ -1496,22 +1516,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-01-15T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(99)));
         assertThat(transaction.getSource(), is("FinTechDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 111111111"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.55))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(77.77))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.22))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -1529,7 +1550,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0006335003"));
         assertThat(security.getWkn(), is("633500"));
@@ -1537,22 +1558,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-06-23T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(15)));
         assertThat(transaction.getSource(), is("FinTechDividende03.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1236644834"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(17.13))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.25))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.12))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -1570,37 +1592,41 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US8552441094"));
         assertThat(security.getWkn(), is("884437"));
         assertThat(security.getName(), is("STARBUCKS CORP."));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-08-25T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(105)));
         assertThat(transaction.getSource(), is("FinTechDividende04.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.45))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.23))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.11 + (7.88 / 1.1808)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(26.25))));
     }
 
     @Test
     public void testFinTechDividende04WithSecurityInUSD()
     {
-        Security security = new Security("STARBUCKS CORP.", CurrencyUnit.USD);
+        Security security = new Security("STARBUCKS CORP.", CurrencyUnit.EUR);
         security.setIsin("US8552441094");
         security.setWkn("884437");
 
@@ -1617,22 +1643,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(results.size(), is(1));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-08-25T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(105)));
         assertThat(transaction.getSource(), is("FinTechDividende04.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.45))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.23))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.11 + (7.88 / 1.1808)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
@@ -1656,47 +1683,48 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("GB00B03MLX29"));
         assertThat(security.getWkn(), is("A0D94M"));
         assertThat(security.getName(), is("ROYAL DUTCH SHELL A EO-07"));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-20T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(180)));
         assertThat(transaction.getSource(), is("FinTechDividende05.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 0000000000"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(60.97))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(71.73))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.76))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
-    public void testFinTechZinsgutschrift01()
+    public void testFinTechDividende06()
     {
         FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechZinsgutschrift01.txt"),
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechDividende06.txt"),
                         errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE1234567890"));
         assertThat(security.getWkn(), is("AB1234"));
@@ -1704,22 +1732,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-04-28T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(1000)));
-        assertThat(transaction.getSource(), is("FinTechZinsgutschrift01.txt"));
+        assertThat(transaction.getSource(), is("FinTechDividende06.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 111111111"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(73.75))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(73.75))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -1730,22 +1759,23 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000CM31SV9"));
         assertThat(security.getName(), is("COMMERZBANK INLINE09EO/SF"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1753,6 +1783,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2009-12-02T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(325)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2867.88))));
@@ -1771,22 +1802,23 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang02.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000CK1Q3N7"));
         assertThat(security.getName(), is("COMMERZBANK INLINE11EO/SF"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1794,6 +1826,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-07-18T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(200)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
@@ -1812,22 +1845,23 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang03.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang03.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(6));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000CB81KN1"));
         assertThat(security.getName(), is("COMMERZBANK PUT10 EOLS"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check 1st transfer_out transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.TRANSFER_OUT));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.TRANSFER_OUT));
@@ -1835,6 +1869,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-03-16T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2000)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
@@ -1846,8 +1881,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 2nd transfer_out transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.TRANSFER_OUT));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.TRANSFER_OUT));
@@ -1855,6 +1890,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-03-16T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1250)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
@@ -1866,8 +1902,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 3rd transfer_out transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(2).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.TRANSFER_OUT));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.TRANSFER_OUT));
@@ -1875,6 +1911,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-03-16T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(750)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
@@ -1893,14 +1930,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang04.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang04.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE000SG0WRD3"));
         assertThat(security.getWkn(), is("SG0WRD"));
@@ -1908,8 +1946,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1917,6 +1955,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-09-28T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(83)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang04.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(111.22))));
@@ -1935,14 +1974,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang05.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang05.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("CH0585795898"));
         assertThat(security.getWkn(), is("UE5KPQ"));
@@ -1950,8 +1990,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -1959,6 +1999,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-06-25T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(400)));
         assertThat(entry.getSource(), is("FinTechWertpapierAusgang05.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(305.20))));
@@ -1969,14 +2010,16 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
-        // check tax-refund buy sell transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check tax refund transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-06-25T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(400)));
         assertThat(transaction.getSource(), is("FinTechWertpapierAusgang05.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(88.53))));
@@ -1995,34 +2038,67 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang06.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierAusgang06.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check security items
-        List<Item> securities = results.stream().filter(i -> i instanceof SecurityItem).collect(Collectors.toList());
-        assertThat(securities.get(0).getSecurity().getIsin(), is("LU0392494562"));
-        assertThat(securities.get(1).getSecurity().getIsin(), is("LU0444605645"));
+        // check security
+        Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security1.getIsin(), is("LU0392494562"));
+        assertThat(security1.getName(), is("COMS.-MSCI WORL.T.U.ETF I"));
+        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transaction items
-        List<Item> entries = results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList());
-        BuySellEntry entry = (BuySellEntry) entries.get(0).getSubject();
+        Security security2 = results.stream().filter(SecurityItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security2.getIsin(), is("LU0444605645"));
+        assertThat(security2.getName(), is("C-IBO.E.L.S.D.O.T.U.ETF I"));
+        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check 1st buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-09-18T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(310)));
+        assertThat(entry.getSource(), is("FinTechWertpapierAusgang06.txt"));
+        assertNull(entry.getNote());
 
-        entry = (BuySellEntry) entries.get(1).getSubject();
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        // check 2nd buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-09-18T00:00")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(118)));
+        assertThat(entry.getSource(), is("FinTechWertpapierAusgang06.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -2032,29 +2108,30 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierEingang01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechWertpapierEingang01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(20));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0008474503"));
         assertThat(security.getName(), is("DEKAFONDS CF"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check 1st delivery inbound (Einlieferung) transaction
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        PortfolioTransaction entry = (PortfolioTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        PortfolioTransaction entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
         assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-02-16T00:00")));
         assertThat(entry.getShares(), is(Values.Share.factorize(0.052)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.50))));
@@ -2066,345 +2143,361 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 2nd delivery inbound (Einlieferung) transaction
-        Item item2 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(1);
-        assertThat(item2.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry2 = (PortfolioTransaction) item2.getSubject();
-        assertThat(entry2.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry2.getDateTime(), is(LocalDateTime.parse("2015-02-20T00:00")));
-        assertThat(entry2.getShares(), is(Values.Share.factorize(0.003)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry2.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-02-20T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.003)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.30))));
-        assertThat(entry2.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.30))));
-        assertThat(entry2.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry2.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 3rd delivery inbound (Einlieferung) transaction
-        Item item3 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(2);
-        assertThat(item3.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry3 = (PortfolioTransaction) item3.getSubject();
-        assertThat(entry3.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry3.getDateTime(), is(LocalDateTime.parse("2015-03-16T00:00")));
-        assertThat(entry3.getShares(), is(Values.Share.factorize(0.432)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry3.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-03-16T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.432)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry3.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry3.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry3.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 4th delivery inbound (Einlieferung) transaction
-        Item item4 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(3);
-        assertThat(item4.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry4 = (PortfolioTransaction) item4.getSubject();
-        assertThat(entry4.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry4.getDateTime(), is(LocalDateTime.parse("2015-04-15T00:00")));
-        assertThat(entry4.getShares(), is(Values.Share.factorize(0.424)));
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-04-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.424)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
 
-        assertThat(entry4.getMonetaryAmount(),
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry4.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry4.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry4.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 5th delivery inbound (Einlieferung) transaction
-        Item item5 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(4);
-        assertThat(item5.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry5 = (PortfolioTransaction) item5.getSubject();
-        assertThat(entry5.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry5.getDateTime(), is(LocalDateTime.parse("2015-05-15T00:00")));
-        assertThat(entry5.getShares(), is(Values.Share.factorize(0.446)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry5.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-05-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.446)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry5.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry5.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry5.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 6th delivery inbound (Einlieferung) transaction
-        Item item6 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(5);
-        assertThat(item6.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry6 = (PortfolioTransaction) item6.getSubject();
-        assertThat(entry6.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry6.getDateTime(), is(LocalDateTime.parse("2015-06-15T00:00")));
-        assertThat(entry6.getShares(), is(Values.Share.factorize(0.467)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry6.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-06-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.467)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry6.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry6.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry6.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 7th delivery inbound (Einlieferung) transaction
-        Item item7 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(6);
-        assertThat(item7.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry7 = (PortfolioTransaction) item7.getSubject();
-        assertThat(entry7.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(6).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry7.getDateTime(), is(LocalDateTime.parse("2015-07-15T00:00")));
-        assertThat(entry7.getShares(), is(Values.Share.factorize(0.447)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry7.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-07-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.447)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry7.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry7.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry7.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 8th delivery inbound (Einlieferung) transaction
-        Item item8 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(7);
-        assertThat(item8.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry8 = (PortfolioTransaction) item8.getSubject();
-        assertThat(entry8.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(7).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry8.getDateTime(), is(LocalDateTime.parse("2015-08-17T00:00")));
-        assertThat(entry8.getShares(), is(Values.Share.factorize(0.462)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry8.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-08-17T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.462)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry8.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry8.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry8.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 9th delivery inbound (Einlieferung) transaction
-        Item item9 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(8);
-        assertThat(item9.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry9 = (PortfolioTransaction) item9.getSubject();
-        assertThat(entry9.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(8).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry9.getDateTime(), is(LocalDateTime.parse("2015-09-15T00:00")));
-        assertThat(entry9.getShares(), is(Values.Share.factorize(0.504)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry9.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-09-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.504)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry9.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry9.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry9.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 10th delivery inbound (Einlieferung) transaction
-        Item item10 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(9);
-        assertThat(item10.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry10 = (PortfolioTransaction) item10.getSubject();
-        assertThat(entry10.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(9).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry10.getDateTime(), is(LocalDateTime.parse("2015-10-15T00:00")));
-        assertThat(entry10.getShares(), is(Values.Share.factorize(0.504)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry10.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-10-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.504)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry10.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry10.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry10.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 11th delivery inbound (Einlieferung) transaction
-        Item item11 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(10);
-        assertThat(item11.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry11 = (PortfolioTransaction) item11.getSubject();
-        assertThat(entry11.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(10).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry11.getDateTime(), is(LocalDateTime.parse("2015-11-16T00:00")));
-        assertThat(entry11.getShares(), is(Values.Share.factorize(0.474)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry11.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-11-16T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.474)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry11.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry11.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry11.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 12th delivery inbound (Einlieferung) transaction
-        Item item12 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(11);
-        assertThat(item12.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry12 = (PortfolioTransaction) item12.getSubject();
-        assertThat(entry12.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(11).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry12.getDateTime(), is(LocalDateTime.parse("2015-12-15T00:00")));
-        assertThat(entry12.getShares(), is(Values.Share.factorize(0.49)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry12.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2015-12-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.49)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry12.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry12.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry12.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 13th delivery inbound (Einlieferung) transaction
-        Item item13 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(12);
-        assertThat(item13.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry13 = (PortfolioTransaction) item13.getSubject();
-        assertThat(entry13.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(12).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry13.getDateTime(), is(LocalDateTime.parse("2016-01-15T00:00")));
-        assertThat(entry13.getShares(), is(Values.Share.factorize(0.525)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry13.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-01-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.525)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry13.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry13.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry13.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 14th delivery inbound (Einlieferung) transaction
-        Item item14 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(13);
-        assertThat(item14.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry14 = (PortfolioTransaction) item14.getSubject();
-        assertThat(entry14.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(13).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry14.getDateTime(), is(LocalDateTime.parse("2016-02-15T00:00")));
-        assertThat(entry14.getShares(), is(Values.Share.factorize(0.551)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry14.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-02-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.551)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry14.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry14.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry14.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 15th delivery inbound (Einlieferung) transaction
-        Item item15 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(14);
-        assertThat(item15.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry15 = (PortfolioTransaction) item15.getSubject();
-        assertThat(entry15.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(14).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry15.getDateTime(), is(LocalDateTime.parse("2016-02-19T00:00")));
-        assertThat(entry15.getShares(), is(Values.Share.factorize(0.117)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry15.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-02-19T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.117)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.12))));
-        assertThat(entry15.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.12))));
-        assertThat(entry15.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry15.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 16th delivery inbound (Einlieferung) transaction
-        Item item16 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(15);
-        assertThat(item16.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry16 = (PortfolioTransaction) item16.getSubject();
-        assertThat(entry16.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(15).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry16.getDateTime(), is(LocalDateTime.parse("2016-03-15T00:00")));
-        assertThat(entry16.getShares(), is(Values.Share.factorize(0.523)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry16.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-03-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.523)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry16.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.98))));
-        assertThat(entry16.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry16.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 17th delivery inbound (Einlieferung) transaction
-        Item item17 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(16);
-        assertThat(item17.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry17 = (PortfolioTransaction) item17.getSubject();
-        assertThat(entry17.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(16).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry17.getDateTime(), is(LocalDateTime.parse("2016-04-15T00:00")));
-        assertThat(entry17.getShares(), is(Values.Share.factorize(0.517)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry17.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-04-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.517)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry17.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry17.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry17.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 18th delivery inbound (Einlieferung) transaction
-        Item item18 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(17);
-        assertThat(item18.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry18 = (PortfolioTransaction) item18.getSubject();
-        assertThat(entry18.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(17).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(entry18.getDateTime(), is(LocalDateTime.parse("2016-05-17T00:00")));
-        assertThat(entry18.getShares(), is(Values.Share.factorize(0.521)));
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry18.getMonetaryAmount(),
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-05-17T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.521)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
+
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
-        assertThat(entry18.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
-        assertThat(entry18.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry18.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check 19th delivery inbound (Einlieferung) transaction
-        Item item19 = results.stream().filter(i -> i instanceof TransactionItem)
-                        .collect(Collectors.toList()).get(18);
-        assertThat(item19.getSubject(), instanceOf(PortfolioTransaction.class));
-        PortfolioTransaction entry19 = (PortfolioTransaction) item19.getSubject();
-        assertThat(entry19.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
+        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(18).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
-        assertThat(entry19.getDateTime(), is(LocalDateTime.parse("2016-06-15T00:00")));
-        assertThat(entry19.getShares(), is(Values.Share.factorize(0.541)));
+        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2016-06-15T00:00")));
+        assertThat(entry.getShares(), is(Values.Share.factorize(0.541)));
+        assertThat(entry.getSource(), is("FinTechWertpapierEingang01.txt"));
+        assertNull(entry.getNote());
 
-        assertThat(entry19.getMonetaryAmount(),
+        assertThat(entry.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry19.getGrossValue(),
+        assertThat(entry.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(49.99))));
-        assertThat(entry19.getUnitSum(Unit.Type.TAX),
+        assertThat(entry.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry19.getUnitSum(Unit.Type.FEE),
+        assertThat(entry.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -2415,21 +2508,29 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKontoauszug01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKontoauszug01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-29T00:00")));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1100.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-29T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1100.00))));
+            assertThat(transaction.getSource(), is("FinTechKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
     }
 
     @Test
@@ -2439,23 +2540,29 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKontoauszug02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FinTechKontoauszug02.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-26T00:00")));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15000.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-26T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15000.00))));
+            assertThat(transaction.getSource(), is("FinTechKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
     }
 
     @Test
@@ -2470,18 +2577,24 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Steuertopfoptimierung 2016"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.94))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.94))));
+            assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
+            assertThat(transaction.getNote(), is("Steuertopfoptimierung 2016"));
+        }
     }
 
     @Test
@@ -2496,29 +2609,37 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(2L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(transaction.getNote(), is("EINZAHLUNG"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(1).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000.00))));
+            assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
+            assertThat(transaction.getNote(), is("EINZAHLUNG"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss   01.10.2010 - 31.12.2010"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+            assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
+            assertThat(transaction.getNote(), is("Zinsabschluss   01.10.2010 - 31.12.2010"));
+        }
     }
 
     @Test
@@ -2535,7 +2656,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00BKM4GZ66"));
         assertThat(security.getWkn(), is("A111X9"));
@@ -2543,8 +2664,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -2552,6 +2673,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-04-10T17:30")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(29)));
         assertThat(entry.getSource(), is("FlatExKauf01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(760.09))));
@@ -2577,7 +2699,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US0382221051"));
         assertThat(security.getWkn(), is("865177"));
@@ -2585,8 +2707,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -2594,6 +2716,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-09-01T21:59")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(66)));
         assertThat(entry.getSource(), is("FlatExKauf02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3437.43))));
@@ -2619,7 +2742,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B41RYL63"));
         assertThat(security.getWkn(), is("A1JJTM"));
@@ -2627,8 +2750,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -2636,6 +2759,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-06-20T09:08")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(151)));
         assertThat(entry.getSource(), is("FlatExVerkauf01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9529.81))));
@@ -2661,7 +2785,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B3WJKG14"));
         assertThat(security.getWkn(), is("A142N1"));
@@ -2669,8 +2793,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -2678,6 +2802,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-19T09:22")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(425)));
         assertThat(entry.getSource(), is("FlatExVerkauf02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5681.04))));
@@ -2703,7 +2828,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("DE0009848119"));
         assertThat(security.getWkn(), is("984811"));
@@ -2711,8 +2836,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -2720,6 +2845,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-10T17:55")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(91)));
         assertThat(entry.getSource(), is("FlatExVerkauf03.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10746.30))));
@@ -2730,14 +2856,16 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(9.90))));
 
-        // check tax-refund buy sell transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check tax refund transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-10T17:55")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(91)));
         assertThat(transaction.getSource(), is("FlatExVerkauf03.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(18.87))));
@@ -2764,21 +2892,23 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00BKM4GZ66"));
         assertThat(security.getWkn(), is("A111X9"));
         assertThat(security.getName(), is("ISHS MSCI EM USD-AC"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check tax transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-11T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(476)));
         assertThat(transaction.getSource(), is("FlatExVorabpauschale01.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.69))));
@@ -2804,7 +2934,7 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B945VV12"));
         assertThat(security.getWkn(), is("A1T8FS"));
@@ -2812,22 +2942,23 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-04-10T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(197)));
         assertThat(transaction.getSource(), is("FlatExDividende01.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1234567890"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(36.07))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(36.07))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
@@ -2845,37 +2976,41 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US5949181045"));
         assertThat(security.getWkn(), is("870747"));
         assertThat(security.getName(), is("MICROSOFT    DL-,00000625"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-12T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(15)));
         assertThat(transaction.getSource(), is("FlatExDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1757281127"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.98))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.87))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.86 + (1.15 / 1.1137)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(7.65))));
     }
 
     @Test
-    public void testFlatExDividende02WithSecurityInUSD()
+    public void testFlatExDividende02WithSecurityInEUR()
     {
-        Security security = new Security("MICROSOFT    DL-,00000625", CurrencyUnit.USD);
+        Security security = new Security("MICROSOFT    DL-,00000625", CurrencyUnit.EUR);
         security.setIsin("US5949181045");
         security.setWkn("870747");
 
@@ -2893,22 +3028,23 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-12T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(15)));
         assertThat(transaction.getSource(), is("FlatExDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1757281127"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.98))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.87))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.86 + (1.15 / 1.1137)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
@@ -2932,31 +3068,82 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00B8GKDB10"));
         assertThat(security.getWkn(), is("A1T8FV"));
         assertThat(security.getName(), is("VA.FTSE A.W.H.D.Y.UETFDLD"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-24T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(31.89)));
         assertThat(transaction.getSource(), is("FlatExDividende03.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 2222222222"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.42))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.42))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(12.88))));
+    }
+
+    @Test
+    public void testFlatExDividende03WithSecurityInEUR()
+    {
+        Security security = new Security("VA.FTSE A.W.H.D.Y.UETFDLD", CurrencyUnit.EUR);
+        security.setIsin("IE00B8GKDB10");
+        security.setWkn("A1T8FV");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-24T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(31.89)));
+        assertThat(transaction.getSource(), is("FlatExDividende03.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 2222222222"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.42))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.42))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.EUR);
+        Status s = c.process(transaction, account);
+        assertThat(s, is(Status.OK_STATUS));
     }
 
     @Test
@@ -2973,37 +3160,41 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US46284V1017"));
         assertThat(security.getWkn(), is("A14MS9"));
         assertThat(security.getName(), is("IRON MOUNTAIN (NEW)DL-,01"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-10-02T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(197)));
         assertThat(transaction.getSource(), is("FlatExDividende04.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 2041157988"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(75.30))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(103.87))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.99 + (18.28 / 1.173)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(121.84))));
     }
 
     @Test
-    public void testFlatExDividende04WithSecurityInUSD()
+    public void testFlatExDividende04WithSecurityInEUR()
     {
-        Security security = new Security("IRON MOUNTAIN (NEW)DL-,01", CurrencyUnit.USD);
+        Security security = new Security("IRON MOUNTAIN (NEW)DL-,01", CurrencyUnit.EUR);
         security.setIsin("US46284V1017");
         security.setWkn("A14MS9");
 
@@ -3018,24 +3209,26 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-10-02T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(197)));
         assertThat(transaction.getSource(), is("FlatExDividende04.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 2041157988"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(75.30))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(103.87))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.99 + (18.28 / 1.173)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
@@ -3059,70 +3252,75 @@ public class FinTechGroupBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US5949181045"));
         assertThat(security.getWkn(), is("870747"));
         assertThat(security.getName(), is("MICROSOFT    DL-,00000625"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-11T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(50)));
         assertThat(transaction.getSource(), is("FlatExDividende05.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.73))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.47))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.37 + (3.82 / 1.1348)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(25.50))));
     }
 
     @Test
-    public void testFlatExDividende05WithAccountAndSecurityInUSD()
+    public void testFlatExDividende05WithSecurityInEUR()
     {
-        Security security = new Security("MICROSOFT    DL-,00000625", CurrencyUnit.USD);
+        Security security = new Security("MICROSOFT    DL-,00000625", CurrencyUnit.EUR);
         security.setIsin("US5949181045");
         security.setWkn("870747");
 
         Client client = new Client();
         client.addSecurity(security);
 
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
 
         List<Exception> errors = new ArrayList<>();
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDividende05.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(2));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-11T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(50)));
         assertThat(transaction.getSource(), is("FlatExDividende05.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.73))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(22.47))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.37 + (3.82 / 1.1348)))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
@@ -3135,53 +3333,50 @@ public class FinTechGroupBankPDFExtractorTest
     @Test
     public void testFlatExDividende06()
     {
-        Security security = new Security("MICROSOFT    DL-,00000625", CurrencyUnit.USD);
-        security.setIsin("US5949181045");
-        security.setWkn("870747");
-
-        Client client = new Client();
-        client.addSecurity(security);
-
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDividende06.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(1));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.USD);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("US5949181045"));
+        assertThat(security.getWkn(), is("870747"));
+        assertThat(security.getName(), is("MICROSOFT    DL-,00000625"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-11T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(50)));
         assertThat(transaction.getSource(), is("FlatExDividende06.txt"));
+        assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(18.99))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(25.50))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((2.37 * 1.1348) + 3.82))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
-
-        CheckCurrenciesAction c = new CheckCurrenciesAction();
-        Account account = new Account();
-        account.setCurrencyCode(CurrencyUnit.USD);
-        Status s = c.process(transaction, account);
-        assertThat(s, is(Status.OK_STATUS));
     }
 
     @Test
-    public void testFlatExDividende07()
+    public void testFlatExDividende07WithNegativeAmount()
     {
         /***
-         * This test is a dividend transaction, but to reinvest the dividend.
+         * This test is a dividend transaction with negative amount.
          * Taxes must be paid.
          */
         FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
@@ -3191,20 +3386,40 @@ public class FinTechGroupBankPDFExtractorTest
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDividende07.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(2));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("LU0386882277"));
         assertThat(security.getWkn(), is("A0RLJD"));
         assertThat(security.getName(), is("PICTET-GL.MEGAT.SEL.P EO"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check dividends reinvest taxes transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-21T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(10)));
+        assertThat(transaction.getSource(), is("FlatExDividende07.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1784953069"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.19))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.19))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        // check dividends tax transaction
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
 
@@ -3215,42 +3430,67 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.26))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.26))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
     }
 
+
     @Test
-    public void testFlatExDegiroDividende01()
+    public void testFlatExDegiroDividende01WithNegativeAmount()
     {
         /***
-         * This test is a dividend transaction, but to reinvest the dividend.
+         * This test is a dividend transaction with negative amount.
          * Taxes must be paid.
          */
         FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroDividende01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroDividende01.txt"),
+                        errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(2));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("IE00BFY0GT14"));
         assertThat(security.getWkn(), is("A2N6CW"));
         assertThat(security.getName(), is("SPDR MSCI WORLD ETF"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-10-08T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(168.90)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende01.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 123456789"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(78.81 / 1.156200))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(78.81 / 1.156200))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(78.81))));
+
+        // check dividends tax transaction
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
 
@@ -3261,12 +3501,212 @@ public class FinTechGroupBankPDFExtractorTest
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.24))));
-        assertThat(transaction.getGrossValue(), 
+        assertThat(transaction.getGrossValue(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.24))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), 
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), 
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testFlatExDegiroDividende01WithNegativeAmountAndSecurityInEUR()
+    {
+        Security security = new Security("SPDR MSCI WORLD ETF", CurrencyUnit.EUR);
+        security.setIsin("IE00BFY0GT14");
+        security.setWkn("A2N6CW");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroDividende01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-10-08T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(168.90)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende01.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 123456789"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(78.81 / 1.156200))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(78.81 / 1.156200))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        // check dividends tax transaction
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-10-08T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(168.90)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende01.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 123456789"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.24))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15.24))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.EUR);
+        Status s = c.process(transaction, account);
+        assertThat(s, is(Status.OK_STATUS));
+    }
+
+    @Test
+    public void testFlatExDegiroDividende02WithNegativeAmount()
+    {
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroDividende02.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("IE00BK1PV551"));
+        assertThat(security.getWkn(), is("A1XEY2"));
+        assertThat(security.getName(), is("XTRACKERS MSCI WORLD ETF"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(i -> i instanceof TransactionItem)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-03-02T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(162.19)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1234567891"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(34.66 / 1.110600))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(34.66 / 1.110600))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(34.66))));
+
+        // check dividends tax transaction
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-03-02T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(162.19)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1234567891"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.18))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.18))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testFlatExDegiroDividende02WithNegativeAmountAndSecurityInEUR()
+    {
+        Security security = new Security("XTRACKERS MSCI WORLD ETF", CurrencyUnit.EUR);
+        security.setIsin("IE00BK1PV551");
+        security.setWkn("A1XEY2");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroDividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-03-02T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(162.19)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1234567891"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(34.66 / 1.110600))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(34.66 / 1.110600))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        // check dividends tax transaction
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-03-02T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(162.19)));
+        assertThat(transaction.getSource(), is("FlatExDegiroDividende02.txt"));
+        assertThat(transaction.getNote(), is("Transaktion-Nr.: 1234567891"));
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.18))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(68.18))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.EUR);
+        Status s = c.process(transaction, account);
+        assertThat(s, is(Status.OK_STATUS));
     }
 
     @Test
@@ -3276,14 +3716,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExSammelabrechnung01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExSammelabrechnung01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("CA03765K1049"));
         assertThat(security.getWkn(), is("A12HM0"));
@@ -3291,8 +3732,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -3300,6 +3741,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-04-09T16:52")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(540)));
         assertThat(entry.getSource(), is("FlatExSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4416.52))));
@@ -3325,14 +3767,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExSammelabrechnung02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExSammelabrechnung02.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(3));
 
         // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -3340,6 +3783,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-30T18:09")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(100)));
         assertThat(entry.getSource(), is("FlatExSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4773.36))));
@@ -3351,14 +3795,16 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(7.03 + 0.11))));
 
         // check 2st buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
 
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-11-30T18:09")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(20)));
+        assertThat(entry.getSource(), is("FlatExSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(955.98))));
@@ -3373,279 +3819,318 @@ public class FinTechGroupBankPDFExtractorTest
     @Test
     public void testFlatExKontoauszug01()
     {
-        Client client = new Client();
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
-
-        Security existingSecurity = new Security("Ohne Name AG", CurrencyUnit.EUR);
-        existingSecurity.setIsin("ISIN12345678");
-        client.addSecurity(existingSecurity);
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug01.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug01.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-07T00:00")));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(250))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(1).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-07T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(250.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-20T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Depotgebühren 01.04.2020 - 30.04.2020"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.26))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(2).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-07-20T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.26))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Depotgebühren 01.04.2020 - 30.04.2020"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-30T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss  01.04.2020 - 30.06.2020"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.05))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-30T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.05))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug01.txt"));
+            assertThat(transaction.getNote(), is("Zinsabschluss  01.04.2020 - 30.06.2020"));
+        }
     }
 
     @Test
     public void testFlatExKontoauszug02()
     {
-        Client client = new Client();
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
-
-        Security existingSecurity = new Security("Ohne Name AG", CurrencyUnit.EUR);
-        existingSecurity.setIsin("ISIN12345678");
-        client.addSecurity(existingSecurity);
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug02.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug02.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(13));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(13L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-18T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(1).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-18T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(2).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(3).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(150.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(4).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(150.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(159.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(5).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-25T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(159.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-10T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(160.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(6).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-10T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(160.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("R-Transaktion"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(7).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("R-Transaktion"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("R-Transaktion"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(8).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("R-Transaktion"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("R-Transaktion"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(9).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(53.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("R-Transaktion"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Lastschrift"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(10).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Lastschrift"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(11).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Lastschrift"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(12).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-11-19T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(50.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Lastschrift"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-31T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss  01.10.2019 - 31.12.2019"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.07))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-12-31T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.07))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug02.txt"));
+            assertThat(transaction.getNote(), is("Zinsabschluss  01.10.2019 - 31.12.2019"));
+        }
     }
 
     @Test
     public void testFlatExKontoauszug03()
     {
-        Client client = new Client();
-        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(client);
-
-        Security existingSecurity = new Security("Ohne Name AG", CurrencyUnit.EUR);
-        existingSecurity.setIsin("ISIN12345678");
-        client.addSecurity(existingSecurity);
+        FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug03.txt"), errors);
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExKontoauszug03.txt"),
+                        errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        Optional<Item> item = results.stream().filter(i -> i instanceof TransactionItem).findFirst();
-        assertThat(item.isPresent(), is(true));
-        AccountTransaction transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new)
-                        .getSubject();
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(4L));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-08T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(1).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-08T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-08-10T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(2).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-08-10T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-09-08T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        item = results.stream().filter(i -> i instanceof TransactionItem).skip(3).findFirst();
-        assertThat(item.isPresent(), is(true));
-        transaction = (AccountTransaction) item.orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-09-08T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(200.00))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
+            assertThat(transaction.getNote(), is("Überweisung"));
+        }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-06-30T00:00")));
-        assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss  01.04.2021 - 30.06.2021"));
-        assertThat(transaction.getMonetaryAmount(), 
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.73))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
+
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-06-30T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.73))));
+            assertThat(transaction.getSource(), is("FlatExKontoauszug03.txt"));
+            assertThat(transaction.getNote(), is("Zinsabschluss  01.04.2021 - 30.06.2021"));
+        }
     }
 
     @Test
@@ -3655,23 +4140,24 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDeGiroSammelabrechnung01.txt"), errors);
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "FlatExDeGiroSammelabrechnung01.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US88339J1051"));
         assertThat(security.getWkn(), is("A2ARCV"));
         assertThat(security.getName(), is("THE TRA.DESK A DL-,000001"));
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
-        // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        // check 1st buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
@@ -3679,6 +4165,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-04-09T17:37")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3)));
         assertThat(entry.getSource(), is("FlatExDeGiroSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1737.50))));
@@ -3690,8 +4177,8 @@ public class FinTechGroupBankPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.90 + 2.00))));
 
         // check 2st buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem).collect(Collectors.toList())
-                        .get(1).getSubject();
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -3699,6 +4186,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-04-09T17:40")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(41)));
         assertThat(entry.getSource(), is("FlatExDeGiroSammelabrechnung01.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1796.12))));
@@ -3717,14 +4205,15 @@ public class FinTechGroupBankPDFExtractorTest
 
         List<Exception> errors = new ArrayList<>();
 
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDeGiroSammelabrechnung02.txt"), errors);
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "FlatExDeGiroSammelabrechnung02.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(i -> i instanceof SecurityItem).findFirst()
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSecurity();
         assertThat(security.getIsin(), is("US2561631068"));
         assertThat(security.getWkn(), is("A2JHLZ"));
@@ -3732,8 +4221,8 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(i -> i instanceof BuySellEntryItem)
-                        .collect(Collectors.toList()).get(0).getSubject();
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
         assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
@@ -3741,6 +4230,7 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-12-09T14:14")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(25)));
         assertThat(entry.getSource(), is("FlatExDeGiroSammelabrechnung02.txt"));
+        assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3456.41))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechKontoauszug01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechKontoauszug01.txt
@@ -13,18 +13,18 @@ Max Mustermann
 Musterstra�e. 2
 12345 Stadt
 Kontoauszug Nr:    001/2016                              Seite 1 von 2
-Kontonummer :      1111111111  dazugeh�rige IBAN:  DE00 0000 0000 0000 0000 00
+Kontonummer :      1111111111  dazugehörige IBAN:  DE00 0000 0000 0000 0000 00
 Kontenart   :      Kontokorrentkonto
 Kontow�hrung:      EUR
 Alter Saldo vom    31.12.2015                     in EUR             2.000,00+
 Buchungs-  Valuta  Buchungstext                                         Betrag
 datum                                                                   in EUR
-04.01.     06.01.  Ausf�hrung ORDER Kauf   000000000000              1.000,00-
+04.01.     06.01.  Ausführung ORDER Kauf   000000000000              1.000,00-
                    00000000
-04.01.     04.01.  Ertr�gnisaussch�ttung XXXXXXXXXXXX                    1,00+
-05.01.     06.01.  Geb�hren Ordernummer 00000000 Transnr                 5,90-
+04.01.     04.01.  Erträgnisausschüttung XXXXXXXXXXXX                    1,00+
+05.01.     06.01.  Gebühren Ordernummer 00000000 Transnr                 5,90-
                    000000000
-29.01.     29.01.  �berweisung                                       1.100,00+
+29.01.     29.01.  Überweisung                                       1.100,00+
                    Ubertrag Depot
                    BICBICBICBI
                    DE00000000000000000000
@@ -36,13 +36,13 @@ Vorsitzender des Aufsichtsrats: Frank Niehage   -  Vorstand: Lars Lankes, Bernd 
 Kontoauszug Nr:    001/2016                              Seite 2 von 2
 Buchungs-  Valuta  Buchungstext                                         Betrag
 datum                                                                   in EUR
-11.03.     14.03.  Geb�hren Ordernummer 00000000 Transnr                 5,90-
+11.03.     14.03.  Gebühren Ordernummer 00000000 Transnr                 5,90-
                    0000000000                                                 
-18.03.     22.03.  Ausf�hrung ORDER Verkauf   XXXXXXXXXXXX             500,00+
+18.03.     22.03.  Ausführung ORDER Verkauf   XXXXXXXXXXXX             500,00+
                    00000000
-19.03.     22.03.  Geb�hren Ordernummer 00000000 Transnr                 5,90-
+19.03.     22.03.  Gebühren Ordernummer 00000000 Transnr                 5,90-
                    0000000000                                                 
-30.03.     29.03.  Ertr�gnisaussch�ttung 000000000000                    1,00+
+30.03.     29.03.  Erträgnisausschüttung 000000000000                    1,00+
 31.03.     31.03.  Zinsabschluss   01.01.2016 - 31.03.2016               0,00+
 Neuer Saldo 31.03.2016 Nr. 001/2016         W�hrung EUR              1.584,30+
 Der ausgewiesene Kontosaldo kann durch abweichende Wertstellung (Valuta) vom

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroDividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroDividende02.txt
@@ -1,0 +1,47 @@
+-----------------------------------------
+flatexDEGIRO Bank AG
+Kundenservice
+Opernring 1 / Top 736
+1010 Wien
+Tel.: +43 - (0)720 518 777
+Mail: info@flatex.at
+flatexDEGIRO Bank AG -  Opernring 1 / Top 736 -  A-1010 Wien
+0102262000002439476640
+Herrn
+Max Mustermann
+Musterstr. 1
+1234 Muster
+ÖSTERREICH
+                  Wien, 03.03.2022
+Ertragsmitteilung - ausschüttender/teilthesaurierender Fonds
+Ihre Depotnummer: 12345678910
+Depotinhaber    : Muster, Max
+Nr.2724988793                 XTRACKERS MSCI WORLD ETF (IE00BK1PV551/A1XEY2)  
+St.             :           162,19    Bruttoausschüttung
+                                      pro Stück          :       0,2137000 USD
+Extag           :       17.02.2022    Bruttoausschüttung :           34,66 USD
+Valuta          :       02.03.2022
+                                      Bemessungsgrundlage:          361,42 EUR
+Devisenkurs     :         1,110600   *Einbeh. Steuer     :           99,39 EUR
+                                      Endbetrag          :          -68,18 EUR
+* Einbehaltene Kapitalertragsteuer. Details dazu finden Sie im Steuerreport
+  unter der Transaktion-Nr.: 1234567891.
+Die Verrechnung des Endbetrag erfolgt über Ihr Konto Nr.: 23456789123.
+Fondsinformationen:
+steuerpflichtiger Ertrag                                 :           34,66 USD
+   davon ausländische Erträge mit anrechenb. QSt         :            0,00 USD
+anrechenbare ausländische Quellensteuer**                :            0,00 USD
+**  ggf. mit einbeh. Steuer verrechnet
+Die  Gutschrift erfolgt  unter Vorbehalt  des  Eingangs.  Einwendungen  müssen
+unverzüglich  nach  Zugang  erhoben  werden.  Die  Unterlassung  rechtzeitiger
+Einwendung gilt als Genehmigung.
+Dieser   Beleg   ist    keine   Steuerbescheinigung.    Kapitalerträge   sind
+einkommensteuerpflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+flatexDEGIRO Bank AG Niederlassung Österreich | Aktiengesellschaft | Opernring 1 / Top 736 | 1010 Wien | Handelsgericht Wien | FN 334642 x | DVR 4000544 | UID ATU 65140956
+Hauptniederlassung: flatexDEGIRO Bank AG | Rotfeder-Ring 7 | 60327 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 105687
+- Vorsitzender des Aufsichtsrats: Martin Korbmacher | Vorstand: Frank Niehage (Vors.), Muhamad Said Chahrour, Dr. Benon Janos, Jörn Engelmann, Steffen Jentsch -
+2000002439476640 0351102260000101```
+
+Vielen Dank für Eure Hilfe!

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -36,7 +36,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         addBuySellTransaction();
         addSummaryStatementBuySellTransaction();
         addDividendeTransaction();
-        addDividendeReinvestingTransaction();
+        addDividendeWithNegativeAmountTransaction();
         addAccountStatementTransaction();
         addTransferOutTransaction();
         addTransferInTransaction();
@@ -58,6 +58,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             BuySellEntry entry = new BuySellEntry();
             entry.setType(PortfolioTransaction.Type.BUY);
+
+            /***
+             * If we have multiple entries in the document,
+             * with taxes and tax refunds,
+             * then the "negative" flag must be removed.
+             */
+            type.getCurrentContext().remove("negative");
+
             return entry;
         });
 
@@ -68,7 +76,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(?<type>Verkauf) .*$")
+                .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf"))
                     {
@@ -85,8 +93,17 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Nr.121625906/1     Kauf        IS C.MSCI EMIMI U.ETF DLA (IE00BKM4GZ66/A111X9)
-                .section("name", "isin", "wkn")
+                // Ausgeführt    :              29 St.     Kurswert      :             751,68 EUR
+                .section("name", "isin", "wkn", "currency").optional()
                 .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
+                .match("^.* Kurswert([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                // Nr.76443716/1  Verkauf           UBS AG LONDON 14/16 RWE (DE000US9RGR9/US9RGR)
+                // Kurs           29,0000 %               Kurswert       EUR             7.250,00
+                .section("name", "isin", "wkn", "currency").optional()
+                .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
+                .match("^.* Kurswert([\\s]+)? ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Ausgeführt     25.000,00000 EUR
@@ -111,14 +128,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // ZZZZ ZZ Ausführungszeit    17:30 Uhr. 
                 // Max Mu Stermann Schlusstag        17.01.2019u Ausführungszeit   17:52 Uhr
                 .section("time").optional()
-                .match("^(.*)?Ausf.hrungszeit ([\\s]+)?(?<time>[\\d]{2}:[\\d]{2}).*$")
+                .match("^.* Ausf.hrungszeit ([\\s]+)?(?<time>[\\d]{2}:[\\d]{2}) .*$")
                 .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                 // Max Mustermann Schlusstag        03.12.2015o
                 // ZZZZZ ZZZZ Handelstag         10.04.2019xan
                 // Max Mu Stermann Schlusstag        17.01.2019u Ausführungszeit   17:52 Uhr
                 .section("date")
-                .match("^(.*)?(Handelstag|Schlusstag) ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^.* (Handelstag|Schlusstag) ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> {
                     if (type.getCurrentContext().get("time") != null)
                         t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -128,7 +145,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 
                 // Devisenkurs   :        1,000000         Eigene Spesen :               0,00 EUR
                 .section("exchangeRate").optional()
-                .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
+                .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -150,7 +167,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 //                                        Endbetrag      EUR                 0,95
                                 section -> section
                                         .attributes("amount", "currency")
-                                        .match("^(.* )?Endbetrag([:\\s]+)? ([\\s]+)?(\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .match("^(.* )?Endbetrag ([:\\s]+)?(\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -310,20 +327,22 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Nr.60796942/1  Kauf               BAYWA AG VINK.NA. O.N. (DE0005194062/519406)
-                .section("name", "isin", "wkn")
+                // Kurs         : 39,2480 EUR             Kurswert       :           5.887,20 EUR
+                .section("name", "isin", "wkn", "currency")
                 .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
+                .match("^.* Kurswert([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // davon ausgef.: 150,00 St.              Schlusstag     :  28.01.2014, 12:50 Uhr
                 // davon ausgef. : 4.550,00 St.            Schlusstag    :  01.11.2017, 14:41 Uhr
                 .section("shares")
-                .match("^davon ausgef\\.([\\s]+)?: (?<shares>[\\.,\\d]+) St\\. .*$")
+                .match("^davon ausgef\\.([:\\s]+)? (?<shares>[\\.,\\d]+) St\\. .*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // davon ausgef.: 150,00 St.              Schlusstag     :  28.01.2014, 12:50 Uhr
                 // davon ausgef. : 540,00 St.              Schlusstag    :      09.04.2019, 16:52
                 .section("date", "time")
-                .match("^.* Schlusstag([\\s]+)?: ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), (?<time>\\d+:\\d+).*$")
+                .match("^.* Schlusstag([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), (?<time>[\\d]{2}:[\\d]{2}{2}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
@@ -380,22 +399,41 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        DocumentType type = new DocumentType("Dividendengutschrift|Ertragsmitteilung|Zinsgutschrift");
+        DocumentType type = new DocumentType("(Dividendengutschrift|Ertragsmitteilung|Zinsgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Ertragsmitteilung(?! \\- thesaurierender)|Zinsgutschrift)( .*)?$");
+        Block block = new Block("^(Dividendengutschrift|Ertragsmitteilung|Zinsgutschrift)( .*)?$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {
                 AccountTransaction entry = new AccountTransaction();
                 entry.setType(AccountTransaction.Type.DIVIDENDS);
+
+                /***
+                 * If we have multiple entries in the document,
+                 * with taxes and tax refunds,
+                 * then the "negative" flag must be removed.
+                 */
+                type.getCurrentContext().remove("negative");
+
                 return entry;
             });
 
         pdfTransaction
                 // Nr.716759781                   HANN.RUECK SE NA O.N.     (DE0008402215/840221)
-                .section("name", "isin", "wkn")
+                // Extag           :  08.05.2014          Bruttodividende
+                // Zahlungstag     :  08.05.2014          pro Stück       :       3,0000 EUR
+                .section("name", "isin", "wkn", "currency").optional()
                 .match("^Nr\\.[\\d]+ ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\).*$")
+                .find(".* (Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung)")
+                .match("^.* ([\\s]+)?pro St.ck([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                // Nr.111111111                   ISH.FOOBAR 12345666 x.EFT (DE1234567890/AB1234)
+                // Zinstermin      :  28.04.2016          Zinsbetrag      :        73,75 EUR
+                .section("name", "isin", "wkn", "currency").optional()
+                .match("^Nr\\.[\\d]+ ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\).*$")
+                .match("^.* ([\\s]+)?Zinsbetrag([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // St.             :         360
@@ -407,19 +445,90 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("Valuta ([\\s]+)?: ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                //                                        Endbetrag       :       795,15 EUR
-                .section("amount", "currency")
-                .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})")
-                .assign((t, v) -> {
-                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    t.setAmount(asAmount(v.get("amount")));
-                })
+                .oneOf(
+                                //                                        Endbetrag       :       795,15 EUR
+                                section -> section
+                                        .attributes("amount", "currency")
+                                        .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .assign((t, v) -> {
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                            t.setAmount(asAmount(v.get("amount")));
+                                        })
+                                ,
+
+                                /***
+                                 * If we have a negative amount, 
+                                 * we first post the dividends received 
+                                 * and then the tax charge
+                                 */
+                                // Extag           :    07.10.2021        Bruttothesaurierung:        78,81 USD
+                                // Zuflusstag      :    08.10.2021        Devisenkurs        :         1,156200
+                                //                                        Endbetrag          :       -15,24 EUR
+                                section -> section
+                                        .attributes("fxAmount", "fxCurrency", "exchangeRate", "currency")
+                                        .match("^.* (Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
+                                        .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
+                                        .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?\\-[\\.,\\d]+ (?<currency>[\\w]{3})$")
+                                        .assign((t, v) -> {
+                                            type.getCurrentContext().put("negative", "X");
+
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+
+                                            Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
+
+                                            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                                            if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                                            {
+                                                exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                                            }
+                                            type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+
+                                            // Calculate gross amount in account currency
+                                            Money gross = Money.of(v.get("currency"), 
+                                                            Math.round(fxAmount.getAmount() / exchangeRate.doubleValue()));
+
+                                            // Set amount
+                                            t.setAmount(gross.getAmount());
+
+                                            if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                                            {
+                                                BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                                                RoundingMode.HALF_DOWN);
+
+                                                // check, if forex currency is transaction
+                                                // currency or not and swap amount, if necessary
+                                                Unit grossValue;
+                                                if (!asCurrencyCode(v.get("fxCurrency")).equals(t.getCurrencyCode()))
+                                                {
+                                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, gross, fxAmount, inverseRate);
+                                                }
+                                                else
+                                                {
+                                                    grossValue = new Unit(Unit.Type.GROSS_VALUE, fxAmount, gross, inverseRate);
+                                                }
+                                                t.addUnit(grossValue);
+                                            }
+                                        })
+                                ,
+                                // Extag           :    20.01.2020        Bruttothesaurierung:        23,19 EUR
+                                //                                        Endbetrag          :        -8,26 EUR
+                                section -> section
+                                        .attributes("amount", "currency")
+                                        .match("^.* (Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?\\-[\\.,\\d]+ [\\w]{3}$")
+                                        .assign((t, v) -> {
+                                            type.getCurrentContext().put("negative", "X");
+
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                            t.setAmount(asAmount(v.get("amount")));
+                                        })
+                        )
 
                 // Extag : 08.08.2017 Bruttodividende : 26,25 USD
                 // Devisenkurs     :    1,180800         *Einbeh. Steuer  :         1,11 EUR
-                .section("fxAmountGross", "fxCurrency", "exchangeRate").optional()
-                .match("^.* (Bruttoaussch.ttung|Bruttodividende) ([\\s]+)?: ([\\s]+)?(?<fxAmountGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
-                .match("^Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
+                .section("fxAmount", "fxCurrency", "exchangeRate").optional()
+                .match("^(.* )?(Bruttoaussch.ttung|Bruttodividende|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -427,7 +536,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                     }
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-                    
+
                     // create gross value unit only, 
                     // if transaction currency is different to security currency
                     if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
@@ -442,7 +551,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                             RoundingMode.HALF_DOWN);
 
                             // get gross amount and calculate equivalent in EUR
-                            Money fxAmountGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmountGross")));
+                            Money fxAmountGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
                             BigDecimal amount = BigDecimal.valueOf(fxAmountGross.getAmount())
                                                 .divide(exchangeRate, 10, RoundingMode.HALF_DOWN)
                                                 .setScale(0, RoundingMode.HALF_DOWN);
@@ -454,6 +563,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     }
                 })
 
+                //   unter der Transaktion-Nr.: 132465978
+                .section("note").optional()
+                .match("^.* (?<note>Transaktion-Nr\\.: [\\d]+)(.*)?$")
+                .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
                 .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -462,31 +576,36 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
     }
 
-    private void addDividendeReinvestingTransaction()
+    private void addDividendeWithNegativeAmountTransaction()
     {
-        /***
-         * If dividends amount is negative 
-         * then we switch the transaction to taxes, 
-         * because there is reinvesting and only the taxes 
-         * must be paid from the dividend transaction
-         */
-
-        DocumentType type = new DocumentType("Ertragsmitteilung - thesaurierender transparenter Fonds");
+        DocumentType type = new DocumentType("Ertragsmitteilung \\- (aussch.ttender\\/teil)?thesaurierender( transparenter)? Fonds");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^Ertragsmitteilung \\- thesaurierender transparenter Fonds$");
+        Block block = new Block("^Ertragsmitteilung \\- (aussch.ttender\\/teil)?thesaurierender( transparenter)? Fonds$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {
                 AccountTransaction entry = new AccountTransaction();
                 entry.setType(AccountTransaction.Type.TAXES);
+
+                /***
+                 * If we have multiple entries in the document,
+                 * with taxes and tax refunds,
+                 * then the "negative" flag must be removed.
+                 */
+                type.getCurrentContext().remove("negative");
+
                 return entry;
             });
 
         pdfTransaction
-                // Nr.123456                  SPDR MSCI WORLD ETF       (IE00BFY0GT14/A2N6CW)
-                .section("name", "isin", "wkn")
+                // Nr.1784953069                  PICTET-GL.MEGAT.SEL.P EO  (LU0386882277/A0RLJD)
+                // St.             :          10,0        Bruttothesaurierung
+                //                                        pro Stück          :       2,3189 EUR
+                .section("name", "isin", "wkn", "currency").optional()
                 .match("^Nr\\.[\\d]+ ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\).*$")
+                .find(".* (Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung)")
+                .match("^.* ([\\s]+)?pro St.ck([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // St.             :         168,9        Bruttothesaurierung
@@ -495,23 +614,57 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 .section("date")
-                .match("Valuta ([\\s]+)?: ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^Valuta ([\\s]+)?: ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 //                                       Endbetrag          :        -8,26 EUR
-                .section("amount", "currency")
-                .match(".* Endbetrag([\\s]+)?: ([\\s]+)?-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})")
+                .section("amount", "currency").optional()
+                .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
                 })
 
+                // Extag           :    07.10.2021        Bruttothesaurierung:        78,81 USD
+                // Zuflusstag      :    08.10.2021        Devisenkurs        :         1,156200
+                //                                        Endbetrag          :       -15,24 EUR
+                .section("fxCurrency", "exchangeRate", "currency", "amount").optional()
+                .match("^.* (Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
+                .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
+                .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    // read the forex currency, exchange rate, account
+                    // currency and gross amount in account currency
+                    String forex = asCurrencyCode(v.get("fxCurrency"));
+                    if (t.getSecurity().getCurrencyCode().equals(forex))
+                    {
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal reverseRate = BigDecimal.ONE.divide(exchangeRate, 10,
+                                        RoundingMode.HALF_DOWN);
+
+                        // gross given in account currency
+                        long amount = asAmount(v.get("amount"));
+                        long fxAmount = exchangeRate.multiply(BigDecimal.valueOf(amount))
+                                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+
+                        Unit grossValue = new Unit(Unit.Type.GROSS_VALUE,
+                                        Money.of(asCurrencyCode(v.get("currency")), amount),
+                                        Money.of(forex, fxAmount), reverseRate);
+
+                        t.addUnit(grossValue);
+                    }
+                })
+
                 //   unter der Transaktion-Nr.: 132465978
                 .section("note").optional()
-                .match("^.* (?<note>Transaktion-Nr\\.: [\\d]+)$")
+                .match("^.* (?<note>Transaktion-Nr\\.: [\\d]+)(.*)?$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                .wrap(TransactionItem::new);
+                .wrap(t -> {
+                    if (t.getCurrencyCode() != null && t.getAmount() != 0)
+                        return new TransactionItem(t);
+                    return null;
+                });
 
         block.set(pdfTransaction);
     }
@@ -519,8 +672,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType("Kontoauszug Nr:", (context, lines) -> {
-            Pattern pYear = Pattern.compile("^Kontoauszug Nr:[ ]*[\\d]+\\/(?<year>[\\d]{4}).*$");
-            Pattern pCurrency = Pattern.compile("^Kontow.hrung:[ ]+(?<currency>[\\w]{3})$");
+            Pattern pYear = Pattern.compile("^Kontoauszug Nr: ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4}).*$");
+            Pattern pCurrency = Pattern.compile("^Kontow.hrung: ([:\\s]+)?(?<currency>[\\w]{3})$");
 
             for (String line : lines)
             {
@@ -539,8 +692,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        // 29.01.     29.01.  �berweisung                                       1.100,00+
-        Block block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+.berweisung[ ]+[\\-\\.,\\d]+[\\+|\\-]$");
+        // 29.01.     29.01.  Überweisung                                       1.100,00+
+        Block block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?.berweisung ([\\s]+)?[\\-\\.,\\d]+[\\+|\\-]$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -550,8 +703,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note", "sign")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>.berweisung)[ ]+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
+                .section("date", "note", "amount", "sign")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>.berweisung) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     // Is sign --> "-" change from DEPOSIT to REMOVAL
                     if (v.get("sign").equals("-"))
@@ -573,7 +726,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .wrap(TransactionItem::new));
 
         // 01.10.     01.10.  EINZAHLUNG 4 FLATEX / 0/16765097                  2.000,00+
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+(EINZAHLUNG|AUSZAHLUNG) .*[ ]+[\\-\\.,\\d]+[\\+|\\-]$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(EINZAHLUNG|AUSZAHLUNG) .* ([\\s]+)?+[\\-\\.,\\d]+[\\+|\\-]$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -583,8 +736,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note", "sign")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>(EINZAHLUNG|AUSZAHLUNG)) .*[ ]+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
+                .section("date", "note", "amount", "sign")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>(EINZAHLUNG|AUSZAHLUNG)) .* ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     // Is sign --> "-" change from DEPOSIT to REMOVAL
                     if (v.get("sign").equals("-"))
@@ -606,7 +759,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .wrap(TransactionItem::new));
 
         // 19.11.     19.11.  R-Transaktion                                       -53,00-
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+R-Transaktion .* [\\-\\.,\\d]+\\-$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+R-Transaktion  ([\\s]+)?+[\\-\\.,\\d]+\\-$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -616,8 +769,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>R-Transaktion) .* (?<amount>[\\-\\.,\\d]+)\\-$")
+                .section("date", "note", "amount")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>R-Transaktion)  ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     if (v.get("date") != null)
@@ -633,7 +786,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .wrap(TransactionItem::new));
 
         // Added "Lastschrift" as DEPOSIT option
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+Lastschrift[ ]+[\\-\\.,\\d]+[\\+|\\-]$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+Lastschrift ([\\s]+)?+[\\-\\.,\\d]+[\\+|\\-]$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
                 .subject(() -> {
@@ -642,8 +795,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note", "sign")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>Lastschrift)[ ]+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
+                .section("date", "note", "amount", "sign")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Lastschrift) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     if (v.get("date") != null)
@@ -658,37 +811,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(t -> new TransactionItem(t)));
 
-        // 11.11.     12.11.  Gebühr Kapitaltransaktion Ausland                     4,56-
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+Geb.hr Kapitaltransaktion Ausland[ ]+[\\-\\.,\\d]+\\-$");
-        type.addBlock(block);
-        block.set(new Transaction<AccountTransaction>()
-
-                .subject(() -> {
-                    AccountTransaction t = new AccountTransaction();
-                    t.setType(AccountTransaction.Type.FEES);
-                    return t;
-                })
-
-                .section("date", "amount", "isin", "note")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>Geb.hr Kapitaltransaktion Ausland)[ ]+(?<amount>[\\-\\.,\\d]+)\\-$")
-                .match("^\\s*(?<isin>\\w{12})$")
-                .assign((t, v) -> {
-                    Map<String, String> context = type.getCurrentContext();
-                    if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
-                        t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
-                    t.setSecurity(getOrCreateSecurity(v));
-                    t.setAmount(asAmount(v.get("amount")));
-                    t.setCurrencyCode(asCurrencyCode(context.get("currency")));
-                    t.setNote(v.get("note"));
-                })
-
-                .wrap(TransactionItem::new));
-
         // 19.07.     20.07.  Depotgebühren 01.04.2020 - 30.04.2020,                0,26-
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+Depotgeb.hren[ ]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[ -]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4},[ ]+[\\-\\.,\\d]+\\-$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+Depotgeb.hren ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\- [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}, ([\\s]+)?+[\\-\\.,\\d]+\\-$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -698,8 +822,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>Depotgeb.hren[ ]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[ -]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}),[ ]+(?<amount>[\\-\\.,\\d]+)\\-$")
+                .section("date", "note", "amount")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Depotgeb.hren[ ]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\- [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     if (v.get("date") != null)
@@ -719,7 +843,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 }));
 
         // 30.12.     31.12.  Zinsabschluss   01.10.2014 - 31.12.2014               7,89+
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+Zinsabschluss[ ]+(.*)$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+Zinsabschluss .*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -729,8 +853,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note", "sign")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>Zinsabschluss[ ]+([\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(\\s+)-(\\s+)([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}))(\\s+)(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
+                .section("date", "note", "amount", "sign")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Zinsabschluss ([\\s]+)?+([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\- ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4})) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     // Is sign --> "+" change from INTEREST_CHARGE to INTEREST
                     if (v.get("sign").equals("+"))
@@ -756,7 +880,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        block = new Block("^[\\d]{2}\\.[\\d]{2}\\.[ ]+[\\d]{2}\\.[\\d]{2}\\.[ ]+Steuertopfoptimierung[ ]+(.*)$");
+        block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+Steuertopfoptimierung .*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -766,8 +890,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     return t;
                 })
 
-                .section("date", "amount", "note", "sign")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[ ]+(?<date>[\\d]{2}\\.[\\d]{2}\\.)[ ]+(?<note>Steuertopfoptimierung[ ]+([\\d]{4}))(\\s+)(?<amount>[\\.,\\d\\-]+)(?<sign>[\\+|\\-])$")
+                .section("date", "note", "amount", "sign")
+                .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Steuertopfoptimierung ([\\s]+)?+([\\d]{4})) ([\\s]+)?+(?<amount>[\\.,\\d\\-]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     // Is sign --> "-" change from TAX_REFUND to TAXES
                     if (v.get("sign").equals("-"))
@@ -796,18 +920,18 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
     private void addTransferOutTransaction()
     {
-        DocumentType type = new DocumentType("Depotausgang|Bestandsausbuchung|Gutschrifts- \\/ Belastungsanzeige",
-                        (context, lines) -> {
-                            // Not all documents have a per-security transaction date, so use the letter-head as default.
-                            //              Frankfurt, 18.09.2020
-                            Pattern pDate = Pattern.compile("^[\\s]+Frankfurt( am Main)?,[\\s]+(den )?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
-                            for (String line : lines)
-                            {
-                                Matcher m = pDate.matcher(line);
-                                if (m.matches())
-                                    context.put("date", m.group("date"));
-                            }
-                        });
+        final DocumentType type = new DocumentType("(Depotausgang|Bestandsausbuchung|Gutschrifts- \\/ Belastungsanzeige)", (context, lines) -> {
+            Pattern pDate = Pattern.compile("^([\\s]+)?Frankfurt( am Main)?, ([\\s]+)?(den )?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
+
+            for (String line : lines)
+            {
+                Matcher m = pDate.matcher(line);
+                if (m.matches())
+                {
+                    context.put("date", m.group("date"));
+                }
+            }
+        });
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
@@ -826,16 +950,26 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction
                 // Depotausgang                          COMMERZBANK INLINE09EO/SF (DE000CM31SV9)
+                // Rückzahlungsgrund: Ablauf der Optionsfrist     Betrag/Stk: 10,000000000000 EUR
                 // Bestandsausbuchung                       COMMERZBANK PUT10 EOLS (DE000CB81KN1)
-                .section("isin", "name").optional()
+                .section("name", "isin", "currency").optional()
                 .match("^(Depotausgang|Bestandsausbuchung) ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\)$")
+                .match("^.* Betrag\\/(Stk|Stck\\.)([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                // Depotausgang                          COMS.-MSCI WORL.T.U.ETF I (LU0392494562)
+                //                                          Geldgegenwert***:           0,00 EUR
+                .section("name", "isin", "currency").optional()
+                .match("^Depotausgang ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\)$")
+                .match("^.* Geldgegenwert([:\\*\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // WKN ISIN Wertpapierbezeichnung Anzahl
                 // SG0WRD DE000SG0WRD3 SG EFF. TURBOL ZS 83,00
-                .section("wkn", "isin", "name", "shares").optional()
+                .section("wkn", "isin", "name", "shares", "currency").optional()
                 .find("^WKN ([\\s]+)?ISIN ([\\s]+)?Wertpapierbezeichnung ([\\s]+)?Anzahl$")
                 .match("^(?<wkn>.*) ([\\s]+)?(?<isin>[\\w]{12}) ([\\s]+)?(?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+)$")
+                .match("^.* Betrag\\/(Stk|Stck\\.)([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setSecurity(getOrCreateSecurity(v));
                     t.setShares(asShares(v.get("shares")));
@@ -875,7 +1009,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 // **oben genannten Bestand haben wir wertlos ausgebucht
                 .section().optional()
-                .match("(.*)Bestand haben wir wertlos ausgebucht(.*)")
+                .match("^.* Bestand haben wir wertlos ausgebucht.*$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(t.getAccountTransaction().getSecurity().getCurrencyCode());
                     t.setAmount(0L);
@@ -895,14 +1029,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:           -382,12 EUR
                 //                                           Einbeh. Steuer**:         -10,00 EUR
                 .section("taxRefund").optional()
-                .match("^.* Einbeh\\. Steuer\\*.*([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
+                .match("^.* Einbeh\\. Steuer[\\*\\s]+: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
                 .assign((t, v) -> {
                     t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund")));
                 })
 
                 // Einbeh. Steuer**                                                    -88,53 EUR
                 .section("taxRefund").optional()
-                .match("^Einbeh\\. Steuer\\*.* ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
+                .match("^Einbeh\\. Steuer[\\*\\s]+ \\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
                 .assign((t, v) -> {
                     t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund")));
                 })
@@ -932,8 +1066,10 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction
                 // Depoteingang DEKAFONDS CF (DE0008474503)
-                .section("isin", "name")
+                // Kurs           : 105,769231 EUR         Devisenkurs    :          1,000000
+                .section("isin", "name", "currency")
                 .match("^Depoteingang ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\)$")
+                .match("^Kurs([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3}) .*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Stk./Nominale   : 25.000,000000 EUR    Einbeh. Steuer* :              0,00 EUR
@@ -975,7 +1111,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                  */
                 //                                           Einbeh. Steuer**:          -1,00 EUR
                 .section("taxRefund").optional()
-                .match("^.* Einbeh\\. Steuer\\*.*([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
+                .match("^.* Einbeh\\. Steuer[\\*\\s]+: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
                 .assign((t, v) -> {
                     t.setAmount(t.getAmount() - asAmount(v.get("taxRefund")));
                 })
@@ -990,12 +1126,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     private void addAdvanceTaxTransaction()
     {
         final DocumentType type = new DocumentType("Wertpapierabrechnung Vorabpauschale", (context, lines) -> {
-            Pattern pDate = Pattern.compile("Buchungsdatum +(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) *");
+            Pattern pDate = Pattern.compile("^Buchungsdatum ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$");
             for (String line : lines)
             {
                 Matcher m = pDate.matcher(line);
                 if (m.matches())
-                    context.put("buchungsdatum", m.group("date"));
+                    context.put("date", m.group("date"));
             }
         });
         this.addDocumentTyp(type);
@@ -1012,21 +1148,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 // ISHS MSCI EM USD-AC                 IE00BKM4GZ66/A111X9    
                 .section("wkn", "isin", "name")
-                .match("^(?<name>.*) +(?<isin>[\\w]{12})/(?<wkn>.*) *$")
+                .match("^(?<name>.*) (?<isin>[\\w]{12})\\/(?<wkn>.*) *$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Gesamtbestand       476,000000 St.  zum                             31.12.2019
                 .section("shares")
-                .match("^Gesamtbestand * (?<shares>[\\.,\\d]+) St.*$")
+                .match("^Gesamtbestand ([\\s]+)?(?<shares>[\\.,\\d]+) St\\. .*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Buchungsdatum        11.01.2020
                 // Gesamtbestand       476,000000 St.  zum                             31.12.2019
                 .section("date")
-                .match("Gesamtbestand .*zum +(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("Gesamtbestand .* zum ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                 .assign((t, v) -> {
-                    // prefer "buchungsdatum" over "date" if available
-                    t.setDateTime(asDate(type.getCurrentContext().get("buchungsdatum") != null ? type.getCurrentContext().get("buchungsdatum") : v.get("date")));
+                    t.setDateTime(asDate(type.getCurrentContext().get("date") != null ? type.getCurrentContext().get("date") : v.get("date")));
                 })
 
                 //                                  ** Einbeh. Steuer                    4,69 EUR
@@ -1062,8 +1197,16 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Nr.123441244/1  Kauf            C.S.-MSCI PACIF.T.U.ETF I (LU0392495023/ETF114)
-                .section("name", "isin", "wkn")
+                .section("name", "isin", "wkn", "currency").optional()
                 .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
+                .match("^.* Kurswert([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                // Nr.76443716/1  Verkauf           UBS AG LONDON 14/16 RWE (DE000US9RGR9/US9RGR)
+                // Kurs           29,0000 %               Kurswert       EUR             7.250,00
+                .section("name", "isin", "wkn", "currency").optional()
+                .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
+                .match("^.* Kurswert([\\s]+)? ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Ausgeführt     25.000,00000 EUR
@@ -1071,7 +1214,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Ausgeführt     10 St.
                 // Ausgeführt     19,334524 St.           Kurswert       EUR             1.050,00
                 .section("shares", "notation")
-                .match("^Ausgef.hrt ([:\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>St\\.|[\\w]{3}).*$")
+                .match("^Ausgef.hrt ([:\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>(St\\.|[\\w]{3})).*$")
                 .assign((t, v) -> {
                     if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("St."))
                     {
@@ -1088,14 +1231,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // ZZZZ ZZ Ausführungszeit    17:30 Uhr. 
                 // Max Mu Stermann Schlusstag        17.01.2019u Ausführungszeit   17:52 Uhr
                 .section("time").optional()
-                .match("^(.*)?Ausf.hrungszeit ([\\s]+)?(?<time>[\\d]{2}:[\\d]{2}).*$")
+                .match("^.* Ausf.hrungszeit ([\\s]+)?(?<time>[\\d]{2}:[\\d]{2}).*$")
                 .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                 // Max Mustermann Schlusstag        03.12.2015o
                 // ZZZZZ ZZZZ Handelstag         10.04.2019xan
                 // Max Mu Stermann Schlusstag        17.01.2019u Ausführungszeit   17:52 Uhr
                 .section("date")
-                .match("^(.*)?(Handelstag|Schlusstag) ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^.* (Handelstag|Schlusstag) ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> {
                     if (type.getCurrentContext().get("time") != null)
                         t.setDateTime(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -1118,13 +1261,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                 // Endbetrag     :            -760,09 EUR
                                 section -> section
                                         .attributes("currency")
-                                        .match("^(.* )?Endbetrag([:\\s]+)? ([\\s]+)?(\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
+                                        .match("^(.* )?Endbetrag([:\\s]+)? (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> t.setCurrencyCode(asCurrencyCode(v.get("currency"))))
                         )
 
                 // Gewinn/Verlust 0,00 EUR              **Einbeh. Steuer EUR                -1,00
                 .section("amount", "currency").optional()
-                .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<amount>[\\.,\\d]+)$")
+                .match("^.* \\*\\*Einbeh\\. Steuer([:\\s]+)? (?<currency>[\\w]{3}) ([\\s]+)?\\-(?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (t.getCurrencyCode().contentEquals(v.get("currency")))
                     {
@@ -1136,7 +1279,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Gewinn/Verlust            0,00 EUR    **Einbeh. Steuer                -1,00 EUR
                 // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :            -305,85 EUR
                 .section("amount", "currency").optional()
-                .match("^.* \\*\\*Einbeh\\. (Steuer|KESt) ([:\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^.* \\*\\*Einbeh\\. (Steuer|KESt)([:\\s]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (t.getCurrencyCode().contentEquals(v.get("currency")))
                     {
@@ -1150,8 +1293,8 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :            -305,85 EUR
                 .section("exchangeRate", "fxAmount", "fxCurrency").optional()
-                .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
-                .match("^.* \\*\\*Einbeh\\. (Steuer|KESt) ([:\\s]+)?\\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
+                .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
+                .match("^.* \\*\\*Einbeh\\. (Steuer|KESt)([:\\s]+)? \\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                     {
@@ -1175,7 +1318,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 //                                     ***Einbeh. SichSt EUR                 -1,00
                 .section("amount", "currency").optional()
-                .match("^.* \\*\\*\\*Einbeh\\. SichSt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?-(?<amount>[\\.,\\d]+)$")
+                .match("^.* \\*\\*\\*Einbeh\\. SichSt([:\\s]+)? (?<currency>[\\w]{3}) ([\\s]+)?\\-(?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (t.getCurrencyCode().contentEquals(v.get("currency")))
                     {
@@ -1188,7 +1331,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //                                      ***Einbeh. SichSt EUR                 -1,00
                 .section("exchangeRate", "fxAmount", "fxCurrency").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
-                .match("^.* \\*\\*\\*Einbeh\\. SichSt ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?-(?<fxAmount>[\\.,\\d]+)$")
+                .match("^.* \\*\\*\\*Einbeh\\. SichSt([:\\s]+)? (?<fxCurrency>[\\w]{3}) ([\\s]+)?\\-(?<fxAmount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                     {
@@ -1233,20 +1376,21 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Nr.60797017/1  Verkauf             HANN.RUECK SE NA O.N. (DE0008402215/840221)
+                // Kurs         : 59,4890 EUR             Kurswert       :           5.948,90 EUR
                 .section("name", "isin", "wkn", "currency")
                 .match("^Nr\\.[\\d]+\\/[\\d]+ ([\\s]+)?(Kauf|Verkauf) ([\\s]+)?(?<name>.*) \\((?<isin>[\\w]{12})\\/(?<wkn>.*)\\)$")
-                .match("^Kurs ([\\s]+)?: [\\.,\\d]+ (?<currency>[\\w]{3}) .*$")
+                .match("^.* Kurswert([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // davon ausgef.: 150,00 St.              Schlusstag     :  28.01.2014, 12:50 Uhr
                 .section("shares")
-                .match("^davon ausgef\\.([\\s]+)?: (?<shares>[\\.,\\d]+) St\\. .*$")
+                .match("^davon ausgef\\.([:\\s]+)? (?<shares>[\\.,\\d]+) St\\. .*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // davon ausgef.: 150,00 St.              Schlusstag     :  28.01.2014, 12:50 Uhr
                 // davon ausgef. : 540,00 St.              Schlusstag    :      09.04.2019, 16:52
                 .section("date", "time")
-                .match("^.* Schlusstag([\\s]+)?: ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), (?<time>\\d+:\\d+).*$")
+                .match("^.* Schlusstag([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), (?<time>\\d+:\\d+).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"), v.get("time"))))
 
                 /***
@@ -1255,12 +1399,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 */
                 // Valuta       : 30.01.2014              Endbetrag      :          -5.893,10 EUR
                 .section("currency")
-                .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?(\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .match("^.* Endbetrag([:\\s]+)? (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setCurrencyCode(asCurrencyCode(v.get("currency"))))
 
                 // Lagerland    : Deutschland           **Einbeh. Steuer :            -100,00 EUR
                 .section("amount", "currency").optional()
-                .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^.* \\*\\*Einbeh\\. Steuer([:\\s]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (t.getCurrencyCode().contentEquals(v.get("currency")))
                     {
@@ -1273,7 +1417,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Valuta        : 02.12.2020            **Einbeh. Steuer:              -0,84 EUR
                 .section("exchangeRate", "fxAmount", "fxCurrency").optional()
                 .match("^Devisenkurs ([\\s]+)?: (?<exchangeRate>[\\.,\\d]+).*$")
-                .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
+                .match("^.* \\*\\*Einbeh\\. Steuer([:\\s]+)? \\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                     {
@@ -1323,15 +1467,17 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Depotausgang                          COMMERZBANK INLINE09EO/SF (DE000CM31SV9)
                 // Bestandsausbuchung                       COMMERZBANK PUT10 EOLS (DE000CB81KN1)
                 // Depoteingang                            UBS AG LONDON 14/16 RWE (DE000US9RGR9)
-                .section("isin", "name").optional()
+                .section("name", "isin", "currency").optional()
                 .match("^(Depoteingang|Depotausgang|Bestandsausbuchung) ([\\s]+)?(?<name>.*) ([\\s]+)?\\((?<isin>[\\w]{12})\\)$")
+                .match("^.* Betrag\\/(Stk|Stck\\.)([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // WKN ISIN Wertpapierbezeichnung Anzahl
                 // SG0WRD DE000SG0WRD3 SG EFF. TURBOL ZS 83,00
-                .section("wkn", "isin", "name", "shares").optional()
+                .section("wkn", "isin", "name", "shares", "currency").optional()
                 .find("^WKN ([\\s]+)?ISIN ([\\s]+)?Wertpapierbezeichnung ([\\s]+)?Anzahl$")
                 .match("^(?<wkn>.*) ([\\s]+)?(?<isin>[\\w]{12}) ([\\s]+)?(?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+)$")
+                .match("^.* Betrag\\/(Stk|Stck\\.)([:\\s]+)? [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setSecurity(getOrCreateSecurity(v));
                     t.setShares(asShares(v.get("shares")));
@@ -1339,7 +1485,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:            382,12 EUR
                 .section("shares", "notation").optional()
-                .match("^Stk\\.\\/Nominale([\\*\\s]+)?: ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>St\\.|[\\w]{3})(.*)$")
+                .match("^Stk\\.\\/Nominale([:\\s]+)? (?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>(St\\.|[\\w]{3})) .*$")
                 .assign((t, v) -> {
                     if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stk"))
                     {
@@ -1357,13 +1503,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Fälligkeitstag                                                  25.06.2021
                 // Fälligkeitstag: 18.07.2011 letzter Handel am: 11.07.2011
                 .section("date").optional()
-                .match("^(F.lligkeitstag|Datum)([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^(F.lligkeitstag|Datum)([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:           -382,12 EUR
                 //                                           Einbeh. Steuer**:         -10,00 EUR
                 .section("amount", "currency").optional()
-                .match("^.* Einbeh\\. Steuer\\*(.*)([\\s]+)?: ([\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^.* Einbeh\\. Steuer([:\\s\\*]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -1371,7 +1517,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 // Einbeh. Steuer**                                                    -88,53 EUR
                 .section("amount", "currency").optional()
-                .match("^Einbeh\\. Steuer\\*.* ([\\s]+)?\\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Einbeh\\. Steuer([:\\s\\*]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -1399,143 +1545,180 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
 
                 // Lagerland    : Deutschland           **Einbeh. Steuer EUR               1,00
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
 
                 // Lagerland    : Deutschland           **Einbeh. Steuer                0,00 EUR
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?(?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
                 
                 // Lagerland    : Deutschland           **Einbeh. KESt                0,00 EUR
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. KESt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
 
                 // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :             305,85 EUR
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. KESt([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
 
                 //              ***Einbeh. SichSt EUR                1,00
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*\\*Einbeh\\. SichSt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        {
+                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
-                        BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
+                            BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                                                .setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
+                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
+                        }
+                        processTaxEntries(t, v, type);
                     }
-                    processTaxEntries(t, v, type);
                 })
 
                 //                                      *Einbeh. Steuer  :       284,85 EUR
                 .section("tax", "currency").optional()
                 .match("^.* \\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    processTaxEntries(t, v, type);
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processTaxEntries(t, v, type);
+                    }
                 })
 
                 // Quellenst.-satz :           15,00 %    Gez. Quellenst. :            1,15 USD
                 .section("withHoldingTax", "currency").optional()
                 .match("^.* Gez\\. Quellenst\\.([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                    }
+                })
 
                 // Quellenst.-satz :            15,00 %  Gez. Quellensteuer :           18,28 USD
                 .section("withHoldingTax", "currency").optional()
                 .match("^.* Gez\\. Quellensteuer([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                    }
+                })
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:            382,12 EUR
                 .section("withHoldingTax", "currency").optional()
                 .match("^.* Einbeh\\. Steuer\\*([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type));
+                .assign((t, v) -> {
+                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    {
+                        processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                    }
+                });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -1567,7 +1750,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs                            Provision      EUR                 5,90
                 .section("fee", "currency").optional()
-                .match("^.* Provision([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)$")
+                .match("^.* Provision ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -693,7 +693,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         this.addDocumentTyp(type);
 
         // 29.01.     29.01.  Überweisung                                       1.100,00+
-        Block block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?.berweisung ([\\s]+)?[\\-\\.,\\d]+[\\+|\\-]$");
+        Block block = new Block("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?.berweisung ([\\s]+)?[\\-\\.,\\d]+[\\+|\\-]$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 


### PR DESCRIPTION
Add missing testparts
Add missing testCases
Add notes in all transactions
Fix testbiwAGKontoauszug01() remove create a security
Fix addDividendeTransaction() missing currency to create security
Fix addDividendeReinvestingTransaction() missing currency to create security
Rename addDividendeReinvestingTransaction() to addDividendeWithNegativeAmountTransaction
Delete testFlatExDividende05WithSecurityInUSD() not exist -> change to EUR-Version.
https://forum.portfolio-performance.info/t/pdf-import-von-flatex-at/10776/42
Optimize regEx
Optimize testcases (Standardization)
Delete unused source

---

Hallo @buchen
hier sind ein paar Änderungen nötig und wurde leider mehr als gedacht. :-(

Zu allererst gibt es bei FlatEx auch ein Fremdwährungskonto. Bisher
war FlatEx ausschließlich in EUR geführt. Ich habe daher die Importer angepasst,
dass auch die Wertpapiergenierierung korrekt funktioniert.

_biwAGKontoauszug01.txt_
Im testbiwAGKontoauszug01() wird ein Wertpapier erstellt. Dies wird entfernt.
Es ist "nur" ein Kontoauszug, keine Abrechnung eines Wertpapiers.
Die "Gebühr Kapitaltransaktion Ausland" wird ebenfalls entfernt. 
Hierzu müsste es ein separates Dokument geben für die Dividendentransaktion und
diese Kontoauszug ist der einzige der existiert.
Des Weiteren ist der Kontoauzug in der ISIN manipuliert und ob das so stimmt ist
fraglich.

_FinTechKontoauszug01.txt
testFinTechKontoauszug01()_
Das Dokument steht als nicht UTF-8 Datei zur Verfügung. Ich habe daher,
damit die setNote() korrekt funktioniert, einige Zeichen in der Datei ersetzt.

_FlatExDividende05.txt_
testFlatExDividende05WithSecurityInUSD()
Hier wird kein Wertpapier in USD generiert. 
Ersetzt durch EUR-Version.

_FlatExDegiroDividende01.txt
FlatExDegiroDividende02.txt
FlatExDividende07.txt_
Bei diese drei Buchungen lief der Importer vollkommen falsch.
Bisher wurden die Dividenden nicht gebucht, sondern nur die Steuern.
Es sind zwei Buchungen durchzuführen, da der Endbetrag negativ ist.
1.) Dividende (Brutto) buchen
2.) Steuerbelastung separat buchen
Daher wurde die Funktion addDividendeReinvestingTransaction() umbenannt
und die Buchungen korrigiert.