### PR TITLE
Modify Baader Bank PDF-Importer to support new transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
@@ -1817,64 +1817,9 @@ public class BaaderBankPDFExtractorTest
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Periodenauszug01.txt"), errors);
 
-        assertThat(results.size(), is(5));
+        assertThat(results.size(), is(1));
         assertThat(errors, empty());
         new AssertImportActions().check(results, CurrencyUnit.EUR);
-
-        // check security
-        Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security1.getIsin(), is("IE00B5BMR087"));
-        assertThat(security1.getName(), is("ISHSVII-CORE S+P500 DLACC"));
-        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security2 = results.stream().filter(SecurityItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security2.getIsin(), is("IE00B52MJY50"));
-        assertThat(security2.getName(), is("ISHSVII-C.MSCI P.XJPDLACC"));
-        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-04-13T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
-        assertThat(entry.getSource(), is("Periodenauszug01.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(418.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(418.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-04-13T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
-        assertThat(entry.getSource(), is("Periodenauszug01.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(238.20))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(238.20))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
 
         // check transaction
         Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
@@ -1903,122 +1848,13 @@ public class BaaderBankPDFExtractorTest
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Periodenauszug02.txt"), errors);
 
-        assertThat(results.size(), is(13));
+        assertThat(results.size(), is(3));
         assertThat(errors, empty());
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check security
-        Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security1.getIsin(), is("IE00B1FZS798"));
-        assertThat(security1.getName(), is("ISHSII-DLT.BD7-10YR DLDIS"));
-        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security2 = results.stream().filter(SecurityItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security2.getIsin(), is("LU0908500753"));
-        assertThat(security2.getName(), is("LY.I.-L.CO.ST.EO 600(DR)A"));
-        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security3 = results.stream().filter(SecurityItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security3.getIsin(), is("IE00B4WXJJ64"));
-        assertThat(security3.getName(), is("ISHSIII-C.EO GOV. B.EODIS"));
-        assertThat(security3.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security4 = results.stream().filter(SecurityItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security4.getIsin(), is("IE00B3F81R35"));
-        assertThat(security4.getName(), is("ISHSIII-C.EO CORP.B.EODIS"));
-        assertThat(security4.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4)));
-        assertThat(entry.getSource(), is("Periodenauszug02.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(642.40))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(642.40))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
-        assertThat(entry.getSource(), is("Periodenauszug02.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(304.92))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(304.92))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4)));
-        assertThat(entry.getSource(), is("Periodenauszug02.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(488.72))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(488.72))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4)));
-        assertThat(entry.getSource(), is("Periodenauszug02.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(515.61))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(515.61))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
         // check transaction
         Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(5L));
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
 
         if (iter.hasNext())
         {
@@ -2058,52 +1894,6 @@ public class BaaderBankPDFExtractorTest
             assertThat(transaction.getSource(), is("Periodenauszug02.txt"));
             assertThat(transaction.getNote(), is("Transaktionskostenpauschale o. MwSt."));
         }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
-
-            assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-            assertThat(transaction.getShares(), is(Values.Share.factorize(31)));
-            assertThat(transaction.getSource(), is("Periodenauszug02.txt"));
-            assertThat(transaction.getNote(), is("Coupons/Dividende"));
-
-            assertThat(transaction.getMonetaryAmount(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.69))));
-            assertThat(transaction.getGrossValue(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12.69))));
-            assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-            assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
-
-            assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-07-25T00:00")));
-            assertThat(transaction.getShares(), is(Values.Share.factorize(12)));
-            assertThat(transaction.getSource(), is("Periodenauszug02.txt"));
-            assertThat(transaction.getNote(), is("Coupons/Dividende"));
-
-            assertThat(transaction.getMonetaryAmount(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.96))));
-            assertThat(transaction.getGrossValue(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.96))));
-            assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-            assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        }
     }
 
     @Test
@@ -2115,338 +1905,13 @@ public class BaaderBankPDFExtractorTest
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Periodenauszug03.txt"), errors);
 
