### PR TITLE
Update feature exchange rate in pdf importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -3078,7 +3078,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-05-14T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(16)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende09.txt"));
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende09.txt; Dividende12.txt"));
         assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
@@ -3127,7 +3127,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-05-14T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(16)));
-        assertThat(transaction.getSource(), is("Dividende12.txt"));
+        assertThat(transaction.getSource(), is("Dividende12.txt; SteuermitteilungDividende09.txt"));
         assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
@@ -3176,8 +3176,8 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-04T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende10.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende10.txt; Dividende13.txt"));
+        assertThat(transaction.getNote(), is("Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.19))));
@@ -3225,8 +3225,8 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-04T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(32)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende10.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende10.txt; Dividende13.txt"));
+        assertThat(transaction.getNote(), is("Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.19))));
@@ -3274,8 +3274,8 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-07T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(34)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende11.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende11.txt; Dividende14.txt"));
+        assertThat(transaction.getNote(), is("Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.03))));
@@ -3323,7 +3323,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-07T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(34)));
-        assertThat(transaction.getSource(), is("Dividende14.txt"));
+        assertThat(transaction.getSource(), is("Dividende14.txt; SteuermitteilungDividende11.txt"));
         assertThat(transaction.getNote(), is("Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
@@ -3372,7 +3372,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(81.921)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende16.txt"));
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende16.txt; Dividende17.txt"));
         assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),
@@ -3421,7 +3421,7 @@ public class ComdirectPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(81.921)));
-        assertThat(transaction.getSource(), is("SteuermitteilungDividende16.txt"));
+        assertThat(transaction.getSource(), is("SteuermitteilungDividende16.txt; Dividende17.txt"));
         assertNull(transaction.getNote());
 
         assertThat(transaction.getMonetaryAmount(),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -40,10 +40,10 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-                pdfTransaction.subject(() -> {
-                    BuySellEntry entry = new BuySellEntry();
-                    entry.setType(PortfolioTransaction.Type.BUY);
-                    return entry;
+        pdfTransaction.subject(() -> {
+            BuySellEntry entry = new BuySellEntry();
+            entry.setType(PortfolioTransaction.Type.BUY);
+            return entry;
         });
 
         Block firstRelevantLine = new Block("^B.rsenabrechnung \\- (Kauf|Verkauf)$");
@@ -97,7 +97,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                 // Change EUR/CHF 1.241652 CHF -92'031.25
                 .section("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency", "gross").optional()
                 .match("^Total Kurswert (?<fxCurrency>[\\w]{3}) (\\-)?(?<fxGross>[\\.',\\d]+)$")
-                        .match("^Change (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.',\\d]+) (?<currency>[\\w]{3}) (\\-)?(?<gross>[\\.',\\d]+)$")
+                .match("^Change (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.',\\d]+) (?<currency>[\\w]{3}) (\\-)?(?<gross>[\\.',\\d]+)$")
                 .assign((t, v) -> {
                     type.getCurrentContext().putType(asExchangeRate(v));
 
@@ -120,12 +120,11 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Dividende$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Namen-Aktien nom CHF 100.00 Ex Datum: 02.05.2016
@@ -167,7 +166,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                 // Change EUR / CHF 1.067227 CHF 3'302.00
                 .section("currency", "gross", "termCurrency", "baseCurrency", "fxCurrency", "exchangeRate").optional()
                 .match("^Brutto \\([\\.',\\d]+ \\* [\\w]{3} [\\.',\\d]+\\) (?<currency>[\\w]{3}) (?<gross>[\\.',\\d]+)$")
-                        .match("^Change (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.',\\d]+) (?<fxCurrency>[\\w]{3}) (\\-)?[\\.',\\d]+$")
+                .match("^Change (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.',\\d]+) (?<fxCurrency>[\\w]{3}) (\\-)?[\\.',\\d]+$")
                 .assign((t, v) -> {
                     PDFExchangeRate rate = asExchangeRate(v);
                     type.getCurrentContext().putType(asExchangeRate(v));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -129,12 +129,11 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Steuerliche Behandlung: (Wertpapier(kauf|verkauf)|Verkauf|.*Dividende)");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.TAX_REFUND);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.TAX_REFUND);
+            return entry;
+        });
 
         Block firstRelevantLine = new Block("^Steuerliche Behandlung: (Wertpapier(kauf|verkauf)|Verkauf|.*Dividende) .*$");
         type.addBlock(firstRelevantLine);
@@ -190,12 +189,11 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
         Block block = new Block("^(D i v i d e n d e n g u t s c h r i f t|E r t r a g s g u t s c h r i f t)$");
         type.addBlock(block);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // p e r 2 7 . 0 3 . 2 0 2 0 Samsung E l e c t r o n i c s Co. L t d . 881823
@@ -258,6 +256,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setNote(stripBlanks(v.get("note1")) + " " + stripBlanks(v.get("note2")) + " - " + stripBlanks(v.get("note3"))))
 
                 .conclude(PDFExtractorUtils.fixGrossValueA())
+
                 .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -33,7 +33,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("Ihr Kauf|Ihr Verkauf");
+        DocumentType type = new DocumentType("(Ihr Kauf|Ihr Verkauf)");
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
@@ -53,9 +53,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                 .match("^Ihr (?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf"))
-                    {
                         t.setType(PortfolioTransaction.Type.SELL);
-                    }
                 })
 
                 // 900 Registered Shs Iron Mountain Inc USD 0.01
@@ -130,7 +128,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(t.getPortfolioTransaction().getAmount() + asAmount(v.get("feeRefund")));
                 })
 
-                .wrap(t -> new BuySellEntryItem(t));
+                .wrap(BuySellEntryItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -144,12 +142,11 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Ertragsabrechnung .*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // 900 REGISTERED SHS IRON MOUNTAIN INC

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -3,8 +3,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -63,13 +61,6 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf") || v.get("type").equals("Gesamtfälligkeit"))
                         t.setType(PortfolioTransaction.Type.SELL);
-
-                    /***
-                     * If we have multiple entries in the document,
-                     * with taxes and tax refunds,
-                     * then the "negative" flag must be removed.
-                     */
-                    type.getCurrentContext().remove("negative");
                 })
 
                 // ComStage-MSCI USA TRN UCIT.ETF Inhaber-Anteile I o.N. LU0392495700
@@ -168,11 +159,10 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         )
 
                 /***
-                 * If changes are made in this area, 
-                 * the tax refund function must be adjusted.
+                 * If changes are made in this area, the tax refund
+                 * function must be adjusted.
                  * addBuySellTaxReturnBlock(type);
                  */
-
                 .oneOf(
                                 // 08.01.2015 8022574001 EUR 150,00
                                 section -> section
@@ -195,29 +185,30 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
                 // Handelstag 24.08.2015  Kurswert                    USD 5.205,00
                 // 03.08.2015 0000000000 EUR/USD 1,100297 EUR 4.798,86
-                .section("fxCurrency", "fxGross", "exchangeRate", "currency").optional()
+                .section("fxCurrency", "fxGross", "baseCurrency", "termCurrency", "exchangeRate", "currency").optional()
                 .match("^.* Kurswert ([\\s]+)?(?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)([\\-\\s]+)?$")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) [\\.,\\d]+$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+                    
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
                 .conclude(PDFExtractorUtils.fixGrossValueBuySell())
