### PR TITLE
Link from performance/statement of assets chart widgets back to original chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfigurationStore.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfigurationStore.java
@@ -212,7 +212,7 @@ public class ConfigurationStore
         listeners.forEach(l -> l.onConfigurationPicked(active.getData()));
     }
 
-    private void activate(Configuration config)
+    public void activate(Configuration config)
     {
         listeners.forEach(ConfigurationStoreOwner::beforeConfigurationPicked);
         active = config;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -9,7 +9,10 @@ import java.time.LocalDate;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
 
+import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
@@ -25,12 +28,14 @@ import org.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 
+import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.Aggregation;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
+import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -55,6 +60,7 @@ public class PerformanceChartView extends AbstractHistoricView
 
     private TimelineChart chart;
     private DataSeriesConfigurator picker;
+    private Configuration initViewConfig;
 
     private Aggregation.Period aggregationPeriod;
 
@@ -113,6 +119,10 @@ public class PerformanceChartView extends AbstractHistoricView
         picker = new DataSeriesConfigurator(this, DataSeries.UseCase.PERFORMANCE);
         picker.addListener(this::updateChart);
         picker.setToolBarManager(getViewToolBarManager());
+        if (this.initViewConfig != null)
+        {
+            picker.getStore().activate(this.initViewConfig);
+        }
 
         DataSeriesChartLegend legend = new DataSeriesChartLegend(composite, picker);
         legend.addSelectionChangedListener(e -> setInformationPaneInput(e.getStructuredSelection().getFirstElement()));
@@ -158,6 +168,13 @@ public class PerformanceChartView extends AbstractHistoricView
     {
         seriesBuilder.getCache().clear();
         updateChart();
+    }
+
+    @Inject
+    @Optional
+    public void initViewConfig(@Named(UIConstants.Parameter.VIEW_PARAMETER) Configuration config)
+    {
+        this.initViewConfig = config;
     }
 
     private void updateChart()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.UIEventTopic;
@@ -21,6 +22,7 @@ import org.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 
+import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
@@ -48,6 +50,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
     private TimelineChart chart;
     private DataSeriesConfigurator configurator;
     private StatementOfAssetsSeriesBuilder seriesBuilder;
+    private Configuration initViewConfig;
 
     @Inject
     @Optional
@@ -125,6 +128,10 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
         configurator = new DataSeriesConfigurator(this, DataSeries.UseCase.STATEMENT_OF_ASSETS);
         configurator.addListener(this::updateChart);
         configurator.setToolBarManager(getViewToolBarManager());
+        if (this.initViewConfig != null)
+        {
+            configurator.getStore().activate(this.initViewConfig);
+        }
 
         DataSeriesChartLegend legend = new DataSeriesChartLegend(composite, configurator);
         legend.addSelectionChangedListener(e -> setInformationPaneInput(e.getStructuredSelection().getFirstElement()));
@@ -180,6 +187,13 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
     public void reportingPeriodUpdated()
     {
         notifyModelUpdated();
+    }
+
+    @Inject
+    @Optional
+    public void initViewConfig(@Named(UIConstants.Parameter.VIEW_PARAMETER) Configuration config)
+    {
+        this.initViewConfig = config;
     }
 
     private void updateChart()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesConfigurator.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesConfigurator.java
@@ -50,6 +50,11 @@ public class DataSeriesConfigurator extends BasicDataSeriesConfigurator implemen
         return store.getActiveName();
     }
 
+    public ConfigurationStore getStore()
+    {
+        return this.store;
+    }
+
     /**
      * Shows the menu to add and remove data series from the current set of data
      * series.


### PR DESCRIPTION
This small PR adds a link from the performance and statement of assets chart dashboard widgets back to the original charts.

Issue: https://forum.portfolio-performance.info/t/link-aus-diagramm-im-dashboard-auf-die-grossversion-unter-diagramme/22027/2