### PR TITLE
Some improvements related to trade calendars

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
@@ -310,7 +310,7 @@ public class TradeCalendarTest
     @Test
     public void testEmptyCalendar()
     {
-        TradeCalendar calendar = TradeCalendarManager.getInstance(TradeCalendar.EMPTY_CODE);
+        TradeCalendar calendar = TradeCalendarManager.getInstance("empty");
 
         // we generate a random day
         long minDay = LocalDate.of(2000, 1, 1).toEpochDay();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
@@ -60,8 +60,9 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
 
     protected void createInfo(Composite composite)
     {
+        int year = LocalDate.now().getYear();
         infoLabel = new Label(composite, SWT.WRAP);
-        infoLabel.setText(createHolidayText(TradeCalendarManager.getDefaultInstance().getCode()));
+        infoLabel.setText(createHolidayText(TradeCalendarManager.getDefaultInstance().getCode(), year));
         infoLabel.setFont(getFieldEditorParent().getFont());
 
         GridDataFactory.fillDefaults().span(2, 1).grab(true, true).applyTo(infoLabel);
@@ -74,22 +75,23 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
 
         if (event.getProperty().equals(FieldEditor.VALUE))
         {
+            int year = LocalDate.now().getYear();
             String newCode = (String) event.getNewValue();
-            infoLabel.setText(createHolidayText(newCode));
+            infoLabel.setText(createHolidayText(newCode, year));
             infoLabel.getParent().getParent().layout(true);
         }
     }
 
     private static final DateTimeFormatter shortDayOfWeekFormatter = DateTimeFormatter.ofPattern("E"); //$NON-NLS-1$
 
-    private String createHolidayText(String calendarCode)
+    private String createHolidayText(String calendarCode, int year)
     {
         TradeCalendar calendar = TradeCalendarManager.getInstance(calendarCode);
 
         if (calendar == null)
             return ""; //$NON-NLS-1$
 
-        Collection<Holiday> holidays = calendar.getHolidays(LocalDate.now().getYear());
+        Collection<Holiday> holidays = calendar.getHolidays(year);
 
         StringBuilder buffer = new StringBuilder();
         holidays.stream().sorted((r, l) -> r.getDate().compareTo(l.getDate()))

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.preferences;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,6 +80,8 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
         }
     }
 
+    private static final DateTimeFormatter shortDayOfWeekFormatter = DateTimeFormatter.ofPattern("E"); //$NON-NLS-1$
+
     private String createHolidayText(String calendarCode)
     {
         TradeCalendar calendar = TradeCalendarManager.getInstance(calendarCode);
@@ -91,7 +94,11 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
         StringBuilder buffer = new StringBuilder();
         holidays.stream().sorted((r, l) -> r.getDate().compareTo(l.getDate()))
                         .forEach(h -> buffer.append(Values.Date.format(h.getDate())).append(" ") //$NON-NLS-1$
-                                        .append(h.getLabel()).append("\n")); //$NON-NLS-1$
+                                        .append(h.getLabel())
+                                        .append(calendar.isWeekend(h.getDate()) ?
+                                            " (" + shortDayOfWeekFormatter.format(h.getDate()) + ")" //$NON-NLS-1$ //$NON-NLS-2$
+                                            : "") //$NON-NLS-1$
+                                        .append("\n")); //$NON-NLS-1$
         return buffer.toString();
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayType.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.util;
 
 import static java.time.temporal.TemporalAdjusters.dayOfWeekInMonth;
+import static java.time.temporal.TemporalAdjusters.nextOrSame;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -262,8 +263,8 @@ import java.util.Set;
         for (MoveIf mv : moveIf)
             date = mv.apply(date);
 
-        while (moveTo != null && date.getDayOfWeek() != moveTo)
-            date = date.plusDays(1);
+        if (moveTo != null)
+            date = date.with(nextOrSame(moveTo));
 
         return new Holiday(answer.getName(), date);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayType.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/HolidayType.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.util;
 
 import static java.time.temporal.TemporalAdjusters.dayOfWeekInMonth;