-                .wrap(BuySellEntryItem::new);
+
+                .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document,
+                     * then the "negative" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
+                    return new BuySellEntryItem(t);
+                });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -236,14 +227,6 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.DIVIDENDS);
-
-            /***
-             * If we have multiple entries in the document,
-             * with taxes and tax refunds,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -320,10 +303,18 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         })
                                 ,
                                 // Netto in USD zugunsten IBAN DE90 209,38 USD
+                                section -> section
+                                        .attributes("amount", "currency")
+                                        .match("^Netto in [\\w]{3} zugunsten .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .assign((t, v) -> {
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                            t.setAmount(asAmount(v.get("amount")));
+                                        })
+                                ,
                                 // Netto zugunsten IBAN DE11 7603 0080 0111 1111 14 437,22 EUR
                                 section -> section
                                         .attributes("amount", "currency")
-                                        .match("^Netto .*zugunsten IBAN .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                                        .match("^Netto zugunsten .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -333,89 +324,61 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // 27.08.2020 123456789 USD 4,64
                 // ausländische Dividende EUR 5,25
                 // Devisenkurs: EUR/USD 1,1814
-                // 30.06.2021 5325658010 USD 20,49
-                // Ertrag für 2020/21 USD 25,11
-                // Devisenkurs: EUR/USD 1,1914
-                .section("currency", "exchangeRate", "fxCurrency", "fxGross").optional()
+                .section("currency", "fxCurrency", "fxGross", "exchangeRate", "termCurrency", "baseCurrency").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<currency>[\\w]{3}) [\\.,\\d]+$")
-                .match("^(Ertrag f.r [\\d]{4}\\/[\\d]{2}|ausl.ndische Dividende) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)$")
-                .match("^Devisenkurs: [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+)$")
+                .match("^ausl.ndische Dividende (?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxGross>[\\.,\\d]+).*$")
+                .match("^Devisenkurs: (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+                    
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
-
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
+                    
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
-                // 30.03.2015 0000000000 EUR/ZAR 13,195 EUR 586,80
-                // ausländische Dividende EUR 788,18
-                .section("fxCurrency", "exchangeRate", "currency", "gross").optional()
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/(?<fxCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\.,\\d]+$")
+                // 01.12.2021 1234567891 EUR/JPY 127,99 EUR 3,59
+                // ausländische Dividende EUR 4,84
+                .section("baseCurrency", "termCurrency", "exchangeRate", "currency", "gross").optional()
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\.,\\d]+$")
                 .match("^ausl.ndische Dividende (?<currency>[\\w]{3}) ([\\s]+)?(?<gross>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+                    
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
-
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("termCurrency")), gross);
+                    
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
                 // 07.02.2017 1234567 EUR/USD 1,0797 EUR 11,06
                 // Ertrag für 2016 USD 14,24
-                .section("exchangeRate", "currency", "fxCurrency", "fxGross").optional()
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                .section("baseCurrency", "termCurrency", "exchangeRate", "currency", "fxCurrency", "fxGross").optional()
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) [\\.,\\d]+$")
                 .match("^Ertrag f.r [\\d]{4} (?<fxCurrency>[\\w]{3}) ([\\s]+)?(?<fxGross>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+                    
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
-
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
+                    
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
                 // Brutto in USD 281,25 USD
                 // Devisenkurs 1,249900 USD / EUR
                 // Brutto in EUR 225,02 EUR
-                .section("fxGross", "fxCurrency", "exchangeRate", "gross", "currency").optional()
-                .match("^Brutto in [\\w]{3} (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+) [\\w]{3} \\/ [\\w]{3}$")
+                // Netto in USD zugunsten IBAN DE90 209,38 USD
+                .section("termCurrency", "gross", "currency", "exchangeRate", "baseCurrency", "fxGross", "fxCurrency").optional()
                 .match("^Brutto in [\\w]{3} (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+) (?<termCurrency>[\\w]{3}) \\/ (?<baseCurrency>[\\w]{3})$")
+                .match("^Brutto in [\\w]{3} (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
+                .match("^Netto in [\\w]{3} zugunsten .*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -423,8 +386,33 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
+                // 30.06.2021 5325658010 USD 20,49
+                // Ertrag für 2020/21 USD 25,11
+                // Devisenkurs: EUR/USD 1,1914
+                .section("currency", "gross", "termCurrency", "baseCurrency", "exchangeRate").optional()
+                .match("^Ertrag f.r [\\d]{4}\\/[\\d]{2} (?<currency>[\\w]{3}) ([\\s]+)?(?<gross>[\\.,\\d]+).*$")
+                .match("^Devisenkurs: (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
+                .assign((t, v) -> {
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+
+                    Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("baseCurrency")), gross);
+                    
+                    checkAndSetGrossUnit(gross, fxGross, t, type);
+                })
+
                 .conclude(PDFExtractorUtils.fixGrossValueA())
-                .wrap(TransactionItem::new);
+
+                .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document, then
+                     * the "noTax" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
+                    return new TransactionItem(t);
+                });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -442,14 +430,6 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             PortfolioTransaction entry = new PortfolioTransaction();
             entry.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-
-            /***
-             * If we have multiple entries in the document,
-             * with taxes and tax refunds,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -534,7 +514,15 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(0L);
                 })
 
-                .wrap(TransactionItem::new);
+                .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document, then
+                     * the "noTax" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
+                    return new TransactionItem(t);
+                });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -658,23 +646,17 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                 // zu versteuern (negativ) EUR 341,55
                 // Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
                 // 24.08.2015 0000000000 00000000 EUR 90,09
-                .section("fxCurrency", "exchangeRate", "currency", "gross").optional()
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\w]{3}\\/(?<fxCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\.,\\d]+$")
+                .section("baseCurrency", "termCurrency", "exchangeRate", "currency", "gross").optional()
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\.,\\d]+$")
                 .match("^zu versteuern \\(negativ\\) .*$")
                 .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\d]+ (?<currency>[\\w]{3}) (?<gross>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
-                    
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("termCurrency")), gross);
+
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
 
@@ -695,9 +677,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
             {
                 Matcher m = pCurrency.matcher(line);
                 if (m.matches())
-                {
                     context.put("currency", m.group(1));
-                }
             }
         });
         this.addDocumentTyp(type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -5,7 +5,6 @@ import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAnd
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -108,21 +107,17 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs (EUR/USD) 1,1987 vom 02.03.2021
                 // Kurswert 52,50- EUR
-                .section("fxCurrency", "exchangeRate", "gross", "currency").optional()
-                .match("^Devisenkurs \\([\\w]{3}\\/(?<fxCurrency>[\\w]{3})\\) (?<exchangeRate>[\\.,\\d]+) .*$")
+                .section("baseCurrency", "fxCurrency", "exchangeRate", "gross", "currency").optional()
+                .match("^Devisenkurs \\((?<baseCurrency>[\\w]{3})\\/(?<fxCurrency>[\\w]{3})\\) (?<exchangeRate>[\\.,\\d]+) .*$")
                 .match("^Kurswert (?<gross>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
+
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -189,19 +184,15 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
                 // Devisenkurs EUR / USD 1,2095
                 // Devisenkursdatum 02.01.2018
                 // Ausschüttung 113,16 USD 93,56+ EUR
-                .section("exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
-                .match("^Devisenkurs .* (?<exchangeRate>[\\.,\\d]+)$")
+                .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
+                .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
                 .match("^(Aussch.ttung|Dividendengutschrift) (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
@@ -257,17 +257,38 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                 .section("fxCurrency", "exchangeRate", "gross", "currency").optional()
                 .match("^[\\w]{12} (\\-)?[\\.,\\d]+ [\\.,\\d]+ (?<fxCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+) (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
+
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
+
+                    checkAndSetGrossUnit(gross, fxGross, t, type);
+                })
+
+                // ISIN Anteilsbestand Betrag je Anteil Betrag
+                // GB00B0MY6T00 300,991871 0,012407000 GBP 3,73 GBP
+                // Kapitalertragsteuer Solidaritätszuschlag Kirchensteuer Devisenkurs abzgl. Steuern
+                // 0,73 EUR 0,04 EUR 0,00 EUR 0,899700 0,70 GBP
+                // Zahlungsbetrag 3,03 GBP
+                .section("gross", "currency", "exchangeRate", "fxCurrency").optional()
+                .find("ISIN Anteilsbestand Betrag je Anteil Betrag")
+                .match("^.* [\\.,\\d]+ [\\.,\\d]+ [\\w]{3} (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .find("Kapitalertragsteuer Solidarit.tszuschlag Kirchensteuer Devisenkurs abzgl\\. Steuern")
+                .match("^[\\.,\\d]+ (?<fxCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ [\\w]{3} (?<exchangeRate>[\\.,\\d]+) [\\.,\\d]+ [\\w]{3}$")
+                .match("^Zahlungsbetrag [\\.,\\d]+ [\\w]{3}$")
+                .assign((t, v) -> {
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
+
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+
+                    Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -319,12 +340,11 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Fondsertrag .*$", "^(Zahlungsbetrag nach|Zahlungsbetrag(?! in)|Die Auszahlung|Summe der belasteten) .*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Fondsertrag (Ausschüttung) mit Bestandsdatum 11.12.2019 in Depotposition 1234567890.31
@@ -389,19 +409,14 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                 .match("^.* [\\.,\\d]+ [\\.,\\d]+ [\\w]{3} (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                 .match("^Zahlungsbetrag nach W.hrungskonvertierung .* (?<exchangeRate>[\\.,\\d]+) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
+import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -23,7 +25,6 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 {
-
     public FinTechGroupBankPDFExtractor(Client client)
     {
         super(client);
@@ -58,14 +59,6 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             BuySellEntry entry = new BuySellEntry();
             entry.setType(PortfolioTransaction.Type.BUY);
-
-            /***
-             * If we have multiple entries in the document,
-             * with taxes and tax refunds,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -116,15 +109,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "notation")
                 .match("^Ausgef.hrt ([:\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>St\\.|[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("St."))
-                    {
-                        // Prozent-Notierung, Workaround..
+                    // Prozent-Notierung, Workaround..
+                    if (v.get("notation") != null && !v.get("notation").startsWith("St"))
                         t.setShares((asShares(v.get("shares")) / 100));
-                    }
                     else
-                    {
                         t.setShares(asShares(v.get("shares")));
-                    }
                 })
 
                 // An den  Ausführungszeit   13:59 Häusern 5 
@@ -145,7 +134,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     else
                         t.setDate(asDate(v.get("date")));
                 })
-                
+
                 // Devisenkurs   :        1,000000         Eigene Spesen :               0,00 EUR
                 .section("exchangeRate").optional()
                 .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
@@ -192,74 +181,237 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Gewinn/Verlust 0,00 EUR              **Einbeh. Steuer EUR                -1,00
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust 0,00 EUR              **Einbeh. Steuer EUR                -1,00
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Gewinn/Verlust            0,00 EUR    **Einbeh. Steuer                -1,00 EUR
                 .section("taxRefund", "currency").optional()
+                .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust            0,00 EUR    **Einbeh. Steuer                -1,00 EUR
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. Steuer ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Gewinn/Verlust:            0,00 EUR   **Einbeh. Steuer:              -1,00 EUR
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
                 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust:            0,00 EUR   **Einbeh. Steuer:              -1,00 EUR
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Gewinn/Verlust 0,00 EUR              **Einbeh. KESt   EUR                -1,00
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. KESt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust 0,00 EUR              **Einbeh. KESt   EUR                -1,00
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. KESt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :            -305,85 EUR
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. KESt([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Gewinn/Verlust:        1.112,18 EUR   **Einbeh. KESt  :            -305,85 EUR
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. KESt([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 //                                     ***Einbeh. SichSt EUR                -1,00
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*\\*Einbeh\\. SichSt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 //                                     ***Einbeh. SichSt EUR                -1,00
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([:\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*\\*Einbeh\\. SichSt ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+)$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 //   unter der Transaktion-Nr.: 132465978
                 //   unter der Transaktion-Nr. : 1111111111
@@ -282,6 +434,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document,
+                     * then the "negative" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
                     if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
                     {
                         if (t.getPortfolioTransaction().getNote() == null || !t.getPortfolioTransaction().getNote().equals(Messages.MsgErrorOrderCancellationUnsupported))
@@ -295,40 +453,6 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
         addTaxReturnBlock(type);
-    }
-
-    private void extractTaxRefundDifferentCurrency(BuySellEntry t, Map<String, String> v)
-    {
-        if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
-        {
-            Money taxRefundFX = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
-
-            BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
-            taxRefundFX = Money.of(t.getPortfolioTransaction().getCurrencyCode(),
-                            BigDecimal.valueOf(taxRefundFX.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
-
-            v.put("taxRefund", BigDecimal.valueOf(taxRefundFX.getAmount(), 2).toString().replace('.', ','));
-            addTaxRefund(t, v);
-        }
-    }
-
-    private void extractTaxRefundSameCurrency(BuySellEntry t, Map<String, String> v)
-    {
-        if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
-        {
-            addTaxRefund(t, v);
-        }
-    }
-
-    private void addTaxRefund(BuySellEntry t, Map<String, String> v)
-    {
-        // For SELL transaction we need to subtract refunded taxes.
-        // For BUY transactions we need to add refunded taxes.
-        int negative = t.getPortfolioTransaction().getType() == PortfolioTransaction.Type.SELL ? -1 : 1;
-        t.setAmount(t.getPortfolioTransaction().getAmount() + negative * asAmount(v.get("taxRefund")));
     }
 
     private void addSummaryStatementBuySellTransaction()
@@ -413,14 +537,40 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 // Lagerland    : Deutschland           **Einbeh. Steuer :            -100,00 EUR
                 .section("taxRefund", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundSameCurrency)
+                .assign((t, v) -> {
+                    if (t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 // Devisenkurs   : 1,192200(x)             Provision     :
                 // Lagerland    : Deutschland           **Einbeh. Steuer :            -100,00 EUR
                 .section("taxRefund", "currency", "exchangeRate").optional()
                 .match("^Devisenkurs ([\\s]+)?: (?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign(this::extractTaxRefundDifferentCurrency)
+                .assign((t, v) -> {
+                    if (!t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
+                    {
+                        Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
+
+                        BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+
+                        Money taxRefund = Money.of(t.getPortfolioTransaction().getCurrencyCode(), BigDecimal.valueOf(fxTaxRefund.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+
+                        if (t.getPortfolioTransaction().getType().isLiquidation())
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
+                        else
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().add(taxRefund));
+                    }
+                })
 
                 //   unter der Transaktion-Nr.: 132465978
                 //   unter der Transaktion-Nr. : 1111111111
@@ -450,20 +600,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividendengutschrift|Ertragsmitteilung|Zinsgutschrift)( .*)?$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-
-                /***
-                 * If we have multiple entries in the document,
-                 * with taxes and tax refunds,
-                 * then the "negative" flag must be removed.
-                 */
-                type.getCurrentContext().remove("negative");
-
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Nr.716759781                   HANN.RUECK SE NA O.N.     (DE0008402215/840221)
@@ -564,25 +705,40 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         })
                         )
 