-        assertThat(results.size(), is(27));
+        assertThat(results.size(), is(1));
         assertThat(errors, empty());
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check security
-        Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security1.getIsin(), is("DE0005933931"));
-        assertThat(security1.getName(), is("ISHS CORE DAX UCITS ETF"));
-        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security2 = results.stream().filter(SecurityItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security2.getIsin(), is("DE0002635307"));
-        assertThat(security2.getName(), is("ISH.STOX.EUROPE 600 U.ETF"));
-        assertThat(security2.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security3 = results.stream().filter(SecurityItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security3.getIsin(), is("DE000A1C22M3"));
-        assertThat(security3.getName(), is("HSBC S+P 500 UCITS ETF DZ"));
-        assertThat(security3.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security4 = results.stream().filter(SecurityItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security4.getIsin(), is("LU0480132876"));
-        assertThat(security4.getName(), is("UBS-ETF-MSCI EMERG.MKTS A"));
-        assertThat(security4.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security5 = results.stream().filter(SecurityItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security5.getIsin(), is("LU0136240974"));
-        assertThat(security5.getName(), is("UBS-ETF-MSCI JAPAN INH.A"));
-        assertThat(security5.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security6 = results.stream().filter(SecurityItem.class::isInstance).skip(5).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security6.getIsin(), is("LU0446734526"));
-        assertThat(security6.getName(), is("UBS-ETF-MSCI PAC.EX JAP.A"));
-        assertThat(security6.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security7 = results.stream().filter(SecurityItem.class::isInstance).skip(6).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security7.getIsin(), is("IE00B3F81R35"));
-        assertThat(security7.getName(), is("ISHSIII-C.EO CORP.B.EODIS"));
-        assertThat(security7.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security8 = results.stream().filter(SecurityItem.class::isInstance).skip(7).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security8.getIsin(), is("IE00B4WXJJ64"));
-        assertThat(security8.getName(), is("ISHSIII-C.EO GOV. B.EODIS"));
-        assertThat(security8.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security9 = results.stream().filter(SecurityItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security9.getIsin(), is("IE00B2NPKV68"));
-        assertThat(security9.getName(), is("ISHSII-JPM DL EM BD DLDIS"));
-        assertThat(security9.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security10 = results.stream().filter(SecurityItem.class::isInstance).skip(9).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security10.getIsin(), is("IE00B3B8Q275"));
-        assertThat(security10.getName(), is("ISHSIII-EO COV.BD EO DIS"));
-        assertThat(security10.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security11 = results.stream().filter(SecurityItem.class::isInstance).skip(10).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security11.getIsin(), is("IE00B1FZS350"));
-        assertThat(security11.getName(), is("ISHSII-DEV.MKT.PR.Y.DLDIS"));
-        assertThat(security11.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        Security security12 = results.stream().filter(SecurityItem.class::isInstance).skip(11).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security12.getIsin(), is("FR0010270033"));
-        assertThat(security12.getName(), is("LYX.C.T.R./C.CRB TRUECEO"));
-        assertThat(security12.getCurrencyCode(), is(CurrencyUnit.EUR));
-
-        // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-10T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(444.04))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(444.04))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-10T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(13)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(514.53))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(514.53))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(18)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(397.76))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(397.76))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(5)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(449.95))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(449.95))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(7)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(267.17))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(267.17))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(75.92))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(75.92))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(129.89))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(129.89))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(121.41))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(121.41))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(103.92))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(103.92))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(154.61))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(154.61))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-11T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(46.37))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(46.37))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 12th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-05-12T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(7)));
-        assertThat(entry.getSource(), is("Periodenauszug03.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(105.31))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(105.31))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
         // check transaction
         Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
 
         if (iter.hasNext())
         {
@@ -2460,52 +1925,6 @@ public class BaaderBankPDFExtractorTest
             assertThat(transaction.getSource(), is("Periodenauszug03.txt"));
             assertThat(transaction.getNote(), is("Lastschrift aktiv"));
         }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
-
-            assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-04-28T00:00")));
-            assertThat(transaction.getShares(), is(Values.Share.factorize(9)));
-            assertThat(transaction.getSource(), is("Periodenauszug03.txt"));
-            assertThat(transaction.getNote(), is("Coupons/Dividende"));
-
-            assertThat(transaction.getMonetaryAmount(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.25))));
-            assertThat(transaction.getGrossValue(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.25))));
-            assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-            assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        }
-
-        if (iter.hasNext())
-        {
-            Item item = iter.next();
-
-            // assert transaction
-            AccountTransaction transaction = (AccountTransaction) item.getSubject();
-
-            assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-05-12T00:00")));
-            assertThat(transaction.getShares(), is(Values.Share.factorize(11)));
-            assertThat(transaction.getSource(), is("Periodenauszug03.txt"));
-            assertThat(transaction.getNote(), is("Coupons/Dividende"));
-
-            assertThat(transaction.getMonetaryAmount(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.24))));
-            assertThat(transaction.getGrossValue(),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.24))));
-            assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-            assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        }
     }
 
     @Test
@@ -2517,85 +1936,52 @@ public class BaaderBankPDFExtractorTest
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Periodenauszug04.txt"), errors);
 
-        assertThat(results.size(), is(6));
+        assertThat(results.size(), is(3));
         assertThat(errors, empty());
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        // check security
-        Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security1.getIsin(), is("IE00BZ4BMM98"));
-        assertThat(security1.getName(), is("INVESCOM3 EUROSTX HDL A"));
-        assertThat(security1.getCurrencyCode(), is(CurrencyUnit.EUR));
+        // check transaction
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
 
-        Security security6 = results.stream().filter(SecurityItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security6.getIsin(), is("IE00B0M63060"));
-        assertThat(security6.getName(), is("ISHS-UK DIVIDEND LS D"));
-        assertThat(security6.getCurrencyCode(), is(CurrencyUnit.EUR));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        // check 1st buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-02T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
+            assertThat(transaction.getSource(), is("Periodenauszug04.txt"));
+            assertThat(transaction.getNote(), is("Credit SEPA"));
+        }
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-11-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(28)));
-        assertThat(entry.getSource(), is("Periodenauszug04.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-03T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.00))));
+            assertThat(transaction.getSource(), is("Periodenauszug04.txt"));
+            assertThat(transaction.getNote(), is("Direct Debit"));
+        }
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(701.12))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(701.12))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        if (iter.hasNext())
+        {
+            Item item = iter.next();
 
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-11-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(81)));
-        assertThat(entry.getSource(), is("Periodenauszug04.txt"));
-        assertThat(entry.getNote(), is("Verkauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(702.02))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(702.02))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-11-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(60)));
-        assertThat(entry.getSource(), is("Periodenauszug04.txt"));
-        assertThat(entry.getNote(), is("Kauf"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(302.64))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(302.64))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+            // assert transaction
+            AccountTransaction transaction = (AccountTransaction) item.getSubject();
+            assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
+            assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-28T00:00")));
+            assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
+            assertThat(transaction.getSource(), is("Periodenauszug04.txt"));
+            assertThat(transaction.getNote(), is("Credit SEPA"));
+        }
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
@@ -1573,6 +1573,140 @@ public class BaaderBankPDFExtractorTest
     }
 
     @Test