-import static java.time.temporal.TemporalAdjusters.lastInMonth;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -69,26 +68,6 @@ import java.util.Set;
         {
             LocalDate date = LocalDate.of(year, month, 1);
             return new Holiday(getName(), date.with(dayOfWeekInMonth(which, weekday)));
-        }
-    }
-
-    private static class LastWeekdayHolidayType extends HolidayType
-    {
-        private final DayOfWeek weekday;
-        private final Month month;
-
-        public LastWeekdayHolidayType(HolidayName name, DayOfWeek weekday, Month month)
-        {
-            super(name);
-            this.weekday = weekday;
-            this.month = month;
-        }
-
-        @Override
-        protected Holiday doGetHoliday(int year)
-        {
-            LocalDate date = LocalDate.of(year, month, 1);
-            return new Holiday(getName(), date.with(lastInMonth(weekday)));
         }
     }
 
@@ -213,11 +192,6 @@ import java.util.Set;
     public static HolidayType weekday(HolidayName name, int which, DayOfWeek weekday, Month month)
     {
         return new FixedWeekdayHolidayType(name, which, weekday, month);
-    }
-
-    public static HolidayType last(HolidayName name, DayOfWeek weekday, Month month)
-    {
-        return new LastWeekdayHolidayType(name, weekday, month);
     }
 
     public static HolidayType easter(HolidayName name, int daysToAdd)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -62,6 +62,14 @@ public class TradeCalendar implements Comparable<TradeCalendar>
     }
 
     /**
+     * Tests whether {@code date} is a weekend day in this calendar.
+     */
+    public boolean isWeekend(LocalDate date)
+    {
+        return weekend.contains(date.getDayOfWeek());
+    }
+
+    /**
      * Tests whether {@code date} is a non-trading day, i.e. a holiday or weekend day.
      */
     public boolean isHoliday(LocalDate date)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -63,6 +63,9 @@ public class TradeCalendar implements Comparable<TradeCalendar>
         return getDescription();
     }
 
+    /**
+     * Tests whether {@code date} is a non-trading day, i.e. a holiday or weekend day.
+     */
     public boolean isHoliday(LocalDate date)
     {
         if (EMPTY_CODE.equals(getCode()))
@@ -79,7 +82,7 @@ public class TradeCalendar implements Comparable<TradeCalendar>
     }
 
     /**
-     * @return {@code date}, if date is not a holiday. Otherwise the earliest date after {@code date}, that is not a holiday. 
+     * @return {@code date}, if date is a trading day. Otherwise the earliest date after {@code date} that is a trading day.
      */
     public LocalDate getNextNonHoliday(LocalDate date)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -5,7 +5,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +16,7 @@ public class TradeCalendar implements Comparable<TradeCalendar>
 {
     public static final String EMPTY_CODE = "empty"; //$NON-NLS-1$
 
-    private static final Set<DayOfWeek> WEEKEND = EnumSet.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+    private final Set<DayOfWeek> weekend;
 
     private final String code;
     private final String description;
@@ -36,10 +35,11 @@ public class TradeCalendar implements Comparable<TradeCalendar>
 
     };
 
-    /* package */ TradeCalendar(String code, String description)
+    /* package */ TradeCalendar(String code, String description, Set<DayOfWeek> weekend)
     {
         this.code = Objects.requireNonNull(code);
         this.description = Objects.requireNonNull(description);
+        this.weekend = Objects.requireNonNull(weekend);
     }
 
     /* package */ void add(HolidayType type)
