### PR TITLE
Write backup-after-open even with active autosave

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -368,8 +368,7 @@ public class ClientInput
 
     public void createBackupAfterOpen()
     {
-        if (clientFile != null && preferences.getBoolean(UIConstants.Preferences.CREATE_BACKUP_BEFORE_SAVING, true)
-                        && preferences.getInt(UIConstants.Preferences.AUTO_SAVE_FILE, 0) == 0)
+        if (clientFile != null && preferences.getBoolean(UIConstants.Preferences.CREATE_BACKUP_BEFORE_SAVING, true))
             createBackup(clientFile, "backup-after-open"); //$NON-NLS-1$
     }
 


### PR DESCRIPTION
Normally, immediately after a portfolio file has been successfully opened, a copy of the file with infix `backup-after-open` is created. This serves to always retain one backup with a known good state (for otherwise opening the file would have resulted in an error). However, this behaviour was suppressed when autosave was active, with the original rationale that the autosave file would immediately be written with the same content.

However, as recent events have shown, the autosave functionality is not a suitable replacement for backup-after-open; in case of a bug, the autosave file may become corrupted in the same way as a file saved manually. The “known good state” is no longer guaranteed. Therefore, change the condition for writing a backup-after-open file to be independent of whether autosave is active or not.