### PR TITLE
Fixes Degiro import of dividend statement with dividend and tax on two lines

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/AssertImportActions.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/AssertImportActions.java
@@ -68,8 +68,8 @@ public class AssertImportActions
             for (ImportAction action : actions)
             {
                 ImportAction.Status status = item.apply(action, context);
-                assertThat(status.getMessage() + "\n" //$NON-NLS-1$
-                                + item.getTypeInformation(), status.getCode(), is(ImportAction.Status.Code.OK));
+                assertThat(status.getMessage() + "\n" + item, //$NON-NLS-1$
+                                status.getCode(), is(ImportAction.Status.Code.OK));
             }
         }
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -82,6 +82,11 @@ import name.abuchen.portfolio.model.TypedMap;
             return key.isInstance(v) ? Optional.of(key.cast(v)) : Optional.empty(); 
         }
         
+        public void removeType(Class<?> key)
+        {
+            backingMap.remove(key.getName());
+        }
+        
         public boolean getBoolean(String key)
         {
             Object answer = backingMap.get(key);


### PR DESCRIPTION
* Fixes that the importer (sometimes) uses the "balance" of the account
  statement as dividend amount
* Fixes that the importer was using currency exchange line items only
  if the exchange amount matched exactly. However, sometimes multiple
  payments in forex are collected and converted together
* Changes the logic to parse information about currency exchanges into
  Java objects (no need to manage Strings only)


@Nirus2000 - bitte PR reviewen - der sollte das Problem wie in #2828 beschrieben lösen. Ich habe versucht für jeden Test zu die Originalzeilen im Test zu dokumentieren, damit es einfacher ist zu sehen warum der Test geändert wurde