### PR TITLE
Fix NumberFormat France in CSV-Importer

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
@@ -349,8 +349,12 @@ public final class CSVImporter
                                         NumberFormat.getInstance(Locale.GERMANY)),
                         new FieldFormat("0,000.00", Messages.CSVFormatNumberUS, //$NON-NLS-1$
                                         NumberFormat.getInstance(Locale.US)),
-                        new FieldFormat("0 000.00", Messages.CSVFormatNumberFrance, //$NON-NLS-1$
-                                        NumberFormat.getInstance(Locale.FRANCE)),
+                        new FieldFormat("0 000,00", Messages.CSVFormatNumberFrance, () -> { //$NON-NLS-1$
+                            DecimalFormatSymbols unusualSymbols = new DecimalFormatSymbols(Locale.FRANCE);
+                            unusualSymbols.setDecimalSeparator(',');
+                            unusualSymbols.setGroupingSeparator(' ');
+                            return new DecimalFormat("#,##0.###", unusualSymbols); //$NON-NLS-1$
+                        }),
                         new FieldFormat("0'000,00", Messages.CSVFormatApostrophe, () -> { //$NON-NLS-1$
                             DecimalFormatSymbols unusualSymbols = new DecimalFormatSymbols(Locale.US);
                             unusualSymbols.setGroupingSeparator('\'');


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/csv-imported-transactions-were-rounded-down-on-import/23539/
Testfiles:
[Test_Numberformat_france_whitespace_coma.csv](https://github.com/buchen/portfolio/files/11132566/Test_Numberformat_france_whitespace_coma.csv)

