### PR TITLE
New NYSE holiday: Juneteenth

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayName.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayName.java
@@ -26,6 +26,7 @@ import java.util.ResourceBundle;
     HURRICANE_SANDY,
     INDEPENDENCE,
     INTERNATION_WOMENS_DAY,
+    JUNETEENTH,
     LABOUR_DAY,
     MARTIN_LUTHER_KING,
     MEMORIAL,

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -20,6 +20,7 @@ import static name.abuchen.portfolio.util.HolidayName.GOOD_FRIDAY;
 import static name.abuchen.portfolio.util.HolidayName.HURRICANE_SANDY;
 import static name.abuchen.portfolio.util.HolidayName.INTERNATION_WOMENS_DAY;
 import static name.abuchen.portfolio.util.HolidayName.INDEPENDENCE;
+import static name.abuchen.portfolio.util.HolidayName.JUNETEENTH;
 import static name.abuchen.portfolio.util.HolidayName.LABOUR_DAY;
 import static name.abuchen.portfolio.util.HolidayName.MARTIN_LUTHER_KING;
 import static name.abuchen.portfolio.util.HolidayName.MEMORIAL;
@@ -110,6 +111,7 @@ public class TradeCalendarManager
         tc.add(weekday(WASHINGTONS_BIRTHDAY, 3, DayOfWeek.MONDAY, Month.FEBRUARY));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(last(MEMORIAL, DayOfWeek.MONDAY, Month.MAY));
+        tc.add(fixed(JUNETEENTH, Month.JUNE, 19).moveIf(DayOfWeek.SATURDAY, -1).moveIf(DayOfWeek.SUNDAY, 1).validFrom(2022));
         tc.add(fixed(INDEPENDENCE, Month.JULY, 4).moveIf(DayOfWeek.SATURDAY, -1).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(weekday(LABOUR_DAY, 1, DayOfWeek.MONDAY, Month.SEPTEMBER));
         tc.add(weekday(THANKSGIVING, 4, DayOfWeek.THURSDAY, Month.NOVEMBER));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Independence Day (July 4)
 
 INTERNATION_WOMENS_DAY = International Woman's day
 
+JUNETEENTH = Juneteenth
+
 LABOUR_DAY = Labour day
 
 MARTIN_LUTHER_KING = Martin Luther King, Jr. Day

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_cs.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_cs.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Den nez\u00E1vislosti (4. \u010Dervence)
 
 INTERNATION_WOMENS_DAY = Mezin\u00E1rodn\u00ED den \u017Een
 
+JUNETEENTH = Den nez\u00E1vislosti \u010Dernoch\u016F
+
 LABOUR_DAY = Sv\u00E1tek pr\u00E1ce
 
 MARTIN_LUTHER_KING = Martin Luther King, Jr. Den

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_de.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Unabh\u00E4ngigkeitstag (Vereinigte Staaten)
 
 INTERNATION_WOMENS_DAY = Internationaler Frauentag
 
+JUNETEENTH = Tag der Sklavenbefreiung
+
 LABOUR_DAY = Tag der Arbeit
 
 MARTIN_LUTHER_KING = Martin Luther King, Jr. Tag (Vereinigten Staaten)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_es.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_es.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = D\u00EDa de la Independencia (Estados Unidos)
 
 INTERNATION_WOMENS_DAY = D\u00EDa Internacional de la Mujer
 
+JUNETEENTH = D\u00EDa de la Emancipaci\u00F3n
+
 LABOUR_DAY = D\u00EDa del Trabajo
 
 MARTIN_LUTHER_KING = D\u00EDa de Martin Luther King Jr. (Estados Unidos)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_fr.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_fr.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Jour de l'Ind\u00E9pendance (\u00C9tats-Unis)
 
 INTERNATION_WOMENS_DAY = Journ\u00E9e internationale des femmes
 
+JUNETEENTH = Jour de l'\u00C9mancipation
+
 LABOUR_DAY = F\u00EAte du travail 
 
 MARTIN_LUTHER_KING = Jour de Martin Luther King (\u00C9tats-Unis)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_nl.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_nl.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Independence Day (Verenigde Staten)
 
 INTERNATION_WOMENS_DAY = Internationale vrouwendag
 
+JUNETEENTH = Dag van de afschaffing van de slavernij
+
 LABOUR_DAY = Dag van de Arbeid
 
 MARTIN_LUTHER_KING = Martin Luther Kingdag (Verenigde Staten)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_pt.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/holiday-names_pt.properties
@@ -40,6 +40,8 @@ INDEPENDENCE = Dia da Independ\u00EAncia (Estados Unidos)
 
 INTERNATION_WOMENS_DAY = Dia das Mulheres 
 
+JUNETEENTH = Dia da Emancipa\u00E7\u00E3o
+
 LABOUR_DAY = Dia do Trabalhador
 
 MARTIN_LUTHER_KING = Dia de Martin Luther King (Estados Unidos)


### PR DESCRIPTION
The NYSE has [decided](https://www.sec.gov/rules/sro/nyse/2021/34-93183.pdf) to observe [Juneteenth](https://en.wikipedia.org/wiki/Juneteenth) (commemorating the emancipation of slaves in the US) from 2022, which was made a federal holiday in 2021. Hence, add the new holiday to the NYSE trade calendar.