### PR TITLE
Move custom filters into client file + Add identifier field to custom filter item and use it as new link (fix #2546)

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
@@ -1,0 +1,180 @@
+package name.abuchen.portfolio.ui.editor;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.eclipse.jface.preference.PreferenceStore;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.ConfigurationSet;
+import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
+import name.abuchen.portfolio.ui.util.ClientFilterMenu;
+import name.abuchen.portfolio.ui.util.ClientFilterMenu.Item;
+
+class ClientFilterMigration
+{
+
+    private PreferenceStore preferenceStore;
+    private Client client;
+
+    ClientFilterMigration(PreferenceStore preferenceStore, Client client)
+    {
+        this.preferenceStore = preferenceStore;
+        this.client = client;
+    }
+
+    public static void setOldSettingsToDefault(PreferenceStore pref)
+    {
+        pref.setToDefault("ClientFilterDropDown"); //$NON-NLS-1$
+        pref.setToDefault("ClientFilterDropDown@json"); //$NON-NLS-1$
+        Arrays.stream(pref.preferenceNames()).filter(name -> name.endsWith("-client-filter")) //$NON-NLS-1$
+                        .forEach(name -> pref.setToDefault(name));
+    }
+
+    void migrateClientFilter()
+    {
+        // load custom filters
+        List<ClientFilterMenu.Item> clientFilters = loadFilters();
+        if (clientFilters == null || clientFilters.isEmpty())
+            return;
+
+        moveFiltersIntoClientFile(clientFilters);
+        migrateFilterLinksInSettingsFileAndMoveToClient(clientFilters);
+        migrateWidgets(clientFilters);
+        migrateCharts(clientFilters);
+
+        // signal user to save file
+        client.touch();
+    }
+
+    private void moveFiltersIntoClientFile(List<ClientFilterMenu.Item> clientFilters)
+    {
+        ConfigurationSet set = client.getSettings().getConfigurationSet("ClientFilterDropDown"); //$NON-NLS-1$
+        clientFilters.forEach(cf -> set.add(new Configuration(cf.getIdent(), cf.getLabel(), cf.getUUIDs())));
+    }
+
+    private List<Item> deserializeFromJSON(String json)
+    {
+        Type listType = new TypeToken<ArrayList<Item>>()
+        {
+        }.getType();
+        return new Gson().fromJson(json, listType);
+    }
+
+    private List<ClientFilterMenu.Item> loadFilters()
+    {
+        String json = preferenceStore.getString("ClientFilterDropDown@json"); //$NON-NLS-1$
+        if (json != null && !json.isEmpty())
+            return deserializeFromJSON(json);
+
+        // legacy loading
+        List<ClientFilterMenu.Item> clientFilters = null;
+        String legacy = preferenceStore.getString("ClientFilterDropDown"); //$NON-NLS-1$
+        if (legacy != null && !legacy.isEmpty())
+            return loadCustomItemsLegacy(legacy);
+
+        return clientFilters;
+    }
+
+    private List<Item> loadCustomItemsLegacy(String code)
+    {
+        List<Item> result = new LinkedList<>();
+        String[] items = code.split(";"); //$NON-NLS-1$
+        for (String item : items)
+            ClientFilterMenu.buildItem(UUID.randomUUID().toString(), "", item, client).ifPresent(result::add); //$NON-NLS-1$
+
+        return result;
+    }
+
+    private void migrateFilterLinksInSettingsFileAndMoveToClient(List<ClientFilterMenu.Item> clientFilters)
+    {
+        // prepare filter
+        Map<String, String> oldToNewIdentMap = new HashMap<>();
+        clientFilters.forEach(f -> oldToNewIdentMap.putIfAbsent(f.getUUIDs(), f.getIdent()));
+
+        // migrate each filter link in settings file and move into client file
+        Arrays.stream(preferenceStore.preferenceNames()).filter(name -> name.endsWith("-client-filter")) //$NON-NLS-1$
+                        .forEach(prefKey -> migrateSingleClientFilterAndMoveIntoClientFile(prefKey, oldToNewIdentMap));
+
+    }
+
+    private void migrateSingleClientFilterAndMoveIntoClientFile(String prefKey, Map<String, String> oldToNewIdentMap)
+    {
+        String link = preferenceStore.getString(prefKey);
+        if (oldToNewIdentMap.containsKey(link))
+        {
+            ConfigurationSet set = client.getSettings().getConfigurationSet("client-filter-usages"); //$NON-NLS-1$
+            set.add(new Configuration(prefKey, "", oldToNewIdentMap.get(link))); //$NON-NLS-1$
+        }
+    }
+
+    private void migrateWidgets(List<ClientFilterMenu.Item> clientFilters)
+    {
+        // create map with all possible values as dashboard settings (normal
+        // filter and pretax filter). Then iterate all widgets and check if
+        // any of the possible value is included in widget config, and
+        // migrate link if so.
+        Map<String, String> oldToNewIdentMap = new HashMap<>();
+        clientFilters.forEach(f -> {
+            String oldIdentWithComma = f.getUUIDs();
+            String oldIdentWithoutComma = oldIdentWithComma.replace(",", ""); //$NON-NLS-1$ //$NON-NLS-2$
+            String newIdent = f.getIdent();
+            // For DATA_SERIES and SECONDARY_DATA_SERIES
+            oldToNewIdentMap.putIfAbsent("ClientFilter" + oldIdentWithoutComma, "ClientFilter" + newIdent); //$NON-NLS-1$ //$NON-NLS-2$
+            // For DATA_SERIES and SECONDARY_DATA_SERIES
+            oldToNewIdentMap.putIfAbsent("ClientFilter-PreTax" + oldIdentWithoutComma, //$NON-NLS-1$
+                            "ClientFilter-PreTax" + newIdent); //$NON-NLS-1$
+            // For CLIENT_FILTER.
+            oldToNewIdentMap.putIfAbsent(oldIdentWithComma, newIdent); 
+        });
+        client.getDashboards().forEach(d -> d.getColumns().forEach(c -> c.getWidgets().forEach(w -> {
+            migrateSingleWidgetConfig("DATA_SERIES", w.getConfiguration(), oldToNewIdentMap); //$NON-NLS-1$
+            migrateSingleWidgetConfig("SECONDARY_DATA_SERIES", w.getConfiguration(), oldToNewIdentMap); //$NON-NLS-1$
+            migrateSingleWidgetConfig("CLIENT_FILTER", w.getConfiguration(), oldToNewIdentMap); //$NON-NLS-1$
+        })));
+    }
+
+    private void migrateSingleWidgetConfig(String configName, Map<String, String> configuration,
+                    Map<String, String> oldToNewIdentMap)
+    {
+        String config = configuration.get(configName);
+        if (config != null && oldToNewIdentMap.containsKey(config))
+        {
+            configuration.put(configName, oldToNewIdentMap.get(config));
+        }
+    }
+
+    private void migrateCharts(List<ClientFilterMenu.Item> clientFilters)
+    {
+        Map<String, String> oldToNewIdentMap = new HashMap<>();
+        clientFilters.forEach(f -> oldToNewIdentMap.putIfAbsent(f.getUUIDs().replace(",", ""), f.getIdent())); //$NON-NLS-1$ //$NON-NLS-2$
+        String[] charts = new String[] { "StatementOfAssetsHistoryView-PICKER", "ReturnsVolatilityChartView-PICKER", //$NON-NLS-1$ //$NON-NLS-2$
+                        "PerformanceChartView-PICKER" }; //$NON-NLS-1$
+        for (String chart : charts)
+        {
+            ConfigurationSet conf = client.getSettings().getConfigurationSet(chart);
+            if (conf == null)
+                continue;
+
+            conf.getConfigurations().forEach(c -> {
+                // check all filters if they are present in data and replace
+                // if so
+                oldToNewIdentMap.forEach((key, val) -> {
+                    if (c.getData().contains(key))
+                    {
+                        c.setData(c.getData().replace(key, val));
+                    }
+                });
+            });
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
@@ -18,6 +18,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ConfigurationSet;
 import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
+import name.abuchen.portfolio.ui.util.ClientFilterMenu.ClientFilterStorageHelper;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu.Item;
 
 class ClientFilterMigration
@@ -58,7 +59,7 @@ class ClientFilterMigration
 
     private void moveFiltersIntoClientFile(List<ClientFilterMenu.Item> clientFilters)
     {
-        ConfigurationSet set = client.getSettings().getConfigurationSet("ClientFilterDropDown"); //$NON-NLS-1$
+        ConfigurationSet set = ClientFilterStorageHelper.getFilterConfigurationSet(client);
         clientFilters.forEach(cf -> set.add(new Configuration(cf.getIdent(), cf.getLabel(), cf.getUUIDs())));
     }
 
@@ -112,7 +113,7 @@ class ClientFilterMigration
         String link = preferenceStore.getString(prefKey);
         if (oldToNewIdentMap.containsKey(link))
         {
-            ConfigurationSet set = client.getSettings().getConfigurationSet("client-filter-usages"); //$NON-NLS-1$
+            ConfigurationSet set = ClientFilterStorageHelper.getFilterUsagesConfigurationSet(client);
             set.add(new Configuration(prefKey, "", oldToNewIdentMap.get(link))); //$NON-NLS-1$
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterDropDown.java
@@ -25,17 +25,12 @@ public final class ClientFilterDropDown extends DropDown implements IMenuListene
         this.menu = new ClientFilterMenu(client, preferences, listener);
         this.menu.addListener(filter -> setImage(menu.hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF));
 
-        String selection = preferences.getString(prefKey + ClientFilterMenu.PREF_KEY_POSTFIX);
-        if (selection != null)
-        {
-            this.menu.getAllItems().filter(item -> item.getUUIDs().equals(selection)).findAny().ifPresent(item -> {
-                this.menu.select(item);
-                setImage(menu.hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF);
-            });
-        }
+        String key = prefKey + ClientFilterMenu.PREF_KEY_POSTFIX;
+        menu.loadPreselectedClientFilter(key);
+        setImage(menu.hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF);
 
-        addDisposeListener(e -> preferences.putValue(prefKey + ClientFilterMenu.PREF_KEY_POSTFIX,
-                        this.menu.getSelectedItem().getUUIDs()));
+        // store/save selected filter
+        addDisposeListener(e -> menu.saveSelectedFilter(key));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -385,19 +385,19 @@ public final class ClientFilterMenu implements IMenuListener
 
     public static class ClientFilterStorageHelper
     {
-        public static final String PREF_KEY_FILTER_DEFINITIONS = ClientFilterDropDown.class.getSimpleName();
+        public static final String PREF_KEY_FILTER_DEFINITIONS = "client-filter-definitions"; //$NON-NLS-1$
         /**
          * Key for configuration set where all usages/references of client
          * filters are stored
          **/
         private static final String PREF_KEY_FILTER_USAGES = "client-filter-usages"; //$NON-NLS-1$
 
-        private static ConfigurationSet getFilterUsagesConfigurationSet(Client client)
+        public static ConfigurationSet getFilterUsagesConfigurationSet(Client client)
         {
             return client.getSettings().getConfigurationSet(PREF_KEY_FILTER_USAGES);
         }
 
-        private static ConfigurationSet getFilterConfigurationSet(Client client)
+        public static ConfigurationSet getFilterConfigurationSet(Client client)
         {
             return client.getSettings().getConfigurationSet(PREF_KEY_FILTER_DEFINITIONS);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
@@ -8,7 +8,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -47,7 +46,6 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
-import name.abuchen.portfolio.ui.util.ClientFilterMenu.Item;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -221,36 +219,21 @@ public class AllTransactionsView extends AbstractFinanceView
             clientFilterMenu.addListener(listener);
             clientFilterMenu.addListener(f -> updateIcon());
 
-            loadPreselectedFilter(preferenceStore);
+            loadPreselectedFilter();
 
             updateIcon();
 
             addDisposeListener(e -> preferenceStore.setValue(TRANSACTION_FILTER_PREFERENCE_NAME, typeFilter.name()));
         }
 
-        private void loadPreselectedFilter(IPreferenceStore preferenceStore)
+        private void loadPreselectedFilter()
         {
-            String prefix = AllTransactionsView.class.getSimpleName();
-
-            // client filter
-            String key = prefix + ClientFilterMenu.PREF_KEY_POSTFIX;
-
-            String selection = preferenceStore.getString(key);
-            if (selection != null)
-            {
-                Optional<Item> optionalItem = clientFilterMenu.getAllItems()
-                                .filter(item -> item.getUUIDs().equals(selection)).findAny();
-                if (optionalItem.isPresent())
-                {
-                    clientFilterMenu.select(optionalItem.get());
-                    ClientFilter f = optionalItem.get().getFilter();
-                    if (f instanceof PortfolioClientFilter pcf)
-                        AllTransactionsView.this.clientFilter = pcf;
-                }
-            }
-
-            clientFilterMenu.addListener(
-                            f -> preferenceStore.putValue(key, clientFilterMenu.getSelectedItem().getUUIDs()));
+            var selectedItem = clientFilterMenu.loadPreselectedClientFilterAndAddSaveSelectedFilterListener(
+                            AllTransactionsView.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX);
+            selectedItem.ifPresent(item -> {
+                if (item.getFilter() instanceof PortfolioClientFilter pcf)
+                    AllTransactionsView.this.clientFilter = pcf;
+            });
         }
 
         private void updateIcon()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -115,7 +115,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                 notifyModelUpdated();
             });
 
-            loadPreselectedClientFilter(preferenceStore);
+            clientFilterMenu.loadPreselectedClientFilterAndAddSaveSelectedFilterListener(
+                            SecuritiesPerformanceView.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX);
 
             clientFilter = clientFilterMenu.getSelectedFilter();
 
@@ -130,19 +131,6 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                 preferenceStore.setValue(SecuritiesPerformanceView.class.getSimpleName() + "-sharesEqualZero", //$NON-NLS-1$
                                 recordFilter.contains(sharesEqualZero));
             });
-        }
-
-        private void loadPreselectedClientFilter(IPreferenceStore preferenceStore)
-        {
-            String selection = preferenceStore.getString(
-                            SecuritiesPerformanceView.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX);
-            if (selection != null)
-                clientFilterMenu.getAllItems().filter(item -> item.getUUIDs().equals(selection)).findAny()
-                                .ifPresent(clientFilterMenu::select);
-
-            clientFilterMenu.addListener(filter -> preferenceStore.putValue(
-                            SecuritiesPerformanceView.class.getSimpleName() + ClientFilterMenu.PREF_KEY_POSTFIX,
-                            clientFilterMenu.getSelectedItem().getUUIDs()));
         }
 
         @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ClientFilterConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ClientFilterConfig.java
@@ -21,16 +21,18 @@ public class ClientFilterConfig implements WidgetConfig
         this.menu = new ClientFilterMenu(delegate.getClient(), delegate.getDashboardData().getPreferences(),
                         f -> filterSelected());
 
-        String uuid = delegate.getWidget().getConfiguration().get(Dashboard.Config.CLIENT_FILTER.name());
+        String storedIdent = delegate.getWidget().getConfiguration().get(Dashboard.Config.CLIENT_FILTER.name());
 
-        this.menu.getAllItems().filter(item -> item.getUUIDs().equals(uuid)).findAny()
+        // select stored/saved filter
+        this.menu.getAllItems().filter(item -> item.getIdent().equals(storedIdent)).findAny()
                         .ifPresent(item -> this.menu.select(item));
     }
 
     private void filterSelected()
     {
+        // store/save selected filter
         delegate.getWidget().getConfiguration().put(Dashboard.Config.CLIENT_FILTER.name(),
-                        menu.getSelectedItem().getUUIDs());
+                        menu.getSelectedItem().getIdent());
 
         delegate.update();
         delegate.getClient().touch();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsChartWidget.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.views.dashboard.earnings;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
