### PR TITLE
Solves "Could not find satisfiable constructor in InvestmentPlanDialog" issue

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Streams;
 
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.InvestmentPlan;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
@@ -1043,7 +1044,7 @@ public final class SecuritiesTable implements ModificationListener
 
         new OpenDialogAction(view, Messages.InvestmentPlanMenuCreate) //
                         .type(InvestmentPlanDialog.class) //
-                        .parameters(PortfolioTransaction.class) //
+                        .parameters(InvestmentPlan.Type.BUY_OR_DELIVERY) //
                         .with(security) //
                         .addTo(manager);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityContextMenu.java
@@ -8,6 +8,7 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.jface.wizard.WizardDialog;
 
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.InvestmentPlan;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
@@ -144,7 +145,7 @@ public class SecurityContextMenu
         {
             manager.add(new OpenDialogAction(owner, Messages.InvestmentPlanMenuCreate) //
                             .type(InvestmentPlanDialog.class) //
-                            .parameters(PortfolioTransaction.class) //
+                            .parameters(InvestmentPlan.Type.BUY_OR_DELIVERY) //
                             .with(security));
 
             manager.add(new Separator());


### PR DESCRIPTION
With https://github.com/buchen/portfolio/commit/fa83424b189abcd6c3d6d6985c024c3c7a3209e8#diff-1083f07b564d128d6b04ddb875c146c6488bb8c09b52269c91568e1d5c9edbceR51-R52 the constructor of ``InvestmentPlanDialog`` was changed.But not all factory definitions have taken this change into account. 
So using context menu action"create investmentplan" of security leads to following error:
![grafik](https://user-images.githubusercontent.com/90478568/161812895-90587394-1bca-4957-9528-dfc37c2a94b6.png)
