### PR TITLE
reduce filter size of holdings pie percentage labels

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/html/pie.html
+++ b/name.abuchen.portfolio.ui/META-INF/html/pie.html
@@ -186,7 +186,7 @@ var thePieChart = {
 
         this.valueLabels.enter()
             .append("text")
-            .filter(function(d) { return d.data.value / total > 0.03 })
+            .filter(function(d) { return d.data.value / total > 0.015 })
             .attr("transform", this.transformValueLabels)
             .attr("dy", ".35em")
             .attr("text-anchor", "middle")


### PR DESCRIPTION
Currently the percentage labels on the holdings pie chart are hidden if the position is smaller than 3%. For my sense that is a quite big range being filtered out.

I gave it a play and think we could reduce that filter's size to 1.5% without having issues with overlapping labels.

Here's some screenshots for you to get a feeling of what i mean 😃 

**Current situation:**
![2.98% Position @ FullHD](https://user-images.githubusercontent.com/10389214/211145875-1a3b4a1f-c056-4984-908c-2a0d9411647e.png)


**Proposal:**
![Lower bounds - Small Screen](https://user-images.githubusercontent.com/10389214/211145578-5239eb1c-53e3-4127-890e-ae8fa93470e6.png)

![Higher bounds - Small Screen](https://user-images.githubusercontent.com/10389214/211145580-d9243a36-d0b1-40bf-aeef-907a1bed261d.png)

![Lower bounds - Larger Screen](https://user-images.githubusercontent.com/10389214/211145577-113ed4b6-b375-4d6c-8013-5e73036a1134.png)

![Higher bounds - Larger Screen](https://user-images.githubusercontent.com/10389214/211145579-fff2b73b-de01-41e3-a024-8818a05b3409.png)

Lemme' know what you think 😄 


