### PR TITLE
Add tests for ExtractorUtils.java

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberBigDecimalTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberBigDecimalTest.java
@@ -1,0 +1,63 @@
+package name.abuchen.portfolio.datatransfer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import name.abuchen.portfolio.money.Values;
+
+@RunWith(Parameterized.class)
+public class ExtractorUtilsConvertToNumberBigDecimalTest
+{
+    private String input;
+    private Locale locale;
+    private BigDecimal expectedOutput;
+
+    public ExtractorUtilsConvertToNumberBigDecimalTest(String input, Locale locale, BigDecimal expectedOutput)
+    {
+        this.input = input;
+        this.locale = locale;
+        this.expectedOutput = expectedOutput;
+    }
+
+    @Parameters(name = "{index}: convertToNumberBigDecimal({0}, {1}) = {2}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[][] { //
+                        { "1 234,56", new Locale("fr", "FR"), new BigDecimal("1234.56") }, //
+                        { "1,234.56", new Locale("en", "US"), new BigDecimal("1234.56") }, //
+                        { "1'234.56", new Locale("de", "CH"), new BigDecimal("1234.56") }, //
+                        { "1.234,56", new Locale("de", "DE"), new BigDecimal("1234.56") }, //
+                        { "1 234.56", new Locale("xh", "ZA"), new BigDecimal("1234.56") }, //
+                        { "0,56", new Locale("fr", "FR"), new BigDecimal("0.56") }, //
+                        { "0.56", new Locale("en", "US"), new BigDecimal("0.56") }, //
+                        { "0.56", new Locale("de", "CH"), new BigDecimal("0.56") }, //
+                        { "0,56", new Locale("de", "DE"), new BigDecimal("0.56") }, //
+                        { "0.56", new Locale("xh", "ZA"), new BigDecimal("0.56") }, //
+        });
+    }
+
+    @Test
+    public void testConvertToNumberBigDecimal()
+    {
+        BigDecimal actualOutput = ExtractorUtils.convertToNumberBigDecimal(input, null, locale.getLanguage(),
+                        locale.getCountry());
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConvertToNumberBigDecimalWithInvalidInput()
+    {
+        String input = "abc";
+        Locale locale = new Locale("de", "DE");
+        ExtractorUtils.convertToNumberBigDecimal(input, Values.Share, locale.getLanguage(), locale.getCountry());
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberLongTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberLongTest.java
@@ -1,0 +1,57 @@
+package name.abuchen.portfolio.datatransfer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import name.abuchen.portfolio.money.Values;
+
+@RunWith(Parameterized.class)
+public class ExtractorUtilsConvertToNumberLongTest
+{
+    private final String input;
+    private final Locale locale;
+    private final long expectedOutput;
+
+    public ExtractorUtilsConvertToNumberLongTest(String input, Locale locale, long expectedOutput)
+    {
+        this.input = input;
+        this.locale = locale;
+        this.expectedOutput = expectedOutput;
+    }
+
+    @Parameters(name = "{index}: convert {0} to ({1}) should return {2}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[][] { //
+                        { "1 234,56", new Locale("fr", "FR"), 123456 }, //
+                        { "1,234.56", new Locale("en", "US"), 123456 }, //
+                        { "1'234.56", new Locale("de", "CH"), 123456 }, //
+                        { "1.234,56", new Locale("de", "DE"), 123456 }, //
+                        { "1 234.56", new Locale("xh", "ZA"), 123456 }, //
+        });
+    }
+
+    @Test
+    public void testConvertToNumberLong()
+    {
+        long actualOutput = ExtractorUtils.convertToNumberLong(input, Values.Amount, locale.getLanguage(),
+                        locale.getCountry());
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConvertToNumberLongWithInvalidInput()
+    {
+        String input = "abc";
+        Locale locale = new Locale("de", "DE");
+        ExtractorUtils.convertToNumberLong(input, Values.Amount, locale.getLanguage(), locale.getCountry());
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsDateParserTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsDateParserTest.java
@@ -1,0 +1,144 @@
+package name.abuchen.portfolio.datatransfer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.Messages;
+
+public class ExtractorUtilsDateParserTest
+{
+    @Test
+    public void testAsDateValidFormats()
+    {
+        // Test valid date strings for each pattern in DATE_FORMATTER_GERMANY
+        LocalDateTime expected = LocalDateTime.of(2022, 4, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("11.4.2022"));
+        assertEquals(expected, ExtractorUtils.asDate("11.4.22"));
+        assertEquals(expected, ExtractorUtils.asDate("2022-4-11"));
+        assertEquals(expected, ExtractorUtils.asDate("11-4-2022"));
+        assertEquals(expected, ExtractorUtils.asDate("11.04.22"));
+        assertEquals(expected, ExtractorUtils.asDate("11-04-2022"));
+        assertEquals(expected, ExtractorUtils.asDate("2022-04-11"));
+        assertEquals(expected, ExtractorUtils.asDate("11. April 2022"));
+        assertEquals(expected, ExtractorUtils.asDate("11/04/2022"));
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testAsDateInvalidFormat()
+    {
+        // Test invalid date string
+        ExtractorUtils.asDate("11-April-2022");
+    }
+
+    @Test
+    public void testAsDateValidFormatsWithHints()
+    {
+        // Test valid date strings for each pattern in
+        // DATE_FORMATTER_GERMANY with hints
+        LocalDateTime expected = LocalDateTime.of(2023, 4, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("11.4.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11.4.23", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-4-11", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11-4-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11.04.23", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11-04-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-04-11", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11. April 2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11/04/2023", Locale.GERMANY));
+
+        // Test valid date strings for each pattern in
+        // DATE_FORMATTER_US with hints
+        expected = LocalDateTime.of(2023, 4, 9, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("9 Apr 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("09 Apr 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("20230409", Locale.US));
+
+        // Test valid date strings for each pattern in
+        // DATE_FORMATTER_CANADA with hints
+        expected = LocalDateTime.of(2023, 04, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("Apr. 11, 2023", Locale.CANADA));
+
+        // Test valid date strings for each pattern in
+        // DATE_FORMATTER_CANADA_FRENCH with hints
+        expected = LocalDateTime.of(2023, 4, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("11 avr. 2023", Locale.CANADA_FRENCH));
+
+        // Test valid date strings for each pattern in
+        // DATE_FORMATTER_UK with hints
+        expected = LocalDateTime.of(2023, 4, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("11 Apr 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("04/11/2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("11.04.2023", Locale.UK));
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testAsDateInvalidFormatWithHints()
+    {
+        // Test invalid date string with hints
+        ExtractorUtils.asDate("11-April-2023", Locale.GERMANY);
+
+        // Test invalid date string with hints
+        ExtractorUtils.asDate("11-April-2023", Locale.US);
+    }
+
+    @Test
+    public void testAsDateCanadaWithFallback()
+    {
+        String value = "11 Apr 2023";
+        LocalDateTime expected = LocalDateTime.of(2023, 4, 11, 0, 0);
+        LocalDateTime result = ExtractorUtils.asDate(value, Locale.UK, Locale.CANADA);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testAsDateInvalidValue()
+    {
+        String value = "invalid date value";
+        try
+        {
+            ExtractorUtils.asDate(value, Locale.GERMANY);
+            fail("Expected DateTimeParseException was not thrown");
+        }
+        catch (DateTimeParseException e)
+        {
+            assertEquals(MessageFormat.format(Messages.MsgErrorNotAValidDate, value), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidFormats()
+    {
+        // Test various valid formats
+        assertEquals(LocalTime.of(13, 15), ExtractorUtils.asTime("11-04-2023 13:15"));
+        assertEquals(LocalTime.of(8, 0), ExtractorUtils.asTime("11/04/2023 08:00:00"));
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testInvalidFormat()
+    {
+        // Test an invalid format
+        ExtractorUtils.asTime("2023-04-11");
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testInvalidValue()
+    {
+        // Test an invalid value that cannot be parsed by any formatter
+        ExtractorUtils.asTime("not a time");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullValue()
+    {
+        // Test a null value
+        ExtractorUtils.asTime(null);
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer;
 
+import static name.abuchen.portfolio.util.TextUtil.trim;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -44,7 +46,7 @@ public class ExtractorUtils
                     DateTimeFormatter.ofPattern("yyyyMMdd", Locale.US) }; //$NON-NLS-1$
 
     private static final DateTimeFormatter[] DATE_FORMATTER_CANADA = { //
-                    DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.CANADA) }; //$NON-NLS-1$
+                    DateTimeFormatter.ofPattern("LLL dd, yyyy", Locale.CANADA) }; //$NON-NLS-1$
 
     private static final DateTimeFormatter[] DATE_FORMATTER_CANADA_FRENCH = { //
                     DateTimeFormatter.ofPattern("dd LLL yyyy", Locale.CANADA_FRENCH) }; //$NON-NLS-1$
@@ -168,6 +170,27 @@ public class ExtractorUtils
     {
         DecimalFormat newNumberFormat = (DecimalFormat) NumberFormat.getInstance(new Locale(language, country));
 
+        /**
+         * @formatter:off
+         * 
+         * The group separator for language format French is a space followed by the decimal separator comma.
+         * fr_FR --> 1 234,56
+         * 
+         * If the amount has the group separator space, the string can still have the following format.
+         * xh_ZA --> 1 234.56
+         * 
+         * To simplify the two variants, we remove the spaces in the string, bypassing the generation of an additional identification via the locale.
+         * 
+         * The problem is that we can only pass one main formatting per importer.
+         * e.g. 
+         * Importer: PostfinancePDFExtractor.java
+         * Test file: Kauf01.txt vs. Kauf04.txt
+         * We remove the spaces from the complete string and bypass the formatting.
+         * 
+         * @formatter:on
+         */
+        value = trim(value).replaceAll("\\s", "");
+
         if (country.equals("CH"))
         {
             /***
@@ -197,6 +220,27 @@ public class ExtractorUtils
     public static BigDecimal convertToNumberBigDecimal(String value, Values<Long> valueType, String language,
                     String country)
     {
+        /**
+         * @formatter:off
+         * 
+         * The group separator for language format French is a space followed by the decimal separator comma.
+         * fr_FR --> 1 234,56
+         * 
+         * If the amount has the group separator space, the string can still have the following format.
+         * xh_ZA --> 1 234.56
+         * 
+         * To simplify the two variants, we remove the spaces in the string, bypassing the generation of an additional identification via the locale.
+         * 
+         * The problem is that we can only pass one main formatting per importer.
+         * e.g. 
+         * Importer: PostfinancePDFExtractor.java
+         * Test file: Kauf01.txt vs. Kauf04.txt
+         * We remove the spaces from the complete string and bypass the formatting.
+         * 
+         * @formatter:on
+         */
+        value = trim(value).replaceAll("\\s", "");
+
         DecimalFormat newNumberFormat = (DecimalFormat) NumberFormat.getInstance(new Locale(language, country));
 
         if (country.equals("CH"))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -96,7 +96,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                         country = "CH"; //$NON-NLS-1$
                                     }
 
-                                    t.setAmount(asAmount(v.get("amount").trim().replaceAll("\\s", ""), language, country));
+                                    t.setAmount(asAmount(v.get("amount"), language, country));
                                     t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                     t.setNote(trim(v.get("note")));
                                 })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -2071,8 +2072,6 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 
@@ -2101,8 +2100,6 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 
@@ -2131,8 +2128,6 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+
 import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -943,8 +944,6 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 
@@ -973,8 +972,6 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 
@@ -1003,8 +1000,6 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll("\\s", ""); //$NON-NLS-1$ //$NON-NLS-2$
-
         String language = "de"; //$NON-NLS-1$
         String country = "DE"; //$NON-NLS-1$
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+
 import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -936,21 +937,18 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
     }
 
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
@@ -201,7 +201,6 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
@@ -516,7 +516,6 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
     }
 
@@ -524,14 +523,12 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        value = value.trim().replaceAll("\\s", "");
         return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }


### PR DESCRIPTION
Add ExtractorUtilsConvertToNumberBigDecimalTest
Add ExtractorUtilsConvertToNumberLongTest
Add ExtractorUtilsDateParserTest

Remove the `value = value.trim().replaceAll("\\s", "")` from each importer and moved to the ExractorUtils.java.

The group separator for language format French is a space followed by the decimal separator comma.
[fr_FR](https://www.localeplanet.com/java/fr-FR/index.html) --> `1 234,56`

If the amount has the group separator space, the string can still have the following format.
[xh_ZA](https://www.localeplanet.com/java/xh-ZA/index.html) --> `1 234.56`

To simplify the two variants, we remove the spaces in the string, bypassing the generation of an additional identification via the locale.

The problem is that we can only pass one main formatting per importer.
e.g.
Importer: [PostfinancePDFExtractor.java](https://github.com/buchen/portfolio/blob/master/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java)
Test file:[ Kauf01.txt](https://github.com/buchen/portfolio/blob/master/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/Kauf01.txt) vs. [Kauf04.txt](https://github.com/buchen/portfolio/blob/master/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postfinance/Kauf04.txt)