### PR TITLE
Clarify that reporting periods don’t include day 1

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -592,6 +592,7 @@ public class Messages extends NLS
     public static String LabelCurrentWeek;
     public static String LabelDashboard;
     public static String LabelDataSeries;
+    public static String LabelDateExclusive;
     public static String LabelDateXToY;
     public static String LabelDefaultFontSize;
     public static String LabelDefaultReferenceAccountName;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
@@ -125,6 +125,8 @@ public class ReportingPeriodDialog extends Dialog
         radioFromXtoY = new Button(editArea, SWT.RADIO);
         radioFromXtoY.setText(Messages.LabelReportingDialogFrom);
         dateFrom = new DatePicker(editArea);
+        Label lblFromExcl = new Label(editArea, SWT.NONE);
+        lblFromExcl.setText(Messages.LabelDateExclusive);
         Label lblTo = new Label(editArea, SWT.NONE);
         lblTo.setText(Messages.LabelReportingDialogUntil);
         dateTo = new DatePicker(editArea);
@@ -132,6 +134,8 @@ public class ReportingPeriodDialog extends Dialog
         radioSinceX = new Button(editArea, SWT.RADIO);
         radioSinceX.setText(Messages.LabelReportingDialogSince);
         dateSince = new DatePicker(editArea);
+        Label lblSinceExcl = new Label(editArea, SWT.NONE);
+        lblSinceExcl.setText(Messages.LabelDateExclusive);
 
         radioYearX = new Button(editArea, SWT.RADIO);
         radioYearX.setText(Messages.LabelReportingDialogYear);
@@ -198,19 +202,22 @@ public class ReportingPeriodDialog extends Dialog
 
             FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioLastTradingDays, 20))
                             .thenRight(dateFrom.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP))
+                            .thenRight(lblFromExcl).top(new FormAttachment(radioFromXtoY, 2, SWT.TOP))
                             .thenRight(lblTo).top(new FormAttachment(radioFromXtoY, 2, SWT.TOP))
                             .thenRight(dateTo.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP));
 
             FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioFromXtoY, 20))
-                            .thenRight(dateSince.getControl()).top(new FormAttachment(radioSinceX, -1, SWT.TOP));
+                            .thenRight(dateSince.getControl()).top(new FormAttachment(radioSinceX, -1, SWT.TOP))
+                            .thenRight(lblSinceExcl).top(new FormAttachment(radioSinceX, 2, SWT.TOP));
         }
         else
         {
             FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioLastTradingDays, 20))
-                            .thenRight(dateFrom.getControl()).thenRight(lblTo).thenRight(dateTo.getControl());
+                            .thenRight(dateFrom.getControl()).thenRight(lblFromExcl)
+                            .thenRight(lblTo).thenRight(dateTo.getControl());
 
             FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioFromXtoY, 20))
-                            .thenRight(dateSince.getControl());
+                            .thenRight(dateSince.getControl()).thenRight(lblSinceExcl);
         }
 
         FormDataFactory.startingWith(radioYearX).top(new FormAttachment(radioSinceX, 20)).thenRight(year);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1196,6 +1196,8 @@ LabelDashboard = Dashboard
 
 LabelDataSeries = Data series
 
+LabelDateExclusive = (excl.)
+
 LabelDateXToY = {0} to {1}
 
 LabelDefaultFontSize = Default

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1181,6 +1181,8 @@ LabelDashboard = Dashboard
 
 LabelDataSeries = Datenreihe
 
+LabelDateExclusive = (ausschl.)
+
 LabelDateXToY = {0} bis {1}
 
 LabelDefaultFontSize = Standard


### PR DESCRIPTION
It happens too often that someone sets a reporting period of “from X to Y” or “since X”, then complains on the forums or elsewhere that something that happened on day X is not shown in some report. To make it clear that the reporting period starts only after day X (with initial value as of the end of day X), change the reporting period dialogue to call the options “from X (excl.) to Y” and “since X (excl.)”.

![example of reporting period dialogue with the change](https://user-images.githubusercontent.com/1127374/220344346-6b8aade0-ed27-4646-b5a6-b7bebd6b6dd8.png)