### PR TITLE
Fix calculations for interest transactions with taxes

### DIFF
--- a/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/AccountBuilder.java
+++ b/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/AccountBuilder.java
@@ -53,11 +53,16 @@ public class AccountBuilder
         return transaction(Type.INTEREST, date, amount);
     }
 
+    public AccountBuilder interest(String date, long amount, long taxes)
+    {
+        return transaction(Type.INTEREST, date, amount, taxes, null);
+    }
+
     public AccountBuilder interest(LocalDateTime date, long amount)
     {
         return transaction(Type.INTEREST, date, amount);
     }
-    
+
     public AccountBuilder interest_charge(String date, long amount)
     {
         return transaction(Type.INTEREST_CHARGE, date, amount);

--- a/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/AccountBuilder.java
+++ b/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/AccountBuilder.java
@@ -105,29 +105,34 @@ public class AccountBuilder
 
     public AccountBuilder dividend(String date, long amount, Security security)
     {
-        AccountTransaction t = new AccountTransaction(asDateTime(date), account.getCurrencyCode(), amount,
-                        security, Type.DIVIDENDS);
-        account.addTransaction(t);
-        return this;
+        return transaction(Type.DIVIDENDS, date, amount, 0L, security);
     }
 
     public AccountBuilder dividend(String date, long amount, long taxes, Security security)
     {
-        AccountTransaction t = new AccountTransaction(asDateTime(date), account.getCurrencyCode(), amount, security,
-                        Type.DIVIDENDS);
-        t.addUnit(new Unit(Unit.Type.TAX, Money.of(account.getCurrencyCode(), taxes)));
-        account.addTransaction(t);
-        return this;
+        return transaction(Type.DIVIDENDS, date, amount, taxes, security);
     }
 
     private AccountBuilder transaction(Type type, String date, long amount)
     {
-        return transaction(type, asDateTime(date), amount);
+        return transaction(type, asDateTime(date), amount, 0L, null);
     }
 
     private AccountBuilder transaction(Type type, LocalDateTime date, long amount)
     {
-        AccountTransaction t = new AccountTransaction(date, account.getCurrencyCode(), amount, null, type);
+        return transaction(type, date, amount, 0L, null);
+    }
+
+    private AccountBuilder transaction(Type type, String date, long amount, long taxes, Security security)
+    {
+        return transaction(type, asDateTime(date), amount, taxes, security);
+    }
+
+    private AccountBuilder transaction(Type type, LocalDateTime date, long amount, long taxes, Security security)
+    {
+        AccountTransaction t = new AccountTransaction(date, account.getCurrencyCode(), amount, security, type);
+        if (taxes > 0)
+            t.addUnit(new Unit(Unit.Type.TAX, Money.of(account.getCurrencyCode(), taxes)));
         account.addTransaction(t);
         return this;
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
@@ -384,4 +384,31 @@ public class ClientIndexTest
         assertThat(accumulated[accumulated.length - 1], IsCloseTo.closeTo(0.1d, PRECISION));
     }
 
+    @Test
+    public void testInterestWithTax()
+    {
+        Client client = new Client();
+
+        new AccountBuilder() //
+                        .deposit_("2022-01-01", 1000_00) //
+                        .interest("2022-12-24", 42_50, 7_50) //
+                        .addTo(client);
+
+        Interval reportInterval = Interval.of(LocalDate.of(2021, Month.DECEMBER, 31), //
+                        LocalDate.of(2022, Month.DECEMBER, 31));
+        CurrencyConverter converter = new TestCurrencyConverter();
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval, new ArrayList<>());
+
+        long totals[] = index.getTotals();
+        assertThat(totals[totals.length - 9], is(1000_00L));
+        assertThat(totals[totals.length - 8], is(1042_50L));
+        assertThat(totals[totals.length - 1], is(1042_50L));
+
+        long interest[] = index.getInterest();
+        assertThat(interest[interest.length - 8], is(42_50L));
+
+        long taxes[] = index.getTaxes();
+        assertThat(taxes[taxes.length - 8], is(7_50L));
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilterTest.java
@@ -54,6 +54,7 @@ public class WithoutTaxesFilterTest
                             .deposit_("2016-01-01", Values.Amount.factorize(100))
                             .tax_____("2016-01-02", Values.Amount.factorize(5))
                             .taxrefnd("2016-02-02", Values.Amount.factorize(5))
+                            .interest("2016-02-15", Values.Amount.factorize(6), Values.Amount.factorize(1))
                             .dividend("2016-03-01", Values.Amount.factorize(10), Values.Amount.factorize(1), security1) //
                             .addTo(client);
             a.setName(index);
@@ -84,8 +85,8 @@ public class WithoutTaxesFilterTest
 
         Account account = result.getAccounts().get(0);
 
-        // 6 regular transactions + 3 corrections for buy, sell, and dividend tx
-        assertThat(account.getTransactions().size(), is(9));
+        // 7 regular transactions + 4 corrections for buy, sell, interest, and dividend tx
+        assertThat(account.getTransactions().size(), is(11));
 
         assertThat(account.getTransactions().stream() //
                         .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS)
@@ -98,10 +99,10 @@ public class WithoutTaxesFilterTest
         assertThat(account.getTransactions().stream().filter(t -> t.getType() == AccountTransaction.Type.TAXES)
                         .findAny().isPresent(), is(false));
 
-        // expect 3 removals: for the tax transaction + part of buy + sell +
+        // expect 5 removals: for the tax transaction + part of buy + sell + interest +
         // dividend
         assertThat(account.getTransactions().stream().filter(t -> t.getType() == AccountTransaction.Type.REMOVAL)
-                        .count(), is(4L));
+                        .count(), is(5L));
 
         // tax refund converted to deposit
         assertThat(account.getTransactions().stream().filter(t -> t.getType() == AccountTransaction.Type.TAX_REFUND)
@@ -110,7 +111,7 @@ public class WithoutTaxesFilterTest
                         .count(), is(2L));
 
         assertThat(AccountSnapshot.create(account, new TestCurrencyConverter(), LocalDate.parse("2016-09-03"))
-                        .getFunds(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10 + 250))));
+                        .getFunds(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10 + 250 + 6))));
 
         Portfolio portfolio = result.getPortfolios().get(0);
         assertThat(portfolio.getTransactions().size(), is(4));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
