### PR TITLE
Delete temporary files in IBFlex tests after use

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -228,6 +228,7 @@ public class IBFlexStatementExtractorTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithAccountDetailsTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithAccountDetailsTest.java
@@ -181,6 +181,7 @@ public class IBFlexStatementExtractorWithAccountDetailsTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithDuplicateTransactionsTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithDuplicateTransactionsTest.java
@@ -104,6 +104,7 @@ public class IBFlexStatementExtractorWithDuplicateTransactionsTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithFixGrossValueBuySellTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithFixGrossValueBuySellTest.java
@@ -114,6 +114,7 @@ public class IBFlexStatementExtractorWithFixGrossValueBuySellTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithForeignDividendNoAccountInfoTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithForeignDividendNoAccountInfoTest.java
@@ -154,6 +154,7 @@ public class IBFlexStatementExtractorWithForeignDividendNoAccountInfoTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithForeignDividendTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorWithForeignDividendTest.java
@@ -150,6 +150,7 @@ public class IBFlexStatementExtractorWithForeignDividendTest
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
         File tempFile = File.createTempFile("iBFlexStatementExtractorTest", null);
+        tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 
         IOUtils.copy(input, fos);


### PR DESCRIPTION
The temporary files were left behind after each test run, which got somewhat annoying.