### PR TITLE
Reduce redundant regex

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -63,7 +63,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^(Wertpapierabrechnung|Transaction Statement): (?<type>(Kauf|Verkauf|Purchase|Sale))(.*)?$")
+                .match("^(Wertpapierabrechnung|Transaction Statement): (?<type>(Kauf|Verkauf|Purchase|Sale)).*$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf") || v.get("type").equals("Sale"))
                     {
@@ -86,7 +86,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Registered Shares o.N.
                 // Kurswert EUR 208,74
                 .section("isin", "wkn", "name", "nameContinued", "currency").optional()
-                .match("^(Nominale ISIN|Quantity ISIN): (?<isin>[\\w]{12}) WKN: (?<wkn>.*) (Kurs|Bezugspreis|Barabfindung|Price)(.*)?$")
+                .match("^(Nominale ISIN|Quantity ISIN): (?<isin>[\\w]{12}) WKN: (?<wkn>.*) (Kurs|Bezugspreis|Barabfindung|Price).*$")
                 .match("^(STK|Units) [\\.,\\d]+ (?<name>.*) (?<currency>[\\w]{3}) .*$")
                 .match("^(?<nameContinued>.*)$")
                 .assign((t, v) -> {
@@ -108,7 +108,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date", "time")
                                         .find("Handelsdatum Handelsuhrzeit")
-                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2})(.*)?")
+                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}).*")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Handels- Handels- 
@@ -116,7 +116,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date", "time")
                                         .find("Handels- Handels- ")
-                                        .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Einbuchung in Depot yyyyyyyyyy per 09.03.2021
@@ -390,7 +390,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(.*)?Seite 1\\/[\\d]$");
+        Block firstRelevantLine = new Block("^.*Seite 1\\/[\\d]$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -74,14 +74,14 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(\\*[\\s]+)?(Wertpapierkauf|Wertpapierverkauf|Wertpapierbezug)(.*)?$");
+        Block firstRelevantLine = new Block("^(\\*[\\s]+)?(Wertpapierkauf|Wertpapierverkauf|Wertpapierbezug).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^(\\*[\\s]+)?(?<type>(Wertpapierkauf|Wertpapierverkauf|Wertpapierbezug))(.*)?$")
+                .match("^(\\*[\\s]+)?(?<type>(Wertpapierkauf|Wertpapierverkauf|Wertpapierbezug)).*$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Wertpapierverkauf"))
                     {
@@ -102,9 +102,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //  Summe        St.  20                 EUR  71,00        EUR            1.420,00 
                 .section("name", "wkn", "nameContinued", "isin", "shares", "currency")
                 .match("^Wertpapier-Bezeichnung .*$")
-                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
-                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
+                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,}).*$")
+                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12}).*$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -128,7 +128,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 //            Umrechnung zum Devisenkurs 1,216500        : EUR               49,98 
                 .section("exchangeRate").optional()
