### PR TITLE
Make ColoredLabel accessible to screenreaders

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
@@ -8,6 +8,9 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.accessibility.ACC;
+import org.eclipse.swt.accessibility.AccessibleControlAdapter;
+import org.eclipse.swt.accessibility.AccessibleControlEvent;
 
 import name.abuchen.portfolio.ui.util.Colors;
 
@@ -34,6 +37,8 @@ public class ColoredLabel extends Canvas // NOSONAR
         super(parent, SWT.NONE);
 
         this.textStyle = style;
+
+        initAccessibility();
 
         addListener(SWT.Paint, this::handlePaint);
     }
@@ -105,5 +110,17 @@ public class ColoredLabel extends Canvas // NOSONAR
         }
 
         e.type = SWT.None;
+    }
+
+    private void initAccessibility()
+    {
+        getAccessible().addAccessibleControlListener(new AccessibleControlAdapter() {
+            public void getRole(AccessibleControlEvent e) {
+                e.detail = ACC.ROLE_LABEL;
+            }
+            public void getValue(AccessibleControlEvent e) {
+                e.result = text;
+            }
+        });
     }
 }


### PR DESCRIPTION
As a custom widget, the ColoredLabel (despite essentially just presenting some text, like a usual label) cannot be read by assistant technology such as screenreaders. Add some accessibility code to mark it as a label and make the text available.