-                // Extag : 08.08.2017 Bruttodividende : 26,25 USD
-                // Devisenkurs     :    1,180800         *Einbeh. Steuer  :         1,11 EUR
-                .section("fxGross", "fxCurrency", "exchangeRate").optional()
+                // Extag           :      20.05.2020      Bruttodividende :           25,50 USD
+                //                                       *Einbeh. Steuer  :            2,37 EUR
+                // Devisenkurs     :        1,134800
+                .section("fxGross", "fxCurrency", "exchangeRate", "currency").optional()
                 .match("^(.* )?(Bruttoaussch.ttung|Bruttodividende|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^.*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(t.getCurrencyCode()),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
+
+                    checkAndSetGrossUnit(gross, fxGross, t, type);
+                })
+
+                // Extag           :  08.08.2017          Bruttodividende :        26,25 USD
+                // Devisenkurs     :    1,180800         *Einbeh. Steuer  :         1,11 EUR
+                .section("fxGross", "fxCurrency", "exchangeRate", "currency").optional()
+                .match("^(.* )?(Bruttoaussch.ttung|Bruttodividende|Bruttothesaurierung)([\\s]+)?: ([\\s]+)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
+                .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+) .*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?[\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .assign((t, v) -> {
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
+
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
+
+                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -602,6 +758,13 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setNote(trim(v.get("note1")) + " " + trim(v.get("note2"))))
 
                 .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document, with
+                     * taxes and tax refunds, then the "negative" flag
+                     * must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)
                         return new TransactionItem(t);
                     return null;
@@ -620,20 +783,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Ertragsmitteilung \\- (aussch.ttender\\/teil)?thesaurierender( transparenter)? Fonds$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.TAXES);
-
-                /***
-                 * If we have multiple entries in the document,
-                 * with taxes and tax refunds,
-                 * then the "negative" flag must be removed.
-                 */
-                type.getCurrentContext().remove("negative");
-
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.TAXES);
+            return entry;
+        });
 
         pdfTransaction
                 // Nr.1784953069                  PICTET-GL.MEGAT.SEL.P EO  (LU0386882277/A0RLJD)
