### PR TITLE
Fixes wrong dates when exporting transactions as CSV

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -93,7 +93,7 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
             for (TableItem item : items)
             {
                 // if the table is tagged SWT.VIRTUAL, then the item is only
-                // resolved if the text (or other properties are requested)
+                // resolved if the text (or other properties) are requested
                 // Also for invisible items the getText sometimes returns "" so
                 // in case of blank string, additional call of getText required
                 if (item.getData() == null || item.getText().isEmpty())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -96,8 +96,7 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
                 // resolved if the text (or other properties) are requested
                 // Also for invisible items the getText sometimes returns "" so
                 // in case of blank string, additional call of getText required
-                if (item.getData() == null || item.getText().isEmpty())
-                    item.getText();
+                item.getText();
 
                 for (int ii = 0; ii < columnCount; ii++)
                 {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -94,8 +94,9 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
             {
                 // if the table is tagged SWT.VIRTUAL, then the item is only
                 // resolved if the text (or other properties are requested)
-                Object subject = item.getData();
-                if (subject == null)
+                // Also for invisible items the getText sometimes returns "" so
+                // in case of blank string, additional call of getText required
+                if (item.getData() == null || item.getText().isEmpty())
                     item.getText();
 
                 for (int ii = 0; ii < columnCount; ii++)


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/wrong-dates-when-exporting-security-transactions-as-csv/21226
Not visible table items get wrong datetime when exporting the table after re-order.

Don't know much about the background of the error. But an additional check is required to get the text updated. For items which are invisble after an re-order of the table (click on date column header), the ``getData()`` returns a valid object (not null) but ``getText()`` returns empty string. So also in case of empty string the additional call of ``getText()`` seems to be required.