### PR TITLE
Do not abort all quote jobs for a missing API key

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeedTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,10 +27,12 @@ public class AlphavantageQuoteFeedTest
         security.setTickerSymbol("AAPL");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoApiKey()
     {
-        new AlphavantageQuoteFeed().getLatestQuote(security);
+        AlphavantageQuoteFeed feed = new AlphavantageQuoteFeed();
+        Optional<LatestSecurityPrice> result = feed.getLatestQuote(security);
+        assertThat(result.isEmpty(), is(true));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
@@ -101,7 +101,10 @@ public class AlphavantageQuoteFeed implements QuoteFeed
         }
 
         if (apiKey == null)
-            throw new IllegalArgumentException(Messages.MsgAlphaVantageAPIKeyMissing);
+        {
+            PortfolioLog.error(Messages.MsgAlphaVantageAPIKeyMissing);
+            return Optional.empty();
+        }
 
         if (!rateLimiter.tryAcquire())
             throw new RateLimitExceededException(Messages.MsgAlphaVantageRateLimitExceeded);
@@ -178,7 +181,8 @@ public class AlphavantageQuoteFeed implements QuoteFeed
                             new IOException(MessageFormat.format(Messages.MsgMissingTickerSymbol, security.getName())));
 
         if (apiKey == null)
-            throw new IllegalArgumentException(Messages.MsgAlphaVantageAPIKeyMissing);
+            return QuoteFeedData.withError(
+                            new IllegalArgumentException(Messages.MsgAlphaVantageAPIKeyMissing));
 
         if (!rateLimiter.tryAcquire())
             throw new RateLimitExceededException(Messages.MsgAlphaVantageRateLimitExceeded);


### PR DESCRIPTION
Upon trying to retrieve quotes from Alpha Vantage, when an API key wasn’t configured, the `AlphavantageQuoteFeed` would throw an exception. This caused the parallel jobs for retrieving quotes to be cancelled, including for securities that used a different source. Thus, automatic download of quotes was as good as disabled if at least one security was set to use Alpha Vantage, but the API key was not set.

Instead of throwing an exception, report the error without affecting other quote download jobs.

Reported as #3300; most likely also the issue at https://forum.portfolio-performance.info/t/historische-kurse-werden-geladen-aber-nicht-angezeigt/889/19 (not the most computer-literate user, therefore somewhat unclear).