### PR TITLE
Added transaction matcher for Hamcrest assertThat statements

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
@@ -1,0 +1,255 @@
+package name.abuchen.portfolio.datatransfer;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.model.Transaction.Unit.Type;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+public class ExtractorMatchers
+{
+    private static class TransactionPropertyMatcher<V> extends TypeSafeDiagnosingMatcher<Transaction>
+    {
+        private String label;
+        private V expectedValue;
+        private Function<Transaction, V> value;
+
+        public TransactionPropertyMatcher(String label, V expectedValue, Function<Transaction, V> value)
+        {
+            this.label = label;
+            this.expectedValue = expectedValue;
+            this.value = value;
+        }
+
+        @Override
+        protected boolean matchesSafely(Transaction transaction, Description mismatchDescription)
+        {
+            Object actualValue;
+            try
+            {
+                actualValue = value.apply(transaction);
+            }
+            catch (AssertionError e)
+            {
+                mismatchDescription.appendText(label).appendText(" = " + e.getMessage()); //$NON-NLS-1$
+                return false;
+            }
+
+            if (!Objects.equals(expectedValue, actualValue))
+            {
+                mismatchDescription.appendText(label).appendText(" = ").appendText(String.valueOf(actualValue)); //$NON-NLS-1$
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public void describeTo(Description description)
+        {
+            description.appendText(label).appendText(" = ").appendText(String.valueOf(expectedValue)); //$NON-NLS-1$
+        }
+    }
+
+    private static class TransactionMatcher extends TypeSafeDiagnosingMatcher<Extractor.Item>
+    {
+        private String label;
+        private Function<Extractor.Item, Transaction> transaction;
+        private Matcher<Transaction>[] properties;
+
+        public TransactionMatcher(String label, Function<Extractor.Item, Transaction> transaction,
+                        Matcher<Transaction>[] properties)
+        {
+            this.label = label;
+            this.transaction = transaction;
+            this.properties = properties;
+        }
+
+        @Override
+        protected boolean matchesSafely(Extractor.Item item, Description mismatchDescription)
+        {
+            Transaction tx = transaction.apply(item);
+            if (tx == null)
+            {
+                mismatchDescription.appendText("\n* not a '").appendText(label).appendText("' item"); //$NON-NLS-1$ //$NON-NLS-2$
+                return false;
+            }
+
+            for (Matcher<Transaction> property : properties)
+            {
+                if (!property.matches(tx))
+                {
+                    mismatchDescription.appendText("\n* ").appendText(label).appendText(" with "); //$NON-NLS-1$ //$NON-NLS-2$
+                    property.describeMismatch(tx, mismatchDescription);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        @Override
+        public void describeTo(Description description)
+        {
+            description.appendText(label).appendText(" with:"); //$NON-NLS-1$
+            for (Matcher<Transaction> p : properties)
+            {
+                description.appendText("\n - "); //$NON-NLS-1$
+                p.describeTo(description);
+            }
+        }
+    }
+
+    private static class AccountTransactionMatcher extends TransactionMatcher
+    {
+        public AccountTransactionMatcher(String label, AccountTransaction.Type type, Matcher<Transaction>[] properties)
+        {
+            super(label, item -> item instanceof TransactionItem tx //
+                            && tx.getSubject() instanceof AccountTransaction atx && atx.getType() == type ? atx : null,
+                            properties);
+        }
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> dividend(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("dividend", AccountTransaction.Type.DIVIDENDS, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> removal(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("removal", AccountTransaction.Type.REMOVAL, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> deposit(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("deposit", AccountTransaction.Type.DEPOSIT, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> purchase(Matcher<Transaction>... properties)
+    {
+        return new TransactionMatcher("purchase", //$NON-NLS-1$
+                        item -> item instanceof BuySellEntryItem buysell //
+                                        && buysell.getSubject() instanceof BuySellEntry entry
+                                        && entry.getPortfolioTransaction().getType() == PortfolioTransaction.Type.BUY
+                                                        ? entry.getPortfolioTransaction()
+                                                        : null, //
+                        properties);
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> sale(Matcher<Transaction>... properties)
+    {
+        return new TransactionMatcher("sale", //$NON-NLS-1$
+                        item -> item instanceof BuySellEntryItem buysell //
+                                        && buysell.getSubject() instanceof BuySellEntry entry
+                                        && entry.getPortfolioTransaction().getType() == PortfolioTransaction.Type.SELL
+                                                        ? entry.getPortfolioTransaction()
+                                                        : null, //
+                        properties);
+    }
+
+    public static Matcher<Transaction> hasDate(String dateString)
+    {
+        LocalDateTime expectecd = dateString.contains("T") //$NON-NLS-1$
+                        ? LocalDateTime.parse(dateString)
+                        : LocalDate.parse(dateString).atStartOfDay();
+
+        return new TransactionPropertyMatcher<>("date", //$NON-NLS-1$
+                        expectecd, //
+                        Transaction::getDateTime);
+    }
+
+    public static Matcher<Transaction> hasShares(double value)
+    {
+        // work with BigDecimal to have better assertion failed messages
+        return new TransactionPropertyMatcher<BigDecimal>("shares", //$NON-NLS-1$
+                        BigDecimal.valueOf(value).setScale(Values.Share.precision(), Values.MC.getRoundingMode()), //
+                        tx -> BigDecimal.valueOf(tx.getShares()).divide(Values.Share.getBigDecimalFactor(), Values.MC)
+                                        .setScale(Values.Share.precision(), Values.MC.getRoundingMode()));
+    }
+
+    public static Matcher<Transaction> hasSource(String source)
+    {
+        return new TransactionPropertyMatcher<>("source", source, //$NON-NLS-1$
+                        Transaction::getSource);
+    }
+
+    public static Matcher<Transaction> hasNote(String note)
+    {
+        return new TransactionPropertyMatcher<>("note", note, //$NON-NLS-1$
+                        Transaction::getNote);
+    }
+
+    public static Matcher<Transaction> hasAmount(String currencyCode, double value)
+    {
+        return new TransactionPropertyMatcher<>("amount", //$NON-NLS-1$
+                        Money.of(currencyCode, Values.Amount.factorize(value)), //
+                        Transaction::getMonetaryAmount);
+    }
+
+    public static Matcher<Transaction> hasGrossValue(String currencyCode, double value)
+    {
+        return new TransactionPropertyMatcher<>("grossValue", //$NON-NLS-1$
+                        Money.of(currencyCode, Values.Amount.factorize(value)), //
+                        Transaction::getGrossValue);
+    }
+
+    public static Matcher<Transaction> hasForexGrossValue(String currencyCode, double value)
+    {
+        return new TransactionPropertyMatcher<>("forexGrossValue", //$NON-NLS-1$
+                        Money.of(currencyCode, Values.Amount.factorize(value)), //
+                        tx -> {
+                            Unit grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(AssertionError::new);
+                            return grossValueUnit.getForex();
+                        });
+    }
+
+    public static Matcher<Transaction> hasTaxes(String currencyCode, double value)
+    {
+        return new TransactionPropertyMatcher<>("taxes", //$NON-NLS-1$
+                        Money.of(currencyCode, Values.Amount.factorize(value)), //
+                        tx -> tx.getUnitSum(Type.TAX));
+    }
+
+    public static Matcher<Transaction> hasFees(String currencyCode, double value)
+    {
+        return new TransactionPropertyMatcher<>("fees", //$NON-NLS-1$
+                        Money.of(currencyCode, Values.Amount.factorize(value)), //
+                        tx -> tx.getUnitSum(Type.FEE));
+    }
+
+    /**
+     * Run a custom check within a transaction to do custom assertThat for the
+     * given transaction
+     */
+    public static Matcher<Transaction> check(Consumer<Transaction> check)
+    {
+        return new TransactionPropertyMatcher<>("check", //$NON-NLS-1$
+                        null, //
+                        tx -> {
+                            check.accept(tx);
+                            return null;
+                        });
+    }
+
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
@@ -3,12 +3,18 @@ package name.abuchen.portfolio.datatransfer;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,8 +27,10 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
 import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -31,11 +39,21 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class ExtractorMatchersTest
 {
+    private static SecurityItem someSecurity;
     private static TransactionItem someTransactionItem;
 
     @BeforeClass
     public static void setup()
     {
+        Security s = new Security();
+        s.setName("test name");
+        s.setIsin("DE01");
+        s.setWkn("WKN");
+        s.setTickerSymbol("TICKER");
+        s.setCurrencyCode("USD");
+
+        someSecurity = new SecurityItem(s);
+
         AccountTransaction tx = new AccountTransaction();
         tx.setType(AccountTransaction.Type.DIVIDENDS);
         tx.setCurrencyCode(CurrencyUnit.EUR);
@@ -47,6 +65,7 @@ public class ExtractorMatchersTest
         tx.setNote("test");
         tx.setShares(Values.Share.factorize(123));
         tx.setDateTime(LocalDateTime.parse("2023-04-30T12:45"));
+        tx.setSecurity(s);
 
         someTransactionItem = new TransactionItem(tx);
     }
@@ -179,4 +198,65 @@ public class ExtractorMatchersTest
     {
         assertThat(List.of(someTransactionItem), hasItem(dividend(hasForexGrossValue("USD", 260))));
     }
+
+    @Test(expected = AssertionError.class)
+    public void testNameFailure()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasName("test"))));
+    }
+
+    @Test
+    public void testNameSuccess()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasName("test name"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testIsinFailure()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasIsin("test"))));
+    }
+
+    @Test
+    public void testIsinSuccess()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasIsin("DE01"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testWknFailure()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasWkn("test"))));
+    }
+
+    @Test
+    public void testWknSuccess()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasWkn("WKN"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testTickerFailure()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasTicker("test"))));
+    }
+
+    @Test
+    public void testTickerSuccess()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasTicker("TICKER"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testCurrencyCodeFailure()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasCurrencyCode("CHF"))));
+    }
+
+    @Test
+    public void testCurrencyCodeSuccess()
+    {
+        assertThat(List.of(someSecurity), hasItem(security(hasCurrencyCode("USD"))));
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
@@ -1,0 +1,182 @@
+package name.abuchen.portfolio.datatransfer;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+@SuppressWarnings("nls")
+public class ExtractorMatchersTest
+{
+    private static TransactionItem someTransactionItem;
+
+    @BeforeClass
+    public static void setup()
+    {
+        AccountTransaction tx = new AccountTransaction();
+        tx.setType(AccountTransaction.Type.DIVIDENDS);
+        tx.setCurrencyCode(CurrencyUnit.EUR);
+        tx.setAmount(Values.Amount.factorize(100));
+        tx.addUnit(new Unit(Unit.Type.FEE, Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10))));
+        tx.addUnit(new Unit(Unit.Type.TAX, Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20))));
+        tx.addUnit(new Unit(Unit.Type.GROSS_VALUE, Money.of(CurrencyUnit.EUR, Values.Amount.factorize(130)),
+                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(260)), BigDecimal.valueOf(0.5)));
+        tx.setNote("test");
+        tx.setShares(Values.Share.factorize(123));
+        tx.setDateTime(LocalDateTime.parse("2023-04-30T12:45"));
+
+        someTransactionItem = new TransactionItem(tx);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testEmptyList()
+    {
+        List<Extractor.Item> items = Collections.emptyList();
+        assertThat(items, hasItem(dividend(hasAmount("EUR", 0))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testList()
+    {
+        List<Extractor.Item> items = new ArrayList<Extractor.Item>();
+
+        items.add(new Extractor.TransactionItem(new AccountTransaction()));
+
+        assertThat(items, hasItem(dividend(hasAmount("EUR", 0))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testDividend()
+    {
+        List<Extractor.Item> items = new ArrayList<Extractor.Item>();
+
+        items.add(someTransactionItem);
+
+        AccountTransaction tx = new AccountTransaction();
+        tx.setType(AccountTransaction.Type.DIVIDENDS);
+        tx.setCurrencyCode(CurrencyUnit.EUR);
+        tx.setAmount(1000);
+        items.add(new Extractor.TransactionItem(tx));
+
+        assertThat(items, hasItem(dividend(hasAmount("EUR", 20))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testTypeFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(deposit()));
+    }
+
+    @Test
+    public void testTypeSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend()));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAmountFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasAmount("EUR", 200))));
+    }
+
+    @Test
+    public void testAmountSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasAmount("EUR", 100))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testNoteFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasNote("foo"))));
+    }
+
+    @Test
+    public void testNoteSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasNote("test"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFeesFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasFees("EUR", 0))));
+    }
+
+    @Test
+    public void testFeesSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasFees("EUR", 10))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testTaxesFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasTaxes("EUR", 0))));
+    }
+
+    @Test
+    public void testTaxesSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasTaxes("EUR", 20))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testSharesFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasShares(0))));
+    }
+
+    @Test
+    public void testSharesSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasShares(123))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testGrossValueFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasGrossValue("EUR", 0))));
+    }
+
+    @Test
+    public void testGrossValueSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasGrossValue("EUR", 130))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testForexGrossValueFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasForexGrossValue("EUR", 0))));
+    }
+
+    @Test
+    public void testForexGrossValueSuccess()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasForexGrossValue("USD", 260))));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorTestUtilities.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorTestUtilities.java
@@ -1,0 +1,27 @@
+package name.abuchen.portfolio.datatransfer;
+
+import java.util.List;
+
+import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
+import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
+import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
+
+public class ExtractorTestUtilities
+{
+
+    public static long countBuySell(List<Extractor.Item> items)
+    {
+        return items.stream().filter(BuySellEntryItem.class::isInstance).count();
+    }
+
+    public static long countAccountTransactions(List<Extractor.Item> items)
+    {
+        return items.stream().filter(TransactionItem.class::isInstance).count();
+    }
+
+    public static long countSecurities(List<Extractor.Item> items)
+    {
+        return items.stream().filter(SecurityItem.class::isInstance).count();
+    }
+
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -4,17 +4,23 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.check;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -66,13 +72,12 @@ public class DeutscheBankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US17275R1023"));
-        assertThat(security.getWkn(), is("878841"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("CISCO SYSTEMS INC.REGISTERED SHARES DL-,001"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US17275R1023"), //
+                        hasWkn("878841"), //
+                        hasTicker(null), //
+                        hasName("CISCO SYSTEMS INC.REGISTERED SHARES DL-,001"), //
+                        hasCurrencyCode("USD"))));
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -21,6 +21,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1652,9 +1653,9 @@ public class DeutscheBankPDFExtractorTest
 
         // check transaction
         // get transactions
-        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(30L));
+        assertThat(countAccountTransactions(results), is(30L));
 
