### PR TITLE
Added SEPA-Lastschrift to REMOVAL transactions for SolarisbankAG

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/solarisbank/GiroKontoauszug03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/solarisbank/GiroKontoauszug03.txt
@@ -1,0 +1,38 @@
+Herr Peter Pan Ausgestellt am
+Elfenstraße, 1 1 Nov. 2022
+88888, Musterstadt
+Deutschland Abrechnungszeitraum
+26 Okt. 2022 — 31 Okt. 2022
+Rechnungsabschluss
+Kontostand am 26 Okt. 2022
+0,00 EUR
+Tag der Tag der
+Buchung Wertstellung Typ Beschreibung Betrag
+Kd CUSTOMER_NO Wir sagen
+Danke. RG-Nr. INVOICENO
+19.10.2022 19.10.2022 SEPA-Lastschrift 11,99 EUR -11,99 EUR
+an Peter Pan
+DE28110101015031128865
+Monatlich/10 Kontostand am 31 Okt. 2022
+43,20 EUR
+IBAN: DE55 5555 5555 5555 5555 55
+BIC: SOBKDEB2XXX
+DEVISEN: EUR
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen, Berechnungen und den Abschlusssaldo im beiliegenden Kontoauszug, der zugleich
+einen Rechnungsabschluss darstellt. Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs
+Wochen nach Zugang keine Einwendungen erheben. Einwendungen gegen Rechnungsabschlüsse müssen schriftlich
+oder in Textform (z.B. an https://vivid.money/de-de/support) zugehen. Im Falle der Einwendung in Textform genügt
+zur Fristwahrung die rechtzeitige Absendung. Der angegebene Kontostand berücksichtigt nicht die Wertstellung der
+einzelnen Buchungen. Dies bedeutet, dass der genannte Betrag nicht dem für die Zinsrechnung maßgeblichen
+Kontostand entsprechen muss und bei Verfügungen möglicherweise Zinsen für die Inanspruchnahme einer
+eingeräumten oder geduldeten Kontoüberziehung anfallen können. Gutschriften aus eingereichten Lastschriften und
+anderen Einzugspapieren erfolgen unter dem Vorbehalt der Einlösung. Guthaben sind als Einlagen nach Maßgabe des
+Einlagensicherungsgesetzes (EinSiG) entschädigungsfähig. Nähere Informationen können dem Informationsbogen für
+den Einleger entnommen werden, den Sie gemeinsam mit unseren für den Geschäftsverkehr mit Ihnen geltenden
+Allgemeinen Geschäftsbedingungen und besonderen Bedingungen unter www.solarisbank.de/partner einsehen
+können.
+Mit freundlichen Grüßen
+Ihre Solarisbank
+Unterstützt von der Solarisbank AG
+Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/solarisbank/SolarisbankAGPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/solarisbank/SolarisbankAGPDFExtractorTest.java
@@ -101,6 +101,30 @@ public class SolarisbankAGPDFExtractorTest
     }
 
 
+    @Test
+    public void testGiroKontoauszug03()
+    {
+        SolarisbankAGPDFExtractor extractor = new SolarisbankAGPDFExtractor(new Client());
+        List<Exception> errors = new ArrayList<>();
+        List<Item> results = extractor.extract(loadFile("GiroKontoauszug03.txt"), errors);
+
+        assertThat(errors, empty());
+
+        assertThat(results.stream().filter(i -> i instanceof TransactionItem)
+                        .filter(i -> i.getSubject() instanceof AccountTransaction)
+                        .filter(i -> ((AccountTransaction) i.getSubject()).getType() == AccountTransaction.Type.REMOVAL)
+                        .count(), is(1L));
+
+        Iterator<Extractor.Item> iter = results.stream().filter(i -> i instanceof TransactionItem).iterator();
+        Item item = iter.next();
+
+        AccountTransaction transaction = (AccountTransaction) item.getSubject();
+        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
+        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-10-19T00:00")));
+        assertThat(transaction.getAmount(), is(Values.Amount.factorize(11.99)));
+    }
+
     private List<InputFile> loadFile(String filename)
     {
         return PDFInputFile.loadTestCase(getClass(), filename);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
@@ -14,7 +14,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
 {
     
     private static final String DEPOSIT = "^(?<date>\\d+.\\d+.\\d{4}).*(SEPA\\-.berweisung|.berweisung).* (?<amount>[\\d,.]+) (?<currency>\\w{3})$";
-    private static final String REMOVAL = "^(?<date>\\d+.\\d+.\\d{4}).*(Kartenzahlung|Überweisung) (?<note>.*) (?<amount>\\-[\\d,.]+) (?<currency>\\w{3})$";
+    private static final String REMOVAL = "^(?<date>\\d+.\\d+.\\d{4}).*(Kartenzahlung|Überweisung|SEPA-Lastschrift) (?<note>.*) (?<amount>\\-[\\d,.]+) (?<currency>\\w{3})$";
     
     private static final String CONTEXT_KEY_DATE = "date";
     private static final String CONTEXT_KEY_AMOUNT = "amount";


### PR DESCRIPTION
SEPA-Lastschrift was missing within the SolarisbankAGPDFExtractor. 