@@ -672,17 +826,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^(.* )?Devisenkurs([\\s]+)?: ([\\s]+)?(?<exchangeRate>[\\.,\\d]+).*$")
                 .match("^.* Endbetrag([\\s]+)?: ([\\s]+)?\\-(?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
+
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -722,15 +873,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
             {
                 Matcher m = pYear.matcher(line);
                 if (m.matches())
-                {
                     context.put("year", m.group("year"));
-                }
 
                 m = pCurrency.matcher(line);
                 if (m.matches())
-                {
                     context.put("currency", m.group("currency"));
-                }
             }
         });
         this.addDocumentTyp(type);
@@ -749,18 +896,16 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("date", "note", "amount", "sign")
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>.berweisung) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+
                     // Is sign --> "-" change from DEPOSIT to REMOVAL
                     if (v.get("sign").equals("-"))
-                    {
                         t.setType(AccountTransaction.Type.REMOVAL);
-                    }
-
-                    Map<String, String> context = type.getCurrentContext();
+                    
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
+
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
                     t.setNote(v.get("note"));
@@ -782,18 +927,16 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("date", "note", "amount", "sign")
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>(EINZAHLUNG|AUSZAHLUNG)) .* ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+
                     // Is sign --> "-" change from DEPOSIT to REMOVAL
                     if (v.get("sign").equals("-"))
-                    {
                         t.setType(AccountTransaction.Type.REMOVAL);
-                    }
 
-                    Map<String, String> context = type.getCurrentContext();
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
+
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
                     t.setNote(v.get("note"));
@@ -816,11 +959,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>R-Transaktion)  ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
+
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
+
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
                     t.setNote(v.get("note"));
@@ -842,11 +985,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Lastschrift) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
+
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
+
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
                     t.setNote(v.get("note"));
@@ -869,11 +1012,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Depotgeb.hren[ ]+[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\- [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
+
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
+
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
                     t.setNote(v.get("note"));
@@ -899,18 +1042,15 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("date", "note", "amount", "sign")
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Zinsabschluss ([\\s]+)?+([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\- ([\\d]{2}\\.[\\d]{2}\\.[\\d]{4})) ([\\s]+)?+(?<amount>[\\-\\.,\\d]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+
                     // Is sign --> "+" change from INTEREST_CHARGE to INTEREST
                     if (v.get("sign").equals("+"))
-                    {
                         t.setType(AccountTransaction.Type.INTEREST);
-                    }
 
-                    Map<String, String> context = type.getCurrentContext();
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
@@ -936,18 +1076,15 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("date", "note", "amount", "sign")
                 .match("^[\\d]{2}\\.[\\d]{2}\\. ([\\s]+)?+(?<date>[\\d]{2}\\.[\\d]{2}\\.) ([\\s]+)?+(?<note>Steuertopfoptimierung ([\\s]+)?+([\\d]{4})) ([\\s]+)?+(?<amount>[\\.,\\d\\-]+)(?<sign>[\\+|\\-])$")
                 .assign((t, v) -> {
+                    Map<String, String> context = type.getCurrentContext();
+
                     // Is sign --> "-" change from TAX_REFUND to TAXES
                     if (v.get("sign").equals("-"))
-                    {
                         t.setType(AccountTransaction.Type.TAXES);
-                    }
 
-                    Map<String, String> context = type.getCurrentContext();
+                    // create a long date from the year in the context
                     if (v.get("date") != null)
-                    {
-                        // create a long date from the year in the context
                         t.setDateTime(asDate(v.get("date") + context.get("year")));
-                    }
 
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
@@ -970,9 +1107,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
             {
                 Matcher m = pDate.matcher(line);
                 if (m.matches())
-                {
                     context.put("date", m.group("date"));
-                }
             }
         });
         this.addDocumentTyp(type);
@@ -1021,15 +1156,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "notation").optional()
                 .match("^Stk?\\.\\/Nominale([\\*\\s]+)?: ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>St\\.|[\\w]{3})(.*)$")
                 .assign((t, v) -> {
-                    if (v.get("notation") != null && !v.get("notation").toLowerCase().startsWith("st"))
-                    {
-                        // Prozent-Notierung, Workaround..
+                    // Prozent-Notierung, Workaround..
+                    if (v.get("notation") != null && !v.get("notation").startsWith("St"))
                         t.setShares((asShares(v.get("shares")) / 100));
-                    }
                     else
-                    {
                         t.setShares(asShares(v.get("shares")));
-                    }
                 })
 
                 // Fälligkeitstag   : 02.12.2009                  Letzter Handelstag:  20.11.2009
@@ -1071,16 +1202,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //                                           Einbeh. Steuer**:         -10,00 EUR
                 .section("taxRefund").optional()
                 .match("^.* Einbeh\\. Steuer[\\*\\s]+: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
-                .assign((t, v) -> {
-                    t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund")));
-                })
+                .assign((t, v) -> t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund"))))
 
                 // Einbeh. Steuer**                                                    -88,53 EUR
                 .section("taxRefund").optional()
                 .match("^Einbeh\\. Steuer[\\*\\s]+ \\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
-                .assign((t, v) -> {
-                    t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund")));
-                })
+                .assign((t, v) -> t.setAmount(t.getPortfolioTransaction().getAmount() - asAmount(v.get("taxRefund"))))
 
                 //   unter der Transaktion-Nr.: 132465978
                 //   unter der Transaktion-Nr. : 1111111111
@@ -1131,15 +1258,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "notation")
                 .match("^Stk\\.\\/Nominale([\\s]+)?: ([\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>St\\.|[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stk"))
-                    {
-                        // Prozent-Notierung, Workaround..
+                    // Prozent-Notierung, Workaround..
+                    if (v.get("notation") != null && !v.get("notation").startsWith("St"))
                         t.setShares((asShares(v.get("shares")) / 100));
-                    }
                     else
-                    {
                         t.setShares(asShares(v.get("shares")));
-                    }
                 })
 
                 // Datum : 16.03.2015
@@ -1167,9 +1290,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 //                                           Einbeh. Steuer**:          -1,00 EUR
                 .section("taxRefund").optional()
                 .match("^.* Einbeh\\. Steuer[\\*\\s]+: ([\\s]+)?\\-(?<taxRefund>[\\.,\\d]+) [\\w]{3}$")
-                .assign((t, v) -> {
-                    t.setAmount(t.getAmount() - asAmount(v.get("taxRefund")));
-                })
+                .assign((t, v) -> t.setAmount(t.getAmount() - asAmount(v.get("taxRefund"))))
 
                 //   unter der Transaktion-Nr.: 132465978
                 //   unter der Transaktion-Nr. : 1111111111
@@ -1299,15 +1420,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "notation")
                 .match("^Ausgef.hrt ([:\\s]+)?(?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>(St\\.|[\\w]{3})).*$")
                 .assign((t, v) -> {
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("St."))
-                    {
-                        // Prozent-Notierung, Workaround..
+                    // Prozent-Notierung, Workaround..
+                    if (v.get("notation") != null && !v.get("notation").startsWith("St"))
                         t.setShares((asShares(v.get("shares")) / 100));
-                    }
                     else
-                    {
                         t.setShares(asShares(v.get("shares")));
-                    }
                 })
 
                 // An den  Ausführungszeit   13:59 Häusern 5 
@@ -1384,18 +1501,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
                         BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
