### PR TITLE
Parse dividend tax from Dutch DeGiro Account Statement PDF

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht04.txt
@@ -1,0 +1,18 @@
+PDFBox Version: 1.8.16
+Portfolio Performance Version: 0.58.6.qualifier
+-----------------------------------------
+Dhr. John
+Doe
+Hoofdstraat 1
+1001AA Amsterdam
+Gebruikersnaam: ****bob
+Rekeningoverzicht van 13-06-2022 t/m 13-07-2022
+Datum Tijd Valutadatum Product ISIN Omschrijving FX Mutatie Saldo
+11-07-2022 07:45 08-07-2022 LYXOR ETF CAC 40 FR0007052782 Dividend EUR 1,50 EUR 3,21
+11-07-2022 07:45 08-07-2022 LYXOR ETF CAC 40 FR0007052782 Dividendbelasting EUR -0,38 EUR 1,71
+flatex DEGIRO Bank Dutch Branch, handelend onder de naam www.degiro.nl Rekeningoverzicht
+DEGIRO, is de Nederlandse vestiging van flatexDEGIRO Bank AG. klanten@degiro.nl 2022-07-13
+flatexDEGIRO Bank AG staat primair onder supervisie van de Duitse
+Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin). Amstelplein 1 1096 HA Pagina 1 / 6
+[flatexDEGIRO Bank AG Dutch Branch] staat in Nederland onder
+integriteitstoezicht van DNB en gedragstoezicht van de AFM.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -505,12 +505,13 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                         // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividendensteuer USD -0,06 USD -0,06
                         // 17-07-2017 00:00 ISH.S.EU.SEL.DIV.30 U.ETF DE0002635299 Dividendensteuer EUR -0,55 EUR 519,34
                         // 22-03-2021 07:39 19-03-2021 MANULIFE FINANCIAL COR CA56501R1064 Dividend Tax CAD -4.55 CAD -4.55
+                        // 11-07-2022 07:45 08-07-2022 LYXOR ETF CAC 40 FR0007052782 Dividendbelasting EUR -0,38 EUR 1,71
                         .section("isin", "currencyTax", "tax").optional()
                         .match("^([\\d]{2}\\-[\\d]{2}\\-[\\d]{4} [\\d]{2}:[\\d]{2}) "
                                         + "([\\d]{2}\\-[\\d]{2}\\-[\\d]{4} )?"
                                         + "(.*) "
                                         + "(?<isin>[\\w]{12}) .*"
-                                        + "(Dividendensteuer|Dividend Tax) "
+                                        + "(Dividendensteuer|Dividend Tax|Dividendbelasting) "
                                         + "(?<currencyTax>[\\w]{3}) "
                                         + "\\-(?<tax>[\\.,'\\d]+) "
                                         + "[\\w]{3} "


### PR DESCRIPTION
The existing regex in DeGiroPDFExtractor.addAccountStatementTransactions() expected English
(Dividend Tax) or German (Dividendensteuer) so the dividend tax was ignored when importing a Dutch DeGiro account statement PDF.

I added "Dividendbelasting" to the existing regex so it parses the Dutch dividend tax.

I added test file Rekeningoverzicht04.txt and associated test case DegiroPDFExtractorTest.testRekeningoverzicht04()