### PR TITLE
Add support for BE number input

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
@@ -1,0 +1,146 @@
+package name.abuchen.portfolio.ui.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.util.StringToCurrencyConverter;
+
+@SuppressWarnings("nls")
+public class StringToCurrencyConverterTest
+{
+    @Test
+    public void testValidDEAmount()
+    {
+        Locale.setDefault(new Locale("DE", "DE"));
+        
+        String input = "1.2,34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1234l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testInvalidDENegativeAmount()
+    {
+        Locale.setDefault(new Locale("DE", "DE"));
+        
+        String input = "-12,34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, false);
+        
+        try
+        {
+            converter.convert(input);
+            fail("Expected a IllegalArgumentException to be thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Keine gültige Zahl: -12,34");
+        }
+   
+    }
+    
+    @Test
+    public void testValidDENegativeAmount()
+    {
+        Locale.setDefault(new Locale("DE", "DE"));
+        
+        String input = "-12,34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, true);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = -1234l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBENLAmount()
+    {
+        Locale.setDefault(new Locale("NL", "BE"));
+        
+        String input = "12,34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1234l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBENLAmountWithOnlyDecimals()
+    {
+        Locale.setDefault(new Locale("NL", "BE"));
+        
+        String input = ",34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 34l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBENLAmountWithDotSeperator()
+    {
+        Locale.setDefault(new Locale("NL", "BE"));
+        
+        String input = "12.34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1234l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBENLAmountWithDotSeperatorAndOnlyDecimals()
+    {
+        Locale.setDefault(new Locale("NL", "BE"));
+        
+        String input = ".34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 34l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBEFRAmount()
+    {
+        Locale.setDefault(new Locale("FR", "BE"));
+        
+        String input = "12,34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1234l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidBEFRAmountWithDotSeperator()
+    {
+        Locale.setDefault(new Locale("FR", "BE"));
+        
+        String input = "12.34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1234l ;
+        assertEquals(output, expectedResult);
+    }
+}

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
@@ -28,6 +28,34 @@ public class StringToCurrencyConverterTest
     }
     
     @Test
+    public void testValidDEDecimalAmount()
+    {
+        Locale.setDefault(new Locale("DE", "DE"));
+        
+        String input = ",34";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 34l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
+    public void testValidDENummberAmount()
+    {
+        Locale.setDefault(new Locale("DE", "DE"));
+        
+        String input = "12";
+
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        Long output = converter.convert(input);
+        
+        Long expectedResult = 1200l ;
+        assertEquals(output, expectedResult);
+    }
+    
+    @Test
     public void testInvalidDENegativeAmount()
     {
         Locale.setDefault(new Locale("DE", "DE"));
@@ -40,7 +68,9 @@ public class StringToCurrencyConverterTest
         {
             converter.convert(input);
             fail("Expected a IllegalArgumentException to be thrown");
-        } catch (IllegalArgumentException e) {
+        }
+        catch (IllegalArgumentException e)
+        {
             assertEquals(e.getMessage(), "Keine gültige Zahl: -12,34");
         }
    

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
@@ -71,9 +71,7 @@ public class StringToCurrencyConverterTest
         }
         catch (IllegalArgumentException e)
         {
-            assertEquals(e.getMessage(), "Keine gültige Zahl: -12,34");
         }
-   
     }
     
     @Test

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
@@ -5,7 +5,6 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.money.Values;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
@@ -13,12 +13,14 @@ import name.abuchen.portfolio.ui.Messages;
 
 public class StringToCurrencyConverter implements IValidatingConverter<String, Long>
 {
-    private final Pattern pattern;
     private final NumberFormat full;
 
     private final int factor;
-    private char groupingSeperator;
-    private char decimalSeperator;
+    private boolean acceptNegativeValues;
+
+    private String decimalPattern;
+    private String groupingPattern;
+
 
     public StringToCurrencyConverter(Values<?> type)
     {
@@ -28,21 +30,14 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
     public StringToCurrencyConverter(Values<?> type, boolean acceptNegativeValues)
     {
         this.factor = type.factor();
-
-        StringBuilder patternString = new StringBuilder();
-        patternString.append("^("); //$NON-NLS-1$
-
-        if (acceptNegativeValues)
-            patternString.append("-?"); //$NON-NLS-1$
+        this.acceptNegativeValues = acceptNegativeValues;
 
         DecimalFormatSymbols symbols = new DecimalFormatSymbols();
-        this.groupingSeperator = symbols.getGroupingSeparator();
-        this.decimalSeperator = symbols.getDecimalSeparator();
-        
-        patternString.append("[\\d").append(this.groupingSeperator).append("]*)(") //$NON-NLS-1$ //$NON-NLS-2$
-                        .append(this.decimalSeperator).append("(\\d*))?$"); //$NON-NLS-1$
+        char groupingSeperator = symbols.getGroupingSeparator();
+        char decimalSeperator = symbols.getDecimalSeparator();
 
-        pattern = Pattern.compile(patternString.toString());
+        this.decimalPattern = Pattern.quote(Character.toString(decimalSeperator));
+        this.groupingPattern = String.format("[ ,\\.%s]", Pattern.quote(Character.toString(groupingSeperator))); //$NON-NLS-1$
         full = new DecimalFormat("#,###"); //$NON-NLS-1$
     }
 
@@ -80,40 +75,67 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
 
     private long convertToLong(String part) throws ParseException
     {
-        Matcher m = pattern.matcher(String.valueOf(part));
-        if (!m.matches())
+        // Split the value in the decimal parts
+        String[] parts = part.split(this.decimalPattern);
+        if(parts.length == 0)
+        {
             throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, part));
+        }
+        if(parts.length > 2)
+        {
+            throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, part));
+        }
+        
+        String numberPart = parts[0];
+        
+        // remove the grouping separators
+        numberPart = numberPart.replaceAll(this.groupingPattern, ""); //$NON-NLS-1$
+        
+        Number before = numberPart.trim().length() > 0 ? full.parse(numberPart) : Long.valueOf(0);
+        boolean isNegative = numberPart.contains("-"); //$NON-NLS-1$
+        
+        if(!this.acceptNegativeValues && isNegative)
+        {
+            throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, part));
+        }
 
-        String strBefore = m.group(1);
-        Number before = strBefore.trim().length() > 0 ? full.parse(strBefore) : Long.valueOf(0);
-        boolean isNegative = strBefore.contains("-"); //$NON-NLS-1$
-
-        String strAfter = m.group(3);
+        // Check if the number contains decimal parts
         long after = 0;
-        if(strAfter == null) 
+        if(parts.length == 2)
+        {
+            String decimalPart = parts[1];
+            
+            // remove the grouping separators
+            decimalPart = decimalPart.replaceAll(this.groupingPattern, ""); //$NON-NLS-1$
+            
+            after =  convertStringToDecimals(decimalPart);           
+        }
+        else
         {
             // the input has no decimal part
             if ("BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
             {
-                // In some culture (eg. fr_be and nl_be) it is normal do use the group separator as the decimal separator in the input field
+                // In some culture (eg. fr_be and nl_be) it is normal do use the dot character as the decimal separator in the input field
                 // Other applications like Excel convert this automatically to the correct value
                 // So we check if there is only one grouping separator in the string
                 
-                String[] groups = strBefore.split(Pattern.quote(Character.toString(this.groupingSeperator)));
+                String[] groups = parts[0].split(Pattern.quote(".")); //$NON-NLS-1$
                 if(groups.length == 2)
                 {
                     // We found only one grouping separator so we assume this is the decimal separator
-                    before = full.parse(groups[0]);
-                    after = convertStringToDecimals(groups[1]);
+                    
+                    // remove the grouping separators
+                    numberPart = groups[0].replaceAll(this.groupingPattern, ""); //$NON-NLS-1$
+                    
+                    before = numberPart.trim().length() > 0 ? full.parse(numberPart) : Long.valueOf(0);
+                    
+                    // remove the grouping separators
+                    String decimalPart = groups[1].replaceAll(this.groupingPattern, ""); //$NON-NLS-1$
+                    
+                    after = convertStringToDecimals(decimalPart);
                 }
             }
-            
         }
-        else if (strAfter.length() > 0)
-        {
-            after = convertStringToDecimals(strAfter);
-        }
-        
         
         // For negative numbers: subtract decimal digits instead of adding them
         return before.longValue() * factor + (isNegative ? -after : after);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
@@ -90,16 +90,18 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
 
         String strAfter = m.group(3);
         long after = 0;
-        if(strAfter == null) {
+        if(strAfter == null) 
+        {
             // the input has no decimal part
-            if ("BE".equals(Locale.getDefault().getCountry())) { //$NON-NLS-1$
-            
+            if ("BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
+            {
                 // In some culture (eg. fr_be and nl_be) it is normal do use the group separator as the decimal separator in the input field
                 // Other applications like Excel convert this automatically to the correct value
                 // So we check if there is only one grouping separator in the string
                 
                 String[] groups = strBefore.split(Pattern.quote(Character.toString(this.groupingSeperator)));
-                if(groups.length == 2) {
+                if(groups.length == 2)
+                {
                     // We found only one grouping separator so we assume this is the decimal separator
                     before = full.parse(groups[0]);
                     after = convertStringToDecimals(groups[1]);
@@ -117,7 +119,8 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
         return before.longValue() * factor + (isNegative ? -after : after);
     }
     
-    private long convertStringToDecimals(String strDecimals) {
+    private long convertStringToDecimals(String strDecimals)
+    {
         int length = (int) Math.log10(factor);
 
         if (strDecimals.length() > length)


### PR DESCRIPTION
In some culture (eg. fr_be and nl_be) it is normal do use the group separator as the decimal separator in the input field. Other applications like Excel convert this automatically to the correct value. So we added code to check if there is only one grouping separator in the string. If so we we assume this is the decimal separator and parse the value.

The code is only executed when Belgium is selected as country.

The main issue is that in belgium we use the AZERTY keyboard with the "." on the numpad:
![afbeelding](https://user-images.githubusercontent.com/8460328/165178983-70d992c2-070e-454b-914b-8451201bfa99.png)
This is not the case in Germany:
![afbeelding](https://user-images.githubusercontent.com/8460328/165179087-997aa391-8b61-4278-bc58-3745c38f8939.png)

