### PR TITLE
Add tradecalender test

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TradeCalendarTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 @SuppressWarnings("nls")
 public class TradeCalendarTest
 {
-
     @Test
     public void testEasterHolidays()
     {
@@ -159,46 +158,118 @@ public class TradeCalendarTest
     }
 
     @Test
-    public void testNYSE()
+    public void testTradeCalenderNYSE()
     {
         // See https://www.nyse.com/markets/hours-calendars
 
         TradeCalendar calendar = TradeCalendarManager.getInstance("nyse");
 
-        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-10")), is(false)); // regular Monday
-        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-11")), is(true)); // closed after terrorist attacks (9/11)
-        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-14")), is(true)); // ... still closed
-        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-17")), is(false)); // reopened the following Monday
-
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-01-01")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-01-20")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-02-17")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-04-10")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-25")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-07-03")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-09-07")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-11-26")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-12-25")), is(true));
-
+        // New Year
         assertThat(calendar.isHoliday(LocalDate.parse("2021-01-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-01-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Martin Luther King day
         assertThat(calendar.isHoliday(LocalDate.parse("2021-01-18")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-01-17")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-16")), is(true));
+
+        // Washingtons Birthday
         assertThat(calendar.isHoliday(LocalDate.parse("2021-02-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-02-21")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-02-20")), is(true));
+
+        // Good friday
         assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+
+        // Memorial
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-04-10")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+
+        // Juneteenth
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-25")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-05-31")), is(true));
+
+        // Independence Day
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-07-03")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-07-05")), is(true));
+        
+        // Labour day
         assertThat(calendar.isHoliday(LocalDate.parse("2021-09-06")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-09-05")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-09-04")), is(true));
+
+        // Thanksgiving
         assertThat(calendar.isHoliday(LocalDate.parse("2021-11-25")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-11-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-11-23")), is(true));
+
+        // Chrismas
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-12-25")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-12-24")), is(true));
+
+        // Special Holidays
+        assertThat(calendar.isHoliday(LocalDate.parse("1994-04-27")), is(true)); // President Nixon
+        assertThat(calendar.isHoliday(LocalDate.parse("2004-06-11")), is(true)); // President Reagan
+        assertThat(calendar.isHoliday(LocalDate.parse("2007-01-02")), is(true)); // President Ford
+        assertThat(calendar.isHoliday(LocalDate.parse("2012-10-29")), is(true)); // Hurricane Sandy
+        assertThat(calendar.isHoliday(LocalDate.parse("2012-10-30")), is(true)); // Hurricane Sandy
+        assertThat(calendar.isHoliday(LocalDate.parse("2018-12-05")), is(true)); // President Bush Sr.
+
+        // terrorist attacks (9/11)
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-10")), is(false)); // open market
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-11")), is(true)); // closed after terrorist attacks (9/11)
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-12")), is(true)); // closed after terrorist attacks (9/11)
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-13")), is(true)); // closed after terrorist attacks (9/11)
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-14")), is(true)); // closed after terrorist attacks (9/11)
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-09-17")), is(false)); // reopen market (Monday)
     }
 
     @Test
-    public void testLSE()
+    public void testTradeCalenderLSE()
     {
         // See https://www.londonstockexchange.com/trade/trading-access/business-days
 
         TradeCalendar calendar = TradeCalendarManager.getInstance("lse");
 
-        assertThat(calendar.isHoliday(LocalDate.parse("2019-01-01")), is(true));
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-01-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-01-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Good Friday
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-04-19")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+
+        // Eastern
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-04-22")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-10")), is(true));
+
+        // Early May Bank Holiday moved to VE Day in 1995 and 2020
+        assertThat(calendar.isHoliday(LocalDate.parse("1995-05-01")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("1995-05-08")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-04")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-08")), is(true));
+
+        // Spring Bank Holiday moved for royal jubilees in 1977, 2002, 2012, 2022
+        assertThat(calendar.isHoliday(LocalDate.parse("1977-05-30")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("1977-06-06")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("1977-06-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-05-27")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-06-03")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-06-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2012-05-28")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2012-06-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2012-06-05")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-30")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-03")), is(true));
+        
         assertThat(calendar.isHoliday(LocalDate.parse("2019-04-19")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2019-04-22")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2019-05-06")), is(true));
