### PR TITLE
Added mutli-national currencies

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies.properties
@@ -667,6 +667,26 @@ WST = Samoan t\u0101l\u0101
 
 WST.symbol = WS$
 
+XAF = Central African CFA franc
+
+XAF.symbol = F.CFA
+
+XCD = East Caribbean dollar
+
+XCD.symbol = EC$
+
+XDR = IMF Special drawing rights
+
+XDR.symbol = SDR
+
+XOF = West African CFA franc
+
+XOF.symbol = F.CFA
+
+XPF = CFP franc
+
+XPF.symbol = F
+
 YER = Yemeni rial
 
 YER.symbol = Y. Rl

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_cs.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_cs.properties
@@ -668,6 +668,16 @@ WST = Samojsk\u00E1 t\u0101l\u0101
 
 WST.symbol = WS$
 
+XAF = Frank BEAC/CFA
+
+XCD = V\u00FDchodokaribsk\u00FD dolar
+
+XDR = MMF Zvl\u00E1\u0161tn\u00ED pr\u00E1va \u010Derp\u00E1n\u00ED
+
+XOF = Frank BCEAO/CFA
+
+XPF = CFP frank
+
 YER = Jemensk\u00FD ri\u00E1l
 
 YER.symbol = Y. Rl

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_de.properties
@@ -337,6 +337,16 @@ VUV = Vatu
 
 WST = Samoanischer Tala
 
+XAF = Zentralafrikanischer CFA-Franc
+
+XCD = Ostkaribischer Dollar
+
+XDR = IWF-Sonderziehungsrechte
+
+XOF = Westafrikanischer CFA-Franc
+
+XPF = CFP-Franc
+
 YER = Jemen-Rial
 
 ZAC = S\u00FCdafrikanische Cents

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_es.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_es.properties
@@ -337,6 +337,16 @@ VUV = Vatu
 
 WST = T\u0101l\u0101 (Moneda)
 
+XAF = Franco CFA de \u00C1frica Central
+
+XCD = Dólar del Caribe Oriental
+
+XDR = FMI Derechos especiales de giro
+
+XOF = Franco CFA de \u00C1frica Occidental
+
+XPF = Franco CFP
+
 YER = Rial yemen\u00ED
 
 ZAC = C\u00E9ntimos sudafricano

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_fr.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_fr.properties
@@ -337,6 +337,16 @@ VUV = Vatu
 
 WST = Tala
 
+XAF = Franc CFA (CEMAC)
+
+XCD = Dollar des Cara\u00EFbes orientales
+
+XDR = Droits de tirage sp\u00E9ciaux du FMI
+
+XOF = Franc CFA (UEMOA)
+
+XPF = Franc Pacifique
+
 YER = Riyal y\u00E9m\u00E9nite
 
 ZAC = Cents sud-africains

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_nl.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_nl.properties
@@ -337,6 +337,16 @@ VUV = Vanuatuaanse vatu
 
 WST = Samoaanse tala
 
+XAF = Centraal-Afrikaanse CFA-frank
+
+XCD = Oost-Caribische dollar
+
+XDR = IMF Speciale trekkingsrechten
+
+XOF = West-Afrikaanse CFA-frank
+
+XPF = CFP-frank
+
 YER = Jemenitische rial
 
 ZAC = Zuid-Afrikaanse centen

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_pt.properties
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/currencies_pt.properties
@@ -337,6 +337,16 @@ VUV = Vatu do Vanuatu
 
 WST = Tala (Moeda)
 
+XAF = Franco CFA da \u00C1frica Central
+
+XCD = D\u00F3lar do Caribe Oriental
+
+XDR = FMI Direitos especiais de saque
+
+XOF = Franco CFA da \u00C1frica Ocidental
+
+XPF = Franco CFP
+
 YER = Rial iemenita
 
 ZAC = C\u00EAntimos sul-africanos


### PR DESCRIPTION
All multi-national currencies (with an X__ ISO 4217 code) were missing, so I added these. I also included XDR (IMF special drawing rights), even though this currency can not be obtained by individuals, because its value represents a basket of the most important currencies and thus is useful when you want to measure performance with respect to a currency basket.