### PR TITLE
Fixes serialization error after duplicate dashboard column

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -878,7 +879,7 @@ public class DashboardView extends AbstractHistoricView
         Dashboard.Column newColumn = new Dashboard.Column();
         dashboard.getColumns().add(index, newColumn);
 
-        newColumn.setWidgets(column.getWidgets().stream().map(Widget::copy).toList());
+        newColumn.setWidgets(column.getWidgets().stream().map(Widget::copy).collect(Collectors.toList()));
 
         getClient().touch();
 


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/nach-duplizieren-einer-spalte-im-dashboard-kann-xml-nicht-mehr-geparst-werden/23294

Sorry for including the error with #3175. I blindly followed the code change suggestion from eclipse. The ``.toList()`` creates an immutable list which leads to serialization problem.