### PR TITLE
New CSS classes for containers and widget titles

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
@@ -212,6 +212,7 @@ public interface UIConstants
         String HEADING1 = "heading1"; //$NON-NLS-1$
         String HEADING2 = "heading2"; //$NON-NLS-1$
         String KPI = "kpi"; //$NON-NLS-1$
+        String TITLE = "title"; //$NON-NLS-1$
         String DATAPOINT = "datapoint"; //$NON-NLS-1$
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
@@ -31,11 +31,13 @@ public abstract class AbstractIndicatorWidget<D> extends WidgetDelegate<D>
     {
         Composite container = new Composite(parent, SWT.NONE);
         container.setBackground(parent.getBackground());
+        container.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
         GridLayoutFactory.fillDefaults().numColumns(1).margins(5, 5).applyTo(container);
 
         title = new Label(container, SWT.NONE);
         title.setText(TextUtil.tooltip(getWidget().getLabel()));
         title.setBackground(Colors.theme().defaultBackground());
+        title.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.TITLE);
         GridDataFactory.fillDefaults().grab(true, false).applyTo(title);
 
         indicator = new ColoredLabel(container, SWT.NONE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.widgets.Control;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.swt.StyledLabel;
 import name.abuchen.portfolio.ui.views.SecurityListView;
@@ -71,12 +72,14 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
     public Composite createControl(Composite parent, DashboardResources resources)
     {
         Composite container = new Composite(parent, SWT.NONE);
+        container.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
         container.setBackground(parent.getBackground());
         GridLayoutFactory.fillDefaults().numColumns(1).margins(5, 5).applyTo(container);
 
         title = new StyledLabel(container, SWT.NONE);
         title.setBackground(container.getBackground());
         title.setText(TextUtil.tooltip(getWidget().getLabel()));
+        title.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.TITLE);
 
         title.setOpenLinkHandler(d -> {
             @SuppressWarnings("unchecked")

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
@@ -186,11 +186,13 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
     public Composite createControl(Composite parent, DashboardResources resources)
     {
         Composite container = new Composite(parent, SWT.NONE);
+        container.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
         GridLayoutFactory.fillDefaults().numColumns(1).margins(5, 5).applyTo(container);
         container.setBackground(parent.getBackground());
 
         title = new Label(container, SWT.NONE);
         title.setBackground(container.getBackground());
+        title.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.TITLE);
         title.setText(TextUtil.tooltip(getWidget().getLabel()));
         GridDataFactory.fillDefaults().grab(true, false).applyTo(title);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DescriptionWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DescriptionWidget.java
@@ -8,6 +8,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.swt.StyledLabel;
 import name.abuchen.portfolio.util.TextUtil;
@@ -28,6 +29,8 @@ public class DescriptionWidget extends WidgetDelegate<Object>
     {
         Composite container = new Composite(parent, SWT.NONE);
         container.setBackground(parent.getBackground());
+        container.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
+
         FillLayout layout = new FillLayout();
         layout.marginWidth = 5;
         layout.marginHeight = 10;
@@ -37,6 +40,7 @@ public class DescriptionWidget extends WidgetDelegate<Object>
         description.setForeground(Colors.HEADINGS);
         description.setBackground(container.getBackground());
         description.setText(TextUtil.tooltip(getWidget().getLabel()));
+        description.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.TITLE);
 
         return container;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/HeadingWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/HeadingWidget.java
@@ -27,6 +27,7 @@ public class HeadingWidget extends WidgetDelegate<Object>
     {
         Composite heading = new Composite(parent, SWT.NONE);
         heading.setBackground(parent.getBackground());
+        heading.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
         FillLayout layout = new FillLayout();
         layout.marginWidth = 5;
         layout.marginHeight = 10;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -74,10 +74,12 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         container = new Composite(parent, SWT.NONE);
         GridLayoutFactory.fillDefaults().numColumns(3).margins(5, 5).spacing(3, 3).applyTo(container);
         container.setBackground(parent.getBackground());
+        container.setData(UIConstants.CSS.CLASS_NAME, this.getContainerCssClassNames());
 
         title = new Label(container, SWT.NONE);
         title.setText(TextUtil.tooltip(getWidget().getLabel()));
         title.setBackground(container.getBackground());
+        title.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.TITLE);
         GridDataFactory.fillDefaults().span(3, 1).grab(true, false).applyTo(title);
 
         TableLayout layout = get(LayoutConfig.class).getValue();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetDelegate.java
@@ -91,4 +91,15 @@ public abstract class WidgetDelegate<D>
      * attached.
      */
     public abstract Control getTitleControl();
+
+    /**
+     * Generates the container CSS class names by using the label text of the
+     * widget. Therefore all non-alphanumeric characters are stripped and the
+     * result is capped to 30 characters.
+     */
+    protected String getContainerCssClassNames()
+    {
+        String cssClassName = widget.getLabel().replaceAll("[^a-zA-Z0-9]", "").toLowerCase(); //$NON-NLS-1$ //$NON-NLS-2$
+        return "dashboard-widget " + cssClassName.substring(0, Math.min(cssClassName.length(), 30)); //$NON-NLS-1$
+    }
 }


### PR DESCRIPTION
This PR improves the SWT CSS selectors for widgets on the dashboard: 
In addition to the existing `kpi` and `heading1/2` CSS classes, the label of the widget is added as a (unique) CSS class name removing all non-alphanumeric characters and limiting it to 30 characters. This allows for more specific [CSS styles](https://wiki.eclipse.org/Eclipse4/RCP/CSS) of individual dashboard elements. 

E.g. if you use the dashboard widget for the total wealth value and label it "Mein Vermögen:", you can style it with CSS like this:
```css
.dashboard-widget.meinvermgen { background-color: #738290; }
.dashboard-widget.meinvermgen .title { font-size: 13px; font-weight: bold; background-color: #738290; color: #000000;   }
.dashboard-widget.meinvermgen .kpi { font-size: 25px; background-color: #738290; font-weight: bold; }
``` 

In addition if you want to e.g. hide _all_ titles of each widget, you can use:
```css
.dashboard-widget .title { visibility: hidden }
```

Note: At the moment I have not done the modification for all the existing widgets as I am not sure if I can test all those widgets thoroughly.