-                        fxAmount = Money.of(v.get("fxCurrency"),
-                                        BigDecimal.valueOf(fxAmount.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                        Money amount = Money.of(t.getCurrencyCode(), BigDecimal.valueOf(fxAmount.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("fxCurrency", t.getCurrencyCode());
-                        v.put("fxAmount", BigDecimal.valueOf(fxAmount.getAmount(), 2).toString().replace('.', ','));
-
-                        t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
-                        t.setAmount(asAmount(v.get("fxAmount")));
+                        t.setMonetaryAmount(amount);
                     }
                 })
 
@@ -1419,18 +1530,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                     {
                         Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
+
                         BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
-                        fxAmount = Money.of(v.get("fxCurrency"), 
-                                        BigDecimal.valueOf(fxAmount.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                        Money amount = Money.of(t.getCurrencyCode(), BigDecimal.valueOf(fxAmount.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("fxCurrency", t.getCurrencyCode());
-                        v.put("fxAmount", BigDecimal.valueOf(fxAmount.getAmount(), 2).toString().replace('.', ','));
-                        t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
-                        t.setAmount(asAmount(v.get("fxAmount")));
+                        t.setMonetaryAmount(amount);
                     }
                 })
 
@@ -1521,18 +1628,12 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
                         BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                        type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                        BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
-                        fxAmount = Money.of(v.get("fxCurrency"), 
-                                        BigDecimal.valueOf(fxAmount.getAmount()).multiply(exchangeRate)
-                                            .setScale(0, RoundingMode.HALF_UP).longValue());
+                        Money amount = Money.of(t.getCurrencyCode(), BigDecimal.valueOf(fxAmount.getAmount())
+                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
 
-                        v.put("fxCurrency", t.getCurrencyCode());
-                        v.put("fxAmount", BigDecimal.valueOf(fxAmount.getAmount(), 2).toString().replace('.', ','));
-
-                        t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
-                        t.setAmount(asAmount(v.get("fxAmount")));
+                        t.setMonetaryAmount(amount);
                     }
                 })
 
@@ -1598,15 +1699,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("shares", "notation").optional()
                 .match("^Stk\\.\\/Nominale([:\\s]+)? (?<shares>[\\.,\\d]+) ([\\s]+)?(?<notation>(St\\.|[\\w]{3})) .*$")
                 .assign((t, v) -> {
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stk"))
-                    {
-                        // Prozent-Notierung, Workaround..
+                    // Prozent-Notierung, Workaround..
+                    if (v.get("notation") != null && !v.get("notation").startsWith("St"))
                         t.setShares((asShares(v.get("shares")) / 100));
-                    }
                     else
-                    {
                         t.setShares(asShares(v.get("shares")));
-                    }
                 })
 
                 // Fälligkeitstag   : 02.12.2009                  Letzter Handelstag:  20.11.2009
@@ -1670,23 +1767,22 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
 
@@ -1696,20 +1792,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
 
@@ -1719,20 +1815,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
                 
@@ -1742,20 +1838,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
 
@@ -1765,20 +1861,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
 
@@ -1788,20 +1884,20 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
                     {
-                        if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                        Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+
+                        if (!tax.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                         {
-                            Money taxFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
+                            Money fxTax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
                             BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                            taxFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                            BigDecimal.valueOf(taxFX.getAmount()).multiply(exchangeRate)
+                            tax = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                            BigDecimal.valueOf(fxTax.getAmount()).multiply(exchangeRate)
                                                 .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                            v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                            v.put("tax", BigDecimal.valueOf(taxFX.getAmount(), 2).toString().replace('.', ','));
                         }
-                        processTaxEntries(t, v, type);
+
+                        checkAndSetTax(tax, t, type);
                     }
                 })
 
@@ -1810,9 +1906,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* \\*Einbeh\\. Steuer([\\s]+)?: ([\\s]+)?(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
                         processTaxEntries(t, v, type);
-                    }
                 })
 
                 // Quellenst.-satz :           15,00 %    Gez. Quellenst. :            1,15 USD
@@ -1820,9 +1914,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* Gez\\. Quellenst\\.([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
-                    }
                 })
 
                 // Quellenst.-satz :            15,00 %  Gez. Quellensteuer :           18,28 USD
@@ -1830,9 +1922,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* Gez\\. Quellensteuer([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
-                    }
                 })
 
                 // Stk./Nominale  : 325,000000 Stk         Einbeh. Steuer*:            382,12 EUR
@@ -1840,9 +1930,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* Einbeh\\. Steuer\\*([\\s]+)?: ([\\s]+)?(?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("negative")))
-                    {
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
-                    }
                 });
     }
 