@@ -126,12 +127,13 @@ public class EarningsChartWidget extends WidgetDelegate<PaymentsViewModel>
             {
                 int tab = chartBuilder.getTabIndex();
                 int startYear = get(StartYearConfig.class).getStartYear();
-                String clientFilter = get(ClientFilterConfig.class).getSelectedItem().getUUIDs();
+                String filterIdent = get(ClientFilterConfig.class).getSelectedItem().getIdent();
                 EarningType earningsType = get(EarningTypeConfig.class).getValue();
                 PaymentsViewModel.Mode mode = earningsType.getPaymentsViewModelMode();
                 GrossNetType grossNetType = get(GrossNetTypeConfig.class).getValue();
 
-                part.activateView(PaymentsView.class, new PaymentsViewInput(tab, startYear, clientFilter, mode,
+                part.activateView(PaymentsView.class, new PaymentsViewInput(tab, startYear, Optional.of(filterIdent),
+                                mode,
                                 grossNetType == GrossNetType.GROSS, false));
             }
         });

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -56,8 +56,8 @@ public final class DataSeries implements Adaptable
         PORTFOLIO_PLUS_ACCOUNT("[+]Portfolio", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
         PORTFOLIO_PLUS_ACCOUNT_PRETAX("[+]Portfolio-PreTax", i -> ((Portfolio) i).getUUID()), //$NON-NLS-1$
         CLASSIFICATION("Classification", i -> ((Classification) i).getId()), //$NON-NLS-1$
-        CLIENT_FILTER("ClientFilter", i -> ((ClientFilterMenu.Item) i).getUUIDs().replaceAll(",", "")), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        CLIENT_FILTER_PRETAX("ClientFilter-PreTax", i -> ((ClientFilterMenu.Item) i).getUUIDs().replaceAll(",", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        CLIENT_FILTER("ClientFilter", i -> ((ClientFilterMenu.Item) i).getIdent()), //$NON-NLS-1$ $
+        CLIENT_FILTER_PRETAX("ClientFilter-PreTax", i -> ((ClientFilterMenu.Item) i).getIdent()); //$NON-NLS-1$
 
         private final String label;
         private final Function<Object, String> uuidProvider;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewInput.java
@@ -7,6 +7,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
+import name.abuchen.portfolio.ui.util.ClientFilterMenu.ClientFilterStorageHelper;
 import name.abuchen.portfolio.ui.views.payments.PaymentsViewModel.Mode;
 
 public class PaymentsViewInput
@@ -108,8 +109,7 @@ public class PaymentsViewInput
         if (year < 1900 || year > now.getYear())
             year = now.getYear() - 2;
 
-        Optional<String> filterIdent = ClientFilterMenu.ClientFilterStorageHelper.getSelectedFilter(client,
-                        KEY_USED_FILTER);
+        Optional<String> filterIdent = ClientFilterStorageHelper.getSelectedFilter(client, KEY_USED_FILTER);
 
         PaymentsViewModel.Mode mode = PaymentsViewModel.Mode.ALL;
         String prefMode = preferences.getString(KEY_MODE);
@@ -140,7 +140,6 @@ public class PaymentsViewInput
         preferences.setValue(KEY_USE_GROSS_VALUE, useGrossValue);
         preferences.setValue(KEY_USE_CONSOLIDATE_RETIRED, useConsolidateRetired);
 
-        filterIdent.ifPresent(ident -> ClientFilterMenu.ClientFilterStorageHelper.saveSelectedFilter(client,
-                        KEY_USED_FILTER, ident));
+        filterIdent.ifPresent(ident -> ClientFilterStorageHelper.saveSelectedFilter(client, KEY_USED_FILTER, ident));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
@@ -89,15 +89,8 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
             String prefix = TaxonomyView.class.getSimpleName() + "-" + taxonomy.getId(); //$NON-NLS-1$
 
             // client filter
-            String key = prefix + ClientFilterMenu.PREF_KEY_POSTFIX;
-
-            String selection = preferenceStore.getString(key);
-            if (selection != null)
-                clientFilterMenu.getAllItems().filter(item -> item.getUUIDs().equals(selection)).findAny()
-                                .ifPresent(clientFilterMenu::select);
-
-            clientFilterMenu.addListener(
-                            filter -> preferenceStore.putValue(key, clientFilterMenu.getSelectedItem().getUUIDs()));
+            clientFilterMenu.loadPreselectedClientFilterAndAddSaveSelectedFilterListener(
+                            prefix + ClientFilterMenu.PREF_KEY_POSTFIX);
 
             // predicates
             if (preferenceStore.getBoolean(prefix + TaxonomyModel.KEY_FILTER_NON_ZERO))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -25,6 +25,7 @@ public class Client
 {
     public static final int CURRENT_VERSION = 56;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
+    public static final int VERSION_WITH_UNIQUE_FILTER_KEY = 57; // TODO: assign correct version here
 
     private transient PropertyChangeSupport propertyChangeSupport; // NOSONAR
 
@@ -120,6 +121,11 @@ public class Client
     void setFileVersionAfterRead(int fileVersionAfterRead)
     {
         this.fileVersionAfterRead = fileVersionAfterRead;
+    }
+
+    public boolean shouldDoFilterMigration()
+    {
+        return getFileVersionAfterRead() < Client.VERSION_WITH_UNIQUE_FILTER_KEY;
     }
 
     public String getBaseCurrency()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ConfigurationSet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ConfigurationSet.java
@@ -32,7 +32,12 @@ public class ConfigurationSet
 
         public Configuration(String name, String data)
         {
-            this.uuid = UUID.randomUUID().toString();
+            this(UUID.randomUUID().toString(), name, data);
+        }
+
+        public Configuration(String uuid, String name, String data)
+        {
+            this.uuid = uuid;
             this.name = name;
             this.data = data;
         }
@@ -111,5 +116,13 @@ public class ConfigurationSet
     public void remove(Configuration configuration)
     {
         configurations.remove(configuration);
+    }
+
+    /**
+     * Removes all configurations from the set.
+     */
+    public void clear()
+    {
+        configurations.clear();
     }
 }


### PR DESCRIPTION
This new unique identifier for the custom filters should solve bug #2546 (link in forum: https://forum.portfolio-performance.info/t/bestehende-filter-erweitern/7355/14).
Description/Analysis for the issue: https://github.com/buchen/portfolio/issues/2546#issuecomment-1191809609

Following points/actions are inlcuded in this PR (as of 5th April 2023):

- [x] Assign unique ident to each custom filter & move them from settings file into client file
- [x] Migrate filter references in settings file and move them into client file
- [x] Migrate filter references from widgets and charts
- [x] Reset old filter links in settings-file only in case XML is saved. Then migration of unsaved XML on next load is still possible. 
- [x] Created/extracted method of common used code (95ab6f0357c74390406432137a7c7b4c5f158d49)


### Old (current) structure

* User Filters are identified by their internal filter data (concatenated UUIDs of the accounts/depots, which are defined in XML)
* List of all user filters (Filter Definition) is stored in settings file
* Usages of the filters (references) are stored in settings file (except widgets filters)

### New structure

* Filters now have a unique ident (UUID) by which they were identified
* The Filter Definitions (List of all user filters) are stored in XML (``ConfigurationSet`` with ident/key ``client-filter-definitions``)
* References of filters (Filter Usages) are all stored in XML (``ConfigurationSet`` with ident/key ``client-filter-usages``; each subelement (``Configuration``) is identified by the that is key choosen by the element/user which uses the filter)