### PR TITLE
Fixes the PDF or IBFlex importer assistent if no portfolio or account exists

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -946,6 +946,7 @@ public class Messages extends NLS
     public static String MsgDialogNotAValidCurrency;
     public static String MsgDialogNotAValidISIN;
     public static String MsgEmbeddedBrowserError;
+    public static String MsgErrorAccountNotExist;
     public static String MsgErrorConvertedAmount;
     public static String MsgErrorConvertToBuySellCurrencyMismatch;
     public static String MsgErrorDividendsYearBetween1900AndNow;
@@ -955,6 +956,7 @@ public class Messages extends NLS
     public static String MsgErrorNoInvestmentVehicleFoundAtURL;
     public static String MsgErrorNotAValidDate;
     public static String MsgErrorOpeningFile;
+    public static String MsgErrorPortfolioNotExist;
     public static String MsgErrorSavingIniFile;
     public static String MsgErrorTradeCollectionWithErrors;
     public static String MsgErrorUpdating;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportCSVHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportCSVHandler.java
@@ -57,13 +57,13 @@ public class ImportCSVHandler
     {
         if (client.getAccounts().isEmpty())
         {
-            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgMissingAccount);
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorAccountNotExist);
             return;
         }
 
         if (client.getPortfolios().isEmpty())
         {
-            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgMissingPortfolio);
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorPortfolioNotExist);
             return;
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportIBHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportIBHandler.java
@@ -47,6 +47,18 @@ public class ImportIBHandler
 
     private void runImport(MPart part, Shell shell, Client client)
     {
+        if (client.getAccounts().isEmpty())
+        {
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorAccountNotExist);
+            return;
+        }
+
+        if (client.getPortfolios().isEmpty())
+        {
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorPortfolioNotExist);
+            return;
+        }
+
         try
         {
             Extractor extractor = new IBFlexStatementExtractor(client);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -87,6 +87,18 @@ public class ImportPDFHandler
 
     public static void runImport(PortfolioPart part, Shell shell, Client client, Account account, Portfolio portfolio)
     {
+        if (client.getAccounts().isEmpty())
+        {
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorAccountNotExist);
+            return;
+        }
+
+        if (client.getPortfolios().isEmpty())
+        {
+            MessageDialog.openError(shell, Messages.LabelError, Messages.MsgErrorPortfolioNotExist);
+            return;
+        }
+
         FilePathHelper helper = new FilePathHelper(part, UIConstants.Preferences.PDF_IMPORT_PATH);
 
         FileDialog fileDialog = new FileDialog(shell, SWT.OPEN | SWT.MULTI);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1912,6 +1912,8 @@ MsgDialogNotAValidISIN = Invalid ISIN: {0}
 
 MsgEmbeddedBrowserError = Unable to create embedded browser to display charts\n\n* Are you running the latest version of your browser?\n* On Linux one has to install the packet 'libwebkitgtk-3.0-0'\n\nThe error message\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates that libwebkitgtk has to be installed. On Ubuntu 18.04, run\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
+MsgErrorAccountNotExist = There is no account.\r\nPlease create a new account.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transaction with currency {0} cannot be booked on account ''{2}'' with the currency {1}.
 
 MsgErrorConvertedAmount = Calculation error: Converted amount cannot result from amount and exchange rate
@@ -1929,6 +1931,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = No investment vehicle found at {0}
 MsgErrorNotAValidDate = Not a valid date: ''{0}''
 
 MsgErrorOpeningFile = Unable to open file: {0}
+
+MsgErrorPortfolioNotExist = There is no securities account.\r\nPlease create a new securities account.
 
 MsgErrorSavingIniFile = Error saving ini file: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
@@ -1900,6 +1900,8 @@ MsgDialogNotAValidISIN = Neplatn\u00FD ISIN: {0}
 
 MsgEmbeddedBrowserError = Nelze vytvo\u0159it vlo\u017Een\u00FD prohl\u00ED\u017Ee\u010D pro zobrazen\u00ED graf\u016F\n\n* Pou\u017E\u00EDv\u00E1te nejnov\u011Bj\u0161\u00ED verzi prohl\u00ED\u017Ee\u010De?\n* V Linuxu je t\u0159eba nainstalovat bal\u00ED\u010Dek 'libwebkitgtk-3.0-0'\n\nChybov\u00E1 zpr\u00E1va\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates that libwebkitgtk has to be installed. On Ubuntu 18.04, run\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nPodrobnosti:\n{0}
 
+MsgErrorAccountNotExist = \u017D\u00E1dn\u00FD \u00FA\u010Det neexistuje.\r\nVytvo\u0159te si pros\u00EDm nov\u00FD \u00FA\u010Det.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transakci s m\u011Bnou {0} nelze za\u00FA\u010Dtovat na \u00FA\u010Det ''{2}'' s m\u011Bnou {1}.
 
 MsgErrorConvertedAmount = Chyba v\u00FDpo\u010Dtu: P\u0159epo\u010Dten\u00E1 \u010D\u00E1stka nem\u016F\u017Ee b\u00FDt v\u00FDsledkem \u010D\u00E1stky a sm\u011Bnn\u00E9ho kurzu.
@@ -1917,6 +1919,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Na adrese {0} nebyl nalezen \u017E\u00E1
 MsgErrorNotAValidDate = Neplatn\u00E9 datum: ''{0}''
 
 MsgErrorOpeningFile = Nepoda\u0159ilo se otev\u0159\u00EDt soubor: {0}
+
+MsgErrorPortfolioNotExist = Neexistuje \u017E\u00E1dn\u00FD \u00FA\u010Det cenn\u00FDch pap\u00EDr\u016F.\r\nVytvo\u0159te si pros\u00EDm nov\u00FD \u00FA\u010Det cenn\u00FDch pap\u00EDr\u016F.
 
 MsgErrorSavingIniFile = Chyba p\u0159i ukl\u00E1d\u00E1n\u00ED ini souboru: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_da.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_da.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = Ugyldig ISIN: {0}
 
 MsgEmbeddedBrowserError = Kan ikke oprette en integreret browser til at vise diagrammer\n\n* K\u00F8rer du den nyeste version af din browser?\n* P\u00E5 Linux skal man installere pakken 'libwebkitgtk-3.0-0'\n\nFejlmeddelelsen\n  "Ikke flere handlinger [Ukendt Mozilla-sti (MOZILLA_FIVE_HOME ikke indstillet)]"\nangiver, at libwebkitgtk skal installeres. K\u00F8r p\u00E5 Ubuntu 18.04\n  sudo apt-get installer libwebkitgtk-3.0-0\n\n\nDetaljer:\n{0}
 
+MsgErrorAccountNotExist = Der er ingen konto.\r\nOpret venligst en ny konto.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transaktion med valuta {0} kan ikke bogf\u00F8res p\u00E5 kontoen ''{2}'' med valutaen {1}.
 
 MsgErrorConvertedAmount = Beregningsfejl: Omregnet bel\u00F8b kan ikke skyldes bel\u00F8b og valutakurs
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Ingen investeringsinstrumenter fundet ve
 MsgErrorNotAValidDate = Ikke en gyldig dato: ''{0}''
 
 MsgErrorOpeningFile = Kan ikke \u00E5bne fil: {0}
+
+MsgErrorPortfolioNotExist = Der findes ingen v\u00E6rdipapirkonto.\r\nOpret venligst en ny v\u00E6rdipapirkonto.
 
 MsgErrorSavingIniFile = Kan ikke gemme ini file: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1897,6 +1897,8 @@ MsgDialogNotAValidISIN = Ung\u00FCltige ISIN: {0}
 
 MsgEmbeddedBrowserError = Fehler beim \u00D6ffnen des Web Browsers zur Darstellung der Grafiken\n\n* Aktuelleste Version des Browsers installiert?\n* Unter Linux muss das Paket 'libwebkitgtk-3.0-0' installiert sein.\n\nDer Fehlertext\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nheisst meistens, dass libwebkitgtk installiert werden muss. Unter Ubuntu 18.04 z.B. mit\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
+MsgErrorAccountNotExist = Es ist kein Konto vorhanden.\r\nBitte erstellen Sie ein Konto.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Buchung in der W\u00E4hrung {0} kann nicht auf Konto ''{2}'' mit der W\u00E4hrung {1} gebucht werden.
 
 MsgErrorConvertedAmount = Rechnung stimmt nicht: Umgerechneter Betrag ergibt sich nicht aus Betrag und Wechselkurs
@@ -1914,6 +1916,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Kein Wertpapier unter {0} gefunden
 MsgErrorNotAValidDate = Ung\u00FCltiges Datum: ''{0}''
 
 MsgErrorOpeningFile = Fehler beim \u00D6ffnen der Datei: {0}
+
+MsgErrorPortfolioNotExist = Es existiert kein Depot.\r\nBitte erstellen Sie ein neues Depot.
 
 MsgErrorSavingIniFile = Fehler beim Speichern der ini Datei: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = ISIN no v\u00E1lido: {0}
 
 MsgEmbeddedBrowserError = No se puede crear el navegador incorporado para mostrar gr\u00E1ficos\n\n* \u00BFEst\u00E1 ejecutando la \u00FAltima versi\u00F3n de su navegador?\n* Por un Linux tiene que instalar el paquete 'libwebkitgtk-3.0-0'\n\nEl mensaje de error\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates libwebkitgtk que tiene que ser instalado. En Ubuntu 18.04, ejecute\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetails:\n{0}
 
+MsgErrorAccountNotExist = No hay ninguna cuenta.\r\nPor favor, cree una cuenta nueva.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Una transacci\u00F3n con {0} moneda no puede ser insertada en la cuenta ''{2}'' con {1} moneda.
 
 MsgErrorConvertedAmount = Error de c\u00E1lculo: la cantidad convertida no puede resultar de la cantidad y el tipo de cambio
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = No se encontraron veh\u00EDculos de inve
 MsgErrorNotAValidDate = No es una fecha v\u00E1lida: ''{0}''
 
 MsgErrorOpeningFile = No se puede abrir el fichero: {0}
+
+MsgErrorPortfolioNotExist = No hay cuenta de valores.\r\nPor favor, cree una nueva cuenta de valores.
 
 MsgErrorSavingIniFile = Error al guardar archivo ini: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1894,6 +1894,8 @@ MsgDialogNotAValidISIN = ISIN invalide : {0}
 
 MsgEmbeddedBrowserError = Impossible de cr\u00E9er le navigateur int\u00E9gr\u00E9 pour affichage des diagrammes\n\n* Disposez-vous de la derni\u00E8re version de votre navigateur ?\n* Sur Linux, il est n\u00E9cessaire d'installer le paquet 'libwebkitgtk-3.0-0'\n\nLe message d'erreur\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindique que libwebkitgtk doit \u00EAtre install\u00E9. Sur Ubuntu 18.04, lancer\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nD\u00E9tails :\n{0}
 
+MsgErrorAccountNotExist = Il n'y a pas de compte .\r\nVeuillez cr\u00E9er un nouveau compte .
+
 MsgErrorConvertToBuySellCurrencyMismatch = Impossible de placer une op\u00E9ration avec devise {0} sur le compte ''{2}'' dont la devise est {1}.
 
 MsgErrorConvertedAmount = Erreur de calcul : le montant converti ne peut r\u00E9sulter du montant et taux de change
@@ -1911,6 +1913,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Pas de titre trouv\u00E9 sur {0}
 MsgErrorNotAValidDate = Date invalide : ''{0}''
 
 MsgErrorOpeningFile = Impossible d'ouvrir le fichier : {0}
+
+MsgErrorPortfolioNotExist = Il n'y a pas de compte titres.\r\nVeuillez cr\u00E9er un nouveau compte titres .
 
 MsgErrorSavingIniFile = Erreur lors de l'enregistrement du fichier ini : {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = ISIN non valido: {0}
 
 MsgEmbeddedBrowserError = Impossibile creare un browser incorporato per visualizzare i grafici\n\n* Stai utilizzando l'ultima versione del browser?\n* Su Linux \u00E8 necessario installare il pacchetto 'libwebkitgtk-3.0-0'\n\nIl messaggio di errore\n   "Nessun aggancio [Percorso Mozilla sconosciuto (MOZILLA_FIVE_HOME non impostato)]"\nindica che libwebkitgtk deve essere installato. Su Ubuntu 18.04, esegui\n   sudo apt-get install libwebkitgtk-3.0-0\n\n\nDettagli:\n{0}
 
+MsgErrorAccountNotExist = Non esiste un account.\r\nCreare un nuovo account.
+
 MsgErrorConvertToBuySellCurrencyMismatch = L'operazione con la valuta {0} non pu\u00F2 essere prenotata sull'account "{2}" con la valuta {1}.
 
 MsgErrorConvertedAmount = Errore di calcolo: l'importo convertito non pu\u00F2 derivare dall'importo e dal tasso di cambio
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Strumento di investimento non trovato in
 MsgErrorNotAValidDate = Data non valida: "{0}"
 
 MsgErrorOpeningFile = Impossibile aprire il file: {0}
+
+MsgErrorPortfolioNotExist = Non esiste un conto titoli.\r\nSi prega di creare un nuovo conto titoli.
 
 MsgErrorSavingIniFile = Errore salvataggio file ini: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = Ongeldige ISIN: {0}
 
 MsgEmbeddedBrowserError = Kan geen ingesloten browser maken om grafieken weer te geven \n\n* Gebruikt u de nieuwste versie van uw browser?\n* Met Linux moet u het pakket 'libwebkitgtk-3.0-0' installeren \n\nHet foutbericht \n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]" \ngeeft aan dat libwebkitgtk moet worden ge\u00EFnstalleerd. Op Ubuntu 18.04, voer \n  sudo apt-get install libwebkitgtk-3.0-0 \n\n \nDetails: \n{0}
 
