### PR TITLE
Add year selection to the calendar preview

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
@@ -12,8 +12,11 @@ import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
@@ -68,6 +71,31 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
         infoLabel = new Label(composite, SWT.WRAP);
         infoLabel.setFont(getFieldEditorParent().getFont());
         GridDataFactory.fillDefaults().span(2, 1).grab(true, true).applyTo(infoLabel);
+
+        new Label(composite, SWT.NONE)
+            .setText(Messages.LabelYear);
+
+        Spinner yearSpinner = new Spinner(composite, SWT.BORDER);
+        yearSpinner.setTextLimit(5);
+        yearSpinner.setIncrement(1);
+        yearSpinner.setPageIncrement(10);
+        // Maximum, minimum, and selection (value) must be set in that order:
+        yearSpinner.setMaximum(2150);
+        yearSpinner.setMinimum(1850);
+        yearSpinner.setSelection(year);
+        yearSpinner.addModifyListener(new ModifyListener()
+        {
+            @Override
+            public void modifyText(ModifyEvent e)
+            {
+                int newYear = yearSpinner.getSelection();
+                if (newYear != year)
+                {
+                    year = newYear;
+                    updateInfoLabel();
+                }
+            }
+        });
 
         updateInfoLabel();
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/CalendarPreferencePage.java
@@ -25,6 +25,8 @@ import name.abuchen.portfolio.util.TradeCalendarManager;
 public class CalendarPreferencePage extends FieldEditorPreferencePage
 {
     private Label infoLabel;
+    private int year;
+    private String calendar;
 
     public CalendarPreferencePage()
     {
@@ -60,12 +62,14 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
 
     protected void createInfo(Composite composite)
     {
-        int year = LocalDate.now().getYear();
-        infoLabel = new Label(composite, SWT.WRAP);
-        infoLabel.setText(createHolidayText(TradeCalendarManager.getDefaultInstance().getCode(), year));
-        infoLabel.setFont(getFieldEditorParent().getFont());
+        year = LocalDate.now().getYear();
+        calendar = TradeCalendarManager.getDefaultInstance().getCode();
 
+        infoLabel = new Label(composite, SWT.WRAP);
+        infoLabel.setFont(getFieldEditorParent().getFont());
         GridDataFactory.fillDefaults().span(2, 1).grab(true, true).applyTo(infoLabel);
+
+        updateInfoLabel();
     }
 
     @Override
@@ -75,11 +79,19 @@ public class CalendarPreferencePage extends FieldEditorPreferencePage
 
         if (event.getProperty().equals(FieldEditor.VALUE))
         {
-            int year = LocalDate.now().getYear();
             String newCode = (String) event.getNewValue();
-            infoLabel.setText(createHolidayText(newCode, year));
-            infoLabel.getParent().getParent().layout(true);
+            if (! newCode.equals(calendar))
+            {
+                calendar = newCode;
+                updateInfoLabel();
+            }
         }
+    }
+
+    private void updateInfoLabel()
+    {
+        infoLabel.setText(createHolidayText(calendar, year));
+        infoLabel.getParent().getParent().layout(true);
     }
 
     private static final DateTimeFormatter shortDayOfWeekFormatter = DateTimeFormatter.ofPattern("E"); //$NON-NLS-1$


### PR DESCRIPTION
On the calendar preference page, a preview of the holidays in the chosen calendar was already shown. It was, however, restricted to the current year. Since it may be relevant to see the holidays of the next year in particular, but sometimes even of other years, add a control through which the user may specify the year for the calendar preview.

![New calendar preference page (in German), showing a preview of the LSE calendar for 2023](https://user-images.githubusercontent.com/1127374/200198273-7c571149-25f7-40a5-b477-6fd6d9ee76c7.png)