+        Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
         Item item = iter.next();
 
         // assert transaction

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -1,5 +1,21 @@
 package name.abuchen.portfolio.datatransfer.pdf.deutschebank;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.check;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -59,27 +75,16 @@ public class DeutscheBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.USD));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-12-15T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(380)));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(64.88))));
-        assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(87.13))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.71 + 0.47 + 13.07))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(98.80))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2014-12-15"), //
+                        hasShares(380), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 64.88), //
+                        hasGrossValue("EUR", 87.13), //
+                        hasForexGrossValue("USD", 98.80), //
+                        hasTaxes("EUR", 8.71 + 0.47 + 13.07), //
+                        hasFees("EUR", 0))));
     }
 
     @Test
@@ -102,30 +107,22 @@ public class DeutscheBankPDFExtractorTest
         assertThat(results.size(), is(1));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-12-15T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(380)));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(64.88))));
-        assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(87.13))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.71 + 0.47 + 13.07))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-
-        CheckCurrenciesAction c = new CheckCurrenciesAction();
-        Account account = new Account();
-        account.setCurrencyCode(CurrencyUnit.EUR);
-        Status s = c.process(transaction, account);
-        assertThat(s, is(Status.OK_STATUS));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2014-12-15"), //
+                        hasShares(380), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 64.88), //
+                        hasGrossValue("EUR", 87.13), //
+                        hasTaxes("EUR", 8.71 + 0.47 + 13.07), //
+                        hasFees("EUR", 0), //
+                        check(tx -> {
+                            CheckCurrenciesAction c = new CheckCurrenciesAction();
+                            Account account = new Account();
+                            account.setCurrencyCode(CurrencyUnit.EUR);
+                            Status s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
     }
 
     @Test
@@ -151,24 +148,15 @@ public class DeutscheBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2014-12-15T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(123)));
-        assertThat(transaction.getSource(), is("Dividende02.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(14.95))));
-        assertThat(transaction.getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.22))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.28 + 0.23 + 0.76))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2014-12-15"), //
+                        hasShares(123), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 14.95), //
+                        hasGrossValue("EUR", 20.22), //
+                        hasTaxes("EUR", 4.28 + 0.23 + 0.76), //
+                        hasFees("EUR", 0))));
     }
 
     @Test
