### PR TITLE
Modify Degiro PDF Importer to support English Exchange Connection Fee

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht05.txt
@@ -1,0 +1,17 @@
+PDFBox Version: 1.8.16
+Portfolio Performance Version: 0.59.1.qualifier
+-----------------------------------------
+Dhr. John
+Doe
+Hoofdstraat 1
+1001AA Amsterdam
+Gebruikersnaam: ****bob
+Rekeningoverzicht van 01-06-2022 t/m 02-06-2022
+Datum Tijd Valutadatum Product ISIN Omschrijving FX Mutatie Saldo
+01-06-2022 19:55 31-05-2022 Giro Exchange Connection Fee 2022 EUR -1,01 EUR -6,39
+flatex DEGIRO Bank Dutch Branch, handelend onder de naam www.degiro.nl Rekeningoverzicht
+DEGIRO, is de Nederlandse vestiging van flatexDEGIRO Bank AG. klanten@degiro.nl 2022-07-17
+flatexDEGIRO Bank AG staat primair onder supervisie van de Duitse
+Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin). Amstelplein 1 1096 HA Pagina 1 / 1
+[flatexDEGIRO Bank AG Dutch Branch] staat in Nederland onder
+integriteitstoezicht van DNB en gedragstoezicht van de AFM.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -745,11 +745,13 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         //  
         // 02-09-2021 21:29 31-08-2021 DEGIRO Aansluitingskosten 2021 (Borsa Italiana S.p.A. - EUR -2,50 EUR 12,91
         // MIL)
+        //
+        // 01-06-2022 19:55 31-05-2022 Giro Exchange Connection Fee 2022 EUR -1,01 EUR -6,39
         //  
         // 02-10-2021 10:46 30-09-2021 DEGIRO Costi di connessione 2021 (Xetra - XET) EUR -1,24 EUR 206,99
         // @formatter:on
         Block blockTrademodalities = new Block("^[\\d]{2}\\-[\\d]{2}\\-[\\d]{4} [\\d]{2}:[\\d]{2} ([\\d]{2}\\-[\\d]{2}\\-[\\d]{4} )?.*"
-                        + "(Einrichtung von|DEGIRO Aansluitingskosten|DEGIRO Costi di connessione) "
+                        + "(Einrichtung von|DEGIRO Aansluitingskosten|Giro Exchange Connection Fee|DEGIRO Costi di connessione) "
                         + ".*$");
         type.addBlock(blockTrademodalities);
         blockTrademodalities.set(new Transaction<AccountTransaction>()
@@ -789,7 +791,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                 .attributes("date", "time", "note", "currency", "type", "amount")
                                 .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
                                                 + "([\\d]{2}\\-[\\d]{2}\\-[\\d]{4} )?"
-                                                + "(?<note>(Einrichtung von Handelsmodalit.ten|DEGIRO Aansluitingskosten|DEGIRO Costi di connessione)( [\\d]{4})?) .* "
+                                                + "(?<note>(Einrichtung von Handelsmodalit.ten|DEGIRO Aansluitingskosten|Giro Exchange Connection Fee|DEGIRO Costi di connessione)( [\\d]{4})?) .* "
                                                 + "(?<currency>[\\w]{3})"
                                                 + "(?<type>\\s(\\-)?)"
                                                 + "(?<amount>[\\.,'\\d]+) "


### PR DESCRIPTION
Modified DegiroPDFExtractor to extract Exchange Connection Fee in English by adding "Giro Exchange Connection Fee" to the existing regex. Although the rest of the account is in Dutch, the connection fee is not so it was ignored.

Added Rekeningoverzicht05.txt and DegiroPDFExtractorTest.testRekeningoverzicht05() to test the extraction.