@@ -220,26 +291,6 @@ public class TradeCalendarTest
         assertThat(calendar.isHoliday(LocalDate.parse("2022-01-03")), is(true)); // Monday, substitute for holiday
         assertThat(calendar.isHoliday(LocalDate.parse("2022-01-04")), is(false));
 
-        // Early May Bank Holiday moved to VE Day in 1995 and 2020
-        assertThat(calendar.isHoliday(LocalDate.parse("1995-05-01")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("1995-05-08")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-04")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-08")), is(true));
-
-        // Spring Bank Holiday moved for royal jubilees in 1977, 2002, 2012, 2022
-        assertThat(calendar.isHoliday(LocalDate.parse("1977-05-30")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("1977-06-06")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("1977-06-07")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2002-05-27")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("2002-06-03")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2002-06-04")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2012-05-28")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("2012-06-04")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2012-06-05")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-30")), is(false));
-        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-02")), is(true));
-        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-03")), is(true));
-
         // special holidays
         assertThat(calendar.isHoliday(LocalDate.parse("1973-11-14")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("1981-07-29")), is(true));
@@ -251,22 +302,42 @@ public class TradeCalendarTest
     }
 
     @Test
-    public void testEuronext()
+    public void testTradeCalenderEuronext()
     {
         // See https://www.euronext.com/en/trading-calendars-hours
 
         TradeCalendar calendar = TradeCalendarManager.getInstance("euronext");
 
+        // New Year
         assertThat(calendar.isHoliday(LocalDate.parse("2019-01-01")), is(true));
+
+        // Good Friday
         assertThat(calendar.isHoliday(LocalDate.parse("2019-04-19")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+
+        // Eastern
         assertThat(calendar.isHoliday(LocalDate.parse("2019-04-22")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-10")), is(true));
+
+        // Labour day
         assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+
+        // Chrismas
         assertThat(calendar.isHoliday(LocalDate.parse("2019-12-25")), is(true));
+
+        // Saint Stephen
         assertThat(calendar.isHoliday(LocalDate.parse("2019-12-26")), is(true));
     }
 
     @Test
-    public void testTSX()
+    public void testTradeCalenderTSX()
     {
         // See https://www.tsx.com/trading/calendars-and-trading-hours/calendar
 
@@ -276,6 +347,41 @@ public class TradeCalendarTest
         assertThat(calendar.isHoliday(LocalDate.parse("2011-01-03")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2012-01-02")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2017-01-02")), is(true));
+
+        // Family day
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-02-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-02-21")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-02-20")), is(true));
+
+        // Good friday
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+
+        // Victoria day
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-23")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-22")), is(true));
+
+        // National day
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-07-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-07-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-07-03")), is(true));
+
+        // Civic Day
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-08-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-08-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-08-07")), is(true));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-09-06")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-09-05")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-09-04")), is(true));
+
+        // Thanksgiving
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-10-11")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-10-10")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-10-09")), is(true));
 
         // Christmas and Boxing Day
         assertThat(calendar.isHoliday(LocalDate.parse("2016-12-26")), is(true));
