### PR TITLE
Drag'n'Drop support for 'All securities' sidebar item

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientEditorSidebar.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientEditorSidebar.java
@@ -21,6 +21,7 @@ import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.dnd.ImportFromFileDropAdapter;
 import name.abuchen.portfolio.ui.dnd.ImportFromURLDropAdapter;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
+import name.abuchen.portfolio.ui.editor.Navigation.AllSecuritiesParameter;
 import name.abuchen.portfolio.ui.editor.Navigation.Item;
 import name.abuchen.portfolio.ui.editor.Navigation.Tag;
 
@@ -87,8 +88,10 @@ import name.abuchen.portfolio.ui.editor.Navigation.Tag;
 
         sidebar = new Sidebar<>(scrolledComposite, model);
 
-        editor.getClientInput().getNavigation().findAll(item -> item.getParameter() instanceof Watchlist)
-                        .forEach(this::setupWatchlistDnD);
+        editor.getClientInput().getNavigation()
+                        .findAll(item -> item.getParameter() instanceof AllSecuritiesParameter
+                                        || item.getParameter() instanceof Watchlist)
+                        .forEach(this::setupAllSecuritesAndWatchlistDnD);
 
         scrolledComposite.setContent(sidebar);
         scrolledComposite.setExpandVertical(true);
@@ -99,8 +102,10 @@ import name.abuchen.portfolio.ui.editor.Navigation.Tag;
 
         Navigation.Listener listener = item -> {
             sidebar.rebuild();
-            editor.getClientInput().getNavigation().findAll(i -> i.getParameter() instanceof Watchlist)
-                            .forEach(this::setupWatchlistDnD);
+            editor.getClientInput().getNavigation()
+                            .findAll(i -> i.getParameter() instanceof AllSecuritiesParameter
+                                            || i.getParameter() instanceof Watchlist)
+                            .forEach(this::setupAllSecuritesAndWatchlistDnD);
 
             scrolledComposite.setMinSize(sidebar.computeSize(SWT.DEFAULT, SWT.DEFAULT));
             sidebar.layout(true);
@@ -122,37 +127,37 @@ import name.abuchen.portfolio.ui.editor.Navigation.Tag;
         sidebar.select(item);
     }
 
-    private void setupWatchlistDnD(Navigation.Item item)
+    private void setupAllSecuritesAndWatchlistDnD(Navigation.Item item)
     {
-        Watchlist watchlist = (Watchlist) item.getParameter();
-
         DropTargetAdapter dropTargetListener = new DropTargetAdapter()
         {
             @Override
             public void drop(DropTargetEvent event)
             {
-                if (SecurityTransfer.getTransfer().isSupportedType(event.currentDataType))
+                if (!SecurityTransfer.getTransfer().isSupportedType(event.currentDataType))
+                    return;
+
+                List<Security> securities = SecurityTransfer.getTransfer().getSecurities();
+                if (securities == null)
+                    return;
+
+                for (Security security : securities)
                 {
-                    List<Security> securities = SecurityTransfer.getTransfer().getSecurities();
-                    if (securities != null)
+                    // if the security is dragged from another file, add
+                    // a deep copy to the client's securities list
+                    if (!editor.getClient().getSecurities().contains(security))
                     {
-                        for (Security security : securities)
-                        {
-                            // if the security is dragged from another file, add
-                            // a deep copy to the client's securities list
-                            if (!editor.getClient().getSecurities().contains(security))
-                            {
-                                security = security.deepCopy();
-                                editor.getClient().addSecurity(security);
-                            }
-
-                            if (!watchlist.getSecurities().contains(security))
-                                watchlist.addSecurity(security);
-                        }
-
-                        editor.getClient().touch();
+                        security = security.deepCopy();
+                        editor.getClient().addSecurity(security);
                     }
+
+                    // if drop target is a watchlist, add
+                    if (item.getParameter() instanceof Watchlist watchlist
+                                    && !watchlist.getSecurities().contains(security))
+                        watchlist.addSecurity(security);
                 }
+
+                editor.getClient().touch();
             }
         };
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
@@ -63,6 +63,11 @@ public final class Navigation
         DEFAULT_VIEW;
     }
 
+    public class AllSecuritiesParameter
+    {
+        // empty class at the moment. Only needed to flag the navigation item
+    }
+
     public static class Item
     {
         private String label;
@@ -338,7 +343,9 @@ public final class Navigation
 
         roots.add(generalData);
 
-        generalData.add(new Item(Messages.LabelAllSecurities, Images.SECURITY, SecurityListView.class));
+        Item allSecuritesItem = new Item(Messages.LabelAllSecurities, Images.SECURITY, SecurityListView.class);
+        allSecuritesItem.setParameter(new AllSecuritiesParameter());
+        generalData.add(allSecuritesItem);
 
         for (Watchlist watchlist : client.getWatchlists())
         {


### PR DESCRIPTION
In the current version, to drag and drop a security from one file to another, you must drop the security onto a watchlist (https://forum.portfolio-performance.info/t/watchlisten-und-wertpapiere-zwischen-portfolios-kopieren/19894/19)

With this PR you can directly drop a security into the ``All securities`` side bar item.