### PR TITLE
Logos are cut off when displayed in the second or following column of a table

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -179,7 +179,7 @@ public class AttributesPage extends AbstractPage implements IMenuListener
             preview.setText(previewPlaceholderText);
 
             ImageConverter conv = (ImageConverter) attribute.getType().getConverter();
-            Image img = ImageUtil.toImage(conv.toString(attribute.getValue()), 16, 16);
+            Image img = ImageUtil.toImage(conv.toString(attribute.getValue()), 0, 16, 16);
             if (img != null)
                 preview.setImage(img);
 
@@ -206,7 +206,7 @@ public class AttributesPage extends AbstractPage implements IMenuListener
                                                         return Status.OK_STATUS;
                                                     }
 
-                                                    Image img = ImageUtil.toImage(s, 16, 16);
+                                                    Image img = ImageUtil.toImage(s, 0, 16, 16);
 
                                                     updatePreview(img);
                                                     return img == null ? Status.CANCEL_STATUS : Status.OK_STATUS;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.model;
 
 import java.util.HashMap;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.swt.graphics.Image;
 
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
@@ -23,7 +24,8 @@ public final class ImageManager
 
     public Image getImage(Attributable target, AttributeType attr)
     {
-        return getImage(target, attr, 1, 16, 16);
+        int xOffset = Platform.OS_WIN32.equals(Platform.getOS()) ? 1 : 0;
+        return getImage(target, attr, xOffset, 16, 16);
     }
 
     public Image getImage(Attributable target, AttributeType attr, int xOffset, int width, int height)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
@@ -23,10 +23,10 @@ public final class ImageManager
 
     public Image getImage(Attributable target, AttributeType attr)
     {
-        return getImage(target, attr, 16, 16);
+        return getImage(target, attr, 1, 16, 16);
     }
 
-    public Image getImage(Attributable target, AttributeType attr, int width, int height)
+    public Image getImage(Attributable target, AttributeType attr, int xOffset, int width, int height)
     {
         if (target != null && target.getAttributes().exists(attr) && attr.getConverter() instanceof ImageConverter)
         {
@@ -35,14 +35,14 @@ public final class ImageManager
                 return null;
 
             String imgString = String.valueOf(imgObject);
-            String imgKey = imgString + width + height;
+            String imgKey = imgString + width + height + xOffset;
             synchronized (imageCache)
             {
                 Image img = imageCache.getOrDefault(imgKey, null);
                 if (img != null)
                     return img;
 
-                img = ImageUtil.toImage(imgString, width, height);
+                img = ImageUtil.toImage(imgString, xOffset, width, height);
                 if (img != null)
                 {
                     imageCache.put(imgKey, img);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
@@ -58,6 +58,14 @@ public class ImageUtil
         }
     }
 
+    /**
+     * 
+     * @param value
+     * @param xOffset Additional transparent offset. Width of the resulting image is (xOffset + maxWidth)
+     * @param logicalWidth
+     * @param logicalHeight
+     * @return
+     */
     public static Image toImage(String value, int xOffset, int logicalWidth, int logicalHeight)
     {
         if (value == null || value.length() == 0)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/ImageUtil.java
@@ -27,11 +27,13 @@ public class ImageUtil
     {
         private int logicalWidth;
         private int logicalHeight;
+        private int xOffset;
         private ImageData fullSize;
         private HashMap<Integer, ImageData> zoomLevels = new HashMap<Integer, ImageData>();
 
-        public ZoomingImageDataProvider(byte[] data, int logicalWidth, int logicalHeight)
+        public ZoomingImageDataProvider(byte[] data, int xOffset, int logicalWidth, int logicalHeight)
         {
+            this.xOffset = xOffset;
             this.logicalWidth = logicalWidth;
             this.logicalHeight = logicalHeight;
             this.fullSize = ImageUtil.toImageData(data);
@@ -47,7 +49,7 @@ public class ImageUtil
             float scaleW = 1f / fullSize.width * logicalWidth * (zoom / 100f);
             float scaleH = 1f / fullSize.height * logicalHeight * (zoom / 100f);
 
-            imageData = ImageUtil.resize(fullSize, (int) (fullSize.width * scaleW), (int) (fullSize.height * scaleH),
+            imageData = ImageUtil.resize(fullSize, xOffset, (int) (fullSize.width * scaleW), (int) (fullSize.height * scaleH),
                             false);
 
             zoomLevels.put(zoom, imageData);
@@ -56,7 +58,7 @@ public class ImageUtil
         }
     }
 
-    public static Image toImage(String value, int logicalWidth, int logicalHeight)
+    public static Image toImage(String value, int xOffset, int logicalWidth, int logicalHeight)
     {
         if (value == null || value.length() == 0)
             return null;
@@ -73,7 +75,7 @@ public class ImageUtil
             if (buff == null || buff.length == 0)
                 return null;
 
-            return new Image(null, new ZoomingImageDataProvider(buff, logicalWidth, logicalHeight));
+            return new Image(null, new ZoomingImageDataProvider(buff, xOffset, logicalWidth, logicalHeight));
         }
         catch (Exception ex)
         {
@@ -119,13 +121,13 @@ public class ImageUtil
 
         if (imgData.width > maxWidth || imgData.height > maxHeight)
         {
-            imgData = ImageUtil.resize(imgData, maxWidth, maxHeight, true);
+            imgData = ImageUtil.resize(imgData, 0, maxWidth, maxHeight, true);
             data = ImageUtil.encode(imgData);
         }
         return BASE64PREFIX + Base64.getEncoder().encodeToString(data);
     }
 
-    private static ImageData resize(ImageData image, int maxWidth, int maxHeight, boolean preserveRatio)
+    private static ImageData resize(ImageData image, int xOffset, int maxWidth, int maxHeight, boolean preserveRatio)
     {
         if (image.width == maxWidth && image.height == maxHeight)
             return image;
@@ -148,7 +150,7 @@ public class ImageUtil
         if (posY + newHeight > imageHeight)
             newWidth = imageHeight - posY;
 
-        ImageData imageData = getTransparentImage(imageWidth, imageHeight);
+        ImageData imageData = getTransparentImage(imageWidth + xOffset, imageHeight);
 
         Image canvas = new Image(null, imageData);
 
@@ -157,7 +159,7 @@ public class ImageUtil
         gc.setInterpolation(SWT.HIGH);
 
         Image source = new Image(null, image);
-        gc.drawImage(source, 0, 0, image.width, image.height, posX, posY, newWidth, newHeight);
+        gc.drawImage(source, 0, 0, image.width, image.height, posX+xOffset, posY, newWidth, newHeight);
         gc.dispose();
         source.dispose();
 


### PR DESCRIPTION
Fixes #2751 