### PR TITLE
Modify sBroker PDF-Importer to support new transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
@@ -191,6 +191,12 @@ public class ExtractorMatchers
     }
 
     @SafeVarargs
+    public static Matcher<Extractor.Item> interestCharge(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("interest charge", AccountTransaction.Type.INTEREST_CHARGE, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
     public static Matcher<Extractor.Item> removal(Matcher<Transaction>... properties)
     {
         return new AccountTransactionMatcher("removal", AccountTransaction.Type.REMOVAL, properties); //$NON-NLS-1$
@@ -206,6 +212,18 @@ public class ExtractorMatchers
     public static Matcher<Extractor.Item> taxRefund(Matcher<Transaction>... properties)
     {
         return new AccountTransactionMatcher("tax refund", AccountTransaction.Type.TAX_REFUND, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> fee(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("fee", AccountTransaction.Type.FEES, properties); //$NON-NLS-1$
+    }
+
+    @SafeVarargs
+    public static Matcher<Extractor.Item> feeRefund(Matcher<Transaction>... properties)
+    {
+        return new AccountTransactionMatcher("fee refund", AccountTransaction.Type.FEES_REFUND, properties); //$NON-NLS-1$
     }
 
     @SafeVarargs

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende11.txt
@@ -1,0 +1,50 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+~$~|ER01|746015||||||||ERTRAEGE.D230508.AFP||||20230508||33844|0000|||||~$~
+S Broker AG & Co. KG ´ Postfach 90 01 50 ´ 39133 Magdeburg Seite 1
+Depotnummer 12345678
+Sebastian Name
+Abrechnungsnr. 12345678
+Datum 08.05.2023
+Herrn
+Sebastian Name
+Stadtteil
+Strasse. 123
+12345 Stadt
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 28 HUHTAMAEKI OYJ FI0009000459 (870740)
+REGISTERED SHARES O.N.
+Zahlbarkeitstag 09.05.2023 Dividende pro Stück 0,50 EUR
+Bestandsstichtag 27.04.2023 Herkunftsland Finnland
+Ex-Tag 28.04.2023 Art der Dividende Zwischendividende
+Geschäftsjahr 01.01.2022 - 31.12.2022
+Dividendengutschrift 14,00+ EUR
+Einbehaltene Quellensteuer 35 % auf 14,00 EUR 4,90- EUR
+Anrechenbare Quellensteuer 15 % auf 14,00 EUR 2,10 EUR
+Kapitalertragsteuerpflichtige Dividende 14,00 EUR
+Verrechneter Sparer-Pauschbetrag 14,00 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Ausmachender Betrag 9,10+ EUR
+20 % rückforderbare Quellensteuer 2,80 EUR
+Lagerstelle Clearstream Banking FFM (849000 / 40030000)
+Jahressteuerbescheinigung folgt.
+Bitte ggf. Rückseite beachten.
+5500.05082144.0040698ER01
+SBRO_ER01_v10.8P.ERTRAEGE.D230508.AFP_33844
+
+Seite 2
+Depotnummer 12345678
+Abrechnungsnr. 12345678
+Datum 08.05.2023
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2023 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 2.306,26 0,00 167,05 31,75 0,00
+Ertrag 0,00 0,00 14,00- 2,10 0,00
+Nachher 2.306,26 0,00 153,05 33,85 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+5500.05082144.0040699ER01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug07.txt
@@ -1,0 +1,107 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+S Sparkasse
+Ostunterfranken
+Herrn Ihr Ansprechpartner:
+XAhqfeA LuZDHL Kundenberatung Hofheim
+yLUFybQF Manuel Jahna
+DkiuYMVPIm 7 Marktplatz 7
+88962 icRQnWi 97461 Hofheim
+ Telefon 09523 9228-12
+ Telefax 09523 9228-39
+ manuel.jahna@spk-ostunterfranken.de
+ 
+  
+  
+30. November 2016
+. Kontoauszug 19/2016 Seite 1 von 2
+Giro Sm@rt 743781, DE07 7935 1730 0000 4250 62 
+Datum Wert Erläuterung Betrag Soll EUR Betrag Haben EUR
+ Kontostand am 07.11.2016, Auszug Nr. 18             7.512,78+
+11.11.2016 11.11.2016 Wertpapierabrechnung            1.800,00-  
+DekaBank DGZ,Frankfurt-P
+Kauf AT 09.11.2016 St 27,976 zu 64,
+340000EUR AA 3,500Proz Deka-BR 100
+Deka-BonusRente
+Depot 3435023219 XF0009994050 00
+. 2834220939586
+Gläubiger-ID: DE02DBD00000081995
+ 
+22.11.2016 22.11.2016 Lastschrift               17,95-  
+KREDITKARTENABRECHNUNG
+21.11.16 5730193115513291
+29.11.2016 29.11.2016 Lohn, Gehalt, Rente             896,91+
+ZF FRIEDRICHSHAFEN A
+Lohn/Gehalt 09099999/201611
+ 
+ Kontostand am 30.11.2016 um 15:11 Uhr             6.591,74+
+Der Kontostand kann Beträge mit späterer Wertstellung enthalten, bitte Hinweise zum Kontoauszug beachten.
+Ihr Dispositionskredit EUR: 2.000,00
+Aktuelle Wertstellung EUR: +8.591,74
+Sparkasse Ostunterfranken Vorstand: Peter Schleich Telefon 09521 58-0 BIC: BYLADEM1HAS
+Marktplatz 14/15 Andreas Linder Telefax 09521 58-499 BLZ: 793 517 30
+97437 Haßfurt Handelsregister www.spk-ostunterfranken.de USt.-Id.Nr.: DE 133906625
+Anstalt des öffentlichen Rechts AG Bamberg HRA 5337 info@spk-ostunterfranken.de Steuer-Nr. 249/114/70639
+Sparkassen-Finanzgruppe
+900 908.000 (Fassung November 2013) - (V1) 
+Finanz Informatik *0000743781100383011160*
+Urheberrechtlich geschützt 0000743781100383011160
+S Sparkasse
+Ostunterfranken
+Kontoauszug 19/2016 Seite 2 von 2
+Giro Sm@rt 743781, DE07 7935 1730 0000 9061 29 tStycmK vvXlhe
+ 
+Kundenmitteilungen:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+auf der Grundlage einer EU-Richtlinie ist am 03.07.2015 in Deutschland das
+Einlagensicherungsgesetz in Kraft getreten. Aufgrund gesetzlicher Vorgaben
+sind wir verpflichtet, Sie einmal jährlich über die Einlagensicherung zu
+informieren und Ihnen den Informationsbogen für den Einleger zur Verfügung
+zu stellen. Dieser Bogen liegt für Sie in allen Geschäftsstellen bereit und
+kann auch auf unserer Homepage unter Preise und Hinweise, Sicherungssystem
+unter der Rubrik Gesetzliche Einlagensicherung eingesehen werden.
+Über diese gesetzliche Einlagensicherung hinaus bleibt die Instituts-
+sicherung der Sparkassen-Finanzgruppe bestehen. Durch diese soll der Ent-
+schädigungsfall vermieden und die Geschäftsbeziehung zum Kunden dauerhaft
+. fortgeführt werden. Für Sie als Kundin/Kunde der Sparkasse Ostunterfrankenändert sich somit nichts.
+Bei Fragen können Sie gerne auf uns zukommen. Wir freuen uns auf Sie!
+Ihre Sparkasse Ostunterfranken
+Hinweise zum Kontoauszug:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen und Berechnungen in diesem Kontoauszug. Eventuelle Rückfragen besprechen Sie bitte mit Ihrem 
+. Kundenberater.
+l Einwendungen gegen den Kontoauszug richten Sie bitte unverzüglich an unsere Revisionsabteilung. Unsere Anschrift(en) 
+entnehmen Sie bitte unserem Preis- und Leistungsverzeichnis.
+l Der angegebene Kontostand berücksichtigt nicht die Wertstellung der einzelnen Buchungen. Dies bedeutet, dass der genannte 
+Betrag nicht dem für die Zinsrechnung maßgeblichen Kontostand entsprechen muss und bei Verfügungen möglicherweise 
+Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können.
+l Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs Wochen nach Zugang keine Einwendungen 
+erheben. Einwendungen gegen Rechnungsabschlüsse müssen der Sparkasse zugehen. Zur Fristwahrung genügt die rechtzeitige 
+Absendung (Nr. 7 Abs. 3 unserer Allgemeinen Geschäftsbedingungen).
+l Gutschriften aus eingereichten Schecks, Lastschriften und anderen Einzugspapieren erfolgen unter dem Vorbehalt der 
+Einlösung.
+l Schecks und andere Einzugspapiere sind erst dann eingelöst, wenn sie nicht bis zum Ablauf des übernächsten Bankarbeitstages 
+storniert oder korrigiert werden. Diese Papiere sind auch eingelöst, wenn die Sparkasse ihren Einlösungswillen schon vorher 
+Dritten gegenüber erkennbar bekundet hat (z. B. durch Bezahltmeldung). Für Lastschriften gelten die Einlösungsregeln in den 
+hierfür vereinbarten besonderen Bedingungen.
+l Sparkontoauszüge heften Sie bitte in Ihr Loseblatt-Sparkassenbuch ein.
+l Dieser Kontoauszug gilt im Zusammenhang mit den zugrunde liegenden Verträgen laut angegebener Kontonummer als 
+Rechnung im Sinne des UStG.
+l Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen 
+können dem Informationsbogen für den Einleger entnommen werden.
+Unsere für den Geschäftsverkehr mit Ihnen geltenden Allgemeinen Geschäftsbedingungen und besonderen Bedingungen stellen 
+wir Ihnen auf Wunsch gern zur Verfügung.
+Mit freundlichen Grüßen
+Ihre Sparkasse Ostunterfranken
+Sparkasse Ostunterfranken Vorstand: Peter Schleich Telefon 09521 58-0 BIC: BYLADEM1HAS
+Marktplatz 14/15 Andreas Linder Telefax 09521 58-499 BLZ: 793 517 30
+97437 Haßfurt Handelsregister www.spk-ostunterfranken.de USt.-Id.Nr.: DE 133906625
+Anstalt des öffentlichen Rechts AG Bamberg HRA 5337 info@spk-ostunterfranken.de Steuer-Nr. 249/114/70639
+Sparkassen-Finanzgruppe
+900 908.000 (Fassung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug08.txt
@@ -1,0 +1,177 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+S Sparkasse
+Schweinfurt-Haßberge
+341 00 00 81
+Herrn Ihr Ansprechpartner:
+Max Musterman Manuel Jahna
+Stöckach Kundenberatung Hofheim
+Strasse 7 Marktplatz 7
+99999 Stadt 97461 Hofheim
+Telefon 09521 58-764
+Fax 09521 58-499
+manuel.jahna@sparkasse-sw-has.de
+ 
+ 
+ 
+2. Januar 2019
+. Kontoauszug 20/2018 Seite 1 von 4
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99
+  
+Datum Wert Erläuterung Betrag Soll EUR Betrag Haben EUR
+ Kontostand am 03.12.2018, Auszug Nr.   19            6.641,87+
+04.12.2018 04.12.2018 Wertpapierabrechnung            1.930,00-
+DekaBank Deutsche Girozentrale
+Kauf AT 30.11.2018 St 25,428 zu 75,
+900000EUR AA 3,500Proz Deka-BR 100
+Deka-BonusRente
+. Depot 0119701696 XF0009994050 00
+0119701696001
+Gläubiger-ID: DE02DBD00000081995
+04.12.2018 04.12.2018 Lastschrift               33,40-
+Telefonica Germany GmbH + Co. OHG
+Kd-Nr.:6031605875,Rg-Nr.:1984621128
+/5,Mehr Infos unter:Ihre Mobilfunkr
+echnung.
+3600716761720001984621128005RCUR
+T0010001B000006031605875
+Gläubiger-ID: DE9700000000142462
+06.12.2018 06.12.2018 Lastschrift              330,37-
+KREDITKARTENABRECHNUNG
+05.12.18 549001XXXXXX0886
+11.12.2018 11.12.2018 Wertpapierabrechnung               12,50-
+DekaBank Deutsche Girozentrale
+0119701696 DEKABANK DEPOT DEPOTPREI
+S 2018 12,50
+Depot 0119701696 DP
+0119701696001
+Gläubiger-ID: DE02DBD00000081995
+Übertrag:            4.335,60+
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.3900902 930382.0.10.02 4(F1a2ssung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 20/2018 Seite 2 von 4
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Musterman
+Datum Wert Erläuterung Betrag Soll EUR Betrag Haben EUR
+Übertrag:            4.335,60+
+11.12.2018 11.12.2018 Wertpapierabrechnung               10,00-
+DekaBank Deutsche Girozentrale
+011970169699940500 Deka-BonusRente
+VERTRAGSPREIS 2018 10,00
+Depot 0119701696 VP
+0119701696001
+Gläubiger-ID: DE02DBD00000081995
+27.12.2018 27.12.2018 Lohn, Gehalt, Rente            1.111,11+
+ZF FRIEDRICHSHAFEN A
+Lohn/Gehalt 09099999/201812
+28.12.2018 29.12.2018 Entgeltabrechnung                4,40-
+. siehe Anlage Nr. 1
+28.12.2018 01.01.2019 Abrechnung 28.12.2018
+                 0,00+
+siehe Anlage Nr. 2
+ Kontostand am 28.12.2018 um 23:07 Uhr            9.676,34+
+Der Kontostand kann Beträge mit späterer Wertstellung enthalten, bitte Hinweise zum Kontoauszug beachten.
+Anzahl Anlagen 2
+Ihr Dispositionskredit EUR: 2.000,00
+.
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.3900902 930382.0.10.02 4(F1a2ssung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 20/2018 Seite 3 von 4
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Musterman
+Entgeltabschluss: Anlage     1
+ 
+Entgelte vom 01.12.2018 bis 28.12.2018                               4,40-
+ 
+Entgelte / Auslagen                                    4,40-
+                                                            --------------
+Abrechnung 28.12.2018                                                4,40-
+Rechnungsnummer: 20181228-BY044-00006681913
+ 
+ 
+Bitte beachten Sie die Hinweise zum Kontoauszug.
+.
+  
+.
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.3900902 930382.0.10.02 4(F1a2ssung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 20/2018 Seite 4 von 4
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Musterman
+Rechnungsabschluss: Anlage     2
+ 
+Kontostand in EUR am 28.12.2018                                 9.676,34 +
+                                                            --------------
+Abrechnungszeitraum vom 01.10.2018 bis 31.12.2018
+Abrechnung 31.12.2018                                                0,00+
+ 
+Sollzinssätze am 30.12.2018
+10,0500 v.H. für eingeräumte Kontoüberziehung
+(aktuell eingeräumte Kontoüberziehung       2.000,00)
+10,0500 v.H. für geduldete Kontoüberziehung
+über die eingeräumte Kontoüberziehung hinaus
+.  
+  Die Anpassungen des Zinssatzes für Kontoüberziehungen sind abhängig von
+der Entwicklung des 3-Monats-Euribor.
+ 
+Kontostand/Rechnungsabschluss in EUR am 28.12.2018              9.676,34 +
+Rechnungsnummer: 20181228-BY044-00006681912
+ 
+Bitte beachten Sie die Hinweise zum Kontoauszug.
+Hinweise zum Kontoauszug:
+.
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen und Berechnungen in diesem Kontoauszug. Eventuelle Rückfragen besprechen Sie bitte mit Ihrem
+Kundenberater.
+l Einwendungen gegen den Kontoauszug richten Sie bitte unverzüglich an unsere Revisionsabteilung. Unsere Anschrift(en)
+entnehmen Sie bitte unserem Preis- und Leistungsverzeichnis.
+l Der angegebene Kontostand berücksichtigt nicht die Wertstellung der einzelnen Buchungen. Dies bedeutet, dass der genannte
+Betrag nicht dem für die Zinsrechnung maßgeblichen Kontostand entsprechen muss und bei Verfügungen möglicherweise
+Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können.
+l Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs Wochen nach Zugang keine Einwendungen erheben.
+Einwendungen gegen Rechnungsabschlüsse müssen der Sparkasse zugehen. Zur Fristwahrung genügt die rechtzeitige
+Absendung (Nr. 7 Abs. 3 unserer Allgemeinen Geschäftsbedingungen).
+l Gutschriften aus eingereichten Schecks, Lastschriften und anderen Einzugspapieren erfolgen unter dem Vorbehalt der
+Einlösung.
+l Schecks und andere Einzugspapiere sind erst dann eingelöst, wenn sie nicht bis zum Ablauf des übernächsten Bankarbeitstages
+storniert oder korrigiert werden. Diese Papiere sind auch eingelöst, wenn die Sparkasse ihren Einlösungswillen schon vorher
+Dritten gegenüber erkennbar bekundet hat (z. B. durch Bezahltmeldung). Für Lastschriften gelten die Einlösungsregeln in den
+hierfür vereinbarten besonderen Bedingungen.
+l Sparkontoauszüge heften Sie bitte in Ihr Loseblatt-Sparkassenbuch ein.
+l Dieser Kontoauszug gilt im Zusammenhang mit den zugrunde liegenden Verträgen laut angegebener Kontonummer als
+Rechnung im Sinne des UStG.
+l Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können
+dem "Informationsbogen für den Einleger" entnommen werden.
+Unsere für den Geschäftsverkehr mit Ihnen geltenden Allgemeinen Geschäftsbedingungen und besonderen Bedingungen stellen
+wir Ihnen auf Wunsch gern zur Verfügung.
+Mit freundlichen Grüßen
+Ihre Sparkasse Schweinfurt-Haßberge
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.3900902 930382.0.10.02 4(F1a2ssung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug09.txt
@@ -1,0 +1,172 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+S Sparkasse
+Schweinfurt-Haßberge
+341 00 00 81
+Herrn Ihr Ansprechpartner:
+Max Mustermann Manuel Jahna
+Strasse Kundenberatung Hofheim
+Strasse 7 Marktplatz 7
+99999 Stadt 97461 Hofheim
+Telefon 09521 58-764
+Fax 09521 58-499
+manuel.jahna@sparkasse-sw-has.de
+ 
+ 
+ 
+2. Januar 2020
+. Kontoauszug 21/2019 Seite 1 von 6
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99
+  
+Datum Wert Erläuterung Betrag Soll EUR Betrag Haben EUR
+ Kontostand am 29.11.2019, Auszug Nr.   20            4.392,93+
+27.12.2019 27.12.2019 Lohn, Gehalt, Rente            1.111,11+
+ZF FRIEDRICHSHAFEN A
+Lohn/Gehalt 09006580/201912
+30.12.2019 01.01.2020 Entgeltabrechnung                6,20-
+siehe Anlage Nr. 1
+30.12.2019 01.01.2020 Abrechnung 30.12.2019                0,00+
+siehe Anlage Nr. 2
+ Kontostand am 30.12.2019 um 23:03 Uhr            2.323,87+
+Der Kontostand kann Beträge mit späterer Wertstellung enthalten, bitte Hinweise zum Kontoauszug beachten.
+Anzahl Anlagen 2
+Ihr Dispositionskredit EUR: 2.000,00
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.4960708 940981.0.10.01 1(Fassung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 21/2019 Seite 4 von 6
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Mustermann
+Kundenmitteilungen:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+ab dem 19. April 2020 gelten neue gesetzliche Bestimmungen für Bargeldaus-
+zahlungen und Zahlungen im stationären Handel mit der Karte innerhalb des
+Europäischen Wirtschaftsraums, die in einer Fremdwährung durchgeführt wer-
+den und eine Währungsumrechnung beinhalten (EU-Preisverordnung 2019/518).
+Zur Umsetzung der gesetzlichen Bestimmungen passen wir zum 19. April 2020
+unser Preis- und Leistungsverzeichnis und die Bedingungen für unsere Mas-
+tercard/Visa Card-Kartenprodukte (Kredit- und Debitkarten) entsprechend an.
+. Die Anpassungen im Preis- und Leistungsverzeichnis bzgl. der EU-Preisver-
+  ordnung für Kartenzahlungen sowie Bedingungen für unsere Mastercard/
+Visa Card-Kartenprodukte (Kredit- und Debitkarten) zum 19. April 2020
+haben wir für Sie übersichtlich zusammengefasst. Die Übersicht können Sie
+unter www.sparkasse-sw-has.de/preise unter dem Titel 'EU-Preisverordnung
+für Kartenzahlungen zum 19. April 2020' bzw. in allen Filialen einsehen.
+Gerne händigen wir Ihnen ein Exemplar aus.
+Das Preis- und Leistungsverzeichnis tritt mit Wirkung zum 19. April 2020 in
+Kraft. Wie mit Ihnen in Nr. 2 Abs. 2 unserer Allgemeinen Geschäftsbedin-
+. gungen vereinbart, gilt Ihre Zustimmung zu den Änderungen des Preis- und
+Leistungsverzeichnisses sowie, falls Sie Inhaber eines unserer Mastercard/
+Visa Card-Kartenprodukte (Kredit- und Debitkarten) sind, der Bedingungen
+für Ihre jeweilige Mastercard/Visa Card und Mastercard Basis (Debitkarte)
+als erteilt, sofern Sie uns Ihre Ablehnung nicht vor dem 19. April 2020
+anzeigen. Wenn Sie mit den angebotenen Vertragsänderungen nicht einverstan-
+den sind, können Sie den jeweils betroffenen Zahlungsdiensterahmenvertrag
+(Ihren Girokontovertrag bzw. die Vereinbarung zu Ihrer jeweiligen Karte)
+auch kostenfrei und fristlos vor dem 19. April 2020 kündigen, was wir
+sehr bedauern würden.
+Mit freundlichen Grüßen
+Ihre Sparkasse Schweinfurt-Haßberge
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.4960708 940981.0.10.01 1(Fassung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 21/2019 Seite 5 von 6
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Mustermann
+Entgeltabschluss: Anlage     1
+ 
+Entgelte vom 30.11.2019 bis 30.12.2019                               6,20-
+ 
+Grundpreis (Kontoführung)                              2,00-
+Zahlungsverkehr                                        4,20-
+                                                            --------------
+Abrechnung 30.12.2019                                                6,20-
+ 
+Es handelt sich hierbei um eine umsatzsteuerfreie Leistung.
+Rechnungsnummer: 20191230-BY044-00008944939
+ 
+.  
+  
+Bitte beachten Sie die Hinweise zum Kontoauszug.
+.
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.4960708 940981.0.10.01 1(Fassung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+S Sparkasse
+Schweinfurt-Haßberge
+Kontoauszug 21/2019 Seite 6 von 6
+Giro Sm@rt 190743781, DE34 7935 0101 0190 9999 99 Max Mustermann
+Rechnungsabschluss: Anlage     2
+ 
+Kontostand in EUR am 30.12.2019                                 2.323,87 +
+                                                            --------------
+Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019
+Abrechnung 31.12.2019                                                0,00+
+ 
+Sollzinssätze am 30.12.2019
+10,0500 v.H. für eingeräumte Kontoüberziehung
+(aktuell eingeräumte Kontoüberziehung       2.000,00)
+10,0500 v.H. für geduldete Kontoüberziehung
+über die eingeräumte Kontoüberziehung hinaus
+.  
+  Die Anpassungen des Zinssatzes für Kontoüberziehungen sind abhängig von
+der Entwicklung des 3-Monats-Euribor.
+ 
+Es handelt sich hierbei um eine umsatzsteuerfreie Leistung.
+ 
+Kontostand/Rechnungsabschluss in EUR am 30.12.2019              2.323,87 +
+Rechnungsnummer: 20191230-BY044-00008944938
+ 
+. Bitte beachten Sie die Hinweise zum Kontoauszug.
+Hinweise zum Kontoauszug:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen und Berechnungen in diesem Kontoauszug. Eventuelle Rückfragen besprechen Sie bitte mit Ihrem
+Kundenberater.
+l Einwendungen gegen den Kontoauszug richten Sie bitte unverzüglich an unsere Revisionsabteilung. Unsere Anschrift(en)
+entnehmen Sie bitte unserem Preis- und Leistungsverzeichnis.
+l Der angegebene Kontostand berücksichtigt nicht die Wertstellung der einzelnen Buchungen. Dies bedeutet, dass der genannte
+Betrag nicht dem für die Zinsrechnung maßgeblichen Kontostand entsprechen muss und bei Verfügungen möglicherweise
+Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können.
+l Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs Wochen nach Zugang keine Einwendungen erheben.
+Einwendungen gegen Rechnungsabschlüsse müssen der Sparkasse zugehen. Zur Fristwahrung genügt die rechtzeitige
+Absendung (Nr. 7 Abs. 3 unserer Allgemeinen Geschäftsbedingungen).
+l Gutschriften aus eingereichten Schecks, Lastschriften und anderen Einzugspapieren erfolgen unter dem Vorbehalt der
+Einlösung.
+l Schecks und andere Einzugspapiere sind erst dann eingelöst, wenn sie nicht bis zum Ablauf des übernächsten Bankarbeitstages
+storniert oder korrigiert werden. Diese Papiere sind auch eingelöst, wenn die Sparkasse ihren Einlösungswillen schon vorher
+Dritten gegenüber erkennbar bekundet hat (z. B. durch Bezahltmeldung). Für Lastschriften gelten die Einlösungsregeln in den
+hierfür vereinbarten besonderen Bedingungen.
+l Sparkontoauszüge heften Sie bitte in Ihr Loseblatt-Sparkassenbuch ein.
+l Dieser Kontoauszug gilt im Zusammenhang mit den zugrunde liegenden Verträgen laut angegebener Kontonummer als
+Rechnung im Sinne des UStG.
+l Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können
+dem "Informationsbogen für den Einleger" entnommen werden.
+Unsere für den Geschäftsverkehr mit Ihnen geltenden Allgemeinen Geschäftsbedingungen und besonderen Bedingungen stellen
+wir Ihnen auf Wunsch gern zur Verfügung.
+Mit freundlichen Grüßen
+Ihre Sparkasse Schweinfurt-Haßberge
+Sparkasse Schweinfurt-Haßberge Anstalt des öffentlichen Rechts Telefon 09721/721-0 www.sparkasse-sw-has.de
+Jägersbrunnen 1-7 HR Nr. A/1124 (AG Schweinfurt) Telefax 09721/721-3229 info@sparkasse-sw-has.de
+97421 Schweinfurt USt-IdNr. DE 133 906 578 BLZ: 793 501 01 BIC: BYLADEM1KSW
+Sparkassen-Finanzgruppe
+0.53.2.4960708 940981.0.10.01 1(Fassung November 2013) - (V1) 
+Finanz Informatik 
+Urheberrechtlich geschützt
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug10.txt
@@ -1,0 +1,104 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+StarMoney 09.05.2023
+Sparkasse Bankleitzahl: 79351730SWIFT-BIC: BYLADEM1HAS
+Ostunterfranken IBAN: DE0779351730000099999 
+Max Mustermann Konto Kontoauszug Seite
+99999 11 1 von 2
+Buch.-Tag Wert Verwendungszweck/Erläuterungen Umsatz (EUR)
+Startsaldo am 26.06.2014 in EUR 3.981,61
+30.06 30.06.14 Überweisung -14,99
+Bon Prix Hamburg
+KREF+ab4b9b042-2640504-1923 3089-20140628
+SVWZ+RF5341635204 DATUM 28.06.2014, 19.24 UHR
+1.TAN 737990
+30.06 30.06.14 Überweisung -400,00
+Mustermann Max
+DATUM 28.06.2014, 19.25 UHR 1.TAN 085005
+01.07 01.07.14 Entgeltabrechnung -4,05
+Entgeltabrechnung siehe Anlage
+01.07 01.07.14 Abrechnung 30.06.2014 0,00
+Abrechnung 30.06.2014 siehe Anlage
+01.07 01.07.14 Lastschrift -119,00
+DAA - Technikum GmbH
+EREF+2001391316 MREF+1799125018001
+CRED+DE68DAA00000092350 SVWZ+2001391316179912501800
+1Nr.SOLL06/2014/1.6.2014Stu diengebuehr 6/2014
+01.07 01.07.14 Lastschrift -28,50
+IGM Schweinfurt
+EREF+9391934 MREF+1140893701
+CRED+DE71ZZZ00000053593 SVWZ+BEITRAG BIS 06/14 MAND
+ATSREF 1140893701 GLAEUBIGE R-ID DE71ZZZ00000053593 NAE
+CHSTER BEITRAGSEINZUG IN BE KANNTER HOEHE UND VEREINBAR
+TEM TURNUS
+07.07 07.07.14 Geldautomat -500,00
+GA NR00002029 BLZ79353090 5
+06.07/15.23UHR BADKOE.NEU EUR     500,00
+Endsaldo am 07.07.2014 in EUR 2.915,07
+Anlage Rechnungsabschluss:
+Abrechnung 30.06.2014
+Information zur Abrechnung
+Entgelte vom 31.05.2014 bis 30.06.2014                               4,05-
+Entgelte / Auslagen                                    4,05-
+--------------
+Abrechnung 30.06.2014                                                4,05-
+Rechnungsnummer: 20140630-BY036-00000346306
+Abrechnung 30.06.2014
+Information zur Abrechnung
+Kontostand am 30.06.2014                                        3.562,57 +
+--------------
+Abrechnungszeitraum vom 01.04.2014 bis 30.06.2014
+Abrechnung 30.06.2014                                                0,00+
+StarMoney 09.05.2023
+Sparkasse Bankleitzahl: 79351730SWIFT-BIC: BYLADEM1HAS
+Ostunterfranken IBAN: DE0779351730000099999 
+Max Mustermann Konto Kontoauszug Seite
+99999 11 2 von 2
+Sollzinssätze am 30.06.2014
+11,9500 v.H. für Dispositionskredit
+(aktuelle Kreditlinie       2.000,00)
+16,9500 v.H. für Kontoüberziehungen
+über die Kreditlinie hinaus
+Die Anpassung des Zinssatzes für Kontoüberziehungen ist abhängig von der
+Entwicklung des "Gleitenden Ein-Jahreszinssatzes für Bundeswertpapiere".
+Kontostand/Rechnungsabschluss am 30.06.2014                     3.562,57 +
+Rechnungsnummer: 20140630-BY036-00000346305
+SPARKASSE OSTUNTERFRANKEN UST ID: DE133906625
+GENEHMIGUNGSFIKTION:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen und Berechnungen in diesem Kontoauszug.
+Eventuelle Rückfragen besprechen Sie bitte mit Ihrem Kundenberater.
+Einwendungen gegen den Kontoauszug richten Sie bitte unverzüglich an unsere
+Revisionsabteilung. Unsere Anschrift(en) entnehmen Sie bitte unserem Preis-
+und Leistungsverzeichnis.
+Der angegebene Kontostand berücksichtigt nicht die Wertstellung der einzel-
+nen Buchungen. Dies bedeutet, dass der genannte Betrag nicht dem für die
+Zinsrechnung maßgeblichen Kontostand entsprechen muss und bei Verfügungen
+möglicherweise Zinsen für die Inanspruchnahme einer eingeräumten oder gedul-
+deten Kontoüberziehung anfallen können.
+Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs
+Wochen nach Zugang keine Einwendungen erheben. Einwendungen gegen Rechnungs-
+abschlüsse müssen der Sparkasse schriftlich oder, wenn im Rahmen der Ge-
+schäftsbeziehung der elektronische Kommunikationsweg vereinbart wurde (z.B.
+Online-Banking), auf diesem Wege zugehen. Zur Fristwahrung genügt die recht-
+zeitige Absendung (Nr. 7 Abs. 3 unserer Allgemeinen Geschäftsbedingungen).
+Gutschriften aus eingereichten Schecks, Lastschriften und anderen
+Einzugspapieren erfolgen unter dem Vorbehalt der Einlösung.
+Schecks und andere Einzugspapiere sind erst dann eingelöst, wenn sie nicht
+bis zum Ablauf des übernächsten Bankarbeitstages storniert oder korrigiert
+werden. Diese Papiere sind auch eingelöst, wenn die Sparkasse ihren
+Einlösungswillen schon vorher Dritten gegenüber erkennbar bekundet hat (z.B.
+durch Bezahltmeldung). Für Lastschriften gelten die Einlösungsregeln in
+den hierfür vereinbarten besonderen Bedingungen.
+Sparkontoauszüge heften Sie bitte in Ihr Loseblatt-Sparkassenbuch ein.
+Dieser Kontoauszug gilt im Zusammenhang mit den zugrunde liegenden Verträgen
+laut angegebener Kontonummer als Rechnung im Sinne des UStG.
+Unsere für den Geschäftsverkehr mit Ihnen geltenden Allgemeinen Geschäfts-
+bedingungen und besonderen Bedingungen stellen wir Ihnen auf Wunsch gern
+zur Verfügung.
+Mit freundlichen Grüßen
+Ihre Sparkasse
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/GiroKontoauszug11.txt
@@ -1,0 +1,95 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.62.1
+-----------------------------------------
+StarMoney 09.05.2023
+Sparkasse Bankleitzahl: 79351730SWIFT-BIC: BYLADEM1HAS
+Ostunterfranken IBAN: DE07793517300000999999 
+Max Mustermann Konto Kontoauszug Seite
+999999 11 1 von 3
+Buch.-Tag Wert Verwendungszweck/Erläuterungen Umsatz (EUR)
+Startsaldo am 16.06.2015 in EUR 807,54
+23.06 23.06.15 Barumsatz 500,00
+SB-EINZAHLUNG HOFHEIM02 GA 2082 / 23.06.15 14.28.51
+0000999999 / 1612 /0 / 5
+01.07 01.07.15 Entgeltabrechnung -3,55
+Entgeltabrechnung siehe Anlage
+01.07 01.07.15 Abrechnung 30.06.2015 0,00
+Abrechnung 30.06.2015 siehe Anlage
+Anlage Rechnungsabschluss:
+Abrechnung 30.06.2015
+Information zur Abrechnung
+StarMoney 09.05.2023
+Sparkasse Bankleitzahl: 79351730SWIFT-BIC: BYLADEM1HAS
+Ostunterfranken IBAN: DE07793517300000999999 
+Max Mustermann Konto Kontoauszug Seite
+999999 11 2 von 3
+Entgelte vom 30.05.2015 bis 30.06.2015                               3,55-
+Entgelte / Auslagen                                    3,55-
+--------------
+Abrechnung 30.06.2015                                                3,55-
+Rechnungsnummer: 20150701-BY036-00000953030
+Abrechnung 30.06.2015
+Information zur Abrechnung
+Kontostand am 30.06.2015                                        2.750,88 +
+--------------
+Abrechnungszeitraum vom 01.04.2015 bis 30.06.2015
+Abrechnung 30.06.2015                                                0,00+
+Sollzinssätze am 30.06.2015
+10,7500 v.H. für Dispositionskredit
+(aktuelle Kreditlinie       2.000,00)
+10,7500 v.H. für Kontoüberziehungen
+über die Kreditlinie hinaus
+Die Anpassung des Zinssatzes für Kontoüberziehungen ist abhängig von der
+Entwicklung des "Gleitenden Ein-Jahreszinssatzes für Bundeswertpapiere".
+Kontostand/Rechnungsabschluss am 30.06.2015                     2.750,88 +
+Rechnungsnummer: 20150701-BY036-00000953029
+SPARKASSE OSTUNTERFRANKEN UST ID: DE133906625
+GENEHMIGUNGSFIKTION:
+Sehr geehrte Kundin, sehr geehrter Kunde,
+bitte prüfen Sie die Buchungen und Berechnungen in diesem Kontoauszug.
+Eventuelle Rückfragen besprechen Sie bitte mit Ihrem Kundenberater.
+Einwendungen gegen den Kontoauszug richten Sie bitte unverzüglich an unsere
+Revisionsabteilung. Unsere Anschrift(en) entnehmen Sie bitte unserem Preis-
+und Leistungsverzeichnis.
+Der angegebene Kontostand berücksichtigt nicht die Wertstellung der einzel-
+nen Buchungen. Dies bedeutet, dass der genannte Betrag nicht dem für die
+Zinsrechnung maßgeblichen Kontostand entsprechen muss und bei Verfügungen
+möglicherweise Zinsen für die Inanspruchnahme einer eingeräumten oder gedul-
+deten Kontoüberziehung anfallen können.
+Rechnungsabschlüsse gelten als genehmigt, sofern Sie innerhalb von sechs
+Wochen nach Zugang keine Einwendungen erheben. Einwendungen gegen Rechnungs-
+abschlüsse müssen der Sparkasse schriftlich oder, wenn im Rahmen der Ge-
+schäftsbeziehung der elektronische Kommunikationsweg vereinbart wurde (z.B.
+Online-Banking), auf diesem Wege zugehen. Zur Fristwahrung genügt die recht-
+zeitige Absendung (Nr. 7 Abs. 3 unserer Allgemeinen Geschäftsbedingungen).
+Gutschriften aus eingereichten Schecks, Lastschriften und anderen
+Einzugspapieren erfolgen unter dem Vorbehalt der Einlösung.
+Schecks und andere Einzugspapiere sind erst dann eingelöst, wenn sie nicht
+bis zum Ablauf des übernächsten Bankarbeitstages storniert oder korrigiert
+werden. Diese Papiere sind auch eingelöst, wenn die Sparkasse ihren
+Einlösungswillen schon vorher Dritten gegenüber erkennbar bekundet hat (z.B.
+durch Bezahltmeldung). Für Lastschriften gelten die Einlösungsregeln in
+StarMoney 09.05.2023
+Sparkasse Bankleitzahl: 79351730SWIFT-BIC: BYLADEM1HAS
+Ostunterfranken IBAN: DE07793517300000999999 
+Max Mustermann Konto Kontoauszug Seite
+999999 11 3 von 3
+den hierfür vereinbarten besonderen Bedingungen.
+Sparkontoauszüge heften Sie bitte in Ihr Loseblatt-Sparkassenbuch ein.
+Dieser Kontoauszug gilt im Zusammenhang mit den zugrunde liegenden Verträgen
+laut angegebener Kontonummer als Rechnung im Sinne des UStG.
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes
+entschädigungsfähig. Nähere Informationen können dem Informationsbogen
+für den Einleger entnommen werden.
+Unsere für den Geschäftsverkehr mit Ihnen geltenden Allgemeinen Geschäfts-
+bedingungen und besonderen Bedingungen stellen wir Ihnen auf Wunsch gern
+zur Verfügung.
+Mit freundlichen Grüßen
+Ihre Sparkasse
+Mitteilung    1
+Bitte beachten Sie: Guthaben sind als Einlagen nach Maßgabe des Einlagen-
+sicherungsgesetzes entschädigungsfähig. Nähere Informationen können dem
+Informationsbogen für den Einleger entnommen werden.
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -1,9 +1,33 @@
 package name.abuchen.portfolio.datatransfer.pdf.sbroker;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertNull;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -70,7 +94,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2014-09-29T20:35")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(16)));
         assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 10000000"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1930.17))));
@@ -114,7 +138,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-11-11T09:02")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(18)));
         assertThat(entry.getSource(), is("Kauf02.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 28116496"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1249.30))));
@@ -202,7 +226,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-05-05T09:04")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(19.916)));
         assertThat(entry.getSource(), is("Kauf04.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 65091167"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(498.20))));
@@ -246,7 +270,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-04-12T10:06")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(66)));
         assertThat(entry.getSource(), is("Kauf05.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 54229911"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3186.41))));
@@ -422,7 +446,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-07-26T15:18:11")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(125)));
         assertThat(entry.getSource(), is("Kauf09.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Auftragsnummer 999999/99.99"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15181.54))));
@@ -468,7 +492,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-07-26T15:18:11")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(125)));
         assertThat(entry.getSource(), is("Kauf09.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Auftragsnummer 999999/99.99"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15181.54))));
@@ -650,7 +674,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2015-06-02T08:05")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(47)));
         assertThat(entry.getSource(), is("Verkauf01.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 10000000"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5648.24))));
@@ -670,7 +694,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2015-06-03T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(47)));
         assertThat(transaction.getSource(), is("Verkauf01.txt"));