@@ -68,9 +68,7 @@ public class TradeCalendar implements Comparable<TradeCalendar>
      */
     public boolean isHoliday(LocalDate date)
     {
-        if (EMPTY_CODE.equals(getCode()))
-            return false;
-        if (WEEKEND.contains(date.getDayOfWeek()))
+        if (weekend.contains(date.getDayOfWeek()))
             return true;
 
         return cache.get(date.getYear()).containsKey(date);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendar.java
@@ -14,8 +14,6 @@ import java.util.stream.Collectors;
 
 public class TradeCalendar implements Comparable<TradeCalendar>
 {
-    public static final String EMPTY_CODE = "empty"; //$NON-NLS-1$
-
     private final Set<DayOfWeek> weekend;
 
     private final String code;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -48,7 +48,6 @@ import static name.abuchen.portfolio.util.HolidayName.WASHINGTONS_BIRTHDAY;
 import static name.abuchen.portfolio.util.HolidayName.WHIT_MONDAY;
 import static name.abuchen.portfolio.util.HolidayType.easter;
 import static name.abuchen.portfolio.util.HolidayType.fixed;
-import static name.abuchen.portfolio.util.HolidayType.last;
 import static name.abuchen.portfolio.util.HolidayType.weekday;
 
 import java.text.MessageFormat;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -56,8 +56,10 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import name.abuchen.portfolio.Messages;
@@ -71,11 +73,13 @@ public class TradeCalendarManager
     public static final String TARGET2_CALENDAR_CODE = "TARGET2"; //$NON-NLS-1$
     public static final String FIRST_OF_THE_MONTH_CODE = "first-of-the-month"; //$NON-NLS-1$
 
+    private static final Set<DayOfWeek> STANDARD_WEEKEND = EnumSet.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
     private static final Map<String, TradeCalendar> CACHE = new HashMap<>();
 
     static
     {
-        TradeCalendar tc = new TradeCalendar("default", Messages.LabelTradeCalendarDefault); //$NON-NLS-1$
+        TradeCalendar tc = new TradeCalendar("default", Messages.LabelTradeCalendarDefault, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -85,7 +89,7 @@ public class TradeCalendarManager
         tc.add(fixed(SECOND_CHRISTMAS_DAY, Month.DECEMBER, 26));
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar("de", Messages.LabelTradeCalendarGermany); //$NON-NLS-1$
+        tc = new TradeCalendar("de", Messages.LabelTradeCalendarGermany, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -106,7 +110,7 @@ public class TradeCalendarManager
         tc.add(fixed(NEW_YEARS_EVE, Month.DECEMBER, 31));
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar("nyse", Messages.LabelTradeCalendarNYSE); //$NON-NLS-1$
+        tc = new TradeCalendar("nyse", Messages.LabelTradeCalendarNYSE, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(weekday(MARTIN_LUTHER_KING, 3, DayOfWeek.MONDAY, Month.JANUARY).validFrom(1998));
         tc.add(weekday(WASHINGTONS_BIRTHDAY, 3, DayOfWeek.MONDAY, Month.FEBRUARY));
@@ -129,7 +133,7 @@ public class TradeCalendarManager
         CACHE.put(tc.getCode(), tc);
 
         // see https://www.gov.uk/bank-holidays
-        tc = new TradeCalendar("lse", Messages.LabelTradeCalendarLSE); //$NON-NLS-1$
+        tc = new TradeCalendar("lse", Messages.LabelTradeCalendarLSE, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -156,7 +160,7 @@ public class TradeCalendarManager
         tc.add(fixed(ROYAL_JUBILEE, Month.JUNE, 3).onlyIn(2022)); // Platinum Jubilee of Elizabeth II
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar("euronext", Messages.LabelTradeCalendarEuronext); //$NON-NLS-1$
+        tc = new TradeCalendar("euronext", Messages.LabelTradeCalendarEuronext, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -167,7 +171,7 @@ public class TradeCalendarManager
 
         // see six trading days on their official website:
         // https://six-group.com/exchanges/exchange_traded_products/trading/trading_and_settlement_calendar_de.html
-        tc = new TradeCalendar("six", Messages.LabelTradeCalendarSix); //$NON-NLS-1$
+        tc = new TradeCalendar("six", Messages.LabelTradeCalendarSix, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(fixed(BERCHTOLDSTAG, Month.JANUARY, 2));
         tc.add(easter(GOOD_FRIDAY, -2));
@@ -184,7 +188,7 @@ public class TradeCalendarManager
 
         // see Italian Stock Exchange trading days on their official website:
         // https://www.borsaitaliana.it/borsaitaliana/calendario-e-orari-di-negoziazione/calendario-borsa-orari-di-negoziazione.en.htm
-        tc = new TradeCalendar("ise", Messages.LabelTradeCalendarISE); //$NON-NLS-1$
+        tc = new TradeCalendar("ise", Messages.LabelTradeCalendarISE, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -198,7 +202,7 @@ public class TradeCalendarManager
 
         // see Vienna Stock Exchange trading days on their official website:
         // https://www.wienerborse.at/handel/handelsinformationen/handelskalender/
-        tc = new TradeCalendar("vse", Messages.LabelTradeCalendarVSE); //$NON-NLS-1$
+        tc = new TradeCalendar("vse", Messages.LabelTradeCalendarVSE, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -215,7 +219,7 @@ public class TradeCalendarManager
         // https://www.moex.com/s371
         // https://de.wikipedia.org/wiki/Feiertage_in_Russland
         // Die offizielle Regelung in Russland lautet: Wenn ein gesetzlicher Feiertag auf einen Samstag oder Sonntag fällt, wird der Feiertag auf einen Arbeitstag verlegt.
-        tc = new TradeCalendar("MICEX-RTS", Messages.LabelTradeCalendarMICEXRTS); //$NON-NLS-1$
+        tc = new TradeCalendar("MICEX-RTS", Messages.LabelTradeCalendarMICEXRTS, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(fixed(NEW_YEAR_HOLIDAY, Month.JANUARY, 2));
         tc.add(fixed(NEW_YEAR_HOLIDAY, Month.JANUARY, 3));
@@ -232,7 +236,7 @@ public class TradeCalendarManager
 
         // see Toronto Stock Exchange trading days on their official website:
         // https://www.tsx.com/trading/calendars-and-trading-hours/calendar
-        tc = new TradeCalendar("tsx", Messages.LabelTradeCalendarTSX); //$NON-NLS-1$
+        tc = new TradeCalendar("tsx", Messages.LabelTradeCalendarTSX, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(weekday(FAMILY_DAY, 3, DayOfWeek.MONDAY, Month.FEBRUARY));
         tc.add(easter(GOOD_FRIDAY, -2));
@@ -247,7 +251,7 @@ public class TradeCalendarManager
 
         // TARGET2 (banking day in euro zone)
         // see https://www.ecb.europa.eu/press/pr/date/2000/html/pr001214_4.en.html
-        tc = new TradeCalendar(TARGET2_CALENDAR_CODE, Messages.LabelTradeCalendarTARGET2);
+        tc = new TradeCalendar(TARGET2_CALENDAR_CODE, Messages.LabelTradeCalendarTARGET2, STANDARD_WEEKEND);
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
@@ -256,7 +260,7 @@ public class TradeCalendarManager
         tc.add(fixed(SECOND_CHRISTMAS_DAY, Month.DECEMBER, 26));
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar(FIRST_OF_THE_MONTH_CODE,  Messages.LabelTradeCalendarFirstOfTheMonth)
+        tc = new TradeCalendar(FIRST_OF_THE_MONTH_CODE, Messages.LabelTradeCalendarFirstOfTheMonth, EnumSet.noneOf(DayOfWeek.class))
         {
             @Override
             /* package */ void add(HolidayType type)
@@ -279,7 +283,7 @@ public class TradeCalendarManager
         };
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar(TradeCalendar.EMPTY_CODE, Messages.LabelTradeCalendarEmpty);
+        tc = new TradeCalendar(TradeCalendar.EMPTY_CODE, Messages.LabelTradeCalendarEmpty, EnumSet.noneOf(DayOfWeek.class)); //$NON-NLS-1$
         CACHE.put(tc.getCode(), tc);
 }
 
@@ -313,7 +317,7 @@ public class TradeCalendarManager
     {
         String description = MessageFormat.format(Messages.LabelTradeCalendarUseDefault,
                         getDefaultInstance().getDescription());
-        return new TradeCalendar("", description); //$NON-NLS-1$
+        return new TradeCalendar("", description, STANDARD_WEEKEND); //$NON-NLS-1$
     }
 
     public static TradeCalendar getDefaultInstance()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -297,7 +297,7 @@ public class TradeCalendarManager
         if (!CACHE.containsKey(defaultCalendarCode))
         {
             PortfolioLog.warning(
-                            MessageFormat.format("Attempting to set unkown calendar code: {0}", defaultCalendarCode)); //$NON-NLS-1$
+                            MessageFormat.format("Attempting to set unknown calendar code: {0}", defaultCalendarCode)); //$NON-NLS-1$
             return;
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -283,7 +283,7 @@ public class TradeCalendarManager
         };
         CACHE.put(tc.getCode(), tc);
 
-        tc = new TradeCalendar(TradeCalendar.EMPTY_CODE, Messages.LabelTradeCalendarEmpty, EnumSet.noneOf(DayOfWeek.class)); //$NON-NLS-1$
+        tc = new TradeCalendar("empty", Messages.LabelTradeCalendarEmpty, EnumSet.noneOf(DayOfWeek.class)); //$NON-NLS-1$
         CACHE.put(tc.getCode(), tc);
 }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -112,7 +112,7 @@ public class TradeCalendarManager
         tc.add(weekday(MARTIN_LUTHER_KING, 3, DayOfWeek.MONDAY, Month.JANUARY).validFrom(1998));
         tc.add(weekday(WASHINGTONS_BIRTHDAY, 3, DayOfWeek.MONDAY, Month.FEBRUARY));
         tc.add(easter(GOOD_FRIDAY, -2));
-        tc.add(last(MEMORIAL, DayOfWeek.MONDAY, Month.MAY));
+        tc.add(weekday(MEMORIAL, -1, DayOfWeek.MONDAY, Month.MAY));
         tc.add(fixed(JUNETEENTH, Month.JUNE, 19).moveIf(DayOfWeek.SATURDAY, -1).moveIf(DayOfWeek.SUNDAY, 1).validFrom(2022));
         tc.add(fixed(INDEPENDENCE, Month.JULY, 4).moveIf(DayOfWeek.SATURDAY, -1).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(weekday(LABOUR_DAY, 1, DayOfWeek.MONDAY, Month.SEPTEMBER));
@@ -135,8 +135,8 @@ public class TradeCalendarManager
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
         tc.add(weekday(EARLY_MAY_BANK_HOLIDAY, 1, DayOfWeek.MONDAY, Month.MAY).exceptIn(1995).exceptIn(2020));
-        tc.add(last(SPRING_MAY_BANK_HOLIDAY, DayOfWeek.MONDAY, Month.MAY).exceptIn(1977).exceptIn(2002).exceptIn(2012).exceptIn(2022));
-        tc.add(last(SUMMER_BANK_HOLIDAY, DayOfWeek.MONDAY, Month.AUGUST));
+        tc.add(weekday(SPRING_MAY_BANK_HOLIDAY, -1, DayOfWeek.MONDAY, Month.MAY).exceptIn(1977).exceptIn(2002).exceptIn(2012).exceptIn(2022));
+        tc.add(weekday(SUMMER_BANK_HOLIDAY, -1, DayOfWeek.MONDAY, Month.AUGUST));
         tc.add(fixed(CHRISTMAS, Month.DECEMBER, 25).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 2));
             // strange but true: if 25th+26th is Sun+Mon, Christmas Day is moved *beyond* Boxing Day, to Tue
         tc.add(fixed(BOXING_DAY, Month.DECEMBER, 26).moveIf(DayOfWeek.SUNDAY, 2).moveIf(DayOfWeek.SATURDAY, 2));


### PR DESCRIPTION
Some improvements related to trade calendars. The only user-visible change is in the trade calendar overview (in the Preferences), where holidays that fall on a weekend are marked with their day of week. Some exchanges don’t list them in their yearly trade calendars (e.g., Deutsche Börse [doesn’t list](https://www.xetra.com/xetra-de/handel/handelskalendar-und-zeiten) Labour Day or Christmas Day this year), so this may avoid some confusion. Example (with many holidays on Saturday and Sunday this year):
<img src="https://user-images.githubusercontent.com/1127374/170874183-e3d854e6-6dba-437d-ad73-6a5424955496.png" alt="Preferences window with trade calendar overview" width="70%" />
Apart from that, I’ve removed some redundant code, made weekends configurable for trade calendars, fixed a typo, etc.