@@ -418,25 +406,15 @@ public class DeutscheBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-04-02T09:04")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(19)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(675.50))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(665.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.90 + 2.00 + 0.60))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2015-04-02T09:04"), //
+                        hasShares(19), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 675.50), //
+                        hasGrossValue("EUR", 665.00), //
+                        hasTaxes("EUR", 0), //
+                        hasFees("EUR", 7.90 + 2.00 + 0.60))));
     }
 
     @Test
@@ -726,25 +704,15 @@ public class DeutscheBankPDFExtractorTest
         assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-01-28T09:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(8)));
-        assertThat(entry.getSource(), is("Verkauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(453.66))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(464.16))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.90 + 2.00 + 0.60))));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2015-01-28T09:00"), //
+                        hasShares(8), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 453.66), //
+                        hasGrossValue("EUR", 464.16), //
+                        hasTaxes("EUR", 0), //
+                        hasFees("EUR", 7.90 + 2.00 + 0.60))));
     }
 
     @Test
@@ -852,20 +820,18 @@ public class DeutscheBankPDFExtractorTest
         Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
         assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(32L));
 
-        Item item = iter.next();
-
         // assert transaction
-        AccountTransaction transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-02T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(40.00))));
-        assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Dauerauftrag an Mustermann, Max"));
+        assertThat(results, hasItem(removal( //
+                        hasDate("2020-11-02"), //
+                        hasSource("Kontoauszug01.txt"), //
+                        hasNote("Dauerauftrag an Mustermann, Max"), //
+                        hasAmount("EUR", 40.00))));
 