@@ -150,6 +150,8 @@ import name.abuchen.portfolio.util.Interval;
                                                         interval, d);
                                         break;
                                     case INTEREST:
+                                        addValue(taxes, t.getCurrencyCode(), t.getUnitSum(Unit.Type.TAX).getAmount(),
+                                                        interval, d);
                                         addValue(interest, t.getCurrencyCode(), t.getAmount(), interval, d);
                                         break;
                                     case INTEREST_CHARGE:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
@@ -372,9 +372,14 @@ public class ClientClassificationFilter implements ClientFilter
                 case REMOVAL:
                 case INTEREST:
                 case INTEREST_CHARGE:
+                    long taxes = value(t.getUnitSum(Unit.Type.TAX).getAmount(), accountWeight); // for INTEREST
                     state.asReadOnly(account).internalAddTransaction(new AccountTransaction(t.getDateTime(),
-                                    t.getCurrencyCode(), amount, null, t.getType()));
+                                    t.getCurrencyCode(), amount + taxes, null, t.getType()));
+                    if (taxes != 0)
+                        state.asReadOnly(account).internalAddTransaction(new AccountTransaction(t.getDateTime(),
+                                        t.getCurrencyCode(), taxes, null, AccountTransaction.Type.REMOVAL));
                     break;
+
                 default:
                     throw new UnsupportedOperationException();
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilter.java
@@ -154,6 +154,7 @@ public class WithoutTaxesFilter implements ClientFilter
                     pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.REMOVAL));
                     break;
                 case DIVIDENDS:
+                case INTEREST:
                     stripTaxes(t, pseudoAccount);
                     break;
                 case BUY:
@@ -171,7 +172,6 @@ public class WithoutTaxesFilter implements ClientFilter
                 case FEES:
                 case DEPOSIT:
                 case REMOVAL:
-                case INTEREST:
                 case INTEREST_CHARGE:
                     pseudoAccount.internalAddTransaction(t);
                     break;
@@ -183,7 +183,7 @@ public class WithoutTaxesFilter implements ClientFilter
 
     private void stripTaxes(AccountTransaction t, ReadOnlyAccount readOnlyAccount)
     {
-        if (t.getType() != AccountTransaction.Type.DIVIDENDS)
+        if (t.getType() != AccountTransaction.Type.DIVIDENDS && t.getType() != AccountTransaction.Type.INTEREST)
             throw new UnsupportedOperationException();
 
         Money taxes = t.getUnitSum(Unit.Type.TAX);


### PR DESCRIPTION
In #1190, it was made possible to enter taxes with interest transactions, but nothing was done to ensure that the backend calculations could actually deal with that. :-1: So here are a number of fixes to the `ClientIndex`, `WithoutTaxesFilter` and `ClientClassificationFilter`, with tests; all the tests failed in current PP. Only `ClientPerformanceSnapshot` happened to work correctly.

Some of the issues were described in https://forum.portfolio-performance.info/t/23589/2 and https://forum.portfolio-performance.info/t/6158/3.