-                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -142,7 +142,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                  * Fees are processed in a separate transaction
                  */
                 .section("negative").optional()
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>\\-)(.*)?$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>\\-).*$")
                 .assign((t, v) -> {
                     if (t.getPortfolioTransaction().getType().isLiquidation())
                     {
@@ -155,8 +155,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern 
                 // EUR     30.12.2020        EUR            1.430,30 
                 .section("amount", "currency")
-                .match("^.* Zu Ihren (Lasten|Gunsten)( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                .match("^.* Zu Ihren (Lasten|Gunsten)( vor Steuern)?.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                 .assign((t, v) -> {                   
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -168,8 +168,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //                           Kurswert                    : USD            4.768,00 
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
-                .match("^.* Ausmachender Betrag ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* Ausmachender Betrag ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+).*$")
+                .match("^.* Umrechn\\. zum Dev\\. kurs (?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -200,9 +200,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern 
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR                8,86- 
                 .section("amount", "currency", "fxCurrency").optional()
-                .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Zu Ihren (Lasten|Gunsten)( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
+                .match("^.* Zu Ihren (Lasten|Gunsten)( vor Steuern)?.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> {                   
                     if ("X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -219,9 +219,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern 
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR                9,61- 
                 .section("amount", "currency", "fxCurrency").optional()
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Zu Ihren Lasten( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St. ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+).*$")
+                .match("^.* Zu Ihren Lasten( vor Steuern)?.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> {                            
                     if ("X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -239,9 +239,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern                                                    
                 // XXXX XXXX XXXX XXXX XXXX XX   EUR     27.08.2020        EUR               10,12- 
                 .section("fxAmount", "currency", "exchangeRate", "fxCurrency").optional()
-                .match("^.* Ausmachender Betrag ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+)(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^.* Ausmachender Betrag ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+).*$")
+                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+).*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -301,7 +301,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift)(.*)?$");
+        Block block = new Block("^(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {
@@ -344,15 +344,15 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 // 000000000  EUR            00000000      15.12.2010         EUR             335,92
                 .section("date")
-                .match("^.* Zu Ihren Gunsten vor Steuern(.*)?$")
-                .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^.* Zu Ihren Gunsten vor Steuern.*$")
+                .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Verrechnung über Konto                  Valuta       Zu Ihren Gunsten vor Steuern
                 // 0000000 00     EUR                      27.04.2009         EUR           1.546,13
                 .section("currency", "amount")
-                .match("^.* Zu Ihren Gunsten vor Steuern(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                .match("^.* Zu Ihren Gunsten vor Steuern.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -361,7 +361,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //              zum Devisenkurs: EUR/USD      1,167800                 EUR              11,65 
                 //     zum Devisenkurs EURUSD      1,185400                 EUR               7,52   
                 .section("exchangeRate").optional()
-                .match("^(.*)?zum Devisenkurs(:)? [\\w]{3}(\\/)?[\\w]{3} ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^.*zum Devisenkurs(:)? [\\w]{3}(\\/)?[\\w]{3} ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -395,8 +395,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // Bruttobetrag                     USD              10,50                           
                 //     zum Devisenkurs EURUSD      1,185400                 EUR               7,52   
                 .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
-                .match("^Bruttobetrag(:)? ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^(.*)?zum Devisenkurs(:)? [\\w]{3}(\\/)?[\\w]{3} ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                .match("^Bruttobetrag(:)? ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+).*$")
+                .match("^.*zum Devisenkurs(:)? [\\w]{3}(\\/)?[\\w]{3} ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                     {
@@ -437,7 +437,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // zahlbar ab 15.12.2010                 Zwischendividende
                 // zahlbar ab 19.10.2017                 monatl. Dividende                            
                 .section("note").optional()
-                .match("^zahlbar ab [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<note>(?i).*dividende)(.*)?$")
+                .match("^zahlbar ab [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<note>(?i).*dividende).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
                 
                 .wrap(TransactionItem::new);
@@ -466,7 +466,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // EUR           5.000 SANHA ANL 13/26 STZ , WKN / ISIN: A1TNA7  / DE000A1TNA70
                 // Z u  Ih r e n G u n s t e n n a c h S t e u er n :       U S D             126,3 2 
                 .section("shares", "name", "wkn", "isin", "currency")
-                .match("^[\\w]{3}(\\.)? ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*), WKN \\/ ISIN: (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
+                .match("^[\\w]{3}(\\.)? ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*), WKN \\/ ISIN: (?<wkn>.*) \\/ (?<isin>[\\w]{12}).*$")
                 .match("^([\\s]+)?Z([\\s]+)?u"
                                 + "([\\s]+)?I([\\s]+)?h([\\s]+)?r([\\s]+)?e([\\s]+)?n"
                                 + "([\\s]+)?G([\\s]+)?u([\\s]+)?n([\\s]+)?s([\\s]+)?t([\\s]+)?e([\\s]+)?n"
@@ -483,7 +483,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 // Die Gutschrift erfolgt mit Valuta 20.02.2020 auf Konto EUR mit der IBAN DE12 3456 7890 1234 5678 00   
                 .section("date")
-                .match("^Die Gutschrift erfolgt mit Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^Die Gutschrift erfolgt mit Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Z u  Ih r e n G u n s t e n n a c h S t e u er n :              E U R             302,5 5   
@@ -553,7 +553,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)?(\\(([\\s]+)?1([\\s]+)?\\))? "
                                 + "([\\s]+)?(?<currency2>[A-Z\\s]+) "
                                 + "([\\s]+)?(?<gross2>[\\.,\\d\\s]+)([\\W]+)?$")
-                .match("^([\\s]+)?Umrechnungen zum Devisenkurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^([\\s]+)?Umrechnungen zum Devisenkurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     v.put("currency1", stripBlanks(v.get("currency1")));
                     v.put("gross1", stripBlanks(v.get("gross1")));
@@ -624,7 +624,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // Stk.              11,486 ISIV-MSCI FRAN. U.ETF EOA , WKN / ISIN: A12ATD  / IE00BP3QZJ36   
                 .section("shares", "name", "wkn", "isin")
-                .match("^Stk\\. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12})(.*)?$")
+                .match("^Stk\\. ([\\s]+)?(?<shares>[\\.,\\d]+) (?<name>.*) , (WKN \\/ ISIN:) (?<wkn>.*) \\/ (?<isin>[\\w]{12}).*$")
                 .assign((t, v) -> {
                     v.put("wkn", stripBlanks(v.get("wkn")));
                     v.put("isin", stripBlanks(v.get("isin")));
@@ -664,7 +664,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Wertpapierverkauf");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(\\*[\\s]+)?Wertpapierverkauf(.*)?$");
+        Block block = new Block("^(\\*[\\s]+)?Wertpapierverkauf.*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
@@ -688,9 +688,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //  Summe        St.  20                 EUR  71,00        EUR            1.420,00 
                 .section("name", "wkn", "nameContinued", "isin", "shares", "currency")
                 .match("^Wertpapier-Bezeichnung .*$")
-                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
-                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
-                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3})(.*)?$")
+                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,}).*$")
+                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12}).*$")
+                .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
                     t.setSecurity(getOrCreateSecurity(v));
@@ -712,8 +712,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("negative").optional()
-                .match("^.* Zu Ihren Lasten( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>\\-)(.*)?$")
+                .match("^.* Zu Ihren Lasten( vor Steuern)?.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(?<negative>\\-).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -728,9 +728,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 // IBAN                                  Valuta         Zu Ihren Lasten vor Steuern 
                 // DExx xxxx xxxx xxxx xxxx xx   EUR     24.11.2016        EUR            1.431,40  
                 .section("fxCurrency", "fxAmount", "currency", "amount").optional()
-                .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+)(.*)?$")
-                .match("^.* Zu Ihren Lasten( vor Steuern)?(.*)?$")
-                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                .match("^.* Kurswert ([\\s]+)?: ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmount>[\\.,\\d]+).*$")
+                .match("^.* Zu Ihren Lasten( vor Steuern)?.*$")
+                .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                 .assign((t, v) -> {                            
                     if ("X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -794,7 +794,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
          * the buy/sell transaction function must be adjusted.
          * addBuySellTransaction();
          */
-        Block block = new Block("^(\\*[\\s]+)?(Wertpapierkauf|Wertpapierverkauf)(.*)?$");
+        Block block = new Block("^(\\*[\\s]+)?(Wertpapierkauf|Wertpapierverkauf).*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -811,8 +811,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //  Summe        St.  20                 EUR  71,00        EUR            1.420,00 
                 .section("name", "wkn", "nameContinued", "isin", "shares", "currency")
                 .match("^Wertpapier-Bezeichnung .*$")
-                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,})(.*)?$")
-                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12})(.*)?$")
+                .match("^(?<name>([\\S]{1,}[\\s]{1})+) [\\s]{3,}(?<wkn>[\\w]{1,}).*$")
+                .match("^(?<nameContinued>.*) ([\\s]+)?(?<isin>[\\w]{12}).*$")
                 .match("^(([\\s]+)?Summe ([\\s]+)?)?St\\. ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setShares(asShares(v.get("shares")));
@@ -837,7 +837,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 //        Umrechn. zum Dev. kurs 1,080600 vom 17.04.2020 : EUR            4.425,22 
                 //            Umrechnung zum Devisenkurs 1,216500        : EUR               49,98 
                 .section("exchangeRate").optional()
-                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^.* (Umrechn\\. zum Dev\\. kurs|Umrechnung zum Devisenkurs) (?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {                   
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -852,7 +852,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                 .match("^([\\s]+)?e([\\s]+)?r([\\s]+)?s([\\s]+)?t([\\s]+)?a([\\s]+)?t([\\s]+)?t([\\s]+)?e([\\s]+)?t([\\s]+)?e"
                                 + "([\\s]+)?S([\\s]+)?t([\\s]+)?e([\\s]+)?u([\\s]+)?e([\\s]+)?r([\\s]+)?n "
                                 + "([\\s]+)?(?<currency>[\\w\\s_]+) "
-                                + "([\\s_]+)?(?<amount>[-\\.,\\d\\s_]+)(.*)?$")
+                                + "([\\s_]+)?(?<amount>[-\\.,\\d\\s_]+).*$")
                 .assign((t, v) -> {
                     v.put("amount", stripBlanksAndUnderscores(v.get("amount")));
                     v.put("currency", stripBlanksAndUnderscores(v.get("currency")));
@@ -1218,7 +1218,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         transaction
                 //                           Provision                   : EUR               12,10 
                 .section("currency", "fee").optional()
-                .match("^.* Provision ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Provision ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1228,7 +1228,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Gesamtprovision             : EUR                9,90 
                 .section("currency", "fee").optional()
-                .match("^.* Gesamtprovision ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Gesamtprovision ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1238,7 +1238,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Börsenplatzabhäng. Entgelt  : EUR                1,50 
                 .section("currency", "fee").optional()
-                .match("^.* B.rsenplatzabh.ng\\. Entgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* B.rsenplatzabh.ng\\. Entgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1248,7 +1248,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Umschreibeentgelt           : EUR                0,60
                 .section("currency", "fee").optional()
-                .match("^.* Umschreibeentgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Umschreibeentgelt ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1258,7 +1258,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Abwickl.entgelt Clearstream : EUR                2,90
                 .section("currency", "fee").optional()
-                .match("^.* Abwickl.entgelt Clearstream ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Abwickl.entgelt Clearstream ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1268,7 +1268,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Variable Börsenspesen       : EUR                3,00
                 .section("currency", "fee").optional()
-                .match("^.* Variable B.rsenspesen ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Variable B.rsenspesen ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1278,7 +1278,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                  0,08000% Maklercourtage              : EUR                0,88- 
                 .section("currency", "fee").optional()
-                .match("^.* Maklercourtage ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Maklercourtage ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1288,7 +1288,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                 //                           Fremde Spesen               : USD               13,90 
                 .section("currency", "fee").optional()
-                .match("^.* Fremde Spesen ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^.* Fremde Spesen ([\\s]+)?: ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -119,7 +119,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Preis pro Anteil 25,640000 EUR  
                 .section("name", "wkn", "isin", "currency").optional()
                 .match("^(?<name>.*) (?<wkn>.*) (?<isin>[\\w]{12})([\\s]+)?$")
-                .match("^(Kurs|Preis pro Anteil) [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Kurs|Preis pro Anteil) [\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // ST 15,75243 WKN: 625952
@@ -171,7 +171,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // ST 1.000,00000 Letzte Fälligkeit 01.09.2021
                 //       ST                        50,00000               WKN: 851144
                 .section("shares")
-                .match("^([\\s]+)?ST ([\\s]+)?(?<shares>[\\.,\\d]+)(.*)?$")
+                .match("^([\\s]+)?ST ([\\s]+)?(?<shares>[\\.,\\d]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // KAUF AM 15.01.2015  UM 08:13:35 MUENCHEN NR. 12345670.001
@@ -338,7 +338,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         Block block = new Block("^(DIVIDENDENGUTSCHRIFT"
                         + "|Dividendengutschrift"
                         + "|ERTRAGSGUTSCHRIFT"
-                        + "|Ertragsgutschrift)(.*)?$");
+                        + "|Ertragsgutschrift).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {
@@ -352,10 +352,10 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 //            COMS.-MSCI WORL.T.U.ETF I                                    
                 //            Namens-Aktien o.N.                                           
                 .section("wkn", "name", "nameContinued", "currency").optional()
-                .match("^ST ([\\s]+)?[\\.,\\d]+ ([\\s]+)?WKN: ([\\s]+)?(?<wkn>.*)(.*)?$")
+                .match("^ST ([\\s]+)?[\\.,\\d]+ ([\\s]+)?WKN: ([\\s]+)?(?<wkn>.*).*$")
                 .match("^(?<name>.*)$")
                 .match("^(?<nameContinued>.*)$")
-                .match("^(ZINS-\\/DIVIDENDENSATZ|ERTRAGSAUSSCHUETTUNG P\\. ST\\.) .* ([\\s]+)?(?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}(.*)?$")
+                .match("^(ZINS-\\/DIVIDENDENSATZ|ERTRAGSAUSSCHUETTUNG P\\. ST\\.) .* ([\\s]+)?(?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // OMNICOM GROUP INC. Registered Shares DL -,15 871706 US6819191064
@@ -398,7 +398,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 // WERT 08.05.2015                               EUR                326,90 
                                 section -> section
                                         .attributes("currency", "amount")
-                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -417,7 +417,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 // UMGER.ZUM DEV.-KURS                 1,093000  EUR                285,60 
                                 section -> section
                                         .attributes("currency", "amount")
-                                        .match("^(?i)UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                                        .match("^(?i)UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -427,8 +427,8 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // BRUTTO                                        USD                180,00 
                 // UMGER.ZUM DEV.-KURS                 1,104300  EUR                138,55 
                 .section("fxAmountGross", "fxCurrency", "exchangeRate").optional()
-                .match("^BRUTTO ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmountGross>[\\.,\\d]+)(.*)?$")
-                .match("^UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(.*)?$")
+                .match("^BRUTTO ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxAmountGross>[\\.,\\d]+).*$")
+                .match("^UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -711,7 +711,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Kapitalertragsteuer (Account)
                 // KAPST                                 25,00 % EUR                111,00 
                 .section("tax", "currency").optional()
-                .match("^KAPST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^KAPST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                     {
@@ -808,7 +808,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Solitaritätszuschlag (Account)
                 // SOLZ                                   5,50 % EUR                  6,10 
                 .section("tax", "currency").optional()
-                .match("^SOLZ ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^SOLZ ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                     {
@@ -905,7 +905,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Kirchensteuer (Account)
                 // KIST                                   5,50 % EUR                  6,10 
                 .section("tax", "currency").optional()
-                .match("^KIST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^KIST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                     {
@@ -1090,7 +1090,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                 // FREMDE SPESEN                                 USD                  1,91 
                 .section("fee", "currency").optional()
-                .match("^(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // abzgl. Fremde Spesen 0,07 USD

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -233,7 +233,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("(Dividendengutschrift|Ertr.gnisgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Ertr.gnisgutschrift(?! (aus|VERSANDARTENSCHLUESSEL)))(.*)?$");
+        Block block = new Block("^(Dividendengutschrift|Ertr.gnisgutschrift(?! (aus|VERSANDARTENSCHLUESSEL))).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
@@ -300,7 +300,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // Netto in USD zugunsten IBAN DE90 209,38 USD
                 // Netto zugunsten IBAN DE11 7603 0080 0111 1111 14 437,22 EUR
                 .section("amount", "currency").optional()
-                .match("^Netto (.*)?zugunsten IBAN .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Netto .*zugunsten IBAN .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(v.get("currency"));
                     t.setAmount(asAmount(v.get("amount")));
@@ -787,7 +787,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 1,62
                 // davon anrechenbare US-Quellensteuer  15% USD             2,430     
                 .section("creditableWithHoldingTax", "currency").optional()
-                .match("^(.*)?davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
+                .match("^.*davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -165,7 +165,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 // Handelsspesen            -5,06 USD  DevKurs        1,170500/30.7.2020
                 .section("fxAmount", "fxCurrency", "exchangeRate").optional()
                 .match("^.* KURSWERT ([\\s]+)?(\\-)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -350,7 +350,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) Ertrag ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$")
                 .match("^ISIN (?<isin>[\\w]{12}) (?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+) STK$")
                 .match("^.* ZINSERTRAG ([\\s]+)?(\\-)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
                     t.setShares(asShares(v.get("shares")));
@@ -438,8 +438,8 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 .section("date", "year", "amount", "isin", "name", "shares", "fxCurrency", "exchangeRate")
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) (Steuern aussch.ttungsgl. Ertr.ge|Steuerdividende) ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$")
                 .match("^ISIN (?<isin>[\\w]{12}) (?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+) STK$")
-                .match("^(.*)?KEST ([\\s]+)?\\-[\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*")
+                .match("^.*KEST ([\\s]+)?\\-[\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
                     t.setShares(asShares(v.get("shares")));
@@ -770,27 +770,27 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         transaction
                 // QUELLENSTEUER: -1,86 USD
                 .section("withHoldingTax", "currency").optional()
-                .match("^QUELLENSTEUER: ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^QUELLENSTEUER: ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // QUELLENSTEUER           -15,60 USD  Auslands-KESt           -13,00 USD
                 .section("withHoldingTax", "currency").optional()
-                .match("^QUELLENSTEUER ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^QUELLENSTEUER ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Auslands-KESt: -1,54 USD
                 .section("tax", "currency").optional()
-                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // QUELLENSTEUER            -3,77 USD  Auslands-KESt            -3,13 USD
                 .section("tax", "currency").optional()
-                .match("^.* Auslands\\-KESt ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.* Auslands\\-KESt ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // KEST                   -140,27 USD  Handelsspesen            -5,07 USD
                 .section("tax", "currency").optional()
-                .match("^KEST ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^KEST ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -799,32 +799,32 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Handelsspesen            -3,66 EUR  DADAT Handelsspesen      -6,36 EUR
                 .section("fee", "currency").optional()
-                .match("^(.*)?  DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // DADAT Handelsspesen      -1,67 EUR
                 .section("fee", "currency").optional()
-                .match("^DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // KEST                   -140,27 USD  Handelsspesen            -5,07 USD
                 .section("fee", "currency").optional()
-                .match("^(.*)?  Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Handelsspesen            -3,66 EUR  DADAT Handelsspesen      -6,36 EUR
                 .section("fee", "currency").optional()
-                .match("^Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Clearing Gebühr          -1,00 EUR
                 .section("fee", "currency").optional()
-                .match("^Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // DADAT Handelsspesen      -7,12 EUR  Clearing Gebühr          -1,00 EUR
                 .section("fee", "currency").optional()
-                .match("^.*  Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -48,14 +48,14 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^Wertpapier Abrechnung (Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds)(.*)?$");
+        Block firstRelevantLine = new Block("^Wertpapier Abrechnung (Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional()
-                .match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds))(.*)?$")
+                .match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds)).*$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf") || v.get("type").equals("Rücknahme Investmentfonds"))
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -146,7 +146,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
                 .match("^(St.ck|[\\w]{3}) [\\.,\\d]+ (?<name>.*) (?<isin>[\\w]{12}) \\((?<wkn>.*)\\)$")
                 .match("^(?<nameContinued>.*)$")
-                .match("^(Kurswert|R.ckzahlungsbetrag) [\\.,\\d]+([\\+|\\-])? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Kurswert|R.ckzahlungsbetrag) [\\.,\\d]+([\\+|\\-])? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setSecurity(getOrCreateSecurity(v));
 
@@ -216,7 +216,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 // Limit 1,75 EUR
                 // Rückzahlungskurs 100 % Rückzahlungsdatum 31.07.2014
                 .section("note").optional()
-                .match("^(?<note>(Limit|R.ckzahlungskurs) [\\.,\\d]+ ([\\w]{3}|%))(.*)?$")
+                .match("^(?<note>(Limit|R.ckzahlungskurs) [\\.,\\d]+ ([\\w]{3}|%)).*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(BuySellEntryItem::new);
@@ -312,7 +312,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 // Devisenkurs EUR / CHF 1,1959
                 // Ausschüttung 51,00 CHF 42,65+ EUR
                 .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
-                .match("^Devisenkurs [\\w]{3} \\/ [\\w]{3} (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^Devisenkurs [\\w]{3} \\/ [\\w]{3} (?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^(Aussch.ttung|Dividendengutschrift|Kurswert) (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<amount>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
@@ -837,7 +837,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. "
                                 + "(?<note1>Rechnung) "
                                 + "(?<amount>[\\.,\\d]+)$")
-                .match("^(.*)?(?<note2>(Bargeldeinzahlung|R.ckruf\\/Nachforschung)).*$")
+                .match("^.*(?<note2>(Bargeldeinzahlung|R.ckruf\\/Nachforschung)).*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     // since year is not within the date correction

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -360,7 +360,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                                 // WP-Bestand : 20,286
                                 section -> section
                                         .attributes("shares")
-                                        .match("^WP\\-Bestand : (?<shares>[\\.',\\d\\s]+)(.*)?$")
+                                        .match("^WP\\-Bestand : (?<shares>[\\.',\\d\\s]+).*$")
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                         )
 
@@ -374,7 +374,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                                 // Zahltag : 29. April 2010
                                 section -> section
                                         .attributes("date")
-                                        .match("^Zahltag : (?<date>[\\d]{2}\\. .* [\\d]{4})(.*)?$")
+                                        .match("^Zahltag : (?<date>[\\d]{2}\\. .* [\\d]{4}).*$")
                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
                         )
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -265,7 +265,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> {
                     if (t.getNote() == null)
                         t.setNote(trim(v.get("note")));
@@ -426,7 +426,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -625,7 +625,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -732,7 +732,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1024,7 +1024,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Depotausgang|Bestandsausbuchung|Gutschrifts\\- \\/ Belastungsanzeige)(.*)?$");
+        Block firstRelevantLine = new Block("^(Depotausgang|Bestandsausbuchung|Gutschrifts\\- \\/ Belastungsanzeige).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -1074,7 +1074,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Fälligkeitstag   : 02.12.2009                  Letzter Handelstag:  20.11.2009
                 // Fälligkeitstag                                                  25.06.2021
                 .section("date").optional()
-                .match("^F.lligkeitstag([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^F.lligkeitstag([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                 // Verwahrart      : GS-Verwahrung        Geldgegenwert***:              0,20 EUR
@@ -1125,7 +1125,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1154,7 +1154,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^Depoteingang(.*)?$");
+        Block firstRelevantLine = new Block("^Depoteingang.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -1214,7 +1214,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1284,7 +1284,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1477,7 +1477,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1579,7 +1579,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
@@ -1604,7 +1604,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
          * addTransferOutTransaction();
          * addTransferInTransaction();
          */
-        Block block = new Block("^(Depoteingang|Depotausgang|Bestandsausbuchung|Gutschrifts\\- \\/ Belastungsanzeige)(.*)?$");
+        Block block = new Block("^(Depoteingang|Depotausgang|Bestandsausbuchung|Gutschrifts\\- \\/ Belastungsanzeige).*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -1653,7 +1653,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Fälligkeitstag                                                  25.06.2021
                 // Fälligkeitstag: 18.07.2011 letzter Handel am: 11.07.2011
                 .section("date").optional()
-                .match("^(F.lligkeitstag|Datum)([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^(F.lligkeitstag|Datum)([:\\s]+)? (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:           -382,12 EUR
@@ -1677,7 +1677,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //   unter der Transaktion-Nr. : 1111111111
                 // Transaktionsnummer: 921414163
                 .section("note").optional()
-                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+)(.*)?$")
+                .match("^(.* )?(?<note>(Transaktion\\-Nr\\.([\\s]+)?|Transaktionsnummer): [\\d]+).*$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 //     Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -68,7 +68,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^Kurs: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kurs: [\\-\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -79,12 +79,12 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // Handelszeit: 11.5.2021
                 // Handelszeit: 30.6.2017 um 09:00:10 Uhr
                 .section("time").optional()
-                .match("^Handelszeit: .* (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                .match("^Handelszeit: .* (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                 .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                 // Handelszeit: 11.5.2021
                 .section("date")
-                .match("^Handelszeit: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Handelszeit: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> {
                     if (type.getCurrentContext().get("time") != null)
                         t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -94,12 +94,12 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Zugang: 74 Stk Teilausführung
                 .section("shares")
-                .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Zu Lasten IBAN AT44 1925 0654 0668 9002 -1.118,80 EUR 
                 .section("amount", "currency")
-                .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -109,8 +109,8 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // -10.360,-- NOK 
                 // Devisenkurs: 9,486 (3.7.2017) -1.092,14 EUR 
                 .section("fxAmount", "fxCurrency", "exchangeRate").optional()
-                .match("^Kurswert: (?<fxAmount>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Kurswert: (?<fxAmount>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {                   
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -136,7 +136,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs: 1,5181 (13.10.2017) 3.126,21 EUR 
                 .section("exchangeRate").optional()
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -170,7 +170,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^(Dividende|Ertrag): (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Dividende|Ertrag): (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -180,17 +180,17 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // 200 Stk
                 .section("shares")
-                .match("^(Abgang: )?(?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^(Abgang: )?(?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Valuta 6.9.2017
                 .section("date")
-                .match("^Valuta (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Valuta (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Zu Gunsten IBAN AT44 1925 0654 0668 9002 48,71 EUR 
                 .section("amount", "currency")
-                .match("^Zu Gunsten .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Zu Gunsten .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -199,8 +199,8 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // Bruttoertrag: 640,-- NOK 
                 // Devisenkurs: 9,308 (5.9.2017) 49,85 EUR 
                 .section("fxAmount", "fxCurrency", "exchangeRate").optional()
-                .match("^Bruttoertrag: (?<fxAmount>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Bruttoertrag: (?<fxAmount>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {                   
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -226,7 +226,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs: 1,5181 (13.10.2017) 3.126,21 EUR 
                 .section("exchangeRate").optional()
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -262,7 +262,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>\\S*) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^steuerlicher Anschaffungswert: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^steuerlicher Anschaffungswert: [\\-\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs") || !v.get("name1").startsWith("Verwahrart"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -272,17 +272,17 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Zugang: 80 Stk
                 .section("shares")
-                .match("^Zugang: (?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^Zugang: (?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Kassatag: 29.3.2017
                 .section("date")
-                .match("^Kassatag: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Kassatag: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // steuerlicher Anschaffungswert: 3.225,37 EUR
                 .section("amount", "currency")
-                .match("^steuerlicher Anschaffungswert: (?<amount>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^steuerlicher Anschaffungswert: (?<amount>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -297,27 +297,27 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Kapitalertragsteuer: -254,10 AUD 
                 .section("tax", "currency").optional()
-                .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // KESt Ausländische Dividende: -176,01 NOK 
                 .section("tax", "currency").optional()
-                .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer US-Emittent: -3,05 USD 
                 .section("withHoldingTax", "currency").optional()
-                .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Quellensteuer: -8,81 EUR 
                 .section("withHoldingTax", "currency").optional()
-                .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Umsatzsteuer: -0,19 EUR 
                 .section("tax", "currency").optional()
-                .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -327,22 +327,22 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Fremde Spesen: -25,20 EUR 
                 .section("fee", "currency").optional()
-                .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Eigene Spesen: -6,42 EUR 
                 .section("fee", "currency").optional()
-                .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Inkassoprovision: -0,95 EUR 
                 .section("fee", "currency").optional()
-                .match("^Inkassoprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Inkassoprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Grundgebühr: -1,46 EUR 
                 .section("fee", "currency").optional()
-                .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -200,7 +200,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift)", jointAccount);
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift)(.*)?$");
+        Block block = new Block("^(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -49,7 +49,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(F.lligkeit\\/Verfall|Wertpapier Abrechnung|WERTPAPIERABRECHNUNG)(.*)?$", "^Ausmachender Betrag.*$");
+        Block firstRelevantLine = new Block("^(F.lligkeit\\/Verfall|Wertpapier Abrechnung|WERTPAPIERABRECHNUNG).*$", "^Ausmachender Betrag.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -110,7 +110,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 // Stück 53 ISHSII-DEV.MKTS PROP.YLD U.ETF IE00B1FZS350 (A0LEW8)
                 // Anzahl/Nominale 9,00
                 .section("shares")
-                .match("^(St.ck|Anzahl)(\\/Nominale(:)?)? (?<shares>[\\.,\\d]+)(.*)?$")
+                .match("^(St.ck|Anzahl)(\\/Nominale(:)?)? (?<shares>[\\.,\\d]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Orderausführung Datum/Zeit: 31 Jul 2020 21:00:15
@@ -526,7 +526,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                                                     + "|Kontof.hrungs\\-u\\.Depotgeb.hren"
                                                     + "|Depot\\- u\\. Verwaltgeb.hr"
                                                     + "|Kontof.hrungsgeb.hr))"
-                                                    + "(.*)?$")
+                                                    + ".*$")
                                     .assign((t, v) -> {
                                         t.setDateTime(asDate(v.get("date")));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -38,7 +38,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     private void addBuySellTransaction()
     {
         final DocumentType type = new DocumentType("(Kauf|Achat|Vente|Verkauf)", (context, lines) -> {
-            Pattern pTransaction = Pattern.compile("^Num.ro.*(Achat|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$");
+            Pattern pTransaction = Pattern.compile("^Num.ro.*(Achat|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3}).*$");
             // read the current context here
 
             /***
@@ -119,19 +119,19 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Date et heure d'exécution : 19/10/2020 11:53:03 CET 
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d.ex.cution)([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d.ex.cution)([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 26/P11/2021L10:05:13 CETDate et heure d'exécution: 26/11/2021 13:25:24 CETDate de comptabilisation: 26/11/2021Date valeur: 30/11/2021Lieu d'exécution: EURONEXT - EURONEXT BRUSS
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^Ordre cr.. .([\\s]+)?: .*Date et heure d.ex.cution([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^Ordre cr.. .([\\s]+)?: .*Date et heure d.ex.cution([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 05/11/2020 11:25:43 CET
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^Ordre cr.. .([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^Ordre cr.. .([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                         )
 
@@ -142,7 +142,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Crédit 908,64 EUR
                 // Débit 1.502,72 EUR
                 .section("amount", "currency")
-                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -156,7 +156,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Lastschrift 953,95 USD Valutadatum 21/06/2016
                 .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
                 .match("^Wechselkurs [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+) (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -188,7 +188,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Type d'ordre: Market
                 // Type d'ordre: Market I
                 .section("note").optional()
-                .match("^(Auftragstyp|Type d'([\\s]+)?ordre)([\\s]+)?: (?<note>(Limit \\([\\.,\\d]+ [\\w]{3}\\)|Market))(.*)?$")
+                .match("^(Auftragstyp|Type d'([\\s]+)?ordre)([\\s]+)?: (?<note>(Limit \\([\\.,\\d]+ [\\w]{3}\\)|Market)).*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(BuySellEntryItem::new);
@@ -200,7 +200,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     private void addDividendeTransaction()
     {
         final DocumentType type = new DocumentType("(Einkommensart|Nature des revenus)", (context, lines) -> {
-            Pattern pTransaction = Pattern.compile("^CREDIT COUPON NR .*: (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$");
+            Pattern pTransaction = Pattern.compile("^CREDIT COUPON NR .*: (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3}).*$");
             // read the current context here
 
             /***
@@ -276,7 +276,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Date valeur: 17/11/2021 C
                                 section -> section
                                         .attributes("date")
-                                        .match("^Date valeur([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})(.*)?$")
+                                        .match("^Date valeur([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}).*$")
                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
                         )
 
@@ -285,7 +285,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Net CREDIT 45,65 EUR Date  03/02/2021
                                 section -> section
                                         .attributes("amount", "currency")
-                                        .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                                        .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                                         .assign((t, v) -> {
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(v.get("currency"));
@@ -307,7 +307,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Wechselkurs 1,05 1,01 EUR
                 .section("exchangeRate", "fxAmount", "fxCurrency", "amount", "currency").optional()
                 .match("^Wechselkurs (?<exchangeRate>[\\.,\\d]+) (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                     {
@@ -362,17 +362,17 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
                 // Impôt à la source 26,38 % 16,35 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+ % (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+ % (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Impôt à la source 26,50% - 6,12 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Précompte mobilier belge 30,00% - 5,09 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Pr.compte mobilier .* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Pr.compte mobilier .* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Précompte mobilier belge
@@ -381,13 +381,13 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // L 30,00% - 14,40 EUR
                 .section("tax", "currency").optional()
                 .match("^Pr.compte mobilier .*$")
-                .match("^.* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Taxe boursière - 0,35% - 5,22 EUR
                 // Montant brut U - 694,50 EURD - 694,50 EURTaxe boursière - 0,35% - 2,43 EURCourtage - 7,50 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Taxe boursi.re \\- [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Taxe boursi.re \\- [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -401,13 +401,13 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
                 // Frais de transaction 24,95 EUR
                 .section("fee", "currency").optional()
-                .match("(^.* .*|^)Frais de transaction (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Frais de transaction (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Courtage - 7,50 EUR
                 // Montant brut U - 694,50 EURD - 694,50 EURTaxe boursière - 0,35% - 2,43 EURCourtage - 7,50 EUR
                 .section("fee", "currency").optional()
-                .match("(^.* .*|^)Courtage \\- (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Courtage \\- (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -744,7 +744,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots)(.*)?");
+        Block firstRelevantLine = new Block("^(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots).*");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -764,7 +764,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // Nominal Ex-Tag
                 // STK 12,000 04.07.2017
                 .section("name", "isin", "name1", "shares")
-                .find("(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots)(.*)?")
+                .find("(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots).*")
                 .find("Gattungsbezeichnung ISIN")
                 .match("^(?<name>.*) (?<isin>[\\w]{12})$")
                 .match("^(?<name1>.*)")
@@ -785,7 +785,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // STK 12,000 04.07.2017
                 // STK 28,000 02.12.2011 02.12.2011
                 .section("date").optional()
-                .match("^STK [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^STK [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Kapitalherabsetzung im Verhältnis 10:1. Weitere Informationen finden Sie im elektronischen Bundesanzeiger
@@ -1261,7 +1261,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^Ausbuchung:(.*)?");
+        Block firstRelevantLine = new Block("^Ausbuchung:.*");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -1271,7 +1271,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // Nominal Ex-Tag
                 // STK 12,000 04.07.2017
                 .section("name", "isin", "name1")
-                .find("(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots)(.*)?")
+                .find("(Einbuchung:|Ausbuchung:|Wir erhielten zu Gunsten Ihres Depots).*")
                 .find("Gattungsbezeichnung ISIN")
                 .match("^(?<name>.*) (?<isin>[\\w]{12})$")
                 .match("^(?<name1>.*)")
@@ -1290,7 +1290,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // STK 12,000 04.07.2017
                 // STK 28,000 02.12.2011 02.12.2011
                 .section("date").optional()
-                .match("^[\\w]{3} [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^[\\w]{3} [\\.,\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // STK 33,000 06.06.2011
@@ -1438,7 +1438,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // einbehaltene Kapitalertragsteuer EUR 1,81
                 // einbehaltene Kapitalertragsteuer EUR              0,39     
                 .section("tax", "currency").optional()
-                .match("^einbehaltene Kapitalertragsteuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^einbehaltene Kapitalertragsteuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
                     {
@@ -1449,7 +1449,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // einbehaltener Solidaritätszuschlag EUR 0,10
                 // einbehaltener Solidaritätszuschlag  EUR              0,02     
                 .section("tax", "currency").optional()
-                .match("^einbehaltener Solidarit.tszuschlag ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^einbehaltener Solidarit.tszuschlag ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
                     {
@@ -1460,7 +1460,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // einbehaltene Kirchensteuer EUR 5,86
                 // einbehaltener Kirchensteuer  EUR              0,02 
                 .section("tax", "currency").optional()
-                .match("^einbehaltene Kirchensteuer(  Ehegatte\\/Lebenspartner)? ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^einbehaltene Kirchensteuer(  Ehegatte\\/Lebenspartner)? ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
                     {
@@ -1470,7 +1470,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
                 // einbehaltene Kirchensteuer Ehegatte/Lebenspartner EUR 1,09
                 .section("tax", "currency").optional()
-                .match("^einbehaltene Kirchensteuer Ehegatte\\/Lebenspartner ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^einbehaltene Kirchensteuer Ehegatte\\/Lebenspartner ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -87,12 +87,12 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // 60 47.29 EUR 2'837.40
                 .section("name", "isin", "currency")
                 .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12}) .*$")
-                .match("^[\\.,'\\d\\s]+ [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+(.*)?$")
+                .match("^[\\.,'\\d\\s]+ [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // 60 47.29 EUR 2'837.40
                 .section("shares")
-                .match("^(?<shares>[\\.,'\\d\\s]+) [\\.,'\\d\\s]+ [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^(?<shares>[\\.,'\\d\\s]+) [\\.,'\\d\\s]+ [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Gemäss Ihrem Kaufauftrag vom 25.09.2018 haben wir folgende Transaktionen vorgenommen:
@@ -104,7 +104,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Zu Ihren Lasten EUR 2'850.24
                 // Zu Ihren Gunsten CHF 7'467.50
                 .section("currency", "amount")
-                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -113,8 +113,8 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Total EUR 2'737.40
                 // Wechselkurs 1.08279
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
-                .match("^Total (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,'\\d\\s]+)(.*)?$")
-                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Total (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,'\\d\\s]+).*$")
+                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -140,7 +140,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
                 // Wechselkurs 1.08279
                 .section("exchangeRate").optional()
-                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -177,18 +177,18 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Pictet - Japan Index - I JPY 1.441 JPY 23 608.200 
                 // ISIN LU0188802960 
                 .section("name", "currency", "isin")
-                .match("^(?<name>.*) [\\w]{3} [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+(.*)?$")
-                .match("^ISIN (?<isin>[\\w]{12})(.*)?$")
+                .match("^(?<name>.*) [\\w]{3} [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
+                .match("^ISIN (?<isin>[\\w]{12}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Pictet - Japan Index - I JPY 1.441 JPY 23 608.200 
                 .section("shares")
-                .match("^(?<name>.*) [\\w]{3} (?<shares>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^(?<name>.*) [\\w]{3} (?<shares>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // E-Vermögensverwaltung Datum: 20.12.2021 
                 .section("date")
-                .match("^E\\-Verm.gensverwaltung Datum: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^E\\-Verm.gensverwaltung Datum: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                 // Der Totalbetrag von CHF 280.91 wurde Ihrem Konto CH11 0100 0000 1111 1111 1 mit Valuta 21.12.2021 belastet. 
@@ -202,8 +202,8 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Total JPY 34 070.00
                 // Total in Kontowährung zum Kurs von JPY/CHF 0.0082450 CHF 280.91 
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
-                .match("^Total (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,'\\d\\s]+)(.*)?$")
-                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^Total (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,'\\d\\s]+).*$")
+                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -229,7 +229,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
                 // Total in Kontowährung zum Kurs von JPY/CHF 0.0082450 CHF 280.91 
                 .section("currency", "exchangeRate").optional()
-                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("currency"))))
@@ -269,31 +269,31 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // UNILEVER DUTCH CERT NKN: 2560588 60
                 // Dividende 0.4104 EUR
                 .section("isin", "name", "currency").optional()
-                .match("^ISIN: (?<isin>[\\w]{12})(.*)?$")
-                .match("^(?<name>.*) NKN: [\\d]+ [\\.,'\\d\\s]+(.*)?$")
-                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^ISIN: (?<isin>[\\w]{12}).*$")
+                .match("^(?<name>.*) NKN: [\\d]+ [\\.,'\\d\\s]+.*$")
+                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // UBS ETF CH - SLI CHF A ISIN: CH0032912732NKN: 3291273 34
                 // Dividende 1.66 CHF
                 .section("name", "isin", "currency").optional()
-                .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12})([\\s]+)?NKN: [\\d]+ [\\.,'\\d\\s]+(.*)?$")
-                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12})([\\s]+)?NKN: [\\d]+ [\\.,'\\d\\s]+.*$")
+                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Anzahl 60
                 .section("shares")
-                .match("^Anzahl (?<shares>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Anzahl (?<shares>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Valutadatum 05.06.2019
                 .section("date")
-                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Total EUR 20.93
                 .section("currency", "amount")
-                .match("^Total (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Total (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -301,7 +301,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
                 // Wechselkurs EUR / CHF : 1.11652
                 .section("exchangeRate").optional()
-                .match("^Wechselkurs [\\w]{3} \\/ [\\w]{3} : (?<exchangeRate>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Wechselkurs [\\w]{3} \\/ [\\w]{3} : (?<exchangeRate>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -343,8 +343,8 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Betrag belastet CHF 90.00
                 .section("date", "currency", "amount")
                 .find("Jahresgeb.hr .*")
-                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
-                .match("^Betrag belastet (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^Betrag belastet (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -366,7 +366,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addInterestTransaction()
     {
         final DocumentType type = new DocumentType("Zinsabschluss", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3}).*$");
             Pattern pYear = Pattern.compile("^[\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) Kontostand nach Zinsabschluss .*$");
             // read the current context here
             for (String line : lines)
@@ -393,7 +393,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) (\\-|\\–) ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+(.*)?$");
+        Block firstRelevantLine = new Block("^([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) (\\-|\\–) ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -405,7 +405,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})) "
                                                     + "[\\.,'\\d\\s]+(%| %) "
                                                     + "(?<amount>[\\.,'\\d\\s]+)"
-                                                    + "(.*)?$")
+                                                    + ".*$")
                                     .assign((t, v) -> {
                                         Map<String, String> context = type.getCurrentContext();
 
@@ -418,7 +418,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                     .attributes("date1", "date2", "amount")
                                     .match("^(?<date1>[\\d]{6}) (\\-|\\–) "
                                                     + "(?<date2>[\\d]{6}) [\\.,'\\d\\s]+(%| %) "
-                                                    + "(?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                                                    + "(?<amount>[\\.,'\\d\\s]+).*$")
                                     .assign((t, v) -> {
                                         Map<String, String> context = type.getCurrentContext();
 
@@ -456,7 +456,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(?i:Geb.hrenausweis) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}(.*)?$");
+        Block firstRelevantLine = new Block("^(?i:Geb.hrenausweis) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -468,7 +468,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 .match("^(?i:Geb.hrenausweis) "
                                 + "(?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                 + "(\\-|\\–) "
-                                + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}))(.*)?$")
+                                + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})).*$")
                 .match("^Zusammenstellung der belasteten Kontof.hrungsgeb.hr: "
                                 + "(?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)$")
                 .assign((t, v) -> {
@@ -488,7 +488,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addTaxesTransaction()
     {
         final DocumentType type = new DocumentType("Zinsabschluss", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3}).*$");
             Pattern pNote = Pattern.compile("^Zinsabschluss (?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$");
             // read the current context here
             for (String line : lines)
@@ -515,7 +515,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+(.*)?$");
+        Block firstRelevantLine = new Block("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -523,7 +523,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Verrechnungssteuer 35.00% 40.83
                 // 31.12.2019 Kontostand nach Zinsabschluss 10 075.83
                 .section("amount", "date")
-                .match("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) (?<amount>[\\.,'\\d\\s]+).*$")
                 .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Kontostand nach Zinsabschluss .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -544,7 +544,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addAccountStatementTransaction()
     {
         DocumentType type = new DocumentType("Kontoauszug", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN){1} (.*) (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN){1} (.*) (?<currency>[A-Z]{3}).*$");
             Pattern pYear = Pattern.compile("^Kontoauszug [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) .*$");
             for (String line : lines)
             {
@@ -565,7 +565,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block removalBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block removalBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
@@ -580,7 +580,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "(?<note>.BERTRAG) "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .match("^AUF KONTO .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -615,7 +615,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ") "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -719,7 +719,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block depositBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block depositBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
@@ -734,7 +734,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "(?<note>.BERTRAG) "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .match("^AUS KONTO .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -764,7 +764,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ") "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -815,7 +815,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block feesBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block feesBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
@@ -837,7 +837,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ")([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -886,7 +886,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block interestBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block interestBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
@@ -902,7 +902,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ")([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -920,7 +920,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -952,17 +952,17 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Abgabe (Eidg. Stempelsteuer) EUR 4.26
                 .section("currency", "tax").optional()
-                .match("^Abgabe \\(Eidg\\. Stempelsteuer\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Abgabe \\(Eidg\\. Stempelsteuer\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer 15.00% (NL) EUR 3.69
                 .section("currency", "withHoldingTax").optional()
-                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Verrechnungssteuer 35% (CH) CHF 19.75
                 .section("currency", "tax").optional()
-                .match("^Verrechnungssteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Verrechnungssteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -971,22 +971,22 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Kommission EUR 8.58
                 .section("currency", "fee").optional()
-                .match("^Kommission (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Kommission (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Börsengebühren CHF 1.50
                 .section("currency", "fee").optional()
-                .match("^B.rsengeb.hren (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^B.rsengeb.hren (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Börsengebühren und sonstige Spesen EUR 0.60
                 .section("currency", "fee").optional()
-                .match("^B.rsengeb.hren und sonstige Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^B.rsengeb.hren und sonstige Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Umsatzabgabe JPY 51.00 
                 .section("currency", "fee").optional()
-                .match("^Umsatzabgabe (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Umsatzabgabe (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -53,7 +53,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Gesch.ftsart:|Wertpapier Abrechnung) (Kauf|Verkauf)(.*)?$");
+        Block firstRelevantLine = new Block("^(Gesch.ftsart:|Wertpapier Abrechnung) (Kauf|Verkauf).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -101,7 +101,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                 // Abgang: 4.500 Stk  
                                 section -> section
                                         .attributes("shares")
-                                        .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+)(.*)?$")
+                                        .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+).*$")
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                                 ,
                                 // Stück 100 QUALCOMM INC.                      US7475251036 (883121)
@@ -114,14 +114,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Handelszeit: 03.05.2021 13:45:18
                 // Schlusstag/-Zeit 09.11.2021 09:58:45 Auftraggeber Muster 
                 .section("date", "time")
-                .match("^(Handelszeit:|Schlusstag\\/\\-Zeit) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                .match("^(Handelszeit:|Schlusstag\\/\\-Zeit) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                 // Zu Lasten IBAN AT99 9999 9000 0011 1110 -107,26 EUR  
                 // Zu Gunsten IBAN AT27 3284 2000 0011 1111 36.115,76 EUR
                 // Ausmachender Betrag 14.399,34- EUR
                 .section("amount", "currency")
-                .match("^(Zu (Lasten|Gunsten) .*|Ausmachender Betrag) (\\-)?(?<amount>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu (Lasten|Gunsten) .*|Ausmachender Betrag) (\\-)?(?<amount>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -130,8 +130,8 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // -1.537,32 CAD 
                 // Devisenkurs: 1,406 (20.01.2022) -1.093,40 EUR 
                 .section("fxCurrency", "fxAmount", "exchangeRate").optional()
-                .match("^(\\-)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^(\\-)?(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {
                     // read the forex currency, exchange rate and gross
                     // amount in forex currency
@@ -157,7 +157,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs: 1,406 (20.01.2022) -1.093,40 EUR 
                 .section("exchangeRate").optional()
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
@@ -221,7 +221,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                 // 90 Stk  
                                 section -> section
                                         .attributes("shares")
-                                        .match("^(?<shares>[\\.,\\d]+) Stk(.*)?$")
+                                        .match("^(?<shares>[\\.,\\d]+) Stk.*$")
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                                 ,
                                 // Stück 100 QUALCOMM INC. US7475251036 (883121)
@@ -248,7 +248,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Zu Gunsten IBAN AT99 9999 9000 0011 1111 110,02 EUR 
                 // Ausmachender Betrag 50,88+ EUR
                 .section("amount", "currency")
-                .match("^(Zu Gunsten .*|Ausmachender Betrag) (?<amount>[\\.,\\d]+)(\\+)? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu Gunsten .*|Ausmachender Betrag) (?<amount>[\\.,\\d]+)(\\+)? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(v.get("currency"));
@@ -558,17 +558,17 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Quellensteuer: -47,48 EUR 
                 .section("tax", "currency").optional()
-                .match("^Quellensteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Auslands-KESt: -22,50 EUR 
                 .section("tax", "currency").optional()
-                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Kursgewinn-KESt: -696,65 EUR 
                 .section("tax", "currency").optional()
-                .match("^Kursgewinn\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kursgewinn\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Einbehaltene Quellensteuer 15 % auf 68,00 USD 8,98- EUR
@@ -587,37 +587,37 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Serviceentgelt: -0,32 EUR 
                 .section("fee", "currency").optional()
-                .match("^Serviceentgelt: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Serviceentgelt: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Provision 0,2000 % vom Kurswert 28,74- EUR
                 .section("fee", "currency").optional()
-                .match("^Provision [\\.,\\d]+ % .* (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^Provision [\\.,\\d]+ % .* (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Eigene Spesen 2,50- EUR
                 .section("fee", "currency").optional()
-                .match("^Eigene Spesen (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^Eigene Spesen (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Übertragungs-/Liefergebühr 0,10- EUR
                 .section("fee", "currency").optional()
-                .match("^.bertragungs\\-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^.bertragungs\\-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Handelsortentgelt inkl. Fremdspesen: -4,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Handelsortentgelt inkl\\. Fremdspesen: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Handelsortentgelt inkl\\. Fremdspesen: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Gebühren: -25,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Geb.hren: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Geb.hren: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Orderleitgebühr: -3,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Orderleitgeb.hr: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Orderleitgeb.hr: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -114,7 +114,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^Handelstag (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$")
-                                        .match("^Handelszeit (?<time>[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^Handelszeit (?<time>[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Schlusstag/-Zeit 14.10.2021 09:00:12 Auftraggeber XXXXXX XXXXXXX
@@ -333,7 +333,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
     private void addTaxReturnBlock(DocumentType type)
     {
-        Block block = new Block("^(Kauf(.*)?|Verkauf(.*)?|Wertpapier Abrechnung Ausgabe Investmentfonds)$");
+        Block block = new Block("^(Kauf.*|Verkauf.*|Wertpapier Abrechnung Ausgabe Investmentfonds)$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
@@ -46,7 +46,7 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^Wertpapier Abrechnung Kauf(.*)?$");
+        Block firstRelevantLine = new Block("^Wertpapier Abrechnung Kauf.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -79,9 +79,9 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                 // NOM. AE-C O.N. LU0565135745
                 // Kurswert EUR 4.803,50
                 .section("name", "name1", "wkn", "isin").optional()
-                .find("Nennbetrag Wertpapierbezeichnung ([\\s]+)?Wertpapierkennnummer\\/ISIN(.*)?")
+                .find("Nennbetrag Wertpapierbezeichnung ([\\s]+)?Wertpapierkennnummer\\/ISIN.*")
                 .match("^ST [\\.,\\d]+ (?<name>.*) (?<wkn>[\\w]{6})[\\s]{2,}(?<name1>.*) (?<isin>[\\w]{12})$")
-                .match("^Kurswert (?<currency>[\\w]{3}) [\\.,\\d]+(.*)?$")
+                .match("^Kurswert (?<currency>[\\w]{3}) [\\.,\\d]+.*$")
                 .assign((t, v) -> {
                     v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
 
@@ -91,7 +91,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                 // ST 22
                 // ST 25 FIRST EAGLE AMUNDI-INTERNATIO. A1JQVV ACTIONS
                 .section("shares")
-                .match("^ST (?<shares>[\\.,\\d]+)(.*)?$")
+                .match("^ST (?<shares>[\\.,\\d]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Zum Kurs von Ausführungstag/Zeit Ausführungsort Verwahrart

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -310,7 +310,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                 // 0.91759 CHF 31.44
                 .section("currency", "amount", "exchangeRate", "fxCurrency", "fxAmount").optional()
                 .match("^(Betrag|Amount) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$")
-                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3}(.*)?$")
+                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3}.*$")
                 .match("^(?<exchangeRate>[\\.,'\\d]+) (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,'\\d]+)$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));


### PR DESCRIPTION
Will resolve violations of Sonar Qube rule:

> A regex should never include a repetitive pattern whose body would match the
> empty string. This is usually a sign that a part of the regex is redundant or
> does not do what the author intended.

cf. discussion at https://github.com/buchen/portfolio/pull/2804