### PR TITLE
Add short American date format with 4-digit year for HTML table quote feed

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedHistoricalSample2.html
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedHistoricalSample2.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html lang="en">
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Feed Sample</title>
+</head>
+
+<body>
+    <div class="container">
+        <header>
+            <h1>Some random header</h1>
+        </header>
+        <div>
+            <table>
+            	<thead>
+	            	<tr>
+	            		<th><div><button><span>Date</span></button></div></th>
+	            		<th><div><button><span>Price</span></button></div></th>
+	            		<th><div><button><span>Open</span></button></div></th>
+	            		<th><div><button><span>High</span></button></div></th>
+	            		<th><div><button><span>Low</span></button></div></th>
+	            		<th><div><button><span>Vol.</span></button></div></th>
+	            		<th><div><button><span>Change %</span></button></div></th>
+	            	</tr>
+            	</thead>
+            	<tbody>
+            		<tr>
+            			<td><time datetime="08/24/2022">08/24/2022</time></td>
+            			<td>1.55</td>
+            			<td>1.73</td>
+            			<td>1.78</td>
+            			<td>1.54</td>
+            			<td>1.10M</td>
+            			<td>-0.30%</td>
+            		</tr>
+            		<tr>
+            			<td><time datetime="08/23/2022">08/23/2022</time></td>
+            			<td>1.73</td>
+            			<td>1.68</td>
+            			<td>1.89</td>
+            			<td>1.73</td>
+            			<td>1.50M</td>
+            			<td>+0.50%</td>
+            		</tr>
+            	</tbody>
+        	</table>
+    	</div>
+    </div>
+</body>
+
+</html>

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedSample2Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeedSample2Test.java
@@ -1,0 +1,41 @@
+package name.abuchen.portfolio.online.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.TestUtilities;
+import name.abuchen.portfolio.model.LatestSecurityPrice;
+import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.online.QuoteFeedData;
+
+@SuppressWarnings("nls")
+public class HTMLTableQuoteFeedSample2Test
+{
+    @Test
+    public void testHistorical()
+    {
+        HTMLTableQuoteFeed feed = new HTMLTableQuoteFeed();
+
+        String html = TestUtilities.read(getClass(), "HTMLTableQuoteFeedHistoricalSample2.html");
+
+        QuoteFeedData data = feed.getHistoricalQuotes(html);
+
+        List<LatestSecurityPrice> prices = data.getLatestPrices();
+
+        assertThat(prices.size(), is(2));
+
+        Collections.sort(prices, new SecurityPrice.ByDate());
+
+        assertThat(prices.get(1).getDate(), is(LocalDate.parse("2022-08-24")));
+        assertThat(prices.get(1).getValue(), is(Values.Quote.factorize(1.55)));
+        assertThat(prices.get(1).getHigh(), is(Values.Quote.factorize(1.78)));
+        assertThat(prices.get(1).getLow(), is(Values.Quote.factorize(1.54)));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/HTMLTableQuoteFeed.java
@@ -195,6 +195,7 @@ public class HTMLTableQuoteFeed implements QuoteFeed
                             DateTimeFormatter.ofPattern("d MMM y", Locale.ENGLISH), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("EEEE, MMMM dd, yEEE, MMM dd, y", Locale.ENGLISH), //$NON-NLS-1$
                             DateTimeFormatter.ofPattern("yyyy.MM.dd."), //$NON-NLS-1$
+                            DateTimeFormatter.ofPattern("M/d/yyyy"), //$NON-NLS-1$
             };
         }
 


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/unable-to-import-historical-data-tables-from-investing-com-anymore/21655