### PR TITLE
Improve links in StyledLabel component

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/StyledLabel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/StyledLabel.java
@@ -20,6 +20,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -176,6 +177,7 @@ public class StyledLabel extends Canvas // NOSONAR
         addListener(SWT.Paint, this::handlePaint);
         addListener(SWT.Dispose, this::handleDispose);
         addListener(SWT.MouseDown, this::openBrowser);
+        addListener(SWT.MouseMove, this::updateCursor);
     }
 
     public void setText(String text)
@@ -262,18 +264,37 @@ public class StyledLabel extends Canvas // NOSONAR
 
     private void openBrowser(Event event)
     {
-        int offset = this.textLayout.getOffset(event.x, event.y, null);
-        if (offset == -1)
-            return;
-
-        TextStyle style = this.textLayout.getStyle(offset);
-        if (style != null && style.data != null && event.button == 1)
+        String linkUrl = this.getLinkUrlAtMousePointer(event);
+        if (linkUrl != null && event.button == 1)
         {
             if (openLinkHandler != null)
-                openLinkHandler.accept(String.valueOf(style.data));
+                openLinkHandler.accept(linkUrl);
             else
-                DesktopAPI.browse(String.valueOf(style.data));
+                DesktopAPI.browse(linkUrl);
         }
     }
 
+    private void updateCursor(Event event)
+    {
+        this.setCursor(this.getLinkUrlAtMousePointer(event) != null ? new Cursor(this.getDisplay(), SWT.CURSOR_HAND)
+                        : null);
+    }
+
+    private String getLinkUrlAtMousePointer(Event event)
+    {
+        int offset = this.textLayout.getOffset(event.x, event.y, null);
+        if (offset == -1)
+            return null;
+        
+        Point mostLeftPoint = this.textLayout.getLocation(offset, false);
+        Point mostRightPoint = this.textLayout.getLocation(offset, true);
+        if (event.x < mostLeftPoint.x || event.x > mostRightPoint.x)
+            return null;
+
+        TextStyle style = this.textLayout.getStyle(offset);
+        if (style == null || style.data == null)
+            return null;
+
+        return String.valueOf(style.data);
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/StyledLabel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/StyledLabel.java
@@ -267,7 +267,7 @@ public class StyledLabel extends Canvas // NOSONAR
             return;
 
         TextStyle style = this.textLayout.getStyle(offset);
-        if (style != null && style.data != null)
+        if (style != null && style.data != null && event.button == 1)
         {
             if (openLinkHandler != null)
                 openLinkHandler.accept(String.valueOf(style.data));


### PR DESCRIPTION
This small PR optimizes the `StyledLabel` component:
1. Hovering over a link shows a hand cursor as known from other links
1. Only left mouse button click on a link opens the browser so that the context menu is still accessible via right click
1. Fixed issue with clickable area of component if link is last element in description widget (this lead to the remaining line being clickable though not a link)