### PR TITLE
Extended file import filter mask with uppercase *.PDF

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -104,7 +104,7 @@ public class ImportPDFHandler
         FileDialog fileDialog = new FileDialog(shell, SWT.OPEN | SWT.MULTI);
         fileDialog.setText(Messages.PDFImportWizardAssistant);
         fileDialog.setFilterNames(new String[] { Messages.PDFImportFilterName });
-        fileDialog.setFilterExtensions(new String[] { "*.pdf;*.zip" }); //$NON-NLS-1$
+        fileDialog.setFilterExtensions(new String[] { "*.pdf;*.PDF;*.zip;*.ZIP" }); //$NON-NLS-1$
         fileDialog.setFilterPath(helper.getPath());
         fileDialog.open();
 


### PR DESCRIPTION
On my linux system with XFCE Environment the file system is case sensitve. 
When I try to import pdfs then only '*.pdf' are shown in the file selection dialog, not the files with the uppercase '*.PDF'. 

This patch extends the file selection mask with the uppercase variants.