### PR TITLE
Delete unnecessary translation file

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/labels_cs.properties
+++ b/name.abuchen.portfolio.ui/META-INF/labels_cs.properties
@@ -1,6 +1,0 @@
-
-lineStyle.DASH       = \u010C\u00E1rka
-lineStyle.DASHDOT    = \u010C\u00E1rka te\u010Dka
-lineStyle.DASHDOTDOT = \u010C\u00E1rka te\u010Dka te\u010Dka
-lineStyle.DOT        = Te\u010Dka
-lineStyle.SOLID      = Pln\u00FD


### PR DESCRIPTION
An unnecessary translation file was created in pull request #2698. This is not needed.

The file already exists under
/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/labels.properties