### PR TITLE
Currency converter layout improvement

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
@@ -37,6 +37,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.BindingHelper;
 import name.abuchen.portfolio.ui.util.BindingHelper.Model;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.SWTHelper;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
@@ -239,7 +240,7 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
 
         Composite tree = createTree(container);
 
-        startingWith(editArea).thenBelow(tree).width(420).height(200);
+        startingWith(editArea).thenBelow(tree).width(SWTHelper.amountWidth(tree) * 7).height(SWTHelper.lineHeight(tree) * 10);
 
         return container;
     }
@@ -250,6 +251,8 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         TreeColumnLayout layout = new TreeColumnLayout();
         area.setLayout(layout);
 
+        int amountWidth = SWTHelper.amountWidth(area);
+
         TreeViewer nodeViewer = new TreeViewer(area, SWT.BORDER);
 
         CopyPasteSupport.enableFor(nodeViewer);
@@ -257,7 +260,7 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         ShowHideColumnHelper support = new ShowHideColumnHelper(getClass().getSimpleName(), preferences, nodeViewer,
                         layout);
 
-        Column column = new Column("label", Messages.ColumnExchangeRate, SWT.NONE, 300); //$NON-NLS-1$
+        Column column = new Column("label", Messages.ColumnExchangeRate, SWT.NONE, amountWidth * 5); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
@@ -270,7 +273,7 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         });
         support.addColumn(column);
 
-        column = new Column("value", Messages.ColumnValue, SWT.RIGHT, 100); //$NON-NLS-1$
+        column = new Column("value", Messages.ColumnValue, SWT.RIGHT, amountWidth); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
@@ -294,7 +294,10 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         nodeViewer.setContentProvider(new ExchangeRateTimeSeriesContentProvider());
         nodeViewer.setInput(model);
 
-        model.addPropertyChangeListener(p -> nodeViewer.refresh(true));
+        model.addPropertyChangeListener(p -> {
+                nodeViewer.refresh(true);
+                nodeViewer.expandAll();
+            });
 
         return area;
     }


### PR DESCRIPTION
Two changes to the currency converter tab, to make the explanation of the exchange rate easier to review:

* The size of the widget that shows the sources of the exchange rate was fixed to 420 pixels wide and 200 pixels high. On a modern, high-resolution screen, this isn’t much, and most of the information was only visible after scrolling. Instead, use a size that depends on the current font.
* The elements of the tree were collapsed by default. This made it tedious to actually review the information, since one had to manually expand often multiple elements. Change the behaviour to have all elements expanded by default.

Current appearance:

| as first shown | after manually expanding everything |
| -- | -- |
| ![before the change, entries collapsed](https://user-images.githubusercontent.com/1127374/236083851-f70db119-7d21-4d90-bda1-8c245c4cd5e0.png) | ![before the change, entries manually expanded](https://user-images.githubusercontent.com/1127374/236083855-c45b6a58-8aa7-4860-9526-9ce3b8b04d9f.png) |

Appearance with the change applied:
![after the change](https://user-images.githubusercontent.com/1127374/236083858-108012ec-932a-4b5c-b214-9c8629df8d77.png)
