### PR TITLE
Fix a bug in the WithoutTaxesFilter

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilter.java
@@ -133,6 +133,9 @@ public class WithoutTaxesFilter implements ClientFilter
         else
             copy.setAmount(deliveryT.getAmount() + taxes.getAmount());
 
+        // copy units, except for taxes
+        deliveryT.getUnits().filter(u -> u.getType() != Unit.Type.TAX).forEach(u -> copy.addUnit(u));
+
         readOnlyPortfolio.internalAddTransaction(copy);
     }
 


### PR DESCRIPTION
When filtering delivery transactions, the WithoutTaxesFilter did not copy units to the result. While it is correct to drop TAX units, missing FEE units caused the results to be wrong; fees from those transactions were missing, while capital gains or realized capital gains were too high.

Copy all units except for TAX units to filtered transactions, like it is already done for buy and sell transactions. Also add a test that catches this bug: Compare performance snapshots with and without the filter applied; they should only differ in taxes and transfers.

Issue: https://forum.portfolio-performance.info/t/what-is-the-difference-if-performance-is-calculated-over-security-account-or-custom-taxonomy/22845