### PR TITLE
support for duplicate a widget by drag'n'drop

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
@@ -167,7 +167,6 @@ public class DashboardView extends AbstractHistoricView
 
         private void doDropCopy(Dashboard.Widget copiedWidget, Dashboard.Column newColumn, Composite newParent)
         {
-            
             Composite elementToMoveAbove = null;
             if (dropTarget.getData() instanceof Dashboard.Widget dropTargetWidget)
             {
@@ -194,8 +193,7 @@ public class DashboardView extends AbstractHistoricView
                             .buildDelegateAndMoveAboveElement(newParent, factory, copiedWidget, elementToMoveAbove);
 
             newDelegateWithComposite.getLeft().update();
-            Composite newComposite = newDelegateWithComposite.getRight();
-            newComposite.setParent(newParent);
+            newDelegateWithComposite.getRight().setParent(newParent);
         }
 
         private void doDropMove(Composite droppedComposite, Dashboard.Widget droppedWidget, Dashboard.Column oldColumn,
@@ -601,7 +599,6 @@ public class DashboardView extends AbstractHistoricView
         Composite filler = (Composite) columnControl.getData(FILLER_KEY);
         return buildDelegateAndMoveAboveElement(columnControl, widgetType, widget, filler);
     }
-
 
     private Pair<WidgetDelegate<?>, Composite> buildDelegateAndMoveAboveElement(Composite columnControl,
                     WidgetFactory widgetType, Dashboard.Widget widget, Composite elementToMoveAbove)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
@@ -10,7 +10,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -71,6 +70,7 @@ import name.abuchen.portfolio.ui.views.panes.SecurityEventsPane;
 import name.abuchen.portfolio.ui.views.panes.SecurityPriceChartPane;
 import name.abuchen.portfolio.ui.views.panes.TradesPane;
 import name.abuchen.portfolio.ui.views.panes.TransactionsPane;
+import name.abuchen.portfolio.util.Pair;
 
 public class DashboardView extends AbstractHistoricView
 {
@@ -117,15 +117,13 @@ public class DashboardView extends AbstractHistoricView
         private final DashboardView dashboardView;
         private final LocalSelectionTransfer transfer;
         private final Composite dropTarget;
-        private final Consumer<Dashboard.Widget> listener;
 
         private WidgetDropTargetAdapter(DashboardView dashboardView, LocalSelectionTransfer transfer,
-                        Composite dropTarget, Consumer<Dashboard.Widget> listener)
+                        Composite dropTarget)
         {
             this.dashboardView = dashboardView;
             this.transfer = transfer;
             this.dropTarget = dropTarget;
-            this.listener = listener;
         }
 
         @Override
@@ -155,14 +153,61 @@ public class DashboardView extends AbstractHistoricView
                 newParent = newParent.getParent();
             Dashboard.Column newColumn = (Dashboard.Column) newParent.getData();
 
+            if ((event.detail & DND.DROP_MOVE) != 0)
+                doDropMove(droppedComposite, droppedWidget, oldColumn, newColumn, newParent);
+
+            if ((event.detail & DND.DROP_COPY) != 0)
+                doDropCopy(droppedWidget.copy(), newColumn, newParent);
+
+            dashboardView.markDirty();
+
+            oldParent.layout();
+            newParent.layout();
+        }
+
+        private void doDropCopy(Dashboard.Widget copiedWidget, Dashboard.Column newColumn, Composite newParent)
+        {
+            
+            Composite elementToMoveAbove = null;
+            if (dropTarget.getData() instanceof Dashboard.Widget dropTargetWidget)
+            {
+                // dropped on another widget, place above drop target
+                elementToMoveAbove = dropTarget;
+                newColumn.getWidgets().add(newColumn.getWidgets().indexOf(dropTargetWidget), copiedWidget);
+            }
+            else if (dropTarget.getData() instanceof Dashboard.Column)
+            {
+                // dropped on another column, place above filler
+                elementToMoveAbove = (Composite) newParent.getData(FILLER_KEY);
+                newColumn.getWidgets().add(copiedWidget);
+            }
+            else
+            {
+                throw new IllegalArgumentException();
+            }
+
+            WidgetFactory factory = WidgetFactory.valueOf(copiedWidget.getType());
+            if (factory == null)
+                throw new IllegalArgumentException();
+
+            Pair<WidgetDelegate<?>, Composite> newDelegateWithComposite = dashboardView
+                            .buildDelegateAndMoveAboveElement(newParent, factory, copiedWidget, elementToMoveAbove);
+
+            newDelegateWithComposite.getLeft().update();
+            Composite newComposite = newDelegateWithComposite.getRight();
+            newComposite.setParent(newParent);
+        }
+
+        private void doDropMove(Composite droppedComposite, Dashboard.Widget droppedWidget, Dashboard.Column oldColumn,
+                        Dashboard.Column newColumn, Composite newParent)
+        {
             droppedComposite.setParent(newParent);
 
-            if (dropTarget.getData() instanceof Dashboard.Widget)
+            if (dropTarget.getData() instanceof Dashboard.Widget dropTargetWidget)
             {
                 // dropped on another widget
                 droppedComposite.moveAbove(dropTarget);
 
-                Dashboard.Widget dropTargetWidget = (Dashboard.Widget) dropTarget.getData();
                 oldColumn.getWidgets().remove(droppedWidget);
                 newColumn.getWidgets().add(newColumn.getWidgets().indexOf(dropTargetWidget), droppedWidget);
             }
@@ -179,11 +224,6 @@ public class DashboardView extends AbstractHistoricView
             {
                 throw new IllegalArgumentException();
             }
-
-            listener.accept(droppedWidget);
-
-            oldParent.layout();
-            newParent.layout();
         }
 
         @Override
