### PR TITLE
Changes sorting of limit price column & limit exceeded widget to order by relative distance

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/AttributeColumn.java
@@ -218,7 +218,7 @@ public class AttributeColumn extends Column
         public static Double calculateNormalizedDistance(LimitPrice limit, SecurityPrice latest)
         {
             // "normalized relative distance": relative distance, but if exceeded then as positive value, otherwise as negative value
-            double relativeDistanceAbs = Math.abs((double) limit.getValue() / latest.getValue() - 1);
+            double relativeDistanceAbs = Math.abs(limit.calculateRelativeDistance(latest.getValue()));
             return  limit.isExceeded(latest) ? relativeDistanceAbs : -relativeDistanceAbs;
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
@@ -26,6 +26,7 @@ import name.abuchen.portfolio.ui.util.FormDataFactory;
 import name.abuchen.portfolio.ui.util.LogoManager;
 import name.abuchen.portfolio.ui.util.swt.ColoredLabel;
 import name.abuchen.portfolio.ui.util.swt.StyledLabel;
+import name.abuchen.portfolio.ui.views.columns.AttributeColumn;
 import name.abuchen.portfolio.ui.views.settings.AttributeFieldType;
 import name.abuchen.portfolio.ui.views.settings.SettingsView;
 
@@ -82,7 +83,7 @@ public class LimitExceededWidget extends AbstractSecurityListWidget<LimitExceede
                 }
             }
 
-            Collections.sort(items, (r, l) -> r.getSecurity().getName().compareTo(l.getSecurity().getName()));
+            Collections.sort(items, (r, l) -> Double.compare(AttributeColumn.LimitPriceComparator.calculateNormalizedDistance(l.limit, l.price), AttributeColumn.LimitPriceComparator.calculateNormalizedDistance(r.limit, r.price)));
 
             return items;
         };

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPrice.java
@@ -61,6 +61,11 @@ public class LimitPrice implements Comparable<LimitPrice>
     {
         return value;
     }
+    
+    public double calculateRelativeDistance(long price)
+    {
+        return ((double) value / price - 1);
+    }
 
     @Override
     public int hashCode()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPriceSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LimitPriceSettings.java
@@ -61,9 +61,8 @@ public class LimitPriceSettings
 
         if (getShowRelativeDiff())
         {
-            double relativeDistance = ((double) limit.getValue() / price.getValue() - 1);
             DecimalFormat df = new DecimalFormat("+#.#%;-#.#%"); //$NON-NLS-1$
-            joiner.add(df.format(relativeDistance));
+            joiner.add(df.format(limit.calculateRelativeDistance(price.getValue())));
         }
 
         return limit.toString() + joiner.toString();


### PR DESCRIPTION
## limit price column
Currently the limit price column is sorted first by the comparison operator and then by the set limit value:
![grafik](https://user-images.githubusercontent.com/90478568/156939723-31430a2d-d2cc-47d1-8173-5f5c4bb4e2d8.png)

In my opinion, sorting by the set limit value does not add any value. In my eyes, sorting by the relative distance/difference of the current price to the limit makes more sense (after sorting by comparison operator).
This PR includes a general sorting of the limit price column based on a "normalized" relative distance (relative distance, but positive if limit exceeded otherwise negative). ~~Alternatively sorting by "IsExceeded" and then by normale relative distance would create the same results (maybe I will change this next week to avoid the "normalized distance" calulation).~~ **Edit: no its not the same**
This would produce this as example:
![grafik](https://user-images.githubusercontent.com/90478568/156939735-147fd0fb-611e-4c7e-9b50-ecfab954120d.png)

If this general sorting is unfavorable (because the sorting is difficult to follow when the SHOW_RELATIVE_DIFF is not active), I could also change the implementation to link the sorting to the "SHOW_RELATIVE_DIFF" setting. Similarly, sorting could also be performed based on the absolute distance if the "SHOW_ABSOLUTE_DIFF" setting is active. A possible behaviour could be:
1. order by comparator
2. then by "normalized" relative distance when option "SHOW_RELATIVE_DIFF" is active
3. then by "normalized" absolute distance when option "SHOW_ABSOLUTE_DIFF" is active
4. then by limit value

Any opinions on this?

## limit exceeded widget
In addition, I changed the sorting in the Limit Exceeded widget:
Current behavior (order by name):
![grafik](https://user-images.githubusercontent.com/90478568/156939775-c5186315-21b6-41e7-86fe-2dd3dec53cb4.png)

Behavior with this PR (order by relative distance):
![grafik](https://user-images.githubusercontent.com/90478568/156939786-b106e713-2c1d-424e-b0f9-60eb8d23a515.png)
