### PR TITLE
Additional limit of securities in BookmarkMenu

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
@@ -68,7 +68,8 @@ public class BookmarkMenu extends MenuManager
         List<Bookmark> templates = ClientSettings.getDefaultBookmarks();
         Collections.sort(templates, (r, l) -> r.getLabel().compareTo(l.getLabel()));
         templates.forEach(bookmark -> templatesMenu.add(new SimpleAction(bookmark.getLabel(),
-                        a -> securities.forEach(s -> DesktopAPI.browse(bookmark.constructURL(client, s))))));
+                        a -> securities.stream().limit(10)
+                                        .forEach(s -> DesktopAPI.browse(bookmark.constructURL(client, s))))));
 
         add(new Separator());
         add(new SimpleAction(Messages.BookmarkMenu_EditBookmarks,


### PR DESCRIPTION
As wrote here: https://github.com/buchen/portfolio/commit/a56614c8a5fafd3c7c552f9c51edd861d86a3132#r101225781

If you want limit then we have to add the ``.stream().limit(10)`` here, too. Or Alternatively limit the securities at central place in constructor.

But I think, implementing a constant and (for the user) hidden limit can cause confusion and unneccessary error reports (sooner or later). So I will try to propose a PR soon were there is no constant limit, but a confirmation message, the user have to confirm if the limit is exceeded. So the users still can use the function without limitation but with extra click.