### PR TITLE
Modify DKB PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -3425,6 +3425,35 @@ public class DkbPDFExtractorTest
     }
 
     @Test
+    public void testGiroKontoauszug19()
+    {
+        DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug19.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(1));
+
+        // check transaction
+        // get transactions
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(1L));
+
+        Item item = iter.next();
+
+        // assert transaction
+        AccountTransaction transaction = (AccountTransaction) item.getSubject();
+        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
+        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-06-12T00:00")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.01)));
+        assertThat(transaction.getSource(), is("GiroKontoauszug19.txt"));
+        assertThat(transaction.getNote(), is("Buchung Identifikationscode"));
+    }
+
+    @Test
     public void testKreditKontoauszug01()
     {
         DkbPDFExtractor extractor = new DkbPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/GiroKontoauszug19.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/GiroKontoauszug19.txt
@@ -1,0 +1,19 @@
+PDFBox Version: 1.8.16
+Portfolio Performance Version: 0.59.3
+-----------------------------------------
+Deutsche Kreditbank, Taubenstr. 7-9, 10117 Berlin
+Max Mustermann
+Musterstr. 1 IHR DISPOKREDIT EUR 0,00
+12345 Musterstadt
+DKB-Cash
+Kontoauszug Nummer 007 / 2018 vom 02.06.2018 bis 04.07.2018
+Kontonummer 1234567890 / IBAN DE21 1203 0000 1234 5678 90
+Bu.Tag Wert Wir haben für Sie gebucht Belastung in EUR Gutschrift in EUR
+12.06. 12.06. BUCHUNG 0,01
+KREDITKARTENABRECHNUNG
+IDENTIFIKATIONSCODE 123456 - KARTENENDNUMMER
+1234. SCH LIEßEN SIE DIE REGISTRIERUN G AB UNTER
+WWW.DKB.DE/SECUR E-VISA
+ALTER KONTOSTAND 0,00 H EUR
+NEUER KONTOSTAND 0,01 H EUR
+[...]


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-dkb/4449/84

Remove leading zeros in the account statement number because it can be only three digits but also five digits before 2019.