+MsgErrorAccountNotExist = Er is geen account.\r\nMaak een nieuwe account aan.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transactie met valuta {0} kan niet worden geboekt op account ''{2}'' met de valuta {1}.
 
 MsgErrorConvertedAmount = Rekenfout: omgerekend bedrag kan niet resulteren uit bedrag en wisselkoers
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Geen investeringsvehikel gevonden bij {0
 MsgErrorNotAValidDate = Geen geldige datum: ''{0}''
 
 MsgErrorOpeningFile = Kan bestand niet openen: {0}
+
+MsgErrorPortfolioNotExist = Er is geen effectenrekening.\r\nGelieve een nieuwe effectenrekening aan te maken.
 
 MsgErrorSavingIniFile = Fout bij opslaan van ini-bestand: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pl.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = Nieprawid\u0142owy kod ISIN: {0}
 
 MsgEmbeddedBrowserError = Nie mo\u017Cna utworzy\u0107 osadzonej przegl\u0105darki dla wy\u015Bwietlenia wykres\u00F3w\n\n* Czy u\u017Cywasz najnowszej wersji Twojej przegl\u0105darki?\n* W systemie Linux mo\u017Ce by\u0107 wymagana instalacja pakietu 'libwebkitgtk-3.0-0'\n\nKomunikat b\u0142\u0119du:\n  "No more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nindicates that libwebkitgtk has to be installed. On Ubuntu 18.04, run\n  sudo apt-get install libwebkitgtk-3.0-0\n\n\nSzczeg\u00F3\u0142y:\n{0}
 
+MsgErrorAccountNotExist = Nie ma konta.\r\nProsz\u0119 za\u0142o\u017Cy\u0107 nowe konto.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transakcja w walucie {0} nie mo\u017Ce zosta\u0107 zaksi\u0119gowana na koncie ''{2}'' o walucie {1}.
 
 MsgErrorConvertedAmount = B\u0142\u0105d oblicze\u0144: przeliczona kwota nie mo\u017Ce wynika\u0107 z kwoty i kursu wymiany
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Nie znaleziono instrumentu inwestycyjneg
 MsgErrorNotAValidDate = Nieprawid\u0142owa data: ''{0}''
 
 MsgErrorOpeningFile = Nie mo\u017Cna otworzy\u0107 pliku: {0}
+
+MsgErrorPortfolioNotExist = Nie ma konta papier\u00F3w warto\u015Bciowych.\r\nProsz\u0119 za\u0142o\u017Cy\u0107 nowe konto papier\u00F3w warto\u015Bciowych.
 
 MsgErrorSavingIniFile = B\u0142\u0105d podczas zapisywania pliku ini: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = ISIN inv\u00E1lido: {0}
 
 MsgEmbeddedBrowserError = N\u00E3o foi poss\u00EDvel criar um navegador incorporado para exibir gr\u00E1ficos\n\n* Voc\u00EA est\u00E1 executando a vers\u00E3o mais recente do seu navegador?\n* No Linux, \u00E9 necess\u00E1rio instalar o pacote 'libwebkitgtk-3.0-0'\n\nA mensagem de erro\n\u00A0\u00A0"No more handles [caminho desconhecido do Mozilla (MOZILLA_FIVE_HOME n\u00E3o definido)]"\nindica que a libwebkitgtk deve ser instalada. No Ubuntu 18.04, execute\n\u00A0\u00A0sudo apt-get install libwebkitgtk-3.0-0\n\n\nDetalhes:\n{0}
 
+MsgErrorAccountNotExist = N\u00E3o h\u00E1 conta.\r\nPor favor, crie uma nova conta.
+
 MsgErrorConvertToBuySellCurrencyMismatch = A transa\u00E7\u00E3o com a moeda {0} n\u00E3o pode ser inserida na conta ''{2}'' com a moeda {1}.
 
 MsgErrorConvertedAmount = Erro de c\u00E1lculo: o valor convertido n\u00E3o pode resultar em valor e taxa de c\u00E2mbio
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Nenhum ve\u00EDculo de investimento enco
 MsgErrorNotAValidDate = N\u00E3o \u00E9 uma data v\u00E1lida: ''{0}''
 
 MsgErrorOpeningFile = N\u00E3o foi poss\u00EDvel abrir o arquivo: {0}
+
+MsgErrorPortfolioNotExist = N\u00E3o h\u00E1 conta de t\u00EDtulos.\r\nPor favor crie uma nova conta de t\u00EDtulos.
 
 MsgErrorSavingIniFile = Erro ao salvar o arquivo ini: {0}
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_sk.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_sk.properties
@@ -1899,6 +1899,8 @@ MsgDialogNotAValidISIN = Neplatn\u00FD ISIN: {0}
 
 MsgEmbeddedBrowserError = Nie je mo\u017En\u00E9 vytvori\u0165 vlo\u017Een\u00FD prehliada\u010D na zobrazenie grafov\n\n* Pou\u017E\u00EDvate najnov\u0161iu verziu prehliada\u010Da? \n* V syst\u00E9me Linux je potrebn\u00E9 nain\u0161talova\u0165 bal\u00EDk 'libwebkitgtk-3.0-0'\n\nChybov\u00E9 hl\u00E1senie "\nNo more handles [Unknown Mozilla path (MOZILLA_FIVE_HOME not set)]"\nznamen\u00E1, \u017Ee je potrebn\u00E9 nain\u0161talova\u0165 libwebkitgtk. V Ubuntu 18.04 spustite pr\u00EDkaz \nsudo apt-get install libwebkitgtk-3.0-0\n\n\nPodrobnosti:\n{0}
 
+MsgErrorAccountNotExist = Neexistuje \u017Eiadny \u00FA\u010Det.\r\nVytvorte si nov\u00E9 konto.
+
 MsgErrorConvertToBuySellCurrencyMismatch = Transakciu s menou {0} nemo\u017Eno za\u00FA\u010Dtova\u0165 na \u00FA\u010Det ''{2}'' s menou {1}.
 
 MsgErrorConvertedAmount = Chyba v\u00FDpo\u010Dtu: Prepo\u010D\u00EDtan\u00E1 suma nem\u00F4\u017Ee by\u0165 v\u00FDsledkom sumy a v\u00FDmenn\u00E9ho kurzu
@@ -1916,6 +1918,8 @@ MsgErrorNoInvestmentVehicleFoundAtURL = Na adrese {0} nebol n\u00E1jden\u00FD \u
 MsgErrorNotAValidDate = Neplatn\u00FD d\u00E1tum: ''{0}''
 
 MsgErrorOpeningFile = Nie je mo\u017En\u00E9 otvori\u0165 s\u00FAbor: {0}
+
+MsgErrorPortfolioNotExist = \u00DA\u010Det cenn\u00FDch papierov neexistuje.\r\nVytvorte si nov\u00FD \u00FA\u010Det cenn\u00FDch papierov.
 
 MsgErrorSavingIniFile = Chyba pri ukladan\u00ED ini s\u00FAboru: {0}
 


### PR DESCRIPTION
With this PR, we fix the import dialog for the PDF and IBFlex importer when no reference account and securities account exists.
We also change (add) the error message for a correct error description in the PDF, CSV and IBFlex importer.
https://forum.portfolio-performance.info/t/pdf-import-von-bondora-go-grow/10760/90 --> Error
https://forum.portfolio-performance.info/t/pdf-import-von-bondora-go-grow/10760/92 --> (Screenshot)