+    public void testDividende10()
+    {
+        BaaderBankPDFExtractor extractor = new BaaderBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende10.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("IE00BYSX4739"));
+        assertThat(security.getWkn(), is("A2PQDR"));
+        assertThat(security.getName(), is("F.UC.-Fid.Em.Mkt.Qual.In.U.ETF Reg. Shs USD Dis. oN"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-25T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(7.367)));
+        assertThat(transaction.getSource(), is("Dividende10.txt"));
+        assertNull(transaction.getNote());
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
+        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.22))));
+    }
+
+    @Test
+    public void testDividende10WithSecurityInEUR()
+    {
+        Security security = new Security("F.UC.-Fid.Em.Mkt.Qual.In.U.ETF Reg. Shs USD Dis. oN", CurrencyUnit.EUR);
+        security.setIsin("IE00BYSX4739");
+        security.setWkn("A2PQDR");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        BaaderBankPDFExtractor extractor = new BaaderBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende10.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-02-25T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(7.367)));
+        assertThat(transaction.getSource(), is("Dividende10.txt"));
+        assertNull(transaction.getNote());
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.20))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+
+        CheckCurrenciesAction c = new CheckCurrenciesAction();
+        Account account = new Account();
+        account.setCurrencyCode(CurrencyUnit.EUR);
+        Status s = c.process(transaction, account);
+        assertThat(s, is(Status.OK_STATUS));
+    }
+
+    @Test
+    public void testDividende11()
+    {
+        BaaderBankPDFExtractor extractor = new BaaderBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende11.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("DE000A0H0744"));
+        assertThat(security.getWkn(), is("A0H074"));
+        assertThat(security.getName(), is("iSh.DJ Asia Pa.S.D.50 U.ETF DE"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check dividends transaction
+        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-03-15T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(1.225)));
+        assertThat(transaction.getSource(), is("Dividende11.txt"));
+        assertNull(transaction.getNote());
+
+        assertThat(transaction.getMonetaryAmount(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(transaction.getGrossValue(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.06))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
     public void testSteuerausgleichsrechnung01()
     {
         BaaderBankPDFExtractor extractor = new BaaderBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Dividende10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Dividende10.txt
@@ -1,0 +1,62 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Scalable Capital GmbH 
+Seitzstrasse 8e
+80538 Munich
+service@scalable.capital
+Page 1/2
+Mr. Munich
+2022-03-01
+John Doe
+Neue Straße 1 John Doe
+12345 Neue Stadt Client ID: 1208374    Portfolio: 1
+Sec. Account No.: 1209625007
+Transaction No.: 204751222
+Reference No.: 339366528
+Fund Distribution
+Ex-Date: 2022-02-18
+Quantity ISIN: IE00BYSX4739 WKN: A2PQDR Distribution
+Units 7.367 F.UC.-Fid.Em.Mkt.Qual.In.U.ETF USD 0.029948 p. Unit
+Reg. Shs USD Dis. oN
+Payment Period: 2021-02-01 - 2022-01-31 
+Payday: 2022-02-25
+Exchange Rate: EUR/USD 1.12177
+Gross Amount USD 0.22
+Gross Amount EUR 0.20
+Amount credited to account 1209625007 Value: 2022-02-25 EUR 0.20
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+This document has been generated electronically and will not be signed.
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. 
+DE300434774 • www.scalable.capital
+ 
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Commercial Register 
+HRB 121537 • Principal Office: Unterschleissheim • TaxNo: 143/107/04009 • VAT ID: DE114123893 • LEI: 529900JFOPPEDUR61H13
+T 00800 00 586336* • service@baaderbank.de DCUP-054.048
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.
+ 
+Fund Distribution
+Continued: Page 2/2
+Basis for Tax Calculation:
+Taxes paid / Tax Funds Before Increase/Reduction Afterwards
+Distribution net Equity Funds
+Freistellungsauftrag EUR 801.00 EUR 0.13 - EUR 800.87
+Distribution net Equity Funds
+Ausnutzung FSA EUR 0.00 EUR 0.13 - EUR 0.13 -
+Assessment Bases Gross Tax Obligation Net Tax Obligation
+Distribution gross Equity Funds EUR 0.20 EUR 0.20
+Distribution net Equity Funds EUR 0.13 EUR 0.00
+Capital Gains Tax on general Profits EUR 0.13 EUR 0.00
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+Please note that some German tax specific terms are not translated into English.
+This document has been generated electronically and will not be signed.
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. 
+DE300434774 • www.scalable.capital
+ 
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Commercial Register 
+HRB 121537 • Principal Office: Unterschleissheim • TaxNo: 143/107/04009 • VAT ID: DE114123893 • LEI: 529900JFOPPEDUR61H13
+T 00800 00 586336* • service@baaderbank.de DCUP-054.048
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Dividende11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Dividende11.txt
@@ -1,0 +1,59 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Scalable Capital GmbH 
+Seitzstrasse 8e
+80538 Munich
+service@scalable.capital
+Page 1/2
+Mr. Munich
+2022-03-16
+John Doe
+Neue Straße 1 John Doe
+12345 Neue Stadt Client ID: 1208374    Portfolio: 1
+Sec. Account No.: 1209625007
+Transaction No.: 204751222
+Reference No.: 339366528
+Fund Distribution
+Ex-Date: 2022-03-15 Declare-Date: 2022-02-25
+Quantity ISIN: DE000A0H0744 WKN: A0H074 Distribution
+Units 1.225 iSh.DJ Asia Pa.S.D.50 U.ETF DE EUR 0.052461 p. Unit
+Payment Period: 2021-05-01 - 2022-04-30 
+Payday: 2022-03-15
+Gross Amount EUR 0.06
+Amount credited to account 1209625007 Value: 2022-03-15 EUR 0.06
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+This document has been generated electronically and will not be signed.
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. 
+DE300434774 • www.scalable.capital
+ 
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Commercial Register 
+HRB 121537 • Principal Office: Unterschleissheim • TaxNo: 143/107/04009 • VAT ID: DE114123893 • LEI: 529900JFOPPEDUR61H13
+T 00800 00 586336* • service@baaderbank.de DCUP-054.048
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.
+ 
+Fund Distribution
+Continued: Page 2/2
+Basis for Tax Calculation:
+Taxes paid / Tax Funds Before Increase/Reduction Afterwards
+Distribution net Equity Funds
+Freistellungsauftrag EUR 800.70 EUR 0.04 - EUR 800.66
+Distribution net Equity Funds
+Ausnutzung FSA EUR 0.30 - EUR 0.04 - EUR 0.34 -
+Assessment Bases Gross Tax Obligation Net Tax Obligation
+Distribution gross Equity Funds EUR 0.06 EUR 0.06
+Distribution net Equity Funds EUR 0.04 EUR 0.00
+Capital Gains Tax on general Profits EUR 0.04 EUR 0.00
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+Please note that some German tax specific terms are not translated into English.
+This document has been generated electronically and will not be signed.
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. 
+DE300434774 • www.scalable.capital
+ 
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Commercial Register 
+HRB 121537 • Principal Office: Unterschleissheim • TaxNo: 143/107/04009 • VAT ID: DE114123893 • LEI: 529900JFOPPEDUR61H13
+T 00800 00 586336* • service@baaderbank.de DCUP-054.048
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Periodenauszug04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Periodenauszug04.txt
@@ -1,71 +1,184 @@
 ﻿PDFBox Version: 1.8.16
 -----------------------------------------
 Scalable Capital GmbH
-Seitzstraße 8e
-80538 München 
+Seitzstrasse 8e
+80538 Munich
 service@scalable.capital
-Seite 1/31
-Herrn München
-01.12.2021
-onir 
+Page 1/3
+Mr. Munich
+2022-03-02
+John Doe
+Neue Straße 1 John Doe
+12345 Neue Stadt Client ID: 1208374    Portfolio: 1
+Account No.: 1209625007
+IBAN: DE44 2114 4200 5506 3530 01
+BLZ: 800 442 11
+BIC: BDWBDEMM
+Transaction No.: 204751222
+Reference No.: 339366528
+Periodic Account Statement: EUR Account
+Account Statement No. 020123
+Posting Description Value Date Debit Credit
+Date in EUR in EUR
+Account Balance in EUR on 0.00
+2022-02-02 Credit SEPA 2022-02-02 1,000.00
+JOHN DOE
+DE48900600677700345201
+CCDDFFFFXXX
+End to end Referenz:
+MOB.32.UE.721300
+Case No.: 910129125
+2022-02-03 Direct Debit 2022-02-03 1.00
+John Doe
+DE48900600677700345201
+CCDDFFFFXXX
+Scalable Capital Broker first depos
+it
+End to end Referenz:
+CJKZ8DKQXHP2BEDYXMMZQY
+Mandatsreferenz:
+U69ZNG8ZPXNA4TUME5FH7R
+Mandatsdatum:
+25.01.2022
+Gläubiger-ID:
+DE63MUC00001787612
+Case No.: 910106563
+2022-02-16 Purchase 2022-02-18 69.97 -
+X(IE)-MSCI WO.IN.TE. 1CDL
+ISIN IE00BM67HT60
+STK               1,304
+Case No.: WWUM 82775816
+Balance: 931.03
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. DE300434774 •
+www.scalable.capital
 
-Stamm-Nr.: -    Portfolio: -
-Konto-Nr.: -
-IBAN: -
-BLZ: -
-BIC: -
-Vorgangs-Nr.: 92719099
-Referenz-Nr.: 176117177
-Perioden-Kontoauszug: EUR-Konto
-Periodenauszugs-Nr. 021005
-Buchungstag Erläuterungen Valuta Belastung Gutschrift
-in EUR in EUR
-Kontostand in EUR am 29.10.2021 668,60
-01.11.2021 Verkauf 03.11.2021 701,12
-INVESCOM3 EUROSTX HDL A
-ISIN IE00BZ4BMM98
-STK              28    -
-Vorgangs-Nr.: WWUM 60922037
-Übertrag: 4.452,26
-Scalable Capital GmbH • Geschäftsführung: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, Amtsgericht München • USt-IdNr. DE300434774 • 
-www.scalable.capital
- 
-Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
-Vorstand: Nico Baader (Vorsitzender), Dietmar von Blücher, Oliver Riedel • Vorsitzender des Aufsichtsrates: Dr. Horst Schiessl • Amtsgericht München HRB 121537 • Sitz der 
-Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Amtsgericht München HRB 121537 •
+Sitz der Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13
 T 00800 00 586336* • service@baaderbank.de
 KKTKK801-040.038
-* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen.
-Perioden-Kontoauszug: EUR-Konto
-Periodenauszugs-Nr. 021005
-Fortsetzung: Seite 2/31
-Konto-Nr.: 1784607002   BLZ: 700 331 00   IBAN: DE70 7003 3100 1784 6070 02   BIC: BDWBDEMM
-Buchungstag Erläuterungen Valuta Belastung Gutschrift
-in EUR in EUR
-Übertrag: 4.452,26
-01.11.2021 Verkauf 03.11.2021 702,02
-ISHS-UK DIVIDEND LS D
-ISIN IE00B0M63060
-STK              81    -
-Vorgangs-Nr.: WWUM 60922509
-Übertrag: 4.663,44
-Scalable Capital GmbH • Geschäftsführung: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, Amtsgericht München • USt-IdNr. DE300434774 • 
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.
+Periodic Account Statement: EUR Account
+Account Statement No. 022001
+Continued: Page 2/3
+Account No.: 1209625007   BLZ: 800 442 11   IBAN: DE44 2114 4200 5506 3530 01   BIC: BDWBDEMM
+Posting Description Value Date Debit Credit
+Date in EUR in EUR
+Balance: 931.03
+2022-02-16 Purchase 2022-02-18 40.00 -
+F.-F.EM.MKT.Q.I.U.ETF DLD
+ISIN IE00BYSX4739
+STK               7,367
+Case No.: WWUM 82788624
+2022-02-16 Purchase 2022-02-18 49.99 -
+HETF-FMNXFIE ETFDLA
+ISIN IE000WF4FCJ3
+STK               7,682
+Case No.: WWUM 82818982
+2022-02-16 Purchase 2022-02-18 39.99 -
+FRAN.LIB.Q GL.DIV.UC.DLD
+ISIN IE00BF2B0M76
+STK               1,364
+Case No.: WWUM 82819562
+2022-02-21 Purchase 2022-02-23 69.98 -
+WISDOMTREE ART. INT.DLAC
+ISIN IE00BDVPNG13
+STK               1,33
+Case No.: WWUM 83417782
+2022-02-21 Purchase 2022-02-23 60.00 -
+FIDELITY GL.QUAL.INC. INC
+ISIN IE00BYXVGZ48
+STK               8,746
+Case No.: WWUM 83423564
+2022-02-21 Purchase 2022-02-23 39.99 -
+VANECK MSTR.DM DIV.UC.ETF
+ISIN NL0011683594
+STK               1,207
+Case No.: WWUM 83424535
+2022-02-21 Purchase 2022-02-23 70.00 -
+L+G-L+G BATT.VALUE-CHAIN
+ISIN IE00BF0M2Z96
+STK               4,499
+Case No.: WWUM 83425253
+2022-02-21 Purchase 2022-02-23 89.98 -
+VANECK VID ESPORTS UC.ETF
+ISIN IE00BYWQWR46
+STK               2,718
+Case No.: WWUM 83449146
+2022-02-21 Purchase 2022-02-23 99.94 -
+INV.COINSH.GL.BLOCKCH. A
+ISIN IE00BGBN6P67
+STK               1,176
+Case No.: WWUM 83456771
+Balance: 371.16
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. DE300434774 •
 www.scalable.capital
- 
-Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
-Vorstand: Nico Baader (Vorsitzender), Dietmar von Blücher, Oliver Riedel • Vorsitzender des Aufsichtsrates: Dr. Horst Schiessl • Amtsgericht München HRB 121537 • Sitz der 
-Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13
+
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Amtsgericht München HRB 121537 •
+Sitz der Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13
 T 00800 00 586336* • service@baaderbank.de
 KKTKK801-040.038
-* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen.
-Perioden-Kontoauszug: EUR-Konto
-Periodenauszugs-Nr. 021005
-Fortsetzung: Seite 3/31
-Konto-Nr.: -   BLZ: 700 331 00   IBAN: DE70 7003 3100 1784 6070 02   BIC: BDWBDEMM
-Buchungstag Erläuterungen Valuta Belastung Gutschrift
-in EUR in EUR
-Übertrag: 4.663,44
-01.11.2021 Kauf 03.11.2021 302,64 -
-ISV-M.W.C.ST.S. DLD
-ISIN IE00BJ5JP329
-STK              60
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.
+Periodic Account Statement: EUR Account
+Account Statement No. 022001
+Continued: Page 3/3
+Account No.: 1209625007   BLZ: 800 442 11   IBAN: DE44 2114 4200 5506 3530 01   BIC: BDWBDEMM
+Posting Description Value Date Debit Credit
+Date in EUR in EUR
+Balance: 371.16
+2022-02-22 Purchase 2022-02-24 60.00 -
+ISHSII-MSCI WL.QUA.DV.DLD
+ISIN IE00BYYHSQ67
+STK              11,029
+Case No.: WWUM 83733935
+2022-02-22 Purchase 2022-02-24 50.00 -
+HANETF-EM.EMI+E.EO ACC
+ISIN IE00BFYN8Y92
+STK               5,344
+Case No.: WWUM 83742941
+2022-02-22 Purchase 2022-02-24 50.00 -
+ISHSV-S+P500 C.S.U.ETF DL
+ISIN IE00BDDRF478
+STK               7,711
+Case No.: WWUM 83744345
+2022-02-22 Purchase 2022-02-24 60.00 -
+WISDOMTREE E.M.EQ.INC.ETF
+ISIN IE00BQQ3Q067
+STK               4,132
+Case No.: WWUM 83745588
+2022-02-25 Purchase 2022-03-01 99.99 -
+VNE-DIG.AS.
+ISIN IE00BMDKNW35
+STK              11,58
+Case No.: WWUM 84619750
+2022-02-25 Purchase 2022-03-01 29.98 -
+IS.DJ AS.PAC.S.D.50 U.ETF
+ISIN DE000A0H0744
+STK               1,225
+Case No.: WWUM 84631114
+2022-02-28 Coupons/Dividends 2022-02-25 0.20
+F.-F.EM.MKT.Q.I.U.ETF DLD
+ISIN IE00BYSX4739
+STK               7,367
+07328743
+Case No.: WWEK 06769057
+2022-02-28 Credit SEPA 2022-02-28 1,000.00
+JOHN DOE
+DE48900600677700345201
+CCDDFFFFXXX
+End to end Referenz:
+MOB.59.UE.6199
+Case No.: 910858517
+Account Balance in EUR on 2022-02-28 1,021.39
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+This document has been generated electronically and will not be signed.
+Scalable Capital GmbH • Managing Directors: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz • HRB 217778, District Court Munich • VAT No. DE300434774 •
+www.scalable.capital
+
+Publisher and responsible for the content is Baader Bank Aktiengesellschaft • Weihenstephaner Strasse 4 • 85716 Unterschleissheim • Germany
+Management Board: Nico Baader (CEO), Dietmar von Blücher, Oliver Riedel • Chairman of the Supervisory Board: Dr. Horst Schiessl • Amtsgericht München HRB 121537 •
+Sitz der Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13
+T 00800 00 586336* • service@baaderbank.de
+KKTKK801-040.038
+* Toll-free from (inter-) national landline networks. Charges may apply from other networks.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Verkauf08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Verkauf08.txt
@@ -1,0 +1,39 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+ Scalable Capital GmbH
+Seitzstraße 8e
+80538 München 
+service@scalable.capital
+Seite 1/2
+Herrn München
+20.05.2022
+...
+Vorgangs-Nr.: 11111111
+Referenz-Nr.: 111111111
+Wertpapierabrechnung: Verkauf
+Auftragsdatum: 20.05.2022 Ausführungsplatz: GETTEX - MM Munich
+Auftragszeit: 21:57:21:02
+Nominale ISIN: DE000TT410K7 WKN: TT410K Kurs 
+STK 1.520    HSBC Trinkaus & Burkhardt AG EUR 0,37
+Call 14.06.23 S&P500 5000
+Auftraggeber: Depotinhaber
+Art der Auftragserteilung: Orderroutingssystem
+Kurswert EUR 562,40
+Zu Gunsten Konto (Removed) Valuta: 24.05.2022 EUR 562,40
+Die Wertpapiere buchen wir zu Lasten Ihres Depots.
+Details zur Ausführung:
+Handels- Handels- 
+Nominale Kurs Ausführungsplatz datum uhrzeit
+STK   1.520    EUR 0,37 GETTEX - MM Munich 20.05.2022 21:57:22:78
+Verwahrart: Girosammelverwahrung Zeitzone der Handelsuhrzeit: MEZ/MESZ
+Lagerstelle: 100 MIC des Ausführungsplatzes: MUNC
+Lagerland: Deutschland
+Für die Ausführung dieses Auftrags gelten die Usancen des jeweiligen Ausführungsplatzes.
+Diese Auftragsbestätigung/Abrechnung wurde von der Baader Bank AG erstellt. Bitte prüfen Sie diese auf Richtigkeit und Vollständigkeit. Etwaige 
+Einwendungen gegen diese Auftragsbestätigung/Abrechnung müssen nach Zugang unverzüglich bei der Baader Bank AG erhoben werden. 
+Dieser Auftrag erfolgte ohne Empfehlung der Bank. Es wurde keine Anlageberatung und keine individuelle Aufklärung durch die Bank erbracht.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind einkommensteuerpflichtig.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+Scalable Capital GmbH • Geschäftsführung: Erik Podzuweit, Florian Prucker, Martin Krebs, Peter Gaubatz, Dirk Urmoneit • HRB 217778, Amtsgericht München • USt-IdNr. 
+DE300434774 • www.scalable.capital

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -54,7 +54,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
             return entry;
         });
 
-        Block firstRelevantLine = new Block("^((Auftragsdatum|Order Date):|Einbuchung in Depot|Ausbuchung aus Depot) .*$");
+        Block firstRelevantLine = new Block("^(Referenz\\-Nr|Reference No)\\.: .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -80,7 +80,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Registered Shares o.N.
                 // Kurswert EUR 208,74
                 .section("isin", "wkn", "name", "nameContinued", "currency").optional()
-                .match("^(Nominale ISIN|Quantity ISIN): (?<isin>[\\w]{12}) WKN: (?<wkn>.*) (Kurs|Bezugspreis|Barabfindung|Price).*$")
+                .match("^(Nominale|Quantity) ISIN: (?<isin>[\\w]{12}) WKN: (?<wkn>.*) (Kurs|Bezugspreis|Barabfindung|Price).*$")
                 .match("^(STK|Units) [\\.,\\d]+ (?<name>.*) (?<currency>[\\w]{3}) .*$")
                 .match("^(?<nameContinued>.*)$")
                 .assign((t, v) -> {
@@ -161,7 +161,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                 // Amount debited to account 1960017000 Value: 2022-03-02 EUR 199.93
                                 section -> section
                                         .attributes("currency", "amount")
-                                        .match("^Amount debited to account .* (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                                        .match("^Amount debited to account [\\d]+ Value: [\\d]{4}\\-[\\d]{2}\\-[\\d]{2} (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -170,7 +170,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Kurswert Umrechnungskurs CAD/EUR: 1,4595 EUR 8,85
                 .section("termCurrency", "baseCurrency", "exchangeRate", "currency", "gross").optional()
-                .match("^Kurswert Umrechnungskurs (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}): (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.\\d]+,[\\d]{2})$")
+                .match("^Kurswert Umrechnungskurs (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}): (?<exchangeRate>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<gross>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     PDFExchangeRate rate = asExchangeRate(v);
                     type.getCurrentContext().putType(asExchangeRate(v));
@@ -203,10 +203,11 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                         + "|Ertragsthesaurierung"
                         + "|Dividendenabrechnung"
                         + "|Aussch.ttung aus"
-                        + "|Wahldividende)");
+                        + "|Wahldividende"
+                        + "|Fund Distribution)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^Ex-Tag: .*$");
+        Block block = new Block("^Ex\\-(Tag|Date): .*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
             AccountTransaction entry = new AccountTransaction();
@@ -220,7 +221,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // If the amount is negative, then it is taxes.
                 .section("type", "sign").optional()
                 .match("^Nominale ISIN: .* (?<type>(Aussch.ttung|Thesaurierung brutto))$")
-                .match("^Zu (?<sign>(Gunsten|Lasten)) Konto [\\d]+ Valuta: [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\w]{3} [\\.\\d]+,[\\d]{2}$")
+                .match("^Zu (?<sign>(Gunsten|Lasten)) Konto [\\d]+ Valuta: [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\w]{3} [\\.,\\d]+$")
                 .assign((t, v) -> {
                     if (v.get("type").equals("Thesaurierung brutto") && v.get("sign").equals("Gunsten"))
                         t.setType(AccountTransaction.Type.TAX_REFUND);
@@ -231,41 +232,69 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Nominale ISIN: FR0000130577 WKN: 859386 Ausschüttung
                 // STK 57 Publicis Groupe S.A. EUR 2,00 p.STK
+                // Zahlungszeitraum: 17.06.2021 - 30.06.2021 
                 .section("isin", "wkn", "name", "name1", "currency")
-                .match("^Nominale ISIN: (?<isin>[\\w]{12}) WKN: (?<wkn>[\\w]{6}) .*$")
-                .match("^STK [\\.,\\d]+ (?<name>.*) (?<currency>[\\w]{3}) .*$")
+                .match("^(Nominale|Quantity) ISIN: (?<isin>[\\w]{12}) WKN: (?<wkn>[\\w]{6}) .*$")
+                .match("^(STK|Units) [\\.,\\d]+ (?<name>.*) (?<currency>[\\w]{3}) .*$")
                 .match("^(?<name1>.*)$")
                 .assign((t, v) -> {
-                    if (!v.get("name1").startsWith("Zahlungszeitraum"))
+                    if (!v.get("name1").startsWith("Zahlungszeitraum") && !v.get("name1").startsWith("Payment"))
                         v.put("name", v.get("name") + " " + v.get("name1"));
 
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
                 // STK 57 Publicis Groupe S.A. EUR 2,00 p.STK
-                .section("shares")
-                .match("^STK (?<shares>[\\.,\\d]+) .*$")
-                .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                .section("date")
-                .match("^Zu Gunsten Konto [\\d]+ Valuta: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\w]{3} [\\.\\d]+,[\\d]{2}$")
-                .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
-
-                // Zu Gunsten Konto 1111111111 Valuta: 06.07.2021 EUR 68,22
-                .section("currency", "amount").optional()
-                .match("^Zu Gunsten Konto [\\d]+ Valuta: [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[\\w]{3}) (?<amount>[\\.\\d]+,[\\d]{2})$")
+                .section("local", "shares")
+                .match("^(?<local>(STK|Units)) (?<shares>[\\.,\\d]+) .*$")
                 .assign((t, v) -> {
-                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                    t.setAmount(asAmount(v.get("amount")));
+                    if (v.get("local").equals("Units"))
+                        t.setShares(asShares(v.get("shares"), "en", "US"));
+                    else
+                        t.setShares(asShares(v.get("shares")));
                 })
+
+                .oneOf(
+                                // Zu Gunsten Konto 1111111111 Valuta: 06.07.2021 EUR 68,22
+                                section -> section
+                                        .attributes("date")
+                                        .match("^Zu Gunsten Konto [\\d]+ Valuta: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\w]{3} [\\.,\\d]+$")
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                                ,
+                                // Amount credited to account 1209625007 Value: 2022-02-25 EUR 0.20
+                                section -> section
+                                        .attributes("date")
+                                        .match("^Amount credited to account [\\d]+ Value: (?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) [\\w]{3} [\\.,\\d]+$")
+                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                        )
+
+                .oneOf(
+                                // Zu Gunsten Konto 1111111111 Valuta: 06.07.2021 EUR 68,22
+                                section -> section
+                                        .attributes("currency", "amount")
+                                        .match("^Zu Gunsten Konto [\\d]+ Valuta: [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                                        .assign((t, v) -> {
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                            t.setAmount(asAmount(v.get("amount")));
+                                        })
+                                ,
+                                // Amount credited to account 1209625007 Value: 2022-02-25 EUR 0.20
+                                section -> section
+                                        .attributes("currency", "amount")
+                                        .match("^Amount credited to account [\\d]+ Value: [\\d]{4}\\-[\\d]{2}\\-[\\d]{2} (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
+                                        .assign((t, v) -> {
+                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                            t.setAmount(asAmount(v.get("amount")));
+                                        })
+                        )
 
                 // Umrechnungskurs: EUR/USD 1,1452
                 // Bruttobetrag USD 3,94
                 // Bruttobetrag EUR 3,44
                 .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
-                .match("^Umrechnungskurs: (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
-                .match("^Bruttobetrag (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.\\d]+,[\\d]{2})$")
-                .match("^Bruttobetrag (?<currency>[\\w]{3}) (?<gross>[\\.\\d]+,[\\d]{2})$")
+                .match("^(Umrechnungskurs|Exchange Rate): (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
+                .match("^(Bruttobetrag|Gross Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)$")
+                .match("^(Bruttobetrag|Gross Amount) (?<currency>[\\w]{3}) (?<gross>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     type.getCurrentContext().putType(asExchangeRate(v));
 
@@ -326,7 +355,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Zu Lasten Konto 1247201005 Valuta: 04.01.2021 EUR 0,04
                 .section("date", "currency", "amount")
-                .match("^Zu Lasten Konto [\\d]+ Valuta: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.\\d]+,[\\d]{2})$")
+                .match("^Zu Lasten Konto [\\d]+ Valuta: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -366,7 +395,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Erstattung EUR 9,01
                 .section("currency", "amount")
-                .match("^Erstattung (?<currency>[\\w]{3}) (?<amount>[\\.\\d]+,[\\d]{2})$")
+                .match("^Erstattung (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -382,8 +411,8 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatementTransaction()
     {
-        final DocumentType type = new DocumentType("(Perioden-Kontoauszug|Tageskontoauszug)", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("(Perioden-Kontoauszug|Tageskontoauszug): (?<currency>[\\w]{3})-Konto(.*)");
+        final DocumentType type = new DocumentType("(Perioden\\-Kontoauszug|Tageskontoauszug)", (context, lines) -> {
+            Pattern pCurrency = Pattern.compile("(Perioden\\-Kontoauszug|Tageskontoauszug): (?<currency>[\\w]{3})\\-Konto(.*)");
             // read the current context here
             for (String line : lines)
             {
@@ -394,7 +423,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block depositBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Lastschrift aktiv|Gutschrift) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.\\d]+,[\\d]{2}$");
+        Block depositBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Lastschrift aktiv|Gutschrift) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$");
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
@@ -406,7 +435,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // 12.04.2018 Lastschrift aktiv 12.04.2018 10.000,00
                 .section("note", "date", "amount")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Lastschrift aktiv|Gutschrift)) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.\\d]+,[\\d]{2})$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Lastschrift aktiv|Gutschrift)) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     t.setDateTime(asDate(v.get("date")));
@@ -417,7 +446,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(TransactionItem::new));
 
-        Block removalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Lastschrift aktiv|SEPA-Ueberweisung) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.\\d]+,[\\d]{2} \\-$");
+        Block removalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Lastschrift aktiv|SEPA\\-Ueberweisung) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+ \\-$");
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
@@ -428,7 +457,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("note", "date", "amount")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Lastschrift aktiv|SEPA-Ueberweisung)) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Lastschrift aktiv|SEPA\\-Ueberweisung)) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     t.setDateTime(asDate(v.get("date")));
@@ -439,7 +468,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(TransactionItem::new));
 
-        Block feesBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Transaktionskostenpauschale o\\. MwSt\\. [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.\\d]+,[\\d]{2} \\-$");
+        Block feesBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Transaktionskostenpauschale o\\. MwSt\\. [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+ \\-$");
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
@@ -450,7 +479,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("note", "date", "amount")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>Transaktionskostenpauschale o\\. MwSt\\.) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>Transaktionskostenpauschale o\\. MwSt\\.) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
                     t.setDateTime(asDate(v.get("date")));
@@ -472,7 +501,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("note", "name", "isin")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Kauf|Verkauf)) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.\\d]+,[\\d]{2}( .*)?$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Kauf|Verkauf)) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+( .*)?$")
                 .match("^(?<name>.*)$")
                 .match("^ISIN (?<isin>[\\w]{12})$")
                 .assign((t, v) -> {
@@ -483,7 +512,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("date", "type", "amount", "shares")
-                .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<type>(Kauf|Verkauf)) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<amount>[\\.\\d]+,[\\d]{2})( .*)?$")
+                .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<type>(Kauf|Verkauf)) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<amount>[\\.,\\d]+)( .*)?$")
                 .match("^STK ([\\s]+)?(?<shares>[\\.,\\d]+)(([\\s]+)?\\-)?$")
                 .assign((t, v) -> {
                     // Is type --> "Verkauf" change from BUY to SELL
@@ -499,7 +528,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 .wrap(BuySellEntryItem::new));
 
-        Block dividendBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Coupons/Dividende [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .*$");
+        Block dividendBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Coupons\\/Dividende [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .*$");
         type.addBlock(dividendBlock);
         dividendBlock.set(new Transaction<AccountTransaction>()
 
@@ -510,7 +539,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("note", "name", "isin")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>Coupons/Dividende) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.\\d]+,[\\d]{2}$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>Coupons\\/Dividende) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$")
                 .match("^(?<name>.*)$")
                 .match("^(ISIN )?(?<isin>[\\w]{12})$")
                 .assign((t, v) -> {
@@ -521,7 +550,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("date", "amount", "shares")
-                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Coupons/Dividende (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.\\d]+,[\\d]{2})$")
+                .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Coupons\\/Dividende (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+)$")
                 .match("^STK ([\\s]+)?(?<shares>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
@@ -536,7 +565,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
     private void addFeesAssetManagerTransaction()
     {
-        DocumentType type = new DocumentType("Vergütung des Vermögensverwalters");
+        DocumentType type = new DocumentType("Verg.tung des Verm.gensverwalters");
         this.addDocumentTyp(type);
 
         Block block = new Block("^Rechnung f.r .*$");
@@ -575,7 +604,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDeliveryInOutBoundTransaction()
     {
-        DocumentType type = new DocumentType("Kapitalerhöhung gegen Bareinzahlung");
+        DocumentType type = new DocumentType("Kapitalerh.hung gegen Bareinzahlung");
         this.addDocumentTyp(type);
 
         Transaction<PortfolioTransaction> pdfTransaction = new Transaction<>();
@@ -659,13 +688,13 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         transaction
                 .section("n").optional()
                 .match("^Ertragsthesaurierung .*$")
-                .match("Steuerliquidität (?<n>.*)")
+                .match("Steuerliquidit.t (?<n>.*)")
                 .assign((t, v) -> type.getCurrentContext().put("noTax", "X"));
 
         transaction
                 // Span. Finanztransaktionssteuer EUR 1,97
                 .section("tax", "currency").optional()
-                .match("^.* Finanztransaktionssteuer (?<currency>[\\w]{3}) (?<tax>[\\.\\d]+,[\\d]{2})$")
+                .match("^.* Finanztransaktionssteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("noTax")))
                         processTaxEntries(t, v, type);
@@ -673,7 +702,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Kapitalertragsteuer EUR 127,73 -
                 .section("tax", "currency").optional()
-                .match("^Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("noTax")))
                         processTaxEntries(t, v, type);
@@ -681,7 +710,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Kirchensteuer EUR 11,49 -
                 .section("tax", "currency").optional()
-                .match("^Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("noTax")))
                         processTaxEntries(t, v, type);
@@ -689,7 +718,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
                 // Solidaritätszuschlag EUR 7,02 -
                 .section("tax", "currency").optional()
-                .match("^Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("noTax")))
                         processTaxEntries(t, v, type);
@@ -698,7 +727,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Quellensteuer EUR 30,21 -
                 // US-Quellensteuer EUR 0,17 -
                 .section("withHoldingTax", "currency").optional()
-                .match("^(US-)?Quellensteuer (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.\\d]+,[\\d]{2}) \\-$")
+                .match("^(US-)?Quellensteuer (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
                     if (!"X".equals(type.getCurrentContext().get("noTax")))
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
@@ -711,7 +740,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 // Provision EUR 0,21
                 // Provision EUR 0,08 -
                 .section("currency", "fee").optional()
-                .match("^Provision (?<currency>[\\w]{3}) (?<fee>[\\.\\d]+,[\\d]{2})( \\-)?$")
+                .match("^Provision (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)( \\-)?$")
                 .assign((t, v) -> processFeeEntries(t, v, type));
     }
 


### PR DESCRIPTION
Fixes #2847
Fixes #2848
https://forum.portfolio-performance.info/t/pdf-import-von-baader-bank-scalable-capital/2057/74

In the periodic account statement transactions, purchase, sale and dividends were previously also read out. This works, but is not correct. No fees or taxes are recorded for these entries. 
We therefore limit ourselves only to deposits and deliveries, as well as any fees for the account. The purchases, sales and dividends are recorded in other documents.