@@ -499,7 +539,7 @@ public class DashboardView extends AbstractHistoricView
                 if (factory == null)
                     continue;
 
-                buildDelegate(columnControl, factory, widget);
+                buildDelegateAndMoveAboveFiller(columnControl, factory, widget);
             }
             catch (IllegalArgumentException e)
             {
@@ -555,7 +595,16 @@ public class DashboardView extends AbstractHistoricView
         manager.add(new SimpleAction(Messages.MenuDeleteDashboardColumn, a -> deleteColumn(columnControl)));
     }
 
-    private WidgetDelegate<?> buildDelegate(Composite columnControl, WidgetFactory widgetType, Dashboard.Widget widget)
+    private Pair<WidgetDelegate<?>, Composite> buildDelegateAndMoveAboveFiller(Composite columnControl,
+                    WidgetFactory widgetType, Dashboard.Widget widget)
+    {
+        Composite filler = (Composite) columnControl.getData(FILLER_KEY);
+        return buildDelegateAndMoveAboveElement(columnControl, widgetType, widget, filler);
+    }
+
+
+    private Pair<WidgetDelegate<?>, Composite> buildDelegateAndMoveAboveElement(Composite columnControl,
+                    WidgetFactory widgetType, Dashboard.Widget widget, Composite elementToMoveAbove)
     {
         WidgetDelegate<?> delegate = widgetType.create(widget, dashboardData);
         inject(delegate);
@@ -564,8 +613,8 @@ public class DashboardView extends AbstractHistoricView
         element.setData(widget);
         element.setData(DELEGATE_KEY, delegate);
 
-        Composite filler = (Composite) columnControl.getData(FILLER_KEY);
-        element.moveAbove(filler);
+        if (elementToMoveAbove != null)
+            element.moveAbove(elementToMoveAbove);
 
         new ContextMenu(delegate.getTitleControl(), manager -> widgetMenuAboutToShow(manager, delegate)).hook();
         InfoToolTip.attach(delegate.getTitleControl(), () -> buildToolTip(delegate));
@@ -577,7 +626,7 @@ public class DashboardView extends AbstractHistoricView
             addDragListener(child);
 
         GridDataFactory.fillDefaults().grab(true, false).applyTo(element);
-        return delegate;
+        return new Pair<>(delegate, element);
     }
 
     private String buildToolTip(WidgetDelegate<?> delegate)
