### PR TITLE
Extend input field calculations to subtractions

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
@@ -144,4 +144,40 @@ public class StringToCurrencyConverterTest
         StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, false);
         converter.convert("1.234,56");
     }
+
+    @Test
+    public void testValidArithmetic()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        StringToCurrencyConverter converter;
+        converter = new StringToCurrencyConverter(Values.Amount, false);
+        assertThat(converter.convert("10+10"), is(20_00L));
+        assertThat(converter.convert("10,01-10"), is(0_01L));
+        assertThat(converter.convert("-1.234,5+2.000,50"), is(766_00L));
+        assertThat(converter.convert("5-4+3-2+1"), is(3_00L));
+        converter = new StringToCurrencyConverter(Values.Amount, true);
+        assertThat(converter.convert("10+10"), is(20_00L));
+        assertThat(converter.convert("10,01-10"), is(0_01L));
+        assertThat(converter.convert("-1.234,5+2.000,50"), is(766_00L));
+        assertThat(converter.convert("5-4+3-2+1"), is(3_00L));
+        assertThat(converter.convert("12,34-23,45"), is(-11_11L));
+        assertThat(converter.convert("-1234"), is(-1234_00L));
+        assertThat(converter.convert("0,00-1.234,00"), is(-1234_00L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidArithmetic()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        converter.convert("1234,56-+0,44");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDisallowedNegativeValue()
+    {
+        Locale.setDefault(Locale.GERMANY);
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, false);
+        converter.convert("12,34-23,45");
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
@@ -88,8 +88,11 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
         String value = fromObject.trim();
 
         long result = 0;
-        for (String part : value.split("\\+")) //$NON-NLS-1$
+        for (String part : value.split("\\+|(?=-)")) //$NON-NLS-1$
             result += convertToLong(part.trim());
+
+        if (result < 0 && !acceptNegativeValues)
+            throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, value));
 
         return Long.valueOf(result);
     }
@@ -128,9 +131,6 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
         BigDecimal answer = (BigDecimal) decimalFormat.parse(string, parsePosition);
 
         if (parsePosition.getIndex() == 0 || parsePosition.getIndex() < string.length())
-            throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, string));
-
-        if (answer.signum() == -1 && !acceptNegativeValues)
             throw new IllegalArgumentException(String.format(Messages.CellEditor_NotANumber, string));
 
         return answer.multiply(type.getBigDecimalFactor()).longValue();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/StringToCurrencyConverter.java
@@ -14,7 +14,7 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
     private static final char NBSP = '\u00A0'; // No-Break Space
     private static final char NNBS = '\u202f'; // Narrow No-Break Space
 
-    private final DecimalFormat defaultPlattern;
+    private final DecimalFormat defaultPattern;
     private final DecimalFormat withSpacePattern;
     private final DecimalFormat belgianPattern;
 
@@ -31,8 +31,8 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
         this.type = type;
         this.acceptNegativeValues = acceptNegativeValues;
 
-        defaultPlattern = new DecimalFormat("#,###.##"); //$NON-NLS-1$
-        defaultPlattern.setParseBigDecimal(true);
+        defaultPattern = new DecimalFormat("#,###.##"); //$NON-NLS-1$
+        defaultPattern.setParseBigDecimal(true);
 
         DecimalFormatSymbols symbols = new DecimalFormatSymbols();
 
@@ -103,7 +103,7 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
             // regular decimal separator
 
             int dot = part.indexOf('.');
-            int comma = part.indexOf(defaultPlattern.getDecimalFormatSymbols().getDecimalSeparator());
+            int comma = part.indexOf(defaultPattern.getDecimalFormatSymbols().getDecimalSeparator());
 
             if (comma < 0 && dot >= 0 && part.lastIndexOf('.') == dot)
                 return parse(part, belgianPattern);
@@ -119,7 +119,7 @@ public class StringToCurrencyConverter implements IValidatingConverter<String, L
             // fall back to default pattern
         }
 
-        return parse(part, defaultPlattern);
+        return parse(part, defaultPattern);
     }
 
     private long parse(String string, DecimalFormat decimalFormat)


### PR DESCRIPTION
It was already possible to do small additions in an input field (e.g., the input `10.01+23.45` was interpreted as 33.46). Extend this to also allow subtractions, such as `33.46-23.45`, or indeed any combination such as `-10.01+23.45+47.11-0.03`. To this end, split the input on plus or minus (instead of only on plus), using a lookahead to retain any minus signs, and only check the total result for an undesired negative value, instead of each part separately.

Also adds some tests and fixes the typo “plattern” in a variable name.