### PR TITLE
Extend time grid of StackedTimelineChart 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.ui.util.chart;
 
 import java.text.DecimalFormat;
 import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -21,6 +23,7 @@ import org.swtchart.Range;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.util.Dates;
+import name.abuchen.portfolio.util.Triple;
 
 public class StackedTimelineChart extends Chart // NOSONAR
 {
@@ -107,19 +110,26 @@ public class StackedTimelineChart extends Chart // NOSONAR
         final LocalDate start = dates.get(0);
         final LocalDate end = dates.get(dates.size() - 1);
 
+        int days = Dates.daysBetween(start, end) + 1;
         int totalDays = Dates.daysBetween(start, end) + 1;
 
-        e.gc.setForeground(getAxisSet().getAxes()[0].getGrid().getForeground());
+        Triple<Period, DateTimeFormatter, LocalDate> data = TimelineChart.getPeriodFormatAndCursor(days, start,
+                        e.width);
+        Period period = data.getFirst();
+        DateTimeFormatter format = data.getSecond();
+        LocalDate cursor = data.getThird();
 
-        LocalDate current = start.plusYears(1).withDayOfYear(1);
-        while (current.isBefore(end))
+        e.gc.setForeground(getTitle().getForeground());
+
+        while (cursor.isBefore(end))
         {
-            int days = Dates.daysBetween(start, current);
-            int y = xAxis.getPixelCoordinate((double) days * range.upper / (double) totalDays);
-            e.gc.drawLine(y, 0, y, e.height);
-            e.gc.drawText(String.valueOf(current.getYear()), y + 5, 5);
+            days = Dates.daysBetween(start, cursor);
+            int x = xAxis.getPixelCoordinate((double) days * range.upper / (double) totalDays);
+            e.gc.drawLine(x, 0, x, e.height);
+            String labelText = format.format(cursor);
+            e.gc.drawText(labelText, x + 5, 5);
 
-            current = current.plusYears(1);
+            cursor = cursor.plus(period);
         }
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -309,7 +309,7 @@ public class StackedChartViewer extends AbstractChartPage
             }
 
             chart.getAxisSet().adjustRange();
-            chart.getAxisSet().getYAxis(0).setRange(new Range(-0.01, 1.01));
+            chart.getAxisSet().getYAxis(0).setRange(new Range(-0.025, 1.025));
         }
         finally
         {


### PR DESCRIPTION
The time grid of the taxonomy area chart is different to other ones (e.g. in statement of assets historical chart). In the current version there is only a vertical line for each year. Additionally the color of the vertical line and the text has a color which is difficult to see. Reported here: https://forum.portfolio-performance.info/t/beschriftung-der-zeitachse-im-flachendiagramm-der-klassifizierung-fehlt/21607

So I changed the color and used the same time grid calculation in the ``StackedTimelineChart`` as in the ``TimelineChart``.
Here some screenshots from current version and same view with this PR:

**Period 3 years**
Current Version:
![grafik](https://user-images.githubusercontent.com/90478568/185808543-96d673ed-1f5b-4b8c-99d8-55244cfba832.png)
With this PR:
![grafik](https://user-images.githubusercontent.com/90478568/185808570-30162bc0-bec8-4d4d-8b00-8f73e9725334.png)

**Period 100 days**
Current Version:
![grafik](https://user-images.githubusercontent.com/90478568/185808582-63d1cacf-bdd5-4194-a4e9-8313ab3c8658.png)
With this PR:
![grafik](https://user-images.githubusercontent.com/90478568/185808590-da429bf2-9ac3-4081-8cee-941ec8908219.png)