@@ -308,6 +414,241 @@ public class TradeCalendarTest
         assertThat(calendar.isHoliday(LocalDate.parse("2021-10-11")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-12-27")), is(true));
         assertThat(calendar.isHoliday(LocalDate.parse("2021-12-28")), is(true));
+    }
+
+    @Test
+    public void testTradeCalenderIBOV()
+    {
+        // See https://www.b3.com.br/pt_br/solucoes/plataformas/puma-trading-system/para-participantes-e-traders/calendario-de-negociacao/feriados/
+
+        TradeCalendar calendar = TradeCalendarManager.getInstance("ibov");
+
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Carnival
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-02-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-02-16")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-02-28")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-03-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-02-20")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-02-21")), is(true));
+
+        // Eastern
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+
+        // Tiradentes' Day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-21")), is(true));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+
+        // Corpus Christi
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-06-03")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-16")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-06-08")), is(true));
+
+        // Independence day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-09-07")), is(true));
+
+        // Patron day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-10-12")), is(true));
+
+        // All soul day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-11-02")), is(true));
+
+        // Republic Proclamation day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-11-02")), is(true));
+
+        // Chrismas
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-25")), is(true));
+    }
+
+    @Test
+    public void testTradeCalenderSIX()
+    {
+        // See https://six-group.com/exchanges/exchange_traded_products/trading/trading_and_settlement_calendar_de.html
+
+        TradeCalendar calendar = TradeCalendarManager.getInstance("six");
+
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Extra Holiday
+        assertThat(calendar.isHoliday(LocalDate.parse("2000-01-03")), is(true));
+
+        // Eastern
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-10")), is(true));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+
+        // Ascension
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-18")), is(true));
+        
+        // Ascension
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-05-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-05-09")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2003-05-29")), is(true));
+
+        // Whit Monday
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-06-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-05-20")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2003-06-09")), is(true));
+
+        // National day
+        assertThat(calendar.isHoliday(LocalDate.parse("1999-08-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2000-08-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2001-08-01")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2002-08-01")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2003-08-01")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2004-08-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2005-08-01")), is(false));
+        assertThat(calendar.isHoliday(LocalDate.parse("2006-08-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2007-08-01")), is(true));
+
+        // Chrismas
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-24")), is(true));
+
+        // Saint Stephen
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-26")), is(true));
+    }
+
+    @Test
+    public void testTradeCalenderISE()
+    {
+        // See https://www.borsaitaliana.it/borsaitaliana/calendario-e-orari-di-negoziazione/calendario-borsa-orari-di-negoziazione.en.htm
+
+        TradeCalendar calendar = TradeCalendarManager.getInstance("ise");
+
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-12-31")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Good friday
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-04-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-04-15")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        
+        // Eastern
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-10")), is(true));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+        
+        // Assumption day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-08-15")), is(true));
+
+        // Chrismas
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-25")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-26")), is(true));
+    }
+
+    @Test
+    public void testTradeCalenderVSE()
+    {
+        // See https://www.wienerborse.at/handel/handelsinformationen/handelskalender/
+
+        TradeCalendar calendar = TradeCalendarManager.getInstance("vse");
+
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-12-31")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+
+        // Eastern
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-07")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-04-10")), is(true));
+
+        // Whit Monday
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-06")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-30")), is(false));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+        
+        // National day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-10-26")), is(true));
+
+        // Chrismas
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-24")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-25")), is(true));
+
+        // Saint Stephen
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-12-26")), is(true));
+    }
+
+    @Test
+    public void testTradeCalenderMICEXRTS()
+    {
+        // See https://www.wienerborse.at/handel/handelsinformationen/handelskalender/
+
+        TradeCalendar calendar = TradeCalendarManager.getInstance("MICEX-RTS");
+
+        // New Year
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-02")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-03")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-05")), is(true));
+
+        // Chrismas eve russia
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-01-07")), is(true));
+
+        // Defender of the fatherland day
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-02-23")), is(true));
+
+        // International womens day
+        assertThat(calendar.isHoliday(LocalDate.parse("2014-03-10")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-03-09")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-03-08")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-03-08")), is(true));
+
+        // Labour day
+        assertThat(calendar.isHoliday(LocalDate.parse("2019-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-05-01")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-01")), is(true));
+        
+        // Victory day
+        assertThat(calendar.isHoliday(LocalDate.parse("2014-05-09")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2015-05-11")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-05-11")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-05-09")), is(true));
+
+        // National day
+        assertThat(calendar.isHoliday(LocalDate.parse("2020-06-12")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-06-14")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-06-13")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-06-12")), is(true));
+
+        // Unity day
+        assertThat(calendar.isHoliday(LocalDate.parse("2018-11-05")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2021-11-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2022-11-04")), is(true));
+        assertThat(calendar.isHoliday(LocalDate.parse("2023-11-06")), is(true));
     }
 
     @Test


### PR DESCRIPTION
Only completion of the open test dates of the trading days. No modification or deletion of tests.

The @chirlu for the latest changes and checks.
So that we prevent this I have added these tests.