@@ -648,7 +697,7 @@ public class DashboardView extends AbstractHistoricView
     {
         LocalSelectionTransfer transfer = LocalSelectionTransfer.getTransfer();
 
-        DropTargetAdapter dragAdapter = new WidgetDropTargetAdapter(this, transfer, parent, w -> markDirty());
+        DropTargetAdapter dragAdapter = new WidgetDropTargetAdapter(this, transfer, parent);
 
         DropTarget dropTarget = new DropTarget(parent, DND.DROP_MOVE | DND.DROP_COPY);
         dropTarget.setTransfer(transfer);
@@ -785,7 +834,7 @@ public class DashboardView extends AbstractHistoricView
         widget.setType(widgetType.name());
         column.getWidgets().add(widget);
 
-        WidgetDelegate<?> delegate = buildDelegate(columnControl, widgetType, widget);
+        WidgetDelegate<?> delegate = buildDelegateAndMoveAboveFiller(columnControl, widgetType, widget).getLeft();
 
         getClient().touch();
         delegate.update();
@@ -833,13 +882,7 @@ public class DashboardView extends AbstractHistoricView
         Dashboard.Column newColumn = new Dashboard.Column();
         dashboard.getColumns().add(index, newColumn);
 
-        newColumn.setWidgets(column.getWidgets().stream().map(widget -> {
-            Widget copy = new Widget();
-            copy.setLabel(widget.getLabel());
-            copy.setType(widget.getType());
-            copy.getConfiguration().putAll(widget.getConfiguration());
-            return copy;
-        }).collect(Collectors.toList()));
+        newColumn.setWidgets(column.getWidgets().stream().map(Widget::copy).toList());
 
         getClient().touch();
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Dashboard.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Dashboard.java
@@ -87,6 +87,15 @@ public final class Dashboard
 
             return configuration;
         }
+
+        public Widget copy()
+        {
+            Widget copy = new Widget();
+            copy.setLabel(this.getLabel());
+            copy.setType(this.getType());
+            copy.getConfiguration().putAll(this.getConfiguration());
+            return copy;
+        }
     }
 
     private String name;
@@ -133,13 +142,7 @@ public final class Dashboard
         for (Column column : columns)
         {
             Column copyColumn = new Column();
-            column.getWidgets().stream().map(w -> {
-                Widget c = new Widget();
-                c.setLabel(w.getLabel());
-                c.setType(w.getType());
-                c.getConfiguration().putAll(w.getConfiguration());
-                return c;
-            }).forEach(copyColumn.getWidgets()::add);
+            column.getWidgets().stream().map(Widget::copy).forEach(copyColumn.getWidgets()::add);
             copy.getColumns().add(copyColumn);
         }
         return copy;


### PR DESCRIPTION
Sometimes it would be very helpful to easily duplicate an existing widget. Here is my suggestion to support this via holding CTRL while drag'n'drop.
This feature was also requested in the forum:

- https://forum.portfolio-performance.info/t/duplizieren-von-dashboard-widgets/9446
- https://forum.portfolio-performance.info/t/strg-ziehen-eines-widgets-fuhrt-zum-verschieben-und-nicht-zum-kopieren/21107
- https://forum.portfolio-performance.info/t/widgets-kopieren-und-datenreihen-zuordnen/2926
- https://forum.portfolio-performance.info/t/copy-and-paste-fur-widgets/23094

And here a short video:

https://user-images.githubusercontent.com/90478568/217916232-75c14865-3546-4044-bea7-18c3295dfb10.mov

