### PR TITLE
Update trade calendar for Germany

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
@@ -88,6 +88,9 @@ public class TradeCalendarTest
         // Whit Monday
         assertThat(calendar.isHoliday(LocalDate.parse("1999-05-24")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2000-06-12")), is(false)); // trading despite public holiday
+        assertThat(calendar.isHoliday(LocalDate.parse("2006-06-05")), is(false)); // trading despite public holiday
+        assertThat(calendar.isHoliday(LocalDate.parse("2007-05-28")), is(true)); // no trading only because Whit Monday coincides with U.S. Memorial Day
+        assertThat(calendar.isHoliday(LocalDate.parse("2008-05-12")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2013-05-20")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2014-06-09")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2015-05-25")), is(true));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
@@ -104,7 +104,8 @@ public class TradeCalendarTest
 
         // German Unity Day
         assertThat(calendar.isHoliday(LocalDate.parse("1999-10-03")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2000-10-03")), is(false)); // trading despite public holiday
+        assertThat(calendar.isHoliday(LocalDate.parse("2000-10-03")), is(true)); // no trading (despite other plans) because of union protests
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-10-03")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2013-10-03")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2014-10-03")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-10-03")), is(true));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
@@ -91,6 +91,8 @@ public class TradeCalendarTest
         assertThat(calendar.isHoliday(LocalDate.parse("2013-05-20")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2014-06-09")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2015-05-25")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-06")), is(false)); // trading despite public holiday
 
         // Corpus Christi
         assertThat(calendar.isHoliday(LocalDate.parse("1999-06-03")), is(true));
@@ -105,6 +107,8 @@ public class TradeCalendarTest
         assertThat(calendar.isHoliday(LocalDate.parse("2000-10-03")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2013-10-03")), is(false)); // trading despite public holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2014-10-03")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-10-03")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-10-03")), is(false)); // trading despite public holiday
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -91,12 +91,12 @@ public class TradeCalendarManager
         tc.add(easter(EASTER_MONDAY, 1));
         tc.add(easter(ASCENSION_DAY, 39).validTo(1999));
         tc.add(easter(WHIT_MONDAY, 50).validTo(1999));
-        tc.add(easter(WHIT_MONDAY, 50).validFrom(2015));
+        tc.add(easter(WHIT_MONDAY, 50).validFrom(2015).validTo(2021));
         tc.add(easter(CORPUS_CHRISTI, 60).validTo(1999));
         tc.add(fixed(LABOUR_DAY, Month.MAY, 1));
         tc.add(fixed(UNIFICATION_GERMANY, Month.JUNE, 17).validFrom(1954).validTo(1990));
         tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(1990).validTo(1999));
-        tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(2014));
+        tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(2014).validTo(2021));
         tc.add(fixed(REFORMATION_DAY, Month.OCTOBER, 31).onlyIn(2017));
         tc.add(fixed(REPENTANCE_AND_PRAYER, Month.NOVEMBER, 16).moveTo(DayOfWeek.WEDNESDAY).validTo(1994));
         tc.add(fixed(CHRISTMAS_EVE, Month.DECEMBER, 24));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -91,6 +91,7 @@ public class TradeCalendarManager
         tc.add(easter(EASTER_MONDAY, 1));
         tc.add(easter(ASCENSION_DAY, 39).validTo(1999));
         tc.add(easter(WHIT_MONDAY, 50).validTo(1999));
+        tc.add(easter(WHIT_MONDAY, 50).onlyIn(2007));
         tc.add(easter(WHIT_MONDAY, 50).validFrom(2015).validTo(2021));
         tc.add(easter(CORPUS_CHRISTI, 60).validTo(1999));
         tc.add(fixed(LABOUR_DAY, Month.MAY, 1));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -95,7 +95,7 @@ public class TradeCalendarManager
         tc.add(easter(CORPUS_CHRISTI, 60).validTo(1999));
         tc.add(fixed(LABOUR_DAY, Month.MAY, 1));
         tc.add(fixed(UNIFICATION_GERMANY, Month.JUNE, 17).validFrom(1954).validTo(1990));
-        tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(1990).validTo(1999));
+        tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(1990).validTo(2000));
         tc.add(fixed(UNIFICATION_GERMANY, Month.OCTOBER, 3).validFrom(2014).validTo(2021));
         tc.add(fixed(REFORMATION_DAY, Month.OCTOBER, 31).onlyIn(2017));
         tc.add(fixed(REPENTANCE_AND_PRAYER, Month.NOVEMBER, 16).moveTo(DayOfWeek.WEDNESDAY).validTo(1994));


### PR DESCRIPTION
Three updates to the trade calendar for the German stock exchanges:
* Deutsche Börse has again decided to make Whit Monday and German Unity Day trading days for 2022, like it was already between around 2000 and 2014.
* German Unity Day in 2000 (2000-10-03) was wrongly classified as a trading day in PP; while this was Deutsche Börse’s original intention, trade unions prevented it from being implemented.
* Whit Monday in 2007 (2007-05-28) was wrongly classified as a trading day in PP, too. In that year, Whit Monday coincided with Memorial Day, so that NYSE was closed as well, and it didn’t seem meaningful (or lucrative) for Deutsche Börse to open on that day.