+        Item item = iter.next();
         item = iter.next();
 
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
+        AccountTransaction transaction = (AccountTransaction) item.getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.REMOVAL));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-02T00:00")));
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000.00))));
@@ -1131,16 +1097,14 @@ public class DeutscheBankPDFExtractorTest
         assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
         assertThat(transaction.getNote(), is("Kartenzahlung"));
 
-        item = iter.next();
-
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-30T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(80.00))));
-        assertThat(transaction.getSource(), is("Kontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Überweisung von Max Mustermann"));
+        assertThat(results, hasItem(deposit( //
+                        hasDate("2020-11-30"), //
+                        hasSource("Kontoauszug01.txt"), //
+                        hasNote("Überweisung von Max Mustermann"), //
+                        hasAmount("EUR", 80.00))));
 
+        item = iter.next();
         item = iter.next();
 
         // assert transaction


### PR DESCRIPTION
Hi @Nirus2000,

I was thinking about how to reduce the boilerplate code needed for the PDF test cases.

With this change, I have tested a couple of custom matchers which can be used with the JUnit ```assertThat```.
It works either for the whole list of result items:

```java
// check dividends transaction
assertThat(results, hasItem(dividend( //
                withDate("2014-12-15"), //
                withShares(380), //
                withSource("Dividende01.txt"), //
                withNote(null), //
                withAmount("EUR", 64.88), //
                withGrossValue("EUR", 87.13), //
                withForexGrossValue("USD", 98.80), //
                withTaxes("EUR", 8.71 + 0.47 + 13.07), //
                withFees("EUR", 0))));
```

or with individual attributes
```java
assertThat(transaction, withAmount("EUR", 16.17));
```

I also tried to make the error messages as readable as possible. This is how the look like. Unfortunately, Infinitest removes the line breaks, but I guess that is okay.

<img width="245" alt="Bildschirmfoto 2023-04-30 um 12 38 04" src="https://user-images.githubusercontent.com/587976/235349787-14406cfd-ae27-4391-858b-51268357d0e9.png">

<img width="413" alt="Bildschirmfoto 2023-04-30 um 12 39 00" src="https://user-images.githubusercontent.com/587976/235349791-245a10f4-5b44-4cb2-bcdc-91a02feddd6c.png">

<img width="1339" alt="Bildschirmfoto 2023-04-30 um 12 39 20" src="https://user-images.githubusercontent.com/587976/235349807-99fbe662-2901-4039-9c31-2daaf3cd3074.png">

What do you think?

(I think we should **not** change all tests at once, but when writing new tests, we could test this approach and then apply it to more tests over time)

Additionally, in the tests we should just use "EUR" or "USD" as string constants. That is much more readable than CurrencyUnit.EUR. The values should never change anyway. And this way the tests are much more readable