@@ -1857,60 +1945,60 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Provision([\\s]+)?: ([\\s]+)?(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    Money fee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+
+                    if (!fee.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                     {
-                        Money feeFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+                        Money fxFee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
 
                         BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        feeFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(feeFX.getAmount()).multiply(exchangeRate)
+                        fee = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                        BigDecimal.valueOf(fxFee.getAmount()).multiply(exchangeRate)
                                             .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("fee", BigDecimal.valueOf(feeFX.getAmount(), 2).toString().replace('.', ','));
                     }
-                    processFeeEntries(t, v, type);
+
+                    checkAndSetFee(fee, t, type);
                 })
 
                 // Devisenkurs                            Provision      EUR                 5,90
                 .section("fee", "currency").optional()
                 .match("^.* Provision ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    Money fee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+
+                    if (!fee.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                     {
-                        Money feeFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+                        Money fxFee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
 
                         BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        feeFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(feeFX.getAmount()).multiply(exchangeRate)
+                        fee = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                        BigDecimal.valueOf(fxFee.getAmount()).multiply(exchangeRate)
                                             .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("fee", BigDecimal.valueOf(feeFX.getAmount(), 2).toString().replace('.', ','));
                     }
-                    processFeeEntries(t, v, type);
+
+                    checkAndSetFee(fee, t, type);
                 })
 
                 // Kurs                 20,835000 EUR      Provision                     5,90 EUR
                 .section("fee", "currency").optional()
                 .match("^.* Provision ([\\s]+)?(?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode().contentEquals(v.get("currency")))
+                    Money fee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+
+                    if (!fee.getCurrencyCode().equals(((name.abuchen.portfolio.model.BuySellEntry) t).getPortfolioTransaction().getCurrencyCode()))
                     {
-                        Money feeFX = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
+                        Money fxFee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
 
                         BigDecimal exchangeRate = new BigDecimal(type.getCurrentContext().get("exchangeRate"));
 
-                        feeFX = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
-                                        BigDecimal.valueOf(feeFX.getAmount()).multiply(exchangeRate)
+                        fee = Money.of(((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode(),
+                                        BigDecimal.valueOf(fxFee.getAmount()).multiply(exchangeRate)
                                             .setScale(0, RoundingMode.HALF_UP).longValue());
-
-                        v.put("currency", ((BuySellEntry) t).getPortfolioTransaction().getCurrencyCode());
-                        v.put("fee", BigDecimal.valueOf(feeFX.getAmount(), 2).toString().replace('.', ','));
                     }
-                    processFeeEntries(t, v, type);
+
+                    checkAndSetFee(fee, t, type);
                 })
 
                 // Bew-Faktor   : 1,0000                  Eigene Spesen  :               1,00 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -5,7 +5,6 @@ import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAnd
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -142,16 +141,13 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
                 // Kurswert USD 1.503,75
                 // umger. zum Devisenkurs EUR 1.311,99 (USD = 1,146163)
-                .section("fxCurrency", "fxGross", "currency", "gross", "exchangeRate").optional()
+                // Endbetrag zu Ihren Lasten EUR 1.335,07
+                .section("fxCurrency", "fxGross", "currency", "baseCurrency", "gross", "termCurrency", "exchangeRate").optional()
                 .match("^Kurswert (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)$")
-                .match("^.* Devisenkurs (?<currency>[\\w]{3}) (?<gross>[\\.,\\d]+) \\([\\w]{3} = (?<exchangeRate>[\\.,\\d]+)\\)$")
-                .assign((t, v) -> {                   
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                .match("^.* Devisenkurs (?<baseCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+) \\((?<termCurrency>[\\w]{3}) = (?<exchangeRate>[\\.,\\d]+)\\)$")
+                .match("^Endbetrag( zu Ihren (Lasten|Gunsten))? (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                .assign((t, v) -> {
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -183,12 +179,11 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividendengutschrift|Ertragsgutschrift|Zinsgutschrift).*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // ISIN (WKN) US5801351017 (856958)
@@ -268,19 +263,14 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .match("^Brutto (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)")
                 .match("^Umg\\. z\\. Dev\\.\\-Kurs \\((?<exchangeRate>[\\.,\\d]+)\\) (?<currency>[\\w]{3}) [\\.,\\d]+$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(type.getCurrentContext().get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -338,10 +328,6 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .match("^Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                /***
-                 * Is the amount negative, 
-                 * then change from TAXES to TAX_REFUND
-                 */
                 // Gesamtbetrag zu Ihren Lasten EUR - 0,16
                 .section("currency", "sign", "amount")
                 .match("^Gesamtbetrag zu Ihren Lasten (?<currency>[\\w]{3}) (?<sign>[\\-\\s]+)?(?<amount>[.,\\d]+)$")
@@ -349,6 +335,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
+                    // Is sign --> "-" change from TAXES to TAX_REFUND
                     if ("".equals(trim(v.get("sign"))))
                         t.setType(AccountTransaction.Type.TAX_REFUND);
                 })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -184,12 +184,11 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividende [^pro]).*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Produktbezeichnung - Kellogg Co.:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -72,7 +72,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
                 .section("date", "time")
                 .match("^Abschlussdatum (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})$")
                 .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
-    
+
                 // Belastung DKK Konto 0037156.021 DKK 82'452.21
                 .section("currency", "amount")
                 .match("^Belastung [\\w]{3} Konto .* (?<currency>[\\w]{3}) (?<amount>[\\.',\\d]+)$")
@@ -85,13 +85,12 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
                 .section("note").optional()
                 .match("^(?<note>Valorennummer .*)$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
-    
+
                 .wrap(BuySellEntryItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
     }
-
 
     private void addDividendeTransaction()
     {
@@ -100,12 +99,11 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Baraussch.ttung .*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // 551 Veolia Environnement SA
@@ -173,7 +171,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^Courtage ([\\s]+)?(?<currency>[\\w]{3}) (?<fee>[\\.,'\\d]+)$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
-        
+
                 // Broker Kommission  DKK 12.12
                 .section("fee", "currency").optional()
                 .match("^Broker Kommission ([\\s]+)?(?<currency>[\\w]{3}) (?<fee>[\\.,'\\d]+)$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -3,8 +3,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -107,23 +105,19 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
                 })
 
+                // Ausführungskurs 167,82 USD
                 // Devisenkurs (EUR/USD) 1,141 vom 18.02.2022
                 // Kurswert 24.013,85 EUR
-                .section("fxCurrency", "exchangeRate", "gross", "currency").optional()
-                .match("^Devisenkurs \\([\\w]{3}\\/(?<fxCurrency>[\\w]{3})\\) (?<exchangeRate>[\\.,\\d]+) .*$")
+                .section("fxCurrency", "baseCurrency", "termCurrency", "exchangeRate", "gross", "currency").optional()
+                .match("^Ausf.hrungskurs [\\.,\\d]+ (?<fxCurrency>[\\w]{3})")
+                .match("^Devisenkurs \\((?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3})\\) (?<exchangeRate>[\\.,\\d]+) .*$")
                 .match("^Kurswert (?<gross>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")),
-                                    BigDecimal.valueOf(gross.getAmount()).multiply(exchangeRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money fxGross = rate.convert(asCurrencyCode(v.get("fxCurrency")), gross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -207,16 +201,11 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs EUR / USD 1,2095
                 // Ausschüttung 113,16 USD 93,56+ EUR
-                .section("exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
-                .match("^Devisenkurs .* (?<exchangeRate>[\\.,\\d]+)$")
+                .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
+                .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
                 .match("^(Aussch.ttung|Dividendengutschrift) (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -5,7 +5,6 @@ import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -115,19 +114,14 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 .match("^Wechselkurs (?<exchangeRate>[\\.,'\\d\\s]+).*$")
                 .match("^Zu Ihren (Lasten|Gunsten) (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("fxCurrency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("currency")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -138,6 +132,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 .conclude(PDFExtractorUtils.fixGrossValueBuySell())
+
                 .wrap(BuySellEntryItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -188,23 +183,15 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
                 // Kurswert in Handelswährung JPY 34 019.00 
                 // Total in Kontowährung zum Kurs von JPY/CHF 0.0082450 CHF 280.91 
-                .section("fxCurrency", "fxGross", "currency", "exchangeRate").optional()
+                .section("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency").optional()
                 .match("^Kurswert in Handelsw.hrung (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d\\s]+).*$")
-                .match("^Total in Kontow.hrung zum Kurs von [\\w]{3}\\/(?<currency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) [\\w]{3} [\\.,'\\d\\s]+.*$")
+                .match("^Total in Kontow.hrung zum Kurs von (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d\\s]+) (?<currency>[\\w]{3}) [\\.,'\\d\\s]+.*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -227,12 +214,11 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividende|Kapitalgewinn) Unsere Referenz: .*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // ISIN: NL0000009355
@@ -945,21 +931,21 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
     }
 
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll(" ", "");
+        value = value.trim().replaceAll("\\s", "");
         return PDFExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -3,8 +3,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -131,19 +129,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .match("^Kurswert: (\\-)?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
                 .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    v.put("baseCurrency", asCurrencyCode(v.get("currency")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -166,12 +159,11 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Gesch.ftsart: Ertrag|Dividendengutschrift)$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Titel: DE000BAY0017 Bayer AG
@@ -241,16 +233,11 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
                 // Devisenkurs EUR / USD  1,1360
                 // Dividendengutschrift 68,00 USD 59,86+ EUR
-                .section("exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
-                .match("^Devisenkurs [\\w]{3} \\/ [\\w]{3} ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)$")
+                .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
+                .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) ([\\s]+)?(?<exchangeRate>[\\.,\\d]+)$")
                 .match("^Dividendengutschrift (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -2,8 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,12 +74,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (v.get("type").equals("Verkauf"))
                         t.setType(PortfolioTransaction.Type.SELL);
-
-                    /***
-                     * If we have multiple entries in the document,
-                     * then the "negative" flag must be removed.
-                     */
-                    type.getCurrentContext().remove("negative");
                 })
 
                 // Clinuvel Pharmaceuticals Ltd. 80 Stk. 22,82 EUR 1.825,60 EUR
@@ -229,27 +221,21 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 // 1 Bruttoertrag 26,80 GBP
                 // 2 Barausgleich 0,37 GBP
                 // Zwischensumme 0,85267 EUR/GBP 0,44 EUR
-                .section("amount1", "currency1", "amount2", "currency2", "exchangeRate", "fxCurrency", "currency").optional()
-                .match("^[\\d] Bruttoertrag (?<amount1>[\\.,\\d]+) (?<currency1>[\\w]{3})$")
-                .match("^[\\d] Barausgleich (?<amount2>[\\.,\\d]+) (?<currency2>[\\w]{3})$")
-                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) [\\w]{3}\\/(?<fxCurrency>[\\w]{3}) [\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .section("gross", "grossCurrency", "cashCompensation", "cashCompensationCurrency", "exchangeRate", "baseCurrency", "fxCurrency", "currency").optional()
+                .match("^[\\d] Bruttoertrag (?<gross>[\\.,\\d]+) (?<grossCurrency>[\\w]{3})$")
+                .match("^[\\d] Barausgleich (?<cashCompensation>[\\.,\\d]+) (?<cashCompensationCurrency>[\\w]{3})$")
+                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})\\/(?<fxCurrency>[\\w]{3}) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    Money amount1 = Money.of(asCurrencyCode(v.get("currency1")), asAmount(v.get("amount1")));
-                    Money amount2 = Money.of(asCurrencyCode(v.get("currency2")), asAmount(v.get("amount2")));
+                    v.put("termCurrency", asCurrencyCode(v.get("fxCurrency")));
 
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    Money grossValueBasis = Money.of(asCurrencyCode(v.get("grossCurrency")), asAmount(v.get("gross")));
+                    Money cashCompensationValue = Money.of(asCurrencyCode(v.get("cashCompensationCurrency")), asAmount(v.get("cashCompensation")));
 
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
-                    Money fxGross = amount1.subtract(amount2);
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money fxGross = grossValueBasis.subtract(cashCompensationValue);
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     t.setAmount(gross.getAmount());
                     t.setCurrencyCode(asCurrencyCode(gross.getCurrencyCode()));
@@ -295,7 +281,15 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                     t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(tax));
                 })
 
-                .wrap(BuySellEntryItem::new);
+                .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document,
+                     * then the "negative" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
+                    return new BuySellEntryItem(t);
+                });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
@@ -311,13 +305,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             BuySellEntry entry = new BuySellEntry();
             entry.setType(PortfolioTransaction.Type.SELL);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -384,13 +371,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.DIVIDENDS);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -476,23 +456,15 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                 // GESAMT 5,63 USD
                 // Zwischensumme 1,102 EUR/USD 5,11 EUR
-                .section("fxGross", "fxCurrency", "exchangeRate", "currency").optional()
+                .section("fxGross", "fxCurrency", "exchangeRate", "baseCurrency", "termCurrency", "currency").optional()
                 .match("^GESAMT (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) [\\w]{3}\\/[\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3})$")
+                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -500,23 +472,15 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 // 1 Bruttoertrag 26,80 GBP
                 // Zwischensumme 0,85267 EUR/GBP 0,44 EUR
                 // GESAMT 0,44 EUR
-                .section("fxGross", "currency", "fxCurrency", "exchangeRate").optional()
+                .section("fxGross", "fxCurrency", "exchangeRate", "baseCurrency", "termCurrency", "currency").optional()
                 .match("^[\\d] Bruttoertrag (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3})\\/[\\w]{3} [\\.,\\d]+ [\\w]{3}$")
+                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     t.setAmount(gross.getAmount());
                     t.setCurrencyCode(asCurrencyCode(gross.getCurrencyCode()));
@@ -525,6 +489,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .conclude(PDFExtractorUtils.fixGrossValueA())
+
                 .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -544,13 +509,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.DIVIDENDS);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -585,16 +543,11 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                 // 1 Barausgleich 1,18 USD
                 // Zwischensumme 1,102 EUR/USD 5,11 EUR
-                .section("fxGross", "fxCurrency","exchangeRate", "gross", "currency").optional()
+                .section("fxGross", "fxCurrency","exchangeRate", "baseCurrency", "termCurrency", "gross", "currency").optional()
                 .match("^[\\d] Barausgleich (?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
-                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) [\\w]{3}\\/[\\w]{3} (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Zwischensumme (?<exchangeRate>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<gross>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -853,13 +806,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.TAX_REFUND);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -868,46 +814,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
-                // Kapitalertragssteuer Optimierung 3,75 EUR
-                .section("amount", "currency", "date").optional()
-                .match("^Kapitalertragssteuer Optimierung (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .find("VERRECHNUNGSKONTO VALUTA BETRAG")
-                .match("^.* (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) [\\.,\\d]+$")
-                .assign((t, v) -> {
-                    t.setAmount(asAmount(v.get("amount")));
-                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    t.setDateTime(asDate(v.get("date")));
-                })
-
                 // Kapitalertragsteuer Optimierung 3,75 EUR
-                .section("amount", "currency", "date").optional()
-                .match("^Kapitalertragsteuer Optimierung (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .section("amount", "currency", "date")
+                .match("^Kapitalertrags(s)?teuer Optimierung [\\.,\\d]+ (?<currency>[\\w]{3})$")
                 .find("VERRECHNUNGSKONTO VALUTA BETRAG")
-                .match("^.* (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) [\\.,\\d]+$")
+                .match("^.* (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) (?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
-                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    t.setDateTime(asDate(v.get("date")));
-                })
-
-                // Solidaritätszuschlag Optimierung 0,21 EUR
-                .section("amount", "currency", "date")
-                .match("^Solidarit.tszuschlag Optimierung (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .find("VERRECHNUNGSKONTO VALUTA BETRAG")
-                .match("^.* (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) [\\.,\\d]+$")
-                .assign((t, v) -> {
-                    t.setAmount(t.getAmount() + asAmount(v.get("amount")));
-                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    t.setDateTime(asDate(v.get("date")));
-                })
-
-                // Kirchensteuer Optimierung 0,30 EUR
-                .section("amount", "currency", "date").optional()
-                .match("^Kirchensteuer Optimierung (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .find("VERRECHNUNGSKONTO VALUTA BETRAG")
-                .match("^.* (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) [\\.,\\d]+$")
-                .assign((t, v) -> {
-                    t.setAmount(t.getAmount() + asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setDateTime(asDate(v.get("date")));
                 })
@@ -924,13 +837,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.TAXES);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return entry;
         });
 
@@ -978,13 +884,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 .subject(() -> {
                     AccountTransaction t = new AccountTransaction();
                     t.setType(AccountTransaction.Type.TAX_REFUND);
-
-                    /***
-                     * If we have multiple entries in the document,
-                     * then the "negative" flag must be removed.
-                     */
-                    type.getCurrentContext().remove("negative");
-
                     return t;
                 })
 
@@ -1058,13 +957,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 .subject(() -> {
                     AccountTransaction t = new AccountTransaction();
                     t.setType(AccountTransaction.Type.TAX_REFUND);
-
-                    /***
-                     * If we have multiple entries in the document,
-                     * then the "negative" flag must be removed.
-                     */
-                    type.getCurrentContext().remove("negative");
-
                     return t;
                 })
 
@@ -1123,7 +1015,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
     private void addSellWithNegativeAmountTransaction()
     {
-
         DocumentType type = new DocumentType("Verkauf");
         this.addDocumentTyp(type);
 
@@ -1133,13 +1024,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         pdfTransaction.subject(() -> {
             AccountTransaction t = new AccountTransaction();
             t.setType(AccountTransaction.Type.FEES);
-
-            /***
-             * If we have multiple entries in the document,
-             * then the "negative" flag must be removed.
-             */
-            type.getCurrentContext().remove("negative");
-
             return t;
         });
 
@@ -1181,7 +1065,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                 // Fremdkostenzuschlag -1,00 EUR
                 .section("currency", "amount").optional()
-                .match("^Fremdkostenzuschlag -(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                .match("^Fremdkostenzuschlag \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {                            
                     if ("X".equals(type.getCurrentContext().get("negative")))
                     {
@@ -1191,6 +1075,12 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .wrap(t -> {
+                    /**
+                     * If we have multiple entries in the document,
+                     * then the "negative" flag must be removed.
+                     */
+                    type.getCurrentContext().remove("negative");
+
                     if (t.getCurrencyCode() != null && t.getAmount() != 0)
                         return new TransactionItem(t);
                     return null;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
@@ -2,9 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAndSetGrossUnit;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -82,7 +79,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
                 // Ausmachender Betrag EUR - 11.116,97
                 // Ausmachender Betrag EUR 26.199,03
                 .section("currency", "amount")
-                .match("^Ausmachender Betrag (?<currency>[\\w]{3}) ([\\-\\s]+)?(?<amount>[\\.,\\d]+)")
+                .match("^Ausmachender Betrag (?<currency>[\\w]{3}) ([\\-\\s]+)?(?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -90,23 +87,17 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
 
                 // Kurswert USD - 16.136,00
                 // Devisenkurs EUR/USD 1,116670
-                .section("fxCurrency", "fxGross", "exchangeRate").optional()
+                // Ausmachender Betrag EUR - 14.480,11
+                .section("fxCurrency", "fxGross", "baseCurrency", "termCurrency", "exchangeRate", "currency").optional()
                 .match("^Kurswert (?<fxCurrency>[\\w]{3}) \\- (?<fxGross>[\\.,\\d]+)$")
-                .match("^Devisenkurs (?<currency>[\\w]{3})\\/[\\w]{3} (?<exchangeRate>[\\.,\\d]+)$")
+                .match("^Devisenkurs (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
+                .match("^Ausmachender Betrag (?<currency>[\\w]{3}) .*$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
-
-                    BigDecimal inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                    PDFExchangeRate rate = asExchangeRate(v);
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")),
-                                    BigDecimal.valueOf(fxGross.getAmount()).multiply(inverseRate)
-                                                    .setScale(0, RoundingMode.HALF_UP).longValue());
+                    Money gross = rate.convert(asCurrencyCode(v.get("currency")), fxGross);
 
                     checkAndSetGrossUnit(gross, fxGross, t, type);
                 })
@@ -124,13 +115,11 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^Ertr.gnisabrechnung$", "^Der Abrechnungsbetrag wird mit Valuta .*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction entry = new AccountTransaction();
-                            entry.setType(AccountTransaction.Type.DIVIDENDS);
-                            return entry;
-                        });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // Wertpapierbezeichnung OptoFlex Inhaber-Ant. P o.N.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -4,7 +4,6 @@ import static name.abuchen.portfolio.datatransfer.pdf.PDFExtractorUtils.checkAnd
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -52,20 +51,20 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
             return transaction;
         })
 
-                        .section("date", "amount", "currency")
-                        .find("(Einzahlung|Deposit) 3a")
-                        .match("^(Gutschrift: Valuta|Credit: Value date) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$")
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                        })
+                .section("date", "amount", "currency")
+                .find("(Einzahlung|Deposit) 3a")
+                .match("^(Gutschrift: Valuta|Credit: Value date) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$")
+                .assign((t, v) -> {
+                    t.setDateTime(asDate(v.get("date")));
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                })
 
-                        .section("note").optional()
-                        .match("^(Zahlungseingang von|Incoming payment from): (?<note>.*)$")
-                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+                .section("note").optional()
+                .match("^(Zahlungseingang von|Incoming payment from): (?<note>.*)$")
+                .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap(TransactionItem::new));
+                .wrap(TransactionItem::new));
     }
 
     private void addBuySellTransaction()
@@ -125,16 +124,11 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
                 // Betrag USD 359.27
                 // Umrechnungskurs CHF/USD 1.00195 CHF 359.98
-                .section("fxCurrency", "fxGross", "exchangeRate", "currency", "gross").optional()
+                .section("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency", "gross").optional()
                 .match("^(Betrag|Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d]+)$")
-                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
+                .match("^(Umrechnungskurs|Exchange rate) (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getPortfolioTransaction().getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -215,12 +209,11 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividendenart|Type of dividend): (Ordentliche Dividende|Ordinary dividend)$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
+            AccountTransaction entry = new AccountTransaction();
+            entry.setType(AccountTransaction.Type.DIVIDENDS);
+            return entry;
+        });
 
         pdfTransaction
                 // 47.817 Ant UBS ETF MSCI USA SRI
@@ -252,16 +245,11 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
                 // Betrag CAD 0.20
                 // Umrechnungskurs CHF/CAD 0.7466 CHF 0.15
-                .section("fxCurrency", "fxGross", "exchangeRate", "currency", "gross").optional()
+                .section("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency", "gross").optional()
                 .match("^(Betrag|Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d]+)$")
-                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3} (?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
+                .match("^(Umrechnungskurs|Exchange rate) (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}) (?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -272,17 +260,12 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                 // Betrag USD 34.26
                 // Umrechnungskurs CHF/USD 
                 // 0.91759 CHF 31.44
-                .section("fxCurrency", "fxGross", "exchangeRate", "currency", "gross").optional()
+                .section("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency", "gross").optional()
                 .match("^(Betrag|Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,'\\d]+)$")
-                .match("^(Umrechnungskurs|Exchange rate) [\\w]{3}\\/[\\w]{3}.*$")
+                .match("^(Umrechnungskurs|Exchange rate) (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}).*$")
                 .match("^(?<exchangeRate>[\\.,'\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,'\\d]+)$")
                 .assign((t, v) -> {
-                    BigDecimal exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                    if (!t.getCurrencyCode().contentEquals(asCurrencyCode(v.get("fxCurrency"))))
-                    {
-                        exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-                    }
-                    type.getCurrentContext().put("exchangeRate", exchangeRate.toPlainString());
+                    type.getCurrentContext().putType(asExchangeRate(v));
 
                     Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
                     Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
@@ -313,35 +296,35 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
             return transaction;
         })
 
-                        .section("name", "isin", "currency")
-                        .match("^[\\.,\\d]+ (Ant|Qty) (?<name>.*)$")
-                        .match("^ISIN: (?<isin>[\\w]{12})$")
-                        .match("^(Aussch.ttung|Dividend payment): (?<currency>[\\w]{3}) .*$")
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+                .section("name", "isin", "currency")
+                .match("^[\\.,\\d]+ (Ant|Qty) (?<name>.*)$")
+                .match("^ISIN: (?<isin>[\\w]{12})$")
+                .match("^(Aussch.ttung|Dividend payment): (?<currency>[\\w]{3}) .*$")
+                .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
-                        .section("shares")
-                        .match("^(?<shares>[\\.,\\d]+) (Ant|Qty) .*$")
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                .section("shares")
+                .match("^(?<shares>[\\.,\\d]+) (Ant|Qty) .*$")
+                .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        .section("date")
-                        .match("^(Gutgeschriebener Betrag: Valuta|Amount credited: Value date) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$")
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                .section("date")
+                .match("^(Gutgeschriebener Betrag: Valuta|Amount credited: Value date) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$")
+                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                        .section("currency", "amount")
-                        .match("^(Gutgeschriebener Betrag: Valuta|Amount credited: Value date) .* (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$")
-                        .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                .section("currency", "amount")
+                .match("^(Gutgeschriebener Betrag: Valuta|Amount credited: Value date) .* (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$")
+                .assign((t, v) -> {
+                    t.setAmount(asAmount(v.get("amount")));
+                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
-                            if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
-                            {
-                                t.setNote(t.getSecurity().getName());
-                                t.setSecurity(null);
-                                t.setShares(0L);
-                            }
-                        })
+                    if (!t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
+                    {
+                        t.setNote(t.getSecurity().getName());
+                        t.setSecurity(null);
+                        t.setShares(0L);
+                    }
+                })
 
-                        .wrap(TransactionItem::new));
+                .wrap(TransactionItem::new));
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)


