### PR TITLE
Fix grossValue Part 2

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -377,7 +377,7 @@ public class DABPDFExtractorTest
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
         assertThat(grossValueUnit.getForex(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6123.98 / 1.08389))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5650.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/direkt1822bankPDFExtractorTest.java
@@ -164,7 +164,7 @@ public class direkt1822bankPDFExtractorTest
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(62.93))));
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(59.94))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ebase/EbasePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ebase/EbasePDFExtractorTest.java
@@ -418,7 +418,7 @@ public class EbasePDFExtractorTest
 
         Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
         assertThat(grossValueUnit.getForex(),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.29 * 1.104600))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.35 * 1.104600))));
     }
 
     @Test
@@ -550,9 +550,9 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.79))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.18))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.10))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((0.34 + 0.01) * 1.117800))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((0.34 + 0.01) / 1.117800))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
     }
@@ -716,9 +716,9 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(10.25))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(13.94))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(12.91))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((2.97 + 0.16) * 1.177700))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((2.97 + 0.16) / 1.177700))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
@@ -903,9 +903,9 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(6.16))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(7.94))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(7.62))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((1.53 + 0.08) * 1.103900))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize((1.53 + 0.08) / 1.103900))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
@@ -3333,9 +3333,9 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of("GBP", Values.Amount.factorize(3.03))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of("GBP", Values.Amount.factorize(3.73))));
+                        is(Money.of("GBP", Values.Amount.factorize(3.88))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of("GBP", Values.Amount.factorize(0.70))));
+                        is(Money.of("GBP", Values.Amount.factorize(0.85))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of("GBP", Values.Amount.factorize(0.00))));
     }
@@ -3662,9 +3662,9 @@ public class EbasePDFExtractorTest
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of("GBP", Values.Amount.factorize(3.03))));
         assertThat(transaction.getGrossValue(),
-                        is(Money.of("GBP", Values.Amount.factorize(3.73))));
+                        is(Money.of("GBP", Values.Amount.factorize(3.88))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of("GBP", Values.Amount.factorize(0.70))));
+                        is(Money.of("GBP", Values.Amount.factorize(0.85))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of("GBP", Values.Amount.factorize(0.00))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/erstebank/erstebankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/erstebank/erstebankPDFExtractorTest.java
@@ -405,11 +405,11 @@ public class erstebankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1397.90))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1351.53))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1377.36))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(46.37))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.54))));
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
@@ -450,11 +450,11 @@ public class erstebankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1397.90))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1351.53))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1377.36))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(46.37))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.54))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
         Account account = new Account();
@@ -936,11 +936,11 @@ public class erstebankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1116.78))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1152.18))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1136.50))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(35.40))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(19.72))));
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
@@ -981,11 +981,11 @@ public class erstebankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1116.78))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1152.18))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1136.50))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(35.40))));
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(19.72))));
 
         CheckCurrenciesAction c = new CheckCurrenciesAction();
         Account account = new Account();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
@@ -838,7 +838,7 @@ public class FILFondbankPDFExtractorTest
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(23.52))));
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(19.50 * 1.175902))));
 
         // check 2st buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
@@ -947,7 +947,7 @@ public class FILFondbankPDFExtractorTest
 
         grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(23.61))));
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(19.52 * 1.180651))));
 
         // check 7th buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
@@ -2954,7 +2954,7 @@ public class FILFondbankPDFExtractorTest
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(21.41))));
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(19.51 * 1.070478))));
 
         // check 2nd security buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinancePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/PostfinancePDFExtractorTest.java
