### PR TITLE
Modify Degiro PDF Importer to support Dutch bank deposits aka Storting

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/degiro/Rekeningoverzicht06.txt
@@ -1,0 +1,17 @@
+PDFBox Version: 1.8.16
+Portfolio Performance Version: 0.59.1.qualifier
+-----------------------------------------
+Dhr. John
+Doe
+Hoofdstraat 1
+1001AA Amsterdam
+Gebruikersnaam: ****bob
+Rekeningoverzicht van 25-07-2022 t/m 26-07-2022
+Datum Tijd Valutadatum Product ISIN Omschrijving FX Mutatie Saldo
+25-07-2022 10:50 25-07-2022 flatex Storting EUR 123,45 EUR 123,47
+flatex DEGIRO Bank Dutch Branch, handelend onder de naam www.degiro.nl Rekeningoverzicht
+DEGIRO, is de Nederlandse vestiging van flatexDEGIRO Bank AG. klanten@degiro.nl 2022-07-31
+flatexDEGIRO Bank AG staat primair onder supervisie van de Duitse
+Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin). Amstelplein 1 1096 HA Pagina 1 / 1
+[flatexDEGIRO Bank AG Dutch Branch] staat in Nederland onder
+integriteitstoezicht van DNB en gedragstoezicht van de AFM.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -297,10 +297,11 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         // 26-11-2021 09:01 25-11-2021 Einzahlung CHF 569.00 CHF 1'754.08
         // 28-10-2021 08:50 28-10-2021 Deposito flatex EUR 200,00 EUR 215,77
         // 01-09-2021 02:44 31-08-2021 Deposito EUR 0,01 EUR 0,01
+        // 25-07-2022 10:50 25-07-2022 flatex Storting EUR 123,45 EUR 123,47
         // @formatter:on
         Block blockDeposit = new Block("^.*([\\d]{2}:[\\d]{2}|[\\d]{4}) "
                         + "(SOFORT |iDEAL |flatex )?"
-                        + "(Einzahlung|Deposit|Deposito)"
+                        + "(Einzahlung|Deposit|Deposito|Storting)"
                         + "( flatex)? "
                         + ".*$");
         type.addBlock(blockDeposit);
@@ -315,7 +316,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                         .section("date", "time", "note", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
                                         + "([\\d]{2}\\-[\\d]{2}\\-[\\d]{4} )?"
-                                        + "(?<note>(SOFORT |iDEAL |flatex )?(Einzahlung|Deposit|Deposito))( flatex)? "
+                                        + "(?<note>(SOFORT |iDEAL |flatex )?(Einzahlung|Deposit|Deposito|Storting))( flatex)? "
                                         + "(?<currency>[\\w]{3}) "
                                         + "(?<amount>[\\.,'\\d]+) "
                                         + "[\\w]{3} "


### PR DESCRIPTION
The Dutch Degiro Account PDF shows bank deposits as "flatex Storting", which was not recognised by the importer. These bank transfers are the non-iDEAL transfers.

For example 
`25-07-2022 10:50 25-07-2022 flatex Storting EUR 123,45 EUR 123,47`

Added "Storting" to the existing regex in DeGiroPDFExtractor.

Added Rekeningoverzicht06.txt and DegiroPDFExtractorTest.testRekeningoverzicht06() to test the extraction.