### PR TITLE
Promote OpenJDK instead of Oracle JDK

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1986,7 +1986,7 @@ MsgUpdateNewInVersionX = New in Version {0}
 
 MsgUpdateNoWritePermissions = No permissions to install the update.\n\nStart Portfolio Performance via the context menu "Start as administrator ...".\n\nIf that doesn't work, reload Portflio Performance and unpack.
 
-MsgUpdateRequiresLatestJavaVersion = This version requires a newer version of the Java runtime environment.\n\nThe Java runtime environment can be downloaded here: http://java.com/download/\n\nIf you do not update the Java runtime environment, Portfolio Performance will not\nstart anymore. If you update the Java first, then this message will disappear.\n\nThe current downloads at https://www.portfolio-performance.info/portfolio/ include\nthe right Java runtime environment, i.e. there is no need to install Java separately.
+MsgUpdateRequiresLatestJavaVersion = This version requires a newer version of the Java runtime environment.\n\nThe Java runtime environment can be downloaded here: https://openjdk.org/install/\n\nIf you do not update the Java runtime environment, Portfolio Performance will not\nstart anymore. If you update the Java first, then this message will disappear.\n\nThe current downloads at https://www.portfolio-performance.info/portfolio/ include\nthe right Java runtime environment, i.e. there is no need to install Java separately.
 
 MsgUpdateRunning32BitOn64BitOS = You seem to be running a 32bit PP on a 64bit Operating System. Instead of updating, <a href="https://www.portfolio-performance.info/portfolio/">download</a> the 64bit version.
 


### PR DESCRIPTION
As I got in PP the message, that I need a newer JRE I was a little bit surprised to find a link to Oracles JDK. I suggest to change to OpenJDK.