@@ -168,7 +168,7 @@ public class PostfinancePDFExtractorTest
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2737.40))));
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2736.80))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -101,7 +101,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                 .match("^Change [\\w]{3}/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.',\\d]+) [\\w]{3} (\\-)?[\\.',\\d]+$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
                     {
                         exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -119,7 +119,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Preis pro Anteil 25,640000 EUR  
                 .section("name", "wkn", "isin", "currency").optional()
                 .match("^(?<name>.*) (?<wkn>.*) (?<isin>[\\w]{12})([\\s]+)?$")
-                .match("^(Kurs|Preis pro Anteil) [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Kurs|Preis pro Anteil) [\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // ST 15,75243 WKN: 625952
@@ -171,7 +171,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // ST 1.000,00000 Letzte Fälligkeit 01.09.2021
                 //       ST                        50,00000               WKN: 851144
                 .section("shares")
-                .match("^([\\s]+)?ST ([\\s]+)?(?<shares>[\\.,\\d]+)(.*)?$")
+                .match("^([\\s]+)?ST ([\\s]+)?(?<shares>[\\.,\\d]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // KAUF AM 15.01.2015  UM 08:13:35 MUENCHEN NR. 12345670.001
@@ -324,7 +324,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         Block block = new Block("^(DIVIDENDENGUTSCHRIFT"
                         + "|Dividendengutschrift"
                         + "|ERTRAGSGUTSCHRIFT"
-                        + "|Ertragsgutschrift)(.*)?$");
+                        + "|Ertragsgutschrift).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
             .subject(() -> {
@@ -338,10 +338,10 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 //            COMS.-MSCI WORL.T.U.ETF I                                    
                 //            Namens-Aktien o.N.                                           
                 .section("wkn", "name", "nameContinued", "currency").optional()
-                .match("^ST ([\\s]+)?[\\.,\\d]+ ([\\s]+)?WKN: ([\\s]+)?(?<wkn>.*)(.*)?$")
+                .match("^ST ([\\s]+)?[\\.,\\d]+ ([\\s]+)?WKN: ([\\s]+)?(?<wkn>.*).*$")
                 .match("^(?<name>.*)$")
                 .match("^(?<nameContinued>.*)$")
-                .match("^(ZINS-\\/DIVIDENDENSATZ|ERTRAGSAUSSCHUETTUNG P\\. ST\\.) .* ([\\s]+)?(?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}(.*)?$")
+                .match("^(ZINS-\\/DIVIDENDENSATZ|ERTRAGSAUSSCHUETTUNG P\\. ST\\.) .* ([\\s]+)?(?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // OMNICOM GROUP INC. Registered Shares DL -,15 871706 US6819191064
@@ -384,7 +384,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 // WERT 08.05.2015                               EUR                326,90 
                                 section -> section
                                         .attributes("currency", "amount")
-                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -403,7 +403,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 // UMGER.ZUM DEV.-KURS                 1,093000  EUR                285,60 
                                 section -> section
                                         .attributes("currency", "amount")
-                                        .match("^(?i)UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)(.*)?$")
+                                        .match("^(?i)UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?[\\.,\\d]+ ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+).*$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -414,9 +414,9 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // UMGER.ZUM DEV.-KURS                 1,104300  EUR                138,55 
                 // KAPST-PFLICHTIGER KAPITALERTRAG               EUR                64,08  
                 .section("fxCurrency", "fxGross", "exchangeRate", "currency", "gross").optional()
-                .match("^BRUTTO ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxGross>[\\.,\\d]+)(.*)?$")
-                .match("^UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+(.*)?$")
-                .match("^KAPST\\-PFLICHTIGER KAPITALERTRAG ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<gross>[\\.,\\d]+)(.*)?$")
+                .match("^BRUTTO ([\\s]+)?(?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxGross>[\\.,\\d]+).*$")
+                .match("^UMGER\\.ZUM DEV\\.\\-KURS ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) ([\\s]+)?[\\w]{3} ([\\s]+)?[\\.,\\d]+.*$")
+                .match("^KAPST\\-PFLICHTIGER KAPITALERTRAG ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<gross>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -653,7 +653,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Kapitalertragsteuer (Account)
                 // KAPST                                 25,00 % EUR                111,00 
                 .section("tax", "currency").optional()
-                .match("^KAPST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^KAPST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                         processTaxEntries(t, v, type);
@@ -740,7 +740,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Solitaritätszuschlag (Account)
                 // SOLZ                                   5,50 % EUR                  6,10 
                 .section("tax", "currency").optional()
-                .match("^SOLZ ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^SOLZ ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                         processTaxEntries(t, v, type);
@@ -827,7 +827,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 // Kirchensteuer (Account)
                 // KIST                                   5,50 % EUR                  6,10 
                 .section("tax", "currency").optional()
-                .match("^KIST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+)(.*)?$")
+                .match("^KIST ([\\s]+)?[\\.,\\d]+ % ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
                     if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
                         processTaxEntries(t, v, type);
@@ -1004,7 +1004,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                 // FREMDE SPESEN                                 USD                  1,91 
                 .section("fee", "currency").optional()
-                .match("^(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+)(.*)?$")
+                .match("^(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // abzgl. Fremde Spesen 0,07 USD

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -229,7 +229,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("(Dividendengutschrift|Ertr.gnisgutschrift)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(Dividendengutschrift|Ertr.gnisgutschrift(?! (aus|VERSANDARTENSCHLUESSEL)))(.*)?$");
+        Block block = new Block("^(Dividendengutschrift|Ertr.gnisgutschrift(?! (aus|VERSANDARTENSCHLUESSEL))).*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
@@ -322,7 +322,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                 // Netto zugunsten IBAN DE11 7603 0080 0111 1111 14 437,22 EUR
                                 section -> section
                                         .attributes("amount", "currency")
-                                        .match("^Netto (.*)?zugunsten IBAN .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .match("^Netto .*zugunsten IBAN .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -783,7 +783,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 1,62
                 // davon anrechenbare US-Quellensteuer  15% USD             2,430     
                 .section("creditableWithHoldingTax", "currency").optional()
-                .match("^(.*)?davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
+                .match("^.*davon anrechenbare (US\\-)?Quellensteuer .* ([\\s]+)?(?<currency>[\\w]{3})([\\s]+)? (?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -161,7 +161,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 // Handelsspesen            -5,06 USD  DevKurs        1,170500/30.7.2020
                 .section("fxGross", "fxCurrency", "exchangeRate").optional()
                 .match("^.* KURSWERT ([\\s]+)?(\\-)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -311,7 +311,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) Ertrag ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$")
                 .match("^ISIN (?<isin>[\\w]{12}) (?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+) STK$")
                 .match("^.* ZINSERTRAG ([\\s]+)?(\\-)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*$")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
                     t.setShares(asShares(v.get("shares")));
@@ -377,8 +377,8 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 .section("date", "year", "gross", "isin", "name", "shares", "fxCurrency", "exchangeRate")
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) (Steuern aussch.ttungsgl. Ertr.ge|Steuerdividende) ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<gross>[\\.,\\d]+)(\\-)?$")
                 .match("^ISIN (?<isin>[\\w]{12}) (?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+) STK$")
-                .match("^(.*)?KEST ([\\s]+)?\\-[\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
-                .match("^(.*)?DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*")
+                .match("^.*KEST ([\\s]+)?\\-[\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
+                .match("^.*DevKurs ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)\\/.*")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
                     t.setShares(asShares(v.get("shares")));
@@ -671,27 +671,27 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         transaction
                 // QUELLENSTEUER: -1,86 USD
                 .section("withHoldingTax", "currency").optional()
-                .match("^QUELLENSTEUER: ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^QUELLENSTEUER: ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // QUELLENSTEUER           -15,60 USD  Auslands-KESt           -13,00 USD
                 .section("withHoldingTax", "currency").optional()
-                .match("^QUELLENSTEUER ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^QUELLENSTEUER ([\\s]+)?\\-(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Auslands-KESt: -1,54 USD
                 .section("tax", "currency").optional()
-                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // QUELLENSTEUER            -3,77 USD  Auslands-KESt            -3,13 USD
                 .section("tax", "currency").optional()
-                .match("^.* Auslands\\-KESt ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.* Auslands\\-KESt ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // KEST                   -140,27 USD  Handelsspesen            -5,07 USD
                 .section("tax", "currency").optional()
-                .match("^KEST ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^KEST ([\\s]+)?\\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -700,32 +700,32 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Handelsspesen            -3,66 EUR  DADAT Handelsspesen      -6,36 EUR
                 .section("fee", "currency").optional()
-                .match("^(.*)?  DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // DADAT Handelsspesen      -1,67 EUR
                 .section("fee", "currency").optional()
-                .match("^DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^DADAT Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // KEST                   -140,27 USD  Handelsspesen            -5,07 USD
                 .section("fee", "currency").optional()
-                .match("^(.*)?  Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Handelsspesen            -3,66 EUR  DADAT Handelsspesen      -6,36 EUR
                 .section("fee", "currency").optional()
-                .match("^Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Handelsspesen ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Clearing Gebühr          -1,00 EUR
                 .section("fee", "currency").optional()
-                .match("^Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // DADAT Handelsspesen      -7,12 EUR  Clearing Gebühr          -1,00 EUR
                 .section("fee", "currency").optional()
-                .match("^.*  Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.*  Clearing Geb.hr ([\\s]+)?\\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -172,8 +172,6 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                     
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
-                
-                .conclude(PDFExtractorUtils.fixGrossValueA())
 
                 .wrap(TransactionItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -127,6 +127,8 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
+                .conclude(PDFExtractorUtils.fixGrossValueBuySell())
+
                 // Limit 40,99 EUR AN
                 .section("note").optional()
                 .match("^(?<note>Limit [\\.,\\d]+ [\\w]{3})( .*)?$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -142,7 +142,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)")
                 .match("^(St.ck|[\\w]{3}) [\\.,\\d]+ (?<name>.*) (?<isin>[\\w]{12}) \\((?<wkn>.*)\\)$")
                 .match("^(?<nameContinued>.*)$")
-                .match("^(Kurswert|R.ckzahlungsbetrag) [\\.,\\d]+([\\+|\\-])? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Kurswert|R.ckzahlungsbetrag) [\\.,\\d]+([\\+|\\-])? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setSecurity(getOrCreateSecurity(v));
 
@@ -212,7 +212,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 // Limit 1,75 EUR
                 // Rückzahlungskurs 100 % Rückzahlungsdatum 31.07.2014
                 .section("note").optional()
-                .match("^(?<note>(Limit|R.ckzahlungskurs) [\\.,\\d]+ ([\\w]{3}|%))(.*)?$")
+                .match("^(?<note>(Limit|R.ckzahlungskurs) [\\.,\\d]+ ([\\w]{3}|%)).*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(BuySellEntryItem::new);
@@ -308,7 +308,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 // Devisenkurs EUR / CHF 1,1959
                 // Ausschüttung 51,00 CHF 42,65+ EUR
                 .section("exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
-                .match("^Devisenkurs [\\w]{3} \\/ [\\w]{3} (?<exchangeRate>[\\.,\\d]+)(.*)?$")
+                .match("^Devisenkurs [\\w]{3} \\/ [\\w]{3} (?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^(Aussch.ttung|Dividendengutschrift|Kurswert) (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
@@ -798,7 +798,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. "
                                 + "(?<note1>Rechnung) "
                                 + "(?<amount>[\\.,\\d]+)$")
-                .match("^(.*)?(?<note2>(Bargeldeinzahlung|R.ckruf\\/Nachforschung)).*$")
+                .match("^.*(?<note2>(Bargeldeinzahlung|R.ckruf\\/Nachforschung)).*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     // since year is not within the date correction

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -204,7 +204,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                 .match("^(Valutatag: .* )?Devisenkurs: (?<exchangeRate>[\\.',\\d\\s]+)$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
                     {
                         exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
@@ -127,6 +127,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                 })
 
+                /***
+                 * All amounts are presented in net
+                 */
                 // Splittkauf Betrag UBS Msci Pacific exJap.U ETF A 1,77 EUR 44,4324 USD 0,045
                 // 2536717769 A0X97T / LU0446734526 1,125168 USD 16.04.2019 1,334
                 // UBS (Luxembourg) S.A. 1,99 USD 0,0000 EUR 1,379
@@ -151,6 +154,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
+
+                // We fix the gross value
+                .conclude(PDFExtractorUtils.fixGrossValueBuySell())
 
                 .wrap(BuySellEntryItem::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -66,7 +66,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^Kurs: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kurs: [\\-\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -77,12 +77,12 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // Handelszeit: 11.5.2021
                 // Handelszeit: 30.6.2017 um 09:00:10 Uhr
                 .section("time").optional()
-                .match("^Handelszeit: .* (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                .match("^Handelszeit: .* (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                 .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                 // Handelszeit: 11.5.2021
                 .section("date")
-                .match("^Handelszeit: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Handelszeit: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> {
                     if (type.getCurrentContext().get("time") != null)
                         t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -92,12 +92,12 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Zugang: 74 Stk Teilausführung
                 .section("shares")
-                .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Zu Lasten IBAN AT44 1925 0654 0668 9002 -1.118,80 EUR 
                 .section("amount", "currency")
-                .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -107,8 +107,8 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // -10.360,-- NOK 
                 // Devisenkurs: 9,486 (3.7.2017) -1.092,14 EUR 
                 .section("fxGross", "fxCurrency", "exchangeRate").optional()
-                .match("^Kurswert: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Kurswert: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {                   
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -155,7 +155,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^(Dividende|Ertrag): (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Dividende|Ertrag): (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -165,17 +165,17 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // 200 Stk
                 .section("shares")
-                .match("^(Abgang: )?(?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^(Abgang: )?(?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Valuta 6.9.2017
                 .section("date")
-                .match("^Valuta (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Valuta (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Zu Gunsten IBAN AT44 1925 0654 0668 9002 48,71 EUR 
                 .section("amount", "currency")
-                .match("^Zu Gunsten .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Zu Gunsten .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -184,8 +184,8 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 // Bruttoertrag: 640,-- NOK 
                 // Devisenkurs: 9,308 (5.9.2017) 49,85 EUR 
                 .section("fxGross", "fxCurrency", "exchangeRate").optional()
-                .match("^Bruttoertrag: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}(.*)?$")
+                .match("^Bruttoertrag: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}\\) [\\-\\.,\\d]+ [\\w]{3}.*$")
                 .assign((t, v) -> {                   
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -234,7 +234,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>\\S*) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
-                .match("^steuerlicher Anschaffungswert: [\\-\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^steuerlicher Anschaffungswert: [\\-\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs") || !v.get("name1").startsWith("Verwahrart"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -244,17 +244,17 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
                 // Zugang: 80 Stk
                 .section("shares")
-                .match("^Zugang: (?<shares>[\\.,\\d]+) Stk(.*)?$")
+                .match("^Zugang: (?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Kassatag: 29.3.2017
                 .section("date")
-                .match("^Kassatag: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4})(.*)?$")
+                .match("^Kassatag: (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // steuerlicher Anschaffungswert: 3.225,37 EUR
                 .section("amount", "currency")
-                .match("^steuerlicher Anschaffungswert: (?<amount>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^steuerlicher Anschaffungswert: (?<amount>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -269,27 +269,27 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Kapitalertragsteuer: -254,10 AUD 
                 .section("tax", "currency").optional()
-                .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // KESt Ausländische Dividende: -176,01 NOK 
                 .section("tax", "currency").optional()
-                .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer US-Emittent: -3,05 USD 
                 .section("withHoldingTax", "currency").optional()
-                .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Quellensteuer: -8,81 EUR 
                 .section("withHoldingTax", "currency").optional()
-                .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Umsatzsteuer: -0,19 EUR 
                 .section("tax", "currency").optional()
-                .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -299,22 +299,22 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 // Fremde Spesen: -25,20 EUR 
                 .section("fee", "currency").optional()
-                .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Eigene Spesen: -6,42 EUR 
                 .section("fee", "currency").optional()
-                .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Inkassoprovision: -0,95 EUR 
                 .section("fee", "currency").optional()
-                .match("^Inkassoprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Inkassoprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Grundgebühr: -1,46 EUR 
                 .section("fee", "currency").optional()
-                .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -40,7 +40,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     private void addBuySellTransaction()
     {
         final DocumentType type = new DocumentType("(Kauf|Achat|Vente|Verkauf)", (context, lines) -> {
-            Pattern pTransaction = Pattern.compile("^Num.ro.*(Achat|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$");
+            Pattern pTransaction = Pattern.compile("^Num.ro.*(Achat|Vente) (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3}).*$");
             // read the current context here
 
             /***
@@ -119,19 +119,19 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Date et heure d'exécution : 19/10/2020 11:53:03 CET 
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d.ex.cution)([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d.ex.cution)([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 26/P11/2021L10:05:13 CETDate et heure d'exécution: 26/11/2021 13:25:24 CETDate de comptabilisation: 26/11/2021Date valeur: 30/11/2021Lieu d'exécution: EURONEXT - EURONEXT BRUSS
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^Ordre cr.. .([\\s]+)?: .*Date et heure d.ex.cution([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^Ordre cr.. .([\\s]+)?: .*Date et heure d.ex.cution([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // Ordre créé à: 05/11/2020 11:25:43 CET
                                 section -> section
                                         .attributes("date", "time")
-                                        .match("^Ordre cr.. .([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                                        .match("^Ordre cr.. .([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                         )
 
@@ -142,7 +142,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Crédit 908,64 EUR
                 // Débit 1.502,72 EUR
                 .section("amount", "currency")
-                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Gutschrift|Cr.dit|Lastschrift|D.bit) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -151,7 +151,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Bruttobetrag 924,00 USD
                 // Wechselkurs EUR/USD 1.123000 849,47 EUR
                 .section("gross", "currency", "exchangeRate", "fxCurrency").optional()
-                .match("^Bruttobetrag (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Bruttobetrag (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .match("^Wechselkurs [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+) [\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
@@ -174,7 +174,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Type d'ordre: Market
                 // Type d'ordre: Market I
                 .section("note").optional()
-                .match("^(Auftragstyp|Type d'([\\s]+)?ordre)([\\s]+)?: (?<note>(Limit \\([\\.,\\d]+ [\\w]{3}\\)|Market))(.*)?$")
+                .match("^(Auftragstyp|Type d'([\\s]+)?ordre)([\\s]+)?: (?<note>(Limit \\([\\.,\\d]+ [\\w]{3}\\)|Market)).*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
                 .wrap(BuySellEntryItem::new);
@@ -186,7 +186,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     private void addDividendeTransaction()
     {
         final DocumentType type = new DocumentType("(Einkommensart|Nature des revenus)", (context, lines) -> {
-            Pattern pTransaction = Pattern.compile("^CREDIT COUPON NR .*: (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$");
+            Pattern pTransaction = Pattern.compile("^CREDIT COUPON NR .*: (?<shares>[\\.,\\d]+) (?<name>.*) \\((?<isin>[\\w]{12})\\) .* [\\.,\\d]+ (?<currency>[\\w]{3}).*$");
             // read the current context here
 
             /***
@@ -262,7 +262,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Date valeur: 17/11/2021 C
                                 section -> section
                                         .attributes("date")
-                                        .match("^Date valeur([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})(.*)?$")
+                                        .match("^Date valeur([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}).*$")
                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
                         )
 
@@ -271,7 +271,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                                 // Net CREDIT 45,65 EUR Date  03/02/2021
                                 section -> section
                                         .attributes("amount", "currency")
-                                        .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                                        .match("^(Nettoguthaben|Net CREDIT) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                                         .assign((t, v) -> {
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -292,7 +292,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // Bruttobetrag 1,25 USD
                 // Wechselkurs 1,05 1,01 EUR
                 .section("gross", "currency", "exchangeRate", "fxCurrency").optional()
-                .match("^Bruttobetrag (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Bruttobetrag (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .match("^Wechselkurs (?<exchangeRate>[\\.,\\d]+) [\\.,\\d]+ (?<fxCurrency>[\\w]{3})$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
@@ -328,17 +328,17 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
                 // Impôt à la source 26,38 % 16,35 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+ % (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+ % (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Impôt à la source 26,50% - 6,12 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Imp.t . la source [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Précompte mobilier belge 30,00% - 5,09 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Pr.compte mobilier .* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Pr.compte mobilier .* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Précompte mobilier belge
@@ -347,13 +347,13 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 // L 30,00% - 14,40 EUR
                 .section("tax", "currency").optional()
                 .match("^Pr.compte mobilier .*$")
-                .match("^.* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^.* [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Taxe boursière - 0,35% - 5,22 EUR
                 // Montant brut U - 694,50 EURD - 694,50 EURTaxe boursière - 0,35% - 2,43 EURCourtage - 7,50 EUR
                 .section("tax", "currency").optional()
-                .match("(^.* .*|^)Taxe boursi.re \\- [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Taxe boursi.re \\- [\\.,\\d]+% \\- (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -367,13 +367,13 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
                 // Frais de transaction 24,95 EUR
                 .section("fee", "currency").optional()
-                .match("(^.* .*|^)Frais de transaction (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Frais de transaction (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Courtage - 7,50 EUR
                 // Montant brut U - 694,50 EURD - 694,50 EURTaxe boursière - 0,35% - 2,43 EURCourtage - 7,50 EUR
                 .section("fee", "currency").optional()
-                .match("(^.* .*|^)Courtage \\- (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("(^.* .*|^)Courtage \\- (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFExtractorUtils.java
@@ -293,6 +293,10 @@ class PDFExtractorUtils
     public static Consumer<Transaction> fixGrossValue()
     {
         return t -> {
+            // There is no transaction that is to be generated
+            if (t.getCurrencyCode() == null && t.getAmount() == 0)
+                return;
+
             // if transaction currency equals to the currency of
             // the security, then there is no forex information required
             if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -85,12 +85,12 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // 60 47.29 EUR 2'837.40
                 .section("name", "isin", "currency")
                 .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12}) .*$")
-                .match("^[\\.,'\\d\\s]+ [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+(.*)?$")
+                .match("^[\\.,'\\d\\s]+ [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // 60 47.29 EUR 2'837.40
                 .section("shares")
-                .match("^(?<shares>[\\.,'\\d\\s]+) [\\.,'\\d\\s]+ [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^(?<shares>[\\.,'\\d\\s]+) [\\.,'\\d\\s]+ [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Gemäss Ihrem Kaufauftrag vom 25.09.2018 haben wir folgende Transaktionen vorgenommen:
@@ -102,21 +102,21 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Zu Ihren Lasten EUR 2'850.24
                 // Zu Ihren Gunsten CHF 7'467.50
                 .section("currency", "amount")
-                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                 })
 
-                // Total EUR 2'737.40
+                // 55 49.76 EUR 2'736.80
                 // Wechselkurs 1.08279
                 .section("fxCurrency", "fxGross", "exchangeRate", "currency").optional()
-                .match("^Total (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d\\s]+)(.*)?$")
-                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+)(.*)?$")
-                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) [\\.,'\\d\\s]+(.*)?$")
+                .match("^[\\.,'\\d\\s]+ [\\.,'\\d\\s]+ (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d\\s]+).*$")
+                .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+).*$")
+                .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
+                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
                     {
                         exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
                     }
@@ -163,18 +163,18 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Pictet - Japan Index - I JPY 1.441 JPY 23 608.200 
                 // ISIN LU0188802960 
                 .section("name", "currency", "isin")
-                .match("^(?<name>.*) [\\w]{3} [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+(.*)?$")
-                .match("^ISIN (?<isin>[\\w]{12})(.*)?$")
+                .match("^(?<name>.*) [\\w]{3} [\\.,'\\d\\s]+ (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
+                .match("^ISIN (?<isin>[\\w]{12}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Pictet - Japan Index - I JPY 1.441 JPY 23 608.200 
                 .section("shares")
-                .match("^(?<name>.*) [\\w]{3} (?<shares>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^(?<name>.*) [\\w]{3} (?<shares>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // E-Vermögensverwaltung Datum: 20.12.2021 
                 .section("date")
-                .match("^E\\-Verm.gensverwaltung Datum: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^E\\-Verm.gensverwaltung Datum: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                 // Der Totalbetrag von CHF 280.91 wurde Ihrem Konto CH11 0100 0000 1111 1111 1 mit Valuta 21.12.2021 belastet. 
@@ -188,8 +188,8 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Kurswert in Handelswährung JPY 34 019.00 
                 // Total in Kontowährung zum Kurs von JPY/CHF 0.0082450 CHF 280.91 
                 .section("fxCurrency", "fxGross", "currency", "exchangeRate").optional()
-                .match("^Kurswert in Handelsw.hrung (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d\\s]+)(.*)?$")
-                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+(.*)?$")
+                .match("^Kurswert in Handelsw.hrung (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d\\s]+).*$")
+                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -238,31 +238,31 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // UNILEVER DUTCH CERT NKN: 2560588 60
                 // Dividende 0.4104 EUR
                 .section("isin", "name", "currency").optional()
-                .match("^ISIN: (?<isin>[\\w]{12})(.*)?$")
-                .match("^(?<name>.*) NKN: [\\d]+ [\\.,'\\d\\s]+(.*)?$")
-                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^ISIN: (?<isin>[\\w]{12}).*$")
+                .match("^(?<name>.*) NKN: [\\d]+ [\\.,'\\d\\s]+.*$")
+                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // UBS ETF CH - SLI CHF A ISIN: CH0032912732NKN: 3291273 34
                 // Dividende 1.66 CHF
                 .section("name", "isin", "currency").optional()
-                .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12})([\\s]+)?NKN: [\\d]+ [\\.,'\\d\\s]+(.*)?$")
-                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^(?<name>.*) ISIN: (?<isin>[\\w]{12})([\\s]+)?NKN: [\\d]+ [\\.,'\\d\\s]+.*$")
+                .match("^(Dividende|Kapitalgewinn) [\\.,'\\d\\s]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                 // Anzahl 60
                 .section("shares")
-                .match("^Anzahl (?<shares>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Anzahl (?<shares>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // Valutadatum 05.06.2019
                 .section("date")
-                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
+                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                 // Total EUR 20.93
                 .section("currency", "amount")
-                .match("^Total (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Total (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -304,8 +304,8 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Betrag belastet CHF 90.00
                 .section("date", "currency", "amount")
                 .find("Jahresgeb.hr .*")
-                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(.*)?$")
-                .match("^Betrag belastet (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Valutadatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
+                .match("^Betrag belastet (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> {
                     t.setDateTime(asDate(v.get("date")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -327,7 +327,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addInterestTransaction()
     {
         final DocumentType type = new DocumentType("Zinsabschluss", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3}).*$");
             Pattern pYear = Pattern.compile("^[\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) Kontostand nach Zinsabschluss .*$");
             // read the current context here
             for (String line : lines)
@@ -350,7 +350,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) (\\-|\\–) ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+(.*)?$");
+        Block firstRelevantLine = new Block("^([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) (\\-|\\–) ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{6}) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -362,7 +362,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})) "
                                                     + "[\\.,'\\d\\s]+(%| %) "
                                                     + "(?<amount>[\\.,'\\d\\s]+)"
-                                                    + "(.*)?$")
+                                                    + ".*$")
                                     .assign((t, v) -> {
                                         Map<String, String> context = type.getCurrentContext();
 
@@ -375,7 +375,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                     .attributes("date1", "date2", "amount")
                                     .match("^(?<date1>[\\d]{6}) (\\-|\\–) "
                                                     + "(?<date2>[\\d]{6}) [\\.,'\\d\\s]+(%| %) "
-                                                    + "(?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                                                    + "(?<amount>[\\.,'\\d\\s]+).*$")
                                     .assign((t, v) -> {
                                         Map<String, String> context = type.getCurrentContext();
 
@@ -413,7 +413,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(?i:Geb.hrenausweis) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}(.*)?$");
+        Block firstRelevantLine = new Block("^(?i:Geb.hrenausweis) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -425,7 +425,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 .match("^(?i:Geb.hrenausweis) "
                                 + "(?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                 + "(\\-|\\–) "
-                                + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}))(.*)?$")
+                                + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})).*$")
                 .match("^Zusammenstellung der belasteten Kontof.hrungsgeb.hr: "
                                 + "(?<currency>[\\w]{3}) (?<amount>[\\.,'\\d\\s]+)(.*)$")
                 .assign((t, v) -> {
@@ -445,7 +445,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addTaxesTransaction()
     {
         final DocumentType type = new DocumentType("Zinsabschluss", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN) .* (?<currency>[A-Z]{3}).*$");
             Pattern pNote = Pattern.compile("^Zinsabschluss (?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$");
             // read the current context here
             for (String line : lines)
@@ -468,7 +468,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+(.*)?$");
+        Block firstRelevantLine = new Block("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) [\\.,'\\d\\s]+.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -476,7 +476,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 // Verrechnungssteuer 35.00% 40.83
                 // 31.12.2019 Kontostand nach Zinsabschluss 10 075.83
                 .section("amount", "date")
-                .match("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) (?<amount>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^(?i:Verrechnungssteuer) [\\.,'\\d\\s]+(%| %) (?<amount>[\\.,'\\d\\s]+).*$")
                 .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Kontostand nach Zinsabschluss .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -497,7 +497,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     private void addAccountStatementTransaction()
     {
         DocumentType type = new DocumentType("Kontoauszug", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN){1} (.*) (?<currency>[A-Z]{3})(.*)?$");
+            Pattern pCurrency = Pattern.compile("^(Kontonummer|IBAN){1} (.*) (?<currency>[A-Z]{3}).*$");
             Pattern pYear = Pattern.compile("^Kontoauszug [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-|\\–) [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) .*$");
             for (String line : lines)
             {
@@ -516,7 +516,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block removalBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block removalBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
@@ -531,7 +531,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "(?<note>.BERTRAG) "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .match("^AUF KONTO .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -566,7 +566,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ") "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -670,7 +670,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block depositBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block depositBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
@@ -685,7 +685,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "(?<note>.BERTRAG) "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .match("^AUS KONTO .*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -715,7 +715,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ") "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -766,7 +766,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block feesBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block feesBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
@@ -788,7 +788,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ")([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{2})"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -837,7 +837,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                     return null;
                 }));
 
-        Block interestBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}(.*)?$");
+        Block interestBlock = new Block("^.* [\\.,'\\d\\s]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{2}.*$");
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
@@ -853,7 +853,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + ")([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -871,7 +871,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                                 + "([\\s]+)? "
                                 + "(?<amount>[\\.,'\\d\\s]+) "
                                 + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{2}"
-                                + "(.*)?$")
+                                + ".*$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
 
@@ -903,17 +903,17 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Abgabe (Eidg. Stempelsteuer) EUR 4.26
                 .section("currency", "tax").optional()
-                .match("^Abgabe \\(Eidg\\. Stempelsteuer\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Abgabe \\(Eidg\\. Stempelsteuer\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Quellensteuer 15.00% (NL) EUR 3.69
                 .section("currency", "withHoldingTax").optional()
-                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Quellensteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                 // Verrechnungssteuer 35% (CH) CHF 19.75
                 .section("currency", "tax").optional()
-                .match("^Verrechnungssteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Verrechnungssteuer [\\.,'\\d\\s]+(%| %) \\(.*\\) (?<currency>[\\w]{3}) (?<tax>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -922,22 +922,22 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Kommission EUR 8.58
                 .section("currency", "fee").optional()
-                .match("^Kommission (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Kommission (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Börsengebühren CHF 1.50
                 .section("currency", "fee").optional()
-                .match("^B.rsengeb.hren (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^B.rsengeb.hren (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Börsengebühren und sonstige Spesen EUR 0.60
                 .section("currency", "fee").optional()
-                .match("^B.rsengeb.hren und sonstige Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^B.rsengeb.hren und sonstige Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Umsatzabgabe JPY 51.00 
                 .section("currency", "fee").optional()
-                .match("^Umsatzabgabe (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+)(.*)?$")
+                .match("^Umsatzabgabe (?<currency>[\\w]{3}) (?<fee>[\\.,'\\d\\s]+).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -53,7 +53,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^(Gesch.ftsart:|Wertpapier Abrechnung) (Kauf|Verkauf)(.*)?$");
+        Block firstRelevantLine = new Block("^(Gesch.ftsart:|Wertpapier Abrechnung) (Kauf|Verkauf).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -99,7 +99,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                 // Abgang: 4.500 Stk  
                                 section -> section
                                         .attributes("shares")
-                                        .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+)(.*)?$")
+                                        .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+).*$")
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                                 ,
                                 // Stück 100 QUALCOMM INC.                      US7475251036 (883121)
@@ -112,14 +112,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Handelszeit: 03.05.2021 13:45:18
                 // Schlusstag/-Zeit 09.11.2021 09:58:45 Auftraggeber Muster 
                 .section("date", "time")
-                .match("^(Handelszeit:|Schlusstag\\/\\-Zeit) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})(.*)?$")
+                .match("^(Handelszeit:|Schlusstag\\/\\-Zeit) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                 // Zu Lasten IBAN AT99 9999 9000 0011 1110 -107,26 EUR  
                 // Zu Gunsten IBAN AT27 3284 2000 0011 1111 36.115,76 EUR
                 // Ausmachender Betrag 14.399,34- EUR
                 .section("amount", "currency")
-                .match("^(Zu (Lasten|Gunsten) .*|Ausmachender Betrag) (\\-)?(?<amount>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu (Lasten|Gunsten) .*|Ausmachender Betrag) (\\-)?(?<amount>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -128,8 +128,8 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Kurswert: -1.464,32 CAD 
                 // Devisenkurs: 1,406 (20.01.2022) -1.093,40 EUR 
                 .section("fxCurrency", "fxGross", "exchangeRate", "currency").optional()
-                .match("^Kurswert: (\\-)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})(.*)?$")
-                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kurswert: (\\-)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
                     if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
@@ -206,7 +206,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                 // 90 Stk  
                                 section -> section
                                         .attributes("shares")
-                                        .match("^(?<shares>[\\.,\\d]+) Stk(.*)?$")
+                                        .match("^(?<shares>[\\.,\\d]+) Stk.*$")
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                                 ,
                                 // Stück 100 QUALCOMM INC. US7475251036 (883121)
@@ -233,7 +233,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 // Zu Gunsten IBAN AT99 9999 9000 0011 1111 110,02 EUR 
                 // Ausmachender Betrag 50,88+ EUR
                 .section("amount", "currency")
-                .match("^(Zu Gunsten .*|Ausmachender Betrag) (?<amount>[\\.,\\d]+)(\\+)? (?<currency>[\\w]{3})(.*)?$")
+                .match("^(Zu Gunsten .*|Ausmachender Betrag) (?<amount>[\\.,\\d]+)(\\+)? (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -513,17 +513,17 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Quellensteuer: -47,48 EUR 
                 .section("tax", "currency").optional()
-                .match("^Quellensteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Quellensteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Auslands-KESt: -22,50 EUR 
                 .section("tax", "currency").optional()
-                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Kursgewinn-KESt: -696,65 EUR 
                 .section("tax", "currency").optional()
-                .match("^Kursgewinn\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Kursgewinn\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
                 // Einbehaltene Quellensteuer 15 % auf 68,00 USD 8,98- EUR
@@ -542,37 +542,37 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         transaction
                 // Serviceentgelt: -0,32 EUR 
                 .section("fee", "currency").optional()
-                .match("^Serviceentgelt: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Serviceentgelt: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Provision 0,2000 % vom Kurswert 28,74- EUR
                 .section("fee", "currency").optional()
-                .match("^Provision [\\.,\\d]+ % .* (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^Provision [\\.,\\d]+ % .* (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Eigene Spesen 2,50- EUR
                 .section("fee", "currency").optional()
-                .match("^Eigene Spesen (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^Eigene Spesen (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Übertragungs-/Liefergebühr 0,10- EUR
                 .section("fee", "currency").optional()
-                .match("^.bertragungs\\-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})(.*)?$")
+                .match("^.bertragungs\\-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Handelsortentgelt inkl. Fremdspesen: -4,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Handelsortentgelt inkl\\. Fremdspesen: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Handelsortentgelt inkl\\. Fremdspesen: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Gebühren: -25,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Geb.hren: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Geb.hren: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // Orderleitgebühr: -3,00 EUR 
                 .section("fee", "currency").optional()
-                .match("^Orderleitgeb.hr: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})(.*)?$")
+                .match("^Orderleitgeb.hr: \\-(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -273,7 +273,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                 // 0.91759 CHF 31.44
                 .section("fxCurrency", "fxGross", "exchangeRate", "currency", "gross").optional()
                 .match("^(Betrag|Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d]+)$")
-                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3}(.*)?$")
+                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3}.*$")
                 .match("^(?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
                 .assign((t, v) -> {
                     BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));


### PR DESCRIPTION
Hallo @buchen
wie telefonisch besprochen das ganze durcharbeitet.

Ich habe den fix nur in PDF-Importer eingebaut, wo er meiner Meinung nach richtig ist.
Das ist nach meiner Meinung dann, wenn das ermittelte Brutto wirklich nicht korrekt ist.
z.B. wenn vom Originalbruttowert Gebühren abgezogen werden

---
!!! Hier wird der Fix diese tatsächlich benötigt !!!
- [WertpapierKauf14 ](name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Kauf14.txt)im Comdirect
- [WertpapierKauf03 ](name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Kauf03.txt)im Direkt1822
- FIL Fondbank --> Es gibt keinen Bruttowert in den Dokumenten

---
Die anderen Importer benötigen dies nicht.
Ich denke, dass es nicht der richtige Weg wäre, den Fix pauschal über alle Fehler drüber zu bügeln.
Es gibt eigentlich zwei Probleme... einmal den Rundungsfehler und einmal mit den Quellensteuern.
Ich denke das es hierfür eine "fluffigere" Lösung gibt...

---
**Folgende Ergebnisse der TestCases:**

DAB
   - Dividende02WithSecurityInEUR -> withholdingTax Problem, wenn 0,00
   - Dividende05WithSecurityInEUR -> withholdingTax Problem
   - Dividende10 -> withholdingTax Problem
   - Dividende12 -> Rundungsproblem +/- 0,01
   - Kauf07 -> Unerklärbar, wenn keine Steuern oder Gebühren
   - Kauf07WithSecurityInEUR -> Unerklärbar, wenn keine Steuern oder Gebühren
   - Verkauf03 -> Rundungsproblem  +/- 0,01
   - Verkauf12 -> Rundungsproblem  +/- 0,01
   - Verkauf12 -> Rundungsproblem  +/- 0,01

CommerzbankPDFExtractor
   - Dividende01 -> `!!!!!!!!!! Dokument manipuliert !!!!!!!!!! `
   - Dividende02 -> `!!!!!!!!!! Dokument manipuliert !!!!!!!!!! `

DkbPDFExtractor
   - Dividende09 -> withholdingTax Problem
   - Dividende10 -> withholdingTax Problem

PostfinancePDFExtractor
   - `Ist mir nicht erklärbar`

BankSLMPDFExtractor
   - Verkauf02 -> Rundungsproblem  +/- 0,01
   - Verkauf02WithSecurityInEUR -> Rundungsproblem  +/- 0,01

WirBankPDFExtractor
   - Kauf01 -> Rundungsproblem  +/- 0,01

DegiroPDFExtractor
   - `Den habe ich aufgegeben :-( sorry`

TradeRepublicPDFExtractor
   - Dividende06 -> withholdingTax Problem

DeutscheBankPDFExtractor
   - Dividende03 -> withholdingTax Problem

ConsorsbankPDFExtractor
   - Dividende08 -> Rundungsproblem  +/- 0,01
   - Dividende15 -> Rundungsproblem  +/- 0,01

ErsteBankPDFExtractor
   - Dividende04 -> Rundungsproblem  +/- 0,01
   - Kauf09 -> Rundungsproblem  +/- 0,01
   - Kauf10 -> Rundungsproblem  +/- 0,01
   - Kauf11 -> Rundungsproblem  +/- 0,01

DreiBankenEDVPDFExtractor
   - Dividende05 -> ????

OnvistaPDFExtractor
   - Dividende04 -> withholdingTax Problem
   - Dividende10 -> withholdingTax Problem
   - Dividende11 -> Rundungsproblem  +/- 0,01
   - Kauf05 -> Rundungsproblem  +/- 0,01