### PR DESCRIPTION
Hallo @buchen
du bist einfach zu schnell für mich... ich komm derzeit kaum noch hinterher 😄😄😄... könnte aber auch daran liegen, dass derzeit einfach nur Biergartenwetter ist... 🍻🍻 🍻

**Offene Punkte... / Gegenkontrolle - PDFExchangeRate**
- [ ] Übersetzungen in PDFExchangeRate.java
- [ ] Übersetzungen in CheckForexGrossValueAction.java
- [ ] bb9f9589d063fb4060021e0fa6bcb3f49e0d698a (Hab mich im Namen verschrieben, sollte ComDirect sein) Combine Source/Note prüfen --> ggf. nur der richtige `getSource()` als Quelle speichern.
- [ ] bb9f9589d063fb4060021e0fa6bcb3f49e0d698a (Hab mich im Namen verschrieben, sollte ComDirect sein) Steuernbescheid `postProcessing()` Optional#isPresent geprüft werden. Ansonsten läuft man da in eine NPE.
- [ ] [TargoBank](https://github.com/buchen/portfolio/blob/a9298cdf8ee29a6e9b218d6273e3926e3764712d/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java) Steuernbescheid `postProcessing()` Optional#isPresent geprüft werden. Ansonsten läuft man da in eine NPE. --> ggf. nur der richtige `getSource()` als Quelle speichern.
- [x] 3ab0f8d5ba0d41a2a20db0754a80a20d780ea99c testDividende08() Line 394 switch baseCurrency and termCurrency -> Preis- /Mengenotierung
- [X] 3ab0f8d5ba0d41a2a20db0754a80a20d780ea99c Add testDividende08WithSecurityinEUR()
- [x] 3ab0f8d5ba0d41a2a20db0754a80a20d780ea99c Fix gross amount testWertpapierKauf07()
- [x] f978e453c2be0b4719cbfe62ecc16791ce690e84 testWertpapierVerkauf07() + testWertpapierKauf09() + testDividende01 switch baseCurrency and termCurrency -> Preis- /Mengenotierung
- [ ] ae841f272d5ff352123e7ff7f6b590724c2cf6a0 L1144 wenn `t.getMonetaryAmount().isZero()`, eventuell in `checkAndSetGrossUnit()` prüfen
- [x] bce64fa24452a649ad10232043c0a24cbe341322 testWertpapierKauf03() + testWertpapierKauf04() switch baseCurrency and termCurrency -> Preis- /Mengenotierung
- [x] 1e4dc76a8cb345b55a776cf026e6dd8a6ee75fc5 BuySell + Dividende --> Preis- /Mengenotierung