-        assertNull(transaction.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 10000000"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.48))));
@@ -714,7 +738,7 @@ public class SBrokerPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-04-26T14:10")));
         assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.836)));
         assertThat(entry.getSource(), is("Verkauf02.txt"));
-        assertNull(entry.getNote());
+        assertThat(entry.getNote(), is("Abrechnungs-Nr. 94703363"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.87))));
@@ -1048,7 +1072,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(250)));
         assertThat(transaction.getSource(), is("Dividende04.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.31))));
@@ -1092,7 +1116,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(250)));
         assertThat(transaction.getSource(), is("Dividende04.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.31))));
@@ -1141,7 +1165,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(150)));
         assertThat(transaction.getSource(), is("Dividende05.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(18.50))));
@@ -1185,7 +1209,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(150)));
         assertThat(transaction.getSource(), is("Dividende05.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(18.50))));
@@ -1234,7 +1258,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(250)));
         assertThat(transaction.getSource(), is("Dividende06.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.36))));
@@ -1278,7 +1302,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-12-31T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(250)));
         assertThat(transaction.getSource(), is("Dividende06.txt"));
-        assertNull(transaction.getNote());
+        assertThat(transaction.getNote(), is("Abrechnungsnr."));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11.36))));
@@ -1327,7 +1351,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-01-10T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
         assertThat(transaction.getSource(), is("Dividende07.txt"));
-        assertThat(transaction.getNote(), is("Quartalsdividende"));
+        assertThat(transaction.getNote(), is("Abrechnungsnr. | Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(58.37))));
@@ -1371,7 +1395,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-01-10T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(100)));
         assertThat(transaction.getSource(), is("Dividende07.txt"));
-        assertThat(transaction.getNote(), is("Quartalsdividende"));
+        assertThat(transaction.getNote(), is("Abrechnungsnr. | Quartalsdividende"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(58.37))));
@@ -1513,7 +1537,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-01-15T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(62.489)));
         assertThat(transaction.getSource(), is("Dividende09.txt"));
-        assertThat(transaction.getNote(), is("Ertragsthesaurierung für 2017 (54,16 USD)"));
+        assertThat(transaction.getNote(), is("Abrechnungs-Nr. 70314707 | Ertragsthesaurierung für 2017 (54,16 USD)"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.65))));
@@ -1556,7 +1580,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-01-15T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(62.489)));
         assertThat(transaction.getSource(), is("Dividende09.txt"));
-        assertThat(transaction.getNote(), is("Ertragsthesaurierung für 2017 (54,16 USD)"));
+        assertThat(transaction.getNote(), is("Abrechnungs-Nr. 70314707 | Ertragsthesaurierung für 2017 (54,16 USD)"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.65))));
@@ -1605,7 +1629,7 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-01-15T00:00")));
         assertThat(transaction.getShares(), is(Values.Share.factorize(0.254)));
         assertThat(transaction.getSource(), is("Dividende10.txt"));
-        assertThat(transaction.getNote(), is("Ertragsthesaurierung für 2017 (0,68 EUR)"));
+        assertThat(transaction.getNote(), is("Abrechnungs-Nr. 61314054 | Ertragsthesaurierung für 2017 (0,68 EUR)"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.01))));
@@ -1615,6 +1639,35 @@ public class SBrokerPDFExtractorTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testDividende11()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende11.txt"), errors);
+
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FI0009000459"), hasWkn("870740"), hasTicker(null), //
+                        hasName("HUHTAMAEKI OYJ REGISTERED SHARES O.N."), // 
+                        hasCurrencyCode("EUR"))));
+
+        // check dividende transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-05-09T00:00"), hasShares(28), //
+                        hasSource("Dividende11.txt"), hasNote("Abrechnungsnr. 12345678 | Zwischendividende"), //
+                        hasAmount("EUR", 9.10), hasGrossValue("EUR", 14.00), //
+                        hasTaxes("EUR", 4.90), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -1651,7 +1704,7 @@ public class SBrokerPDFExtractorTest
         assertThat(((Transaction) cancellation.getSubject()).getDateTime(), is(LocalDateTime.parse("2016-06-15T00:00")));
         assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(84.092)));
         assertThat(((Transaction) cancellation.getSubject()).getSource(), is("DividendeStorno01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Ertrag für 2015/16 (20,24 EUR)"));
+        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Abrechnungs-Nr. 60667425 | Ertrag für 2015/16 (20,24 EUR)"));
 
         assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(20.24))));
@@ -1697,7 +1750,7 @@ public class SBrokerPDFExtractorTest
         assertThat(((Transaction) cancellation.getSubject()).getDateTime(), is(LocalDateTime.parse("2018-01-15T00:00")));
         assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(195.419)));
         assertThat(((Transaction) cancellation.getSubject()).getSource(), is("DividendeStorno02.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Ertragsthesaurierung für 2017 (20,73 EUR)"));
+        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Abrechnungs-Nr. 26495157 | Ertragsthesaurierung für 2017 (20,73 EUR)"));
 
         assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.05))));
@@ -2477,6 +2530,166 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.40))));
         assertThat(transaction.getSource(), is("GiroKontoauszug06.txt"));
         assertThat(transaction.getNote(), is("Entgelte vom 01.03.2017 bis 31.03.2017"));
+    }
+
+    @Test
+    public void testGiroKontoauszug07()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug07.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(2L));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2016-11-22"), hasAmount("EUR", 17.95), //
+                        hasSource("GiroKontoauszug07.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2016-11-29"), hasAmount("EUR", 896.91), //
+                        hasSource("GiroKontoauszug07.txt"), hasNote("Lohn, Gehalt, Rente"))));
+    }
+
+    @Test
+    public void testGiroKontoauszug08()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug08.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(5));
+
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(5L));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2018-12-04"), hasAmount("EUR", 33.40), //
+                        hasSource("GiroKontoauszug08.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2018-12-06"), hasAmount("EUR", 330.37), //
+                        hasSource("GiroKontoauszug08.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2018-12-27"), hasAmount("EUR", 1111.11), //
+                        hasSource("GiroKontoauszug08.txt"), hasNote("Lohn, Gehalt, Rente"))));
+
+        // assert transaction
+        assertThat(results, hasItem(fee(hasDate("2018-12-28"), hasAmount("EUR", 4.40), //
+                        hasSource("GiroKontoauszug08.txt"), hasNote("Entgelte vom 01.12.2018 bis 28.12.2018"))));
+
+        // assert transaction
+        assertThat(results, hasItem(interest(hasDate("2018-12-31"), hasAmount("EUR", 0.00), //
+                        hasSource("GiroKontoauszug08.txt"), hasNote("Abrechnungszeitraum vom 01.10.2018 bis 31.12.2018"))));
+    }
+
+    @Test
+    public void testGiroKontoauszug09()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug09.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2019-12-27"), hasAmount("EUR", 1111.11), //
+                        hasSource("GiroKontoauszug09.txt"), hasNote("Lohn, Gehalt, Rente"))));
+
+        // assert transaction
+        assertThat(results, hasItem(fee(hasDate("2019-12-30"), hasAmount("EUR", 6.20), //
+                        hasSource("GiroKontoauszug09.txt"), hasNote("Entgelte vom 30.11.2019 bis 30.12.2019"))));
+
+        // assert transaction
+        assertThat(results, hasItem(interest(hasDate("2019-12-31"), hasAmount("EUR", 0.00), //
+                        hasSource("GiroKontoauszug09.txt"), hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019"))));
+    }
+
+    @Test
+    public void testGiroKontoauszug10()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug10.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(7));
+
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(7L));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2014-06-30"), hasAmount("EUR", 14.99), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Überweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2014-06-30"), hasAmount("EUR", 400.00), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Überweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2014-07-01"), hasAmount("EUR", 119.00), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2014-07-01"), hasAmount("EUR", 28.50), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2014-07-07"), hasAmount("EUR", 500.00), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Geldautomat"))));
+
+        // assert transaction
+        assertThat(results, hasItem(fee(hasDate("2014-06-30"), hasAmount("EUR", 4.05), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Entgelte vom 31.05.2014 bis 30.06.2014"))));
+
+        // assert transaction
+        assertThat(results, hasItem(interest(hasDate("2014-06-30"), hasAmount("EUR", 0.00), //
+                        hasSource("GiroKontoauszug10.txt"), hasNote("Abrechnungszeitraum vom 01.04.2014 bis 30.06.2014"))));
+    }
+
+    @Test
+    public void testGiroKontoauszug11()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<Exception>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug11.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2015-06-23"), hasAmount("EUR", 500.00), //
+                        hasSource("GiroKontoauszug11.txt"), hasNote("Barumsatz"))));
+
+        // assert transaction
+        assertThat(results, hasItem(fee(hasDate("2015-06-30"), hasAmount("EUR", 3.55), //
+                        hasSource("GiroKontoauszug11.txt"), hasNote("Entgelte vom 30.05.2015 bis 30.06.2015"))));
+
+        // assert transaction
+        assertThat(results, hasItem(interest(hasDate("2015-06-30"), hasAmount("EUR", 0.00), //
+                        hasSource("GiroKontoauszug11.txt"), hasNote("Abrechnungszeitraum vom 01.04.2015 bis 30.06.2015"))));
     }
 
     @Test


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-s-broker-sparkasse/5195/69
Add "fee" to ExtractorTestUtilities
Add "fee refund" to ExtractorTestUtilities
Add new transactions

Hallo @buchen 
Here we still need for the 0.00 transactions a check with error message that this is not imported.
`testGiroKontoauszug08()` and `testGiroKontoauszug09()` --> `interest transaction`

Regards...
Alex