### PR TITLE
Fix assertion with the wrong parameter order

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RebalancerTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RebalancerTest.java
@@ -39,7 +39,7 @@ public class RebalancerTest
         Rebalancer rebalancer = new Rebalancer();
         Rebalancer.RebalancingSolution solution = rebalancer.solve();
         
-        assertEquals(solution.getInvestmentVehicles(), Collections.emptySet());
+        assertEquals(Collections.emptySet(), solution.getInvestmentVehicles());
     }
     @Test
     public void testEmptyConstraints()

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
@@ -33,11 +33,11 @@ public class AccountTest
     @Test
     public void testAddTransaction()
     {
-        assertEquals(account.getTransactions().size(), 0);
+        assertEquals(0, account.getTransactions().size());
 
         account.addTransaction(transaction);
 
-        assertEquals(account.getTransactions().size(), 1);
+        assertEquals(1, account.getTransactions().size());
         assertTrue(account.getTransactions().contains(transaction));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -3,7 +3,6 @@ package name.abuchen.portfolio.model;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.beans.BeanInfo;
@@ -199,22 +198,22 @@ public class SecurityTest
         Security security = new Security();
 
         security.setName("Apple ORD");
-        assertEquals(security.getExternalIdentifier(), "Apple ORD");
+        assertThat(security.getExternalIdentifier(), is("Apple ORD"));
 
         security.setWkn("865985");
-        assertEquals(security.getExternalIdentifier(), "865985");
+        assertThat(security.getExternalIdentifier(), is("865985"));
 
         security.setTickerSymbol("AAPL");
-        assertEquals(security.getExternalIdentifier(), "AAPL");
+        assertThat(security.getExternalIdentifier(), is("AAPL"));
 
         // In some countries there is no ISIN or WKN, only the ticker symbol.
         // If historical prices are retrieved from the stock exchange,
         // the ticker symbol is expanded. (UMAX --> UMAX.AX)
         security.setTickerSymbol("AAPL.BA");
-        assertEquals(security.getExternalIdentifier(), "AAPL");
+        assertThat(security.getExternalIdentifier(), is("AAPL"));
 
         security.setIsin("US0378331005");
-        assertEquals(security.getExternalIdentifier(), "US0378331005");
+        assertThat(security.getExternalIdentifier(), is("US0378331005"));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.online.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -488,7 +489,7 @@ public class GenericJSONQuoteFeedTest
         Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
         LocalDate date = feed.extractDate(object, Optional.empty());
 
-        assertEquals(null, date);
+        assertNull(date);
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/YahooHelperTest.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.online.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -22,7 +23,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
+        assertEquals(LatestSecurityPrice.NOT_AVAILABLE, result);
     }
 
     @Test
@@ -32,7 +33,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
+        assertEquals(LatestSecurityPrice.NOT_AVAILABLE, result);
     }
 
     @Test
@@ -42,7 +43,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, LatestSecurityPrice.NOT_AVAILABLE);
+        assertEquals(LatestSecurityPrice.NOT_AVAILABLE, result);
     }
 
     @Test
@@ -52,7 +53,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, Values.Quote.factorize(277.53));
+        assertEquals(Values.Quote.factorize(277.53), result);
     }
 
     @Test
@@ -62,7 +63,7 @@ public class YahooHelperTest
 
         long result = YahooHelper.asPrice(priceFromYahoo);
 
-        assertEquals(result, Values.Quote.factorize(277));
+        assertEquals(Values.Quote.factorize(277), result);
     }
 
     @Test(expected = ParseException.class)
@@ -81,7 +82,7 @@ public class YahooHelperTest
 
         int result = YahooHelper.asNumber(priceFromYahoo);
 
-        assertEquals(result, -1);
+        assertEquals(-1, result);
     }
 
     @Test
@@ -91,7 +92,7 @@ public class YahooHelperTest
 
         int result = YahooHelper.asNumber(priceFromYahoo);
 
-        assertEquals(result, -1);
+        assertEquals(-1, result);
     }
 
     @Test
@@ -101,7 +102,7 @@ public class YahooHelperTest
 
         int result = YahooHelper.asNumber(priceFromYahoo);
 
-        assertEquals(result, 277);
+        assertEquals(277, result);
     }
 
     @Test
@@ -111,7 +112,7 @@ public class YahooHelperTest
 
         int result = YahooHelper.asNumber(priceFromYahoo);
 
-        assertEquals(result, 277);
+        assertEquals(277, result);
     }
 
     @Test(expected = ParseException.class)
@@ -130,7 +131,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.asDate(dateFromYahoo);
 
-        assertEquals(result, null);
+        assertNull(result);
     }
 
     @Test
@@ -140,7 +141,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.asDate(dateFromYahoo);
 
-        assertEquals(result, LocalDate.of(2020, 4, 20));
+        assertEquals(LocalDate.of(2020, 4, 20), result);
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -159,7 +160,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.fromISODate(isoDateFromYahoo);
 
-        assertEquals(result, null);
+        assertNull(result);
     }
 
     @Test
@@ -169,7 +170,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.fromISODate(isoDateFromYahoo);
 
-        assertEquals(result, null);
+        assertNull(result);
     }
 
     @Test
@@ -179,7 +180,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.fromISODate(isoDateFromYahoo);
 
-        assertEquals(result, null);
+        assertNull(result);
     }
 
     @Test
@@ -189,7 +190,7 @@ public class YahooHelperTest
 
         LocalDate result = YahooHelper.fromISODate(isoDateFromYahoo);
 
-        assertEquals(result, LocalDate.of(2020, 4, 19));
+        assertEquals(LocalDate.of(2020, 4, 19), result);
     }
 
     @Test(expected = DateTimeParseException.class)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentMonthTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentMonthTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class CurrentMonthTest
         String code = "M";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), CurrentMonth.class);
+        assertEquals(CurrentMonth.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class CurrentMonthTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -45,7 +46,7 @@ public class CurrentMonthTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -55,7 +56,7 @@ public class CurrentMonthTest
         ReportingPeriod equal2 = ReportingPeriod.from("M");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualDifferentClass);
 
         assertEquals(equal1, equal1);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentQuarterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentQuarterTest.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -22,7 +23,7 @@ public class CurrentQuarterTest
         String code = "Q";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), CurrentQuarter.class); // NOSONAR
+        assertEquals(CurrentQuarter.class, period.getClass()); // NOSONAR
     }
 
     @Test
@@ -46,7 +47,7 @@ public class CurrentQuarterTest
 
         LocalDate expectedStartDate = LocalDate.of(2020, 12, 31);
         LocalDate expectedEndDate = LocalDate.of(2021, 3, 1).with(lastDayOfMonth());
-        assertEquals(result, Interval.of(expectedStartDate, expectedEndDate));
+        assertEquals(Interval.of(expectedStartDate, expectedEndDate), result);
     }
 
     @Test
@@ -60,7 +61,7 @@ public class CurrentQuarterTest
 
         LocalDate expectedStartDate = LocalDate.of(2021, 3, 31);
         LocalDate expectedEndDate = LocalDate.of(2021, 6, 1).with(lastDayOfMonth());
-        assertEquals(result, Interval.of(expectedStartDate, expectedEndDate));
+        assertEquals(Interval.of(expectedStartDate, expectedEndDate), result);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class CurrentQuarterTest
 
         LocalDate expectedStartDate = LocalDate.of(2021, 6, 30);
         LocalDate expectedEndDate = LocalDate.of(2021, 9, 1).with(lastDayOfMonth());
-        assertEquals(result, Interval.of(expectedStartDate, expectedEndDate));
+        assertEquals(Interval.of(expectedStartDate, expectedEndDate), result);
     }
 
     @Test
@@ -88,7 +89,7 @@ public class CurrentQuarterTest
 
         LocalDate expectedStartDate = LocalDate.of(2021, 9, 30);
         LocalDate expectedEndDate = LocalDate.of(2021, 12, 1).with(lastDayOfMonth());
-        assertEquals(result, Interval.of(expectedStartDate, expectedEndDate));
+        assertEquals(Interval.of(expectedStartDate, expectedEndDate), result);
     }
 
     @Test
@@ -98,7 +99,7 @@ public class CurrentQuarterTest
         ReportingPeriod equal2 = ReportingPeriod.from("Q");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualDifferentClass);
 
         assertEquals(equal1, equal1);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentWeekTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/CurrentWeekTest.java
@@ -7,6 +7,7 @@ import static java.time.temporal.TemporalAdjusters.nextOrSame;
 import static java.time.temporal.TemporalAdjusters.previousOrSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -27,7 +28,7 @@ public class CurrentWeekTest
         String code = "W";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), CurrentWeek.class); // NOSONAR
+        assertEquals(CurrentWeek.class, period.getClass()); // NOSONAR
     }
 
     @Test
@@ -56,7 +57,7 @@ public class CurrentWeekTest
 
             Interval result = period.toInterval(today);
 
-            assertEquals(result, Interval.of(monday.minusDays(1), sunday));
+            assertEquals(Interval.of(monday.minusDays(1), sunday), result);
         }
         finally
         {
@@ -81,9 +82,9 @@ public class CurrentWeekTest
 
             Interval result = period.toInterval(date);
 
-            assertEquals(result, Interval.of(monday.minusDays(1), sunday));
-            assertEquals(result.getStart(), LocalDate.of(2021, 6, 6));
-            assertEquals(result.getEnd(), LocalDate.of(2021, 6, 13));
+            assertEquals(Interval.of(monday.minusDays(1), sunday), result);
+            assertEquals(LocalDate.of(2021, 6, 6), result.getStart());
+            assertEquals(LocalDate.of(2021, 6, 13), result.getEnd());
         }
         finally
         {
@@ -108,9 +109,9 @@ public class CurrentWeekTest
 
             Interval result = period.toInterval(date);
 
-            assertEquals(result, Interval.of(sunday.minusDays(1), saturday));
-            assertEquals(result.getStart(), LocalDate.of(2021, 6, 5));
-            assertEquals(result.getEnd(), LocalDate.of(2021, 6, 12));
+            assertEquals(Interval.of(sunday.minusDays(1), saturday), result);
+            assertEquals(LocalDate.of(2021, 6, 5), result.getStart());
+            assertEquals(LocalDate.of(2021, 6, 12), result.getEnd());
         }
         finally
         {
@@ -126,7 +127,7 @@ public class CurrentWeekTest
         ReportingPeriod equal2 = ReportingPeriod.from("W");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualDifferentClass);
 
         assertEquals(equal1, equal1);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/FromXtoYTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/FromXtoYTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class FromXtoYTest
         String code = "F2020-04-04_2020-04-08";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), FromXtoY.class);
+        assertEquals(FromXtoY.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class FromXtoYTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -43,7 +44,7 @@ public class FromXtoYTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class FromXtoYTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("F2020-04-04_2020-04-09");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXDaysTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXDaysTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -20,7 +21,7 @@ public class LastXDaysTest
     {
         ReportingPeriod period = ReportingPeriod.from("D90");
 
-        assertEquals(period.getClass(), LastXDays.class);
+        assertEquals(LastXDays.class, period.getClass());
     }
 
     @Test
@@ -30,7 +31,7 @@ public class LastXDaysTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -42,7 +43,7 @@ public class LastXDaysTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -53,7 +54,7 @@ public class LastXDaysTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("D91");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class LastXTest
         String code = "L2Y6";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), LastX.class);
+        assertEquals(LastX.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class LastXTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -43,7 +44,7 @@ public class LastXTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class LastXTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("L2Y1");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 
@@ -68,7 +69,7 @@ public class LastXTest
         String code = "2Y";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), LastX.class);
+        assertEquals(LastX.class, period.getClass());
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXTradingDaysTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/LastXTradingDaysTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -43,7 +44,7 @@ public class LastXTradingDaysTest
         String code = "T10";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), LastXTradingDays.class);
+        assertEquals(LastXTradingDays.class, period.getClass());
     }
 
     @Test
@@ -53,7 +54,7 @@ public class LastXTradingDaysTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -65,7 +66,7 @@ public class LastXTradingDaysTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -76,7 +77,7 @@ public class LastXTradingDaysTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("T11");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("D90");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousDayTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousDayTest.java
@@ -17,7 +17,7 @@ public class PreviousDayTest
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
         PreviousDay previousDay = new PreviousDay();
-        assertEquals(ReportingPeriod.from(previousDay.getCode()), previousDay);
+        assertEquals(previousDay, ReportingPeriod.from(previousDay.getCode()));
     }
 
     @Test
@@ -27,7 +27,7 @@ public class PreviousDayTest
 
         LocalDate today = LocalDate.now();
 
-        assertEquals(period.toInterval(today), Interval.of(today.minusDays(2), today.minusDays(1)));
+        assertEquals(Interval.of(today.minusDays(2), today.minusDays(1)), period.toInterval(today));
     }
 
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousMonthTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousMonthTest.java
@@ -16,7 +16,7 @@ public class PreviousMonthTest
     @Test
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
-        assertEquals(ReportingPeriod.from(new PreviousMonth().getCode()), new PreviousMonth());
+        assertEquals(new PreviousMonth(), ReportingPeriod.from(new PreviousMonth().getCode()));
     }
 
     @Test
@@ -26,6 +26,6 @@ public class PreviousMonthTest
 
         LocalDate today = LocalDate.of(2021, 7, 11);
 
-        assertEquals(period.toInterval(today), Interval.of(LocalDate.of(2021, 5, 31), LocalDate.of(2021, 6, 30)));
+        assertEquals(Interval.of(LocalDate.of(2021, 5, 31), LocalDate.of(2021, 6, 30)), period.toInterval(today));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousQuarterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousQuarterTest.java
@@ -16,7 +16,7 @@ public class PreviousQuarterTest
     @Test
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
-        assertEquals(ReportingPeriod.from(new PreviousQuarter().getCode()), new PreviousQuarter());
+        assertEquals(new PreviousQuarter(), ReportingPeriod.from(new PreviousQuarter().getCode()));
     }
 
     @Test
@@ -26,6 +26,6 @@ public class PreviousQuarterTest
 
         LocalDate today = LocalDate.of(2021, 7, 11);
 
-        assertEquals(period.toInterval(today), Interval.of(LocalDate.of(2021, 3, 31), LocalDate.of(2021, 6, 30)));
+        assertEquals(Interval.of(LocalDate.of(2021, 3, 31), LocalDate.of(2021, 6, 30)), period.toInterval(today));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousTradingDayTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousTradingDayTest.java
@@ -17,7 +17,7 @@ public class PreviousTradingDayTest
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
         PreviousTradingDay previousDay = new PreviousTradingDay();
-        assertEquals(ReportingPeriod.from(previousDay.getCode()), previousDay);
+        assertEquals(previousDay, ReportingPeriod.from(previousDay.getCode()));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousWeekTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousWeekTest.java
@@ -17,7 +17,7 @@ public class PreviousWeekTest
     @Test
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
-        assertEquals(ReportingPeriod.from(new PreviousWeek().getCode()), new PreviousWeek());
+        assertEquals(new PreviousWeek(), ReportingPeriod.from(new PreviousWeek().getCode()));
     }
 
     @Test
@@ -35,8 +35,8 @@ public class PreviousWeekTest
 
             Interval result = period.toInterval(date);
 
-            assertEquals(result.getStart(), LocalDate.of(2021, 5, 30));
-            assertEquals(result.getEnd(), LocalDate.of(2021, 6, 6));
+            assertEquals(LocalDate.of(2021, 5, 30), result.getStart());
+            assertEquals(LocalDate.of(2021, 6, 6), result.getEnd());
         }
         finally
         {
@@ -59,8 +59,8 @@ public class PreviousWeekTest
 
             Interval result = period.toInterval(date);
 
-            assertEquals(result.getStart(), LocalDate.of(2021, 5, 29));
-            assertEquals(result.getEnd(), LocalDate.of(2021, 6, 5));
+            assertEquals(LocalDate.of(2021, 5, 29), result.getStart());
+            assertEquals(LocalDate.of(2021, 6, 5), result.getEnd());
         }
         finally
         {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousYearTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/PreviousYearTest.java
@@ -16,7 +16,7 @@ public class PreviousYearTest
     @Test
     public void testSerializationDeserializationRoundtrip() throws IOException
     {
-        assertEquals(ReportingPeriod.from(new PreviousYear().getCode()), new PreviousYear());
+        assertEquals(new PreviousYear(), ReportingPeriod.from(new PreviousYear().getCode()));
     }
 
     @Test
@@ -28,6 +28,6 @@ public class PreviousYearTest
 
         Interval result = period.toInterval(today);
 
-        assertEquals(result, Interval.of(LocalDate.of(2019, 12, 31), LocalDate.of(2020, 12, 31)));
+        assertEquals(Interval.of(LocalDate.of(2019, 12, 31), LocalDate.of(2020, 12, 31)), result);
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/ReportingYearTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/ReportingYearTest.java
@@ -18,7 +18,7 @@ public class ReportingYearTest
         ReportingPeriod period = ReportingPeriod.from(code);
         String result = period.getCode();
 
-        assertEquals(result, code);
+        assertEquals(code, result);
     }
 
     @Test(expected = IOException.class)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/SinceXTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/SinceXTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class SinceXTest
         String code = "S2020-04-04";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), SinceX.class);
+        assertEquals(SinceX.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class SinceXTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -43,7 +44,7 @@ public class SinceXTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class SinceXTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("S2020-04-05");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearToDateTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearToDateTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class YearToDateTest
         String code = "X";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), YearToDate.class);
+        assertEquals(YearToDate.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class YearToDateTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -44,7 +45,7 @@ public class YearToDateTest
 
         Interval result = period.toInterval(intervalEnd);
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class YearToDateTest
         ReportingPeriod equal2 = ReportingPeriod.from("X");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualDifferentClass);
 
         assertEquals(equal1, equal1);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearXTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/reportingperiod/YearXTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.reportingperiod;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -21,7 +22,7 @@ public class YearXTest
         String code = "Y2019";
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getClass(), YearX.class);
+        assertEquals(YearX.class, period.getClass());
     }
 
     @Test
@@ -31,7 +32,7 @@ public class YearXTest
 
         ReportingPeriod period = ReportingPeriod.from(code);
 
-        assertEquals(period.getCode(), code);
+        assertEquals(code, period.getCode());
     }
 
     @Test
@@ -44,7 +45,7 @@ public class YearXTest
         // The input of toInterval will be ignored
         Interval result = period.toInterval(LocalDate.of(2020, 12, 31));
 
-        assertEquals(result, Interval.of(intervalStart, intervalEnd));
+        assertEquals(Interval.of(intervalStart, intervalEnd), result);
     }
 
     @Test
@@ -55,7 +56,7 @@ public class YearXTest
         ReportingPeriod notEqualSameClass = ReportingPeriod.from("Y2020");
         ReportingPeriod notEqualDifferentClass = ReportingPeriod.from("T10");
 
-        assertNotEquals(equal1, null);
+        assertNotNull(equal1);
         assertNotEquals(equal1, notEqualSameClass);
         assertNotEquals(equal1, notEqualDifferentClass);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
@@ -57,7 +57,7 @@ public class DividendTransactionTest
         Money result = t.getGrossValue();
         Money expected = Money.of(CurrencyUnit.EUR, 100L);
 
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class DividendTransactionTest
         Money result = t.getGrossValue();
         Money expected = Money.of(CurrencyUnit.EUR, 95L);
 
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class DividendTransactionTest
 
         long result = t.getDividendPerShare();
 
-        assertEquals(result, Values.Share.factorize(9500));
+        assertEquals(Values.Share.factorize(9500), result);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class DividendTransactionTest
 
         long result = t.getDividendPerShare();
 
-        assertEquals(result, 0L);
+        assertEquals(0L, result);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class DividendTransactionTest
         Money result = t1.getMovingAverageCost();
         Money expected = Money.of(CurrencyUnit.EUR, 1000L);
 
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class DividendTransactionTest
         Money result = t1.getFifoCost();
         Money expected = Money.of(CurrencyUnit.EUR, 2000L);
 
-        assertEquals(result, expected);
+        assertEquals(expected, result);
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/ColorConversionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/ColorConversionTest.java
@@ -16,9 +16,9 @@ public class ColorConversionTest
     {
         String hex = "#K10203";
         RGB rgb = ColorConversion.hex2RGB(hex);
-        assertEquals(rgb.red, 0);
-        assertEquals(rgb.green, 0);
-        assertEquals(rgb.blue, 0);
+        assertEquals(0, rgb.red);
+        assertEquals(0, rgb.green);
+        assertEquals(0, rgb.blue);
     }
 
     @Test
@@ -26,9 +26,9 @@ public class ColorConversionTest
     {
         String hex = "#010203";
         RGB rgb = ColorConversion.hex2RGB(hex);
-        assertEquals(rgb.red, 1);
-        assertEquals(rgb.green, 2);
-        assertEquals(rgb.blue, 3);
+        assertEquals(1, rgb.red);
+        assertEquals(2, rgb.green);
+        assertEquals(3, rgb.blue);
     }
 
     @Test
@@ -55,9 +55,9 @@ public class ColorConversionTest
         String hex = "#123456";
         float[] hsb = ColorConversion.toHSB(hex);
         float delta = (float) 0.0001;
-        assertEquals(hsb[0], 210.0, delta);
-        assertEquals(hsb[1], 0.7906977, delta);
-        assertEquals(hsb[2], 0.3372549, delta);
+        assertEquals(210.0, hsb[0], delta);
+        assertEquals(0.7906977, hsb[1], delta);
+        assertEquals(0.3372549, hsb[2], delta);
     }
 
     @Test


### PR DESCRIPTION
Fix #2948

Changed mismatching parameter order for actuals and expected values to match _org.junit.Assert.assertEquals_ semantics.
Changed _assertEquals_ checks for **not null values** to use _assertNotNull_ 