### PR TITLE
Enhancement of the PDF importer by cleaning up the source code

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
-
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -29,7 +28,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Baader Bank"); //$NON-NLS-1$
+        addBankIdentifier("Baader Bank");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -44,7 +43,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Baader Bank AG / Scalable Capital Vermögensverwaltung GmbH"; //$NON-NLS-1$
+        return "Baader Bank AG / Scalable Capital Vermögensverwaltung GmbH";
     }
 
     private void addBuySellTransaction()
@@ -81,7 +80,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // @formatter:off
-                // Nominale ISIN: IE0032895942 WKN: 911950 Kurs 
+                // Nominale ISIN: IE0032895942 WKN: 911950 Kurs
                 // STK 2 iShs DL Corp Bond UCITS ETF EUR 104,37
                 // Registered Shares o.N.
                 // Kurswert EUR 208,74
@@ -114,8 +113,8 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                 // @formatter:off
                                 // Handelsdatum Handelsuhrzeit
                                 // 20.03.2017 15:31:10:00
-                                // 
-                                // Handelsdatum Handelsuhrzeit 
+                                //
+                                // Handelsdatum Handelsuhrzeit
                                 // 11.04.2023 12:31:19:07
                                 // @formatter:on
                                 section -> section
@@ -125,10 +124,10 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // @formatter:off
-                                // Handels- Handels- 
+                                // Handels- Handels-
                                 // STK   70 EUR 14,045 GETTEX - MM Munich 24.02.2021 14:49:46:04
                                 //
-                                // Handels- Handels- 
+                                // Handels- Handels-
                                 // STK   50 EUR 30,79 GETTEX - MM Munich 12.04.2023 09:00:06:185
                                 // @formatter:on
                                 section -> section
@@ -138,7 +137,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
                                 ,
                                 // @formatter:off
-                                // Details zur Ausführung: Handels- Handels- 
+                                // Details zur Ausführung: Handels- Handels-
                                 // STK   6 EUR 146,34 GETTEX - MM Munich 27.01.2022 16:25:24:39
                                 // @formatter:on
                                 section -> section
@@ -552,12 +551,12 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     {
         final DocumentType type = new DocumentType("(Perioden\\-Kontoauszug|Tageskontoauszug|Periodic Account Statement)", (context, lines) -> {
             Pattern pCurrency = Pattern.compile("(Perioden\\-Kontoauszug|Tageskontoauszug|Periodic Account Statement): (?<currency>[\\w]{3})(\\-Konto| Account)");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -909,7 +908,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("n").optional()
                 .match("^Ertragsthesaurierung .*$")
                 .match("Steuerliquidit.t (?<n>.*)")
-                .assign((t, v) -> type.getCurrentContext().put("noTax", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("noTax", true));
 
         transaction
                 // @formatter:off
@@ -918,7 +917,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* Finanztransaktionssteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -928,7 +927,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -938,7 +937,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -948,7 +947,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -959,7 +958,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .section("withHoldingTax", "currency").optional()
                 .match("^(US-)?Quellensteuer (?<currency>[\\w]{3}) (?<withHoldingTax>[\\.,\\d]+) \\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 });
     }
@@ -976,7 +975,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
                 // @formatter:off
-                // Gebühren extern ADR EUR 2,00 
+                // Gebühren extern ADR EUR 2,00
                 // @formatter:on
                 .section("currency", "fee").optional()
                 .match("^Geb.hren extern ADR (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)( \\-)?$")
@@ -993,17 +992,17 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
@@ -1012,17 +1011,17 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -23,8 +23,8 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Bank SLM AG"); //$NON-NLS-1$
-        addBankIdentifier("Spar + Leihkasse"); //$NON-NLS-1$
+        addBankIdentifier("Bank SLM AG");
+        addBankIdentifier("Spar + Leihkasse");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -33,7 +33,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Bank SLM AG"; //$NON-NLS-1$
+        return "Bank SLM AG";
     }
 
     private void addBuySellTransaction()
@@ -56,11 +56,11 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^B.rsenabrechnung \\- (?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
-                // 17'000 Inhaber-Aktien 
+                // 17'000 Inhaber-Aktien
                 // Nokia Corp
                 // Valor: 472672
                 // Total Kurswert EUR -74'120.00

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -18,8 +18,8 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Zusammenfassung"); //$NON-NLS-1$
-        addBankIdentifier("Summary"); //$NON-NLS-1$
+        addBankIdentifier("Zusammenfassung");
+        addBankIdentifier("Summary");
 
         addAccountStatementTransaction();
     }
@@ -27,7 +27,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Bondora Capital"; //$NON-NLS-1$
+        return "Bondora Capital";
     }
 
     private void addAccountStatementTransaction()
@@ -57,9 +57,9 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                 + "|Withdrawal)"
                                 + ") .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Überweisen") || v.get("type").equals("Transfer"))
+                    if ("Überweisen".equals(v.get("type")) || "Transfer".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.DEPOSIT);
-                    else if (v.get("type").equals("Abheben") || v.get("type").equals("Withdrawal"))
+                    else if ("Abheben".equals(v.get("type")) || "Withdrawal".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.REMOVAL);
                 })
 
@@ -86,14 +86,14 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                 .assign((t, v) -> {
                                     t.setDateTime(asDate(v.get("date")));
 
-                                    String language = "de"; //$NON-NLS-1$
-                                    String country = "DE"; //$NON-NLS-1$
+                                    String language = "de";
+                                    String country = "DE";
 
-                                    int apostrophe = v.get("amount").indexOf("\'"); //$NON-NLS-1$
+                                    int apostrophe = v.get("amount").indexOf("\'");
                                     if (apostrophe >= 0)
                                     {
-                                        language = "de"; //$NON-NLS-1$
-                                        country = "CH"; //$NON-NLS-1$
+                                        language = "de";
+                                        country = "CH";
                                     }
 
                                     t.setAmount(asAmount(v.get("amount"), language, country));
@@ -122,17 +122,17 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                 .assign((t, v) -> {
                                     t.setDateTime(asDate(v.get("date"), Locale.UK));
 
-                                    String language = "de"; //$NON-NLS-1$
-                                    String country = "DE"; //$NON-NLS-1$
+                                    String language = "de";
+                                    String country = "DE";
 
-                                    int lastDot = v.get("amount").lastIndexOf("."); //$NON-NLS-1$
-                                    int lastComma = v.get("amount").lastIndexOf(","); //$NON-NLS-1$
-    
+                                    int lastDot = v.get("amount").lastIndexOf(".");
+                                    int lastComma = v.get("amount").lastIndexOf(",");
+
                                     // returns the greater of two int values
                                     if (Math.max(lastDot, lastComma) == lastDot)
                                     {
-                                        language = "en"; //$NON-NLS-1$
-                                        country = "US"; //$NON-NLS-1$
+                                        language = "en";
+                                        country = "US";
                                     }
 
                                     t.setAmount(asAmount(v.get("amount"), language, country));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
@@ -23,7 +23,7 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Commonwealth Securities Limited"); //$NON-NLS-1$
+        addBankIdentifier("Commonwealth Securities Limited");
 
         addBuySellTransaction();
     }
@@ -31,7 +31,7 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Commonwealth Securities Limited"; //$NON-NLS-1$
+        return "Commonwealth Securities Limited";
     }
 
     private void addBuySellTransaction()
@@ -41,9 +41,9 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
 
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -64,7 +64,7 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^WE HAVE (?<type>SOLD) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("SOLD"))
+                    if ("SOLD".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -29,9 +29,9 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("C O M M E R Z B A N K"); //$NON-NLS-1$
-        addBankIdentifier("Commerzbank AG"); //$NON-NLS-1$
-        addBankIdentifier("COBADE"); //$NON-NLS-1$
+        addBankIdentifier("C O M M E R Z B A N K");
+        addBankIdentifier("Commerzbank AG");
+        addBankIdentifier("COBADE");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -42,7 +42,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Commerzbank AG"; //$NON-NLS-1$
+        return "Commerzbank AG";
     }
 
     private void addBuySellTransaction()
@@ -66,7 +66,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("(?<type>W e r t p a p i e r v e r k a u f)")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("W e r t p a p i e r v e r k a u f"))
+                    if ("W e r t p a p i e r v e r k a u f".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -85,7 +85,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
-                // S t . 2 0 0 EUR 2 0 1 , 7 0 
+                // S t . 2 0 0 EUR 2 0 1 , 7 0
                 // Summe S t . 2 5 0 EUR 1 9 1 , 0 0 8 6 4 EUR 4 7 . 7 5 2 , 1 6
                 .section("shares")
                 .match("^(Summe )?S([\\s]+)?t([\\s]+)?\\. (?<shares>[\\.,\\d\\s]+) .*$")
@@ -146,7 +146,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(abgef.hrte Steuern|erstattete Steuern) [\\w]{3}(?<type>[\\-\\s]+)?[\\.,\\d\\s]+$")
                 .assign((t, v) -> {
-                    if (stripBlanks(v.get("type")).equals("-"))
+                    if ("-".equals(stripBlanks(v.get("type"))))
                         t.setType(AccountTransaction.Type.TAXES);
                 })
 
@@ -235,7 +235,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 // zum D e v i s e n k u r s : EUR/USD 1 ,098400 EUR 6 1 , 3 0
                 .section("fxCurrency", "fxGross", "exchangeRate", "baseCurrency", "termCurrency", "currency").optional()
                 .match("^B r u t t o b e t r a g : (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d\\s]+)$")
-                .match("^.* (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d\\s]+) (?<currency>[\\w]{3}) [\\.,\\d\\s]+$")                     
+                .match("^.* (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d\\s]+) (?<currency>[\\w]{3}) [\\.,\\d\\s]+$")
                 .assign((t, v) -> {
                     v.put("exchangeRate", stripBlanks(v.get("exchangeRate")));
 
@@ -278,7 +278,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                 Matcher m = pCurrency.matcher(line);
                 if (m.matches())
                 {
-                    if (m.group("currency").equals("Euro"))
+                    if ("Euro".equals(m.group("currency")))
                         context.put("currency", CurrencyUnit.EUR);
                 }
 
@@ -303,7 +303,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^(.*)(?<day>(0 [1-9])|([1-2] [0-9])|(3 [0-1])) \\. (?<month>((0 [1-9])|(1 [0-2])) )(?<amount>((\\. )?(\\d ){1,3})+\\, (\\d \\d))( \\-)$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
-                            t.setDateTime(asDate(stripBlanks(v.get("day")) + "." + stripBlanks(v.get("month")) + "." + context.get("year")));          
+                            t.setDateTime(asDate(stripBlanks(v.get("day")) + "." + stripBlanks(v.get("month")) + "." + context.get("year")));
                             t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                             t.setCurrencyCode(context.get("currency"));
                         })
@@ -324,7 +324,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                         .match("^(.*)(?<day>(0 [1-9])|([1-2] [0-9])|(3 [0-1])) \\. (?<month>((0 [1-9])|(1 [0-2])) )(?<amount>((\\. )?(\\d ){1,3})+\\, (\\d \\d))$")
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
-                            t.setDateTime(asDate(stripBlanks(v.get("day")) + "." + stripBlanks(v.get("month")) + "." + context.get("year")));     
+                            t.setDateTime(asDate(stripBlanks(v.get("day")) + "." + stripBlanks(v.get("month")) + "." + context.get("year")));
                             t.setAmount(asAmount(stripBlanks(v.get("amount"))));
                             t.setCurrencyCode(context.get("currency"));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -22,16 +22,17 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
+@SuppressWarnings("nls")
 public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String IS_JOINT_ACCOUNT = "isjointaccount"; //$NON-NLS-1$
+    private static final String IS_JOINT_ACCOUNT = "isJointAccount";
 
     BiConsumer<DocumentContext, String[]> isJointAccount = (context, lines) -> {
-        Pattern pJointAccount = Pattern.compile("^(abzgl\\. Kapitalertragssteuer|KAPST) anteilig 50,00.*$"); //$NON-NLS-1$
+        Pattern pJointAccount = Pattern.compile("^(abzgl\\. Kapitalertragssteuer|KAPST) anteilig 50,00.*$");
+
         for (String line : lines)
         {
-            Matcher m = pJointAccount.matcher(line);
-            if (m.matches())
+            if (pJointAccount.matcher(line).matches())
             {
                 context.putBoolean(IS_JOINT_ACCOUNT, true);
                 break;
@@ -43,9 +44,9 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Consorsbank"); //$NON-NLS-1$
-        addBankIdentifier("POSTFACH 17 43"); //$NON-NLS-1$
-        addBankIdentifier("Cortal Consors"); //$NON-NLS-1$
+        addBankIdentifier("Consorsbank");
+        addBankIdentifier("POSTFACH 17 43");
+        addBankIdentifier("Cortal Consors");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -58,10 +59,9 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Consorsbank"; //$NON-NLS-1$
+        return "Consorsbank";
     }
 
-    @SuppressWarnings("nls")
     private void addBuySellTransaction()
     {
         DocumentType type = new DocumentType("(?i)(Kauf"
@@ -93,11 +93,11 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 + "|VERK\\. TEIL\\-\\/BEZUGSR\\."
                                 + "|VERKAUF KAPITALMA.*) ([\\s]+)?AM .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("VERKAUF") 
-                        || v.get("type").equals("Verkauf")
-                        || v.get("type").equals("VERK. TEIL-/BEZUGSR.")
-                        || v.get("type").equals("VERKAUF KAPITALMAßN.")
-                        || v.get("type").equals("VERKAUF KAPITALMASSN."))
+                    if ("VERKAUF".equals(v.get("type"))
+                        || "Verkauf".equals(v.get("type"))
+                        || "VERK. TEIL-/BEZUGSR.".equals(v.get("type"))
+                        || "VERKAUF KAPITALMAßN.".equals(v.get("type"))
+                        || "VERKAUF KAPITALMASSN.".equals(v.get("type")))
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }
@@ -106,7 +106,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 .oneOf(
                                 // @formatter:off
                                 // COMS.-MSCI WORL.T.U.ETF I ETF110 LU0392494562
-                                // Kurs 37,650000 EUR P.ST. NETTO  
+                                // Kurs 37,650000 EUR P.ST. NETTO
                                 // Preis pro Anteil 25,640000 EUR
                                 // @formatter:on
                                 section -> section
@@ -353,7 +353,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    @SuppressWarnings("nls")
     private void addDividendeTransaction()
     {
         DocumentType type = new DocumentType("(?i)(Dividendengutschrift|Ertragsgutschrift)");
@@ -377,9 +376,9 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                 .oneOf(
                                 // @formatter:off
-                                // ST                    1.370,00000          WKN:  ETF110                 
-                                //            COMS.-MSCI WORL.T.U.ETF I                                    
-                                //            Namens-Aktien o.N.                                           
+                                // ST                    1.370,00000          WKN:  ETF110
+                                //            COMS.-MSCI WORL.T.U.ETF I
+                                //            Namens-Aktien o.N.
                                 // ZINS-/DIVIDENDENSATZ            1,200000  EUR SCHLUSSTAG PER 07.05.2015
                                 // @formatter:on
                                 section -> section
@@ -476,7 +475,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                 .optionalOneOf(
                                 // @formatter:off
-                                // BRUTTO                                        USD                180,00 
+                                // BRUTTO                                        USD                180,00
                                 // UMGER.ZUM DEV.-KURS                 1,104300  EUR                138,55
                                 // @formatter:on
                                 section -> section
@@ -561,7 +560,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
     }
 
-    @SuppressWarnings("nls")
     private void addEncashmentTransaction()
     {
         DocumentType type = new DocumentType("Einl.sung");
@@ -624,7 +622,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    @SuppressWarnings("nls")
     private void addAdvanceTaxTransaction()
     {
         DocumentType type = new DocumentType("Vorabpauschale");
@@ -686,7 +683,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 });
     }
 
-    @SuppressWarnings("nls")
     private void addTaxAdjustmentTransaction()
     {
 
@@ -729,7 +725,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     t.setAmount(asAmount(v.get("amount")));
 
-                    if (v.get("sign").equals("-"))
+                    if ("-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.TAXES);
                 })
 
@@ -741,7 +737,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 }));
     }
 
-    @SuppressWarnings("nls")
     private void addDepotStatementTransaction()
     {
         final DocumentType type = new DocumentType("Kontoauszug", (context, lines) -> {
@@ -786,13 +781,13 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("GUTSCHRIFT"))
+                    if ("GUTSCHRIFT".equals(v.get("note")))
                         v.put("note", "Gutschrift");
 
-                    if (v.get("note").equals("D-GUTSCHRIFT"))
+                    if ("D-GUTSCHRIFT".equals(v.get("note")))
                         v.put("note", "D-Gutschrift");
 
-                    if (v.get("note").equals("EURO-UEBERW."))
+                    if ("EURO-UEBERW.".equals(v.get("note")))
                         v.put("note", "Euro-Überweisung");
 
                     t.setNote(v.get("note"));
@@ -828,10 +823,10 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("UEBERWEISUNG"))
+                    if ("UEBERWEISUNG".equals(v.get("note")))
                         v.put("note", "Überweisung");
 
-                    if (v.get("note").equals("EURO-UEBERW."))
+                    if ("EURO-UEBERW.".equals(v.get("note")))
                         v.put("note", "Euro-Überweisung");
 
                     t.setNote(v.get("note"));
@@ -866,7 +861,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("ABSCHLUSS"))
+                    if ("ABSCHLUSS".equals(v.get("note")))
                         v.put("note", "Abschluss");
 
                     t.setNote(v.get("note"));
@@ -879,7 +874,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 }));
     }
 
-    @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
@@ -962,7 +956,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^KAPST [\\.,\\d]+% (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1063,7 +1057,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^SOLZ [\\.,\\d]+% (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1204,7 +1198,6 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                 });
     }
 
-    @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -22,7 +22,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("CREDIT SUISSE"); //$NON-NLS-1$
+        addBankIdentifier("CREDIT SUISSE");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -31,7 +31,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Credit Suisse AG"; //$NON-NLS-1$
+        return "Credit Suisse AG";
     }
 
     private void addBuySellTransaction()
@@ -55,7 +55,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Ihr (?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CrowdestorPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CrowdestorPDFExtractor.java
@@ -16,7 +16,7 @@ public class CrowdestorPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("FLEX STATEMENT"); // $NON-NLS-1$
+        addBankIdentifier("FLEX STATEMENT");
 
         addAccountStatementTransaction();
     }
@@ -24,7 +24,7 @@ public class CrowdestorPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Crowdestor OÜ"; //$NON-NLS-1$
+        return "Crowdestor OÜ";
     }
 
     private void addAccountStatementTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -24,8 +24,8 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("DADAT - Bankhaus"); //$NON-NLS-1$
-        addBankIdentifier("DADAT-Bank"); //$NON-NLS-1$
+        addBankIdentifier("DADAT - Bankhaus");
+        addBankIdentifier("DADAT-Bank");
 
         addBuySellTransaction();
         addBuySellAccountStatementTransaction();
@@ -41,7 +41,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "DADAT / Bankhaus Schelhammer & Schattera AG"; //$NON-NLS-1$
+        return "DADAT / Bankhaus Schelhammer & Schattera AG";
     }
 
     private void addBuySellTransaction()
@@ -61,7 +61,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction
-                // Titel: US09247X1019 B L A C K R O C K I NC. 
+                // Titel: US09247X1019 B L A C K R O C K I NC.
                 // Reg. Shares Class A DL -,01
                 // Kurswert: -1.800,-- EUR
                 .section("isin", "name", "name1", "currency")
@@ -106,9 +106,9 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -129,7 +129,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^[\\d]{1,2}\\.[\\d]{1,2} (?<type>(Kauf|Kauf aus Dauerauftrag|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -209,9 +209,9 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         });
 
         pdfTransaction
-                // Titel: US09247X1019 B L A C K R O C K I NC. 
+                // Titel: US09247X1019 B L A C K R O C K I NC.
                 // Reg. Shares Class A DL -,01
-                // Dividende: 4,13 USD 
+                // Dividende: 4,13 USD
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) ([\\s]+)?(?<name>.*)$")
                 .match("^(?<name1>.*)$")
@@ -275,9 +275,9 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -294,7 +294,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
         pdfTransaction
                 // 31.07 Ertrag                           Depot    7800000000/20200730-45756156 30.07 8,16
                 // ISIN AT0000969985 AT+S AUST. TECH.SYS.O.N.               45,00000 STK
-                // Kurs                      0,250000  ZINSERTRAG               11,25 EUR                
+                // Kurs                      0,250000  ZINSERTRAG               11,25 EUR
                 .section("date", "year", "amount", "isin", "name", "shares", "currency").optional()
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) Ertrag ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$")
                 .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*) ([\\s]+)?(?<shares>[\\.,\\d]+) STK$")
@@ -358,9 +358,9 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -450,7 +450,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction
                 // 15.10 KESt-Verlustausgleich            Depot    7806000200/20211014-41350584 18.10 159,57
-                // ISIN US92556H2067 VIACOMCBS INC. BDL-,001                
+                // ISIN US92556H2067 VIACOMCBS INC. BDL-,001
                 // KEST                    159,57 EUR
                 .section("date", "note", "year", "amount", "isin", "name", "currency")
                 .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) (?<note>KESt\\-Verlustausgleich) ([\\s]+)?Depot ([\\s]+)?[\\d]+\\/(?<year>[\\d]{4})[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
-
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -39,7 +38,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("DEGIRO");  //$NON-NLS-1$
+        addBankIdentifier("DEGIRO");
 
         addAccountStatementTransactions();
         addDepotStatementTransactions();
@@ -49,7 +48,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "DEGIRO"; //$NON-NLS-1$
+        return "DEGIRO";
     }
 
     private void addDividendeTransaction()
@@ -129,13 +128,13 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
             // Einbuchung:
             // 19-07-2017 00:00 Währungswechsel 1,1528 EUR 0,75 EUR 1.783,89
             // 03-08-2019 06:55 02-08-2019 Währungswechsel (Ausbuchung) 1,1120 USD -3,84 USD -0,00
-            // 
+            //
             // 23-03-2021 08:17 22-03-2021 FX Debit EUR 9.12 EUR -2,681.14
             // 23-03-2021 08:17 22-03-2021 FX Debit 1.4958 CAD -13.65 CAD 0.00
-            // 
+            //
             // 17-11-2021 07:38 16-11-2021 Währungswechsel (Einbuchung) CHF 2.02 CHF 1'185.08
             // 17-11-2021 07:38 16-11-2021 Währungswechsel (Ausbuchung) 1.0760 USD -2.18 USD 0.00
-            // 
+            //
             // 13-11-2021 07:45 12-11-2021 Währungswechsel (Einbuchung) CHF 1.54 CHF 1'183.06
             // 13-11-2021 07:45 12-11-2021 Währungswechsel (Ausbuchung) 1.0866 USD -1.68 USD 0.00
             //
@@ -178,7 +177,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
             // Ausbuchung:
             // 19-07-2017 00:00 Währungswechsel USD -0,86 USD 0,00
             // 03-08-2019 06:55 02-08-2019 Währungswechsel (Einbuchung) EUR 3,45 EUR 1.552,27
-            // 
+            //
             // 16-03-2021 09:24 15-03-2021 FX Debit EUR 31.66 EUR -1,542.30
             // 16-03-2021 09:24 15-03-2021 FX Debit 1.1942 USD -37.82 USD -0.00
             //
@@ -251,7 +250,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                 item.baseAmount = item.termAmount;
                                 item.termCurrency = mBase.group("currency");
                                 item.termAmount = asAmount(mBase.group("amount"));
-                            } 
+                            }
                             exchangeRateHelper.items.add(item);
                             break;
                         }
@@ -276,9 +275,9 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
             DividendTransactionHelper dividendeTransactionHelper = new DividendTransactionHelper();
             context.putType(dividendeTransactionHelper);
 
-            for (int i = 0; i < lines.length; i++)
+            for (String line : lines)
             {
-                Matcher m = pDividendeTransactions.matcher(lines[i]);
+                Matcher m = pDividendeTransactions.matcher(line);
                 if (m.matches())
                 {
                     DividendeTransactionsItem item = new DividendeTransactionsItem();
@@ -432,7 +431,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         // 15-06-2019 06:44 14-06-2019 Währungswechsel (Ausbuchung) 1,1219 USD -0,34 USD 0,00
         // (...)
         // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividende USD 0,40 USD 0,34
-        // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividendensteuer USD -0,06 USD -0,06 
+        // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividendensteuer USD -0,06 USD -0,06
         // -------------------------------------
         // 05-07-2019 06:49 04-07-2019 Währungswechsel (Einbuchung) EUR 10,12 EUR 2.119,03
         // 05-07-2019 06:49 04-07-2019 Währungswechsel (Ausbuchung) 1,1297 USD -11,44 USD -0,00
@@ -464,22 +463,22 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         // -------------------------------------
         // 22-03-2021 07:39 19-03-2021 MANULIFE FINANCIAL COR CA56501R1064 Dividend CAD 18.20 CAD 13.65
         // 22-03-2021 07:39 19-03-2021 MANULIFE FINANCIAL COR CA56501R1064 Dividend Tax CAD -4.55 CAD -4.55
-        // 
+        //
         // **********************************
         // Calculation of taxes:            *
         // **********************************
         // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividende USD 0,40 USD 0,34
         // 14-06-2019 07:55 14-06-2019 THE KRAFT HEINZ COMPAN US5007541064 Dividendensteuer USD -0,06 USD -0,06
-        // 
+        //
         // Gross amount: 0,40 USD + 0,06 USD = 0,46 USD
-        // 
+        //
         // **********************************
         // Calculation of taxes and fee:    *
         // **********************************
         // 12-06-2019 09:12 11-06-2019 NOKIA CORPORATION SPON US6549022043 Dividende USD 1,74 USD 2,36
         // 12-06-2019 09:12 11-06-2019 NOKIA CORPORATION SPON US6549022043 Dividendensteuer USD -0,52 USD 0,62
         // 12-06-2019 09:12 11-06-2019 NOKIA CORPORATION SPON US6549022043 ADR/GDR Weitergabegebühr USD -0,08 USD 1,14
-        // 
+        //
         // ExchangeRage: 0,8851124093 --> 0,89
         // Gross amount in EUR: (1,74 * 0,89) + (0,52 * 0,89) + (0,08 * 0,89) = 2,0826 EUR
         // @formatter:on
@@ -506,10 +505,10 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                         // 22-03-2021 07:39 19-03-2021 MANULIFE FINANCIAL COR CA56501R1064 Dividend CAD 18.20 CAD 13.65
                                         // 31-03-2022 07:36 30-03-2022 ISHARES GLOB HIG YLD CORP BOND UCITS IE00B74DQ490 Dividendo USD 24,19 USD 24,19
                                         // 30-09-2022 07:25 29-09-2022 T. ROWE PRICE GROUP I US74144T1088 Dividendo USD 31,20 USD 26,52
-                                        // 
+                                        //
                                         // -------------------------------------
                                         // Date of currency exchange is different from the dividend date
-                                        // 
+                                        //
                                         // 27-06-2022 07:30 24-06-2022 Valuta Creditering EUR 497,44 EUR 2.648,76
                                         // 27-06-2022 07:30 24-06-2022 Valuta Debitering 1,0582 USD -526,37 USD 0,00
                                         // 26-06-2022 06:41 24-06-2022 VANGUARD TOTAL INTERNA US9219097683 Dividend USD 751,95 USD 526,37
@@ -557,7 +556,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                                 t.getDateTime().toLocalDate());
 
                                                 // @formatter:off
-                                                // If no exchange rate is found, 
+                                                // If no exchange rate is found,
                                                 // search for the exchange rate on the value date
                                                 // @formatter:on
                                                 if (!item.isPresent())
@@ -728,7 +727,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             DocumentContext context = type.getCurrentContext();
                             Money fee = Money.of(asCurrencyCode(v.get("currencyFee")), asAmount(v.get("feeFx")));
-                            
+
                             Optional<CurrencyExchangeItem> item = context.getType(CurrencyExchangeItem.class);
                             if (item.isPresent() && v.get("isin").equalsIgnoreCase(t.getSecurity().getIsin()))
                             {
@@ -844,16 +843,16 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                             t.setDateTime(asDate(v.get("date"), v.get("time")));
                             t.setSecurity(getOrCreateSecurity(v));
                             t.setNote(v.get("note") + ": " + v.get("isin"));
-                            
+
                             if ("-".equals(trim(v.get("type"))))
                                 t.setType(AccountTransaction.Type.TAXES);
 
                             // @formatter:off
                             // Sometimes the dividend tax is settled without a dividend transaction.
                             //
-                            // To capture this, we note all these dividend transactions and look for whether 
+                            // To capture this, we note all these dividend transactions and look for whether
                             // this tax belongs to a dividend transaction or not.
-                            // 
+                            //
                             // If there is no dividend transaction, then we record this tax.
                             // @formatter:on
 
@@ -871,7 +870,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
 
                                     Optional<CurrencyExchangeItem> item = exchangeRateHelper.findItem(v.getStartLineNumber(), money,
                                                     t.getDateTime().toLocalDate());
-                                    
+
                                     if (item.isPresent())
                                     {
                                         Money converted = Money.of(item.get().baseCurrency,
@@ -1034,22 +1033,22 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         // -------------------------------------
         // 03-07-2019 11:47 30-06-2019 Einrichtung von Handelsmodalitäten 2019 (New York Stock EUR -0,54 EUR 22,16
         // 01-02-2019 16:31 31-01-2019 Einrichtung von Handelsmodalitäten 2019 (NASDAQ - NDQ) EUR 2,50 EUR 108,21
-        //  
+        //
         // 30-06-2017 00:00 Einrichtung von EUR -2,50 EUR 1.116,79
         // Handelsmodalitäten
         // 2017
-        // 
+        //
         // 31-08-2017 00:00 Einrichtung von EUR -0,89 EUR 35,63
         // Handelsmodalitäten
         // 2017
-        //  
+        //
         // 02-09-2021 21:29 31-08-2021 DEGIRO Aansluitingskosten 2021 (Borsa Italiana S.p.A. - EUR -2,50 EUR 12,91
         // MIL)
         //
         // 01-06-2022 19:55 31-05-2022 Giro Exchange Connection Fee 2022 EUR -1,01 EUR -6,39
         // 02-10-2021 10:46 30-09-2021 DEGIRO Costi di connessione 2021 (Xetra - XET) EUR -1,24 EUR 206,99
         // 05-07-2022 08:32 30-06-2022 Giro Exchange Connection Fee 2022 EUR -2,50 EUR 7.390,07
-        // 
+        //
         // 28-04-2022 15:33 27-04-2022 JINKOSOLAR HOLDING COM US47759T1007 ADR/GDR Weitergabegebühr USD -0,01 USD 0,64
         // 29-04-2022 17:34 18-08-2021 GAZPROM PAO US3682872078 ADR/GDR Weitergabegebühr USD 7,12 USD 11,93
         //
@@ -1111,7 +1110,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                     + "(?<type>\\s(\\-)?)"
                                                     + "(?<amount>[\\.,'\\d\\s]+) "
                                                     + "[\\w]{3} "
-                                                    + "(\\-)?[\\.,'\\d\\s]+$") 
+                                                    + "(\\-)?[\\.,'\\d\\s]+$")
                                     .match("^(?<note2>[\\d]{4} \\(.*\\)).*$")
                                     .assign((t, v) -> {
                                         t.setDateTime(asDate(v.get("date"), v.get("time")));
@@ -1135,7 +1134,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                     + "(?<type>\\s(\\-)?)"
                                                     + "(?<amount>[\\.,'\\d\\s]+) "
                                                     + "[\\w]{3} "
-                                                    + "(\\-)?[\\.,'\\d\\s]+$") 
+                                                    + "(\\-)?[\\.,'\\d\\s]+$")
                                     .assign((t, v) -> {
                                         t.setDateTime(asDate(v.get("date"), v.get("time")));
                                         t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -1168,9 +1167,9 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Sometimes the ADR/GDR transfer fee is settled without a dividend transaction.
                                         //
-                                        // To capture this, we remember all this dividend transactions and search for whether 
+                                        // To capture this, we remember all this dividend transactions and search for whether
                                         // these charges belong to a dividend transaction or not.
-                                        // 
+                                        //
                                         // If there is no dividend transaction, then we record this fee.
                                         // @formatter:on
 
@@ -1188,7 +1187,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
 
                                                 Optional<CurrencyExchangeItem> item = exchangeRateHelper.findItem(v.getStartLineNumber(), money,
                                                                 t.getDateTime().toLocalDate());
-                                                
+
                                                 if (item.isPresent())
                                                 {
                                                     Money converted = Money.of(item.get().baseCurrency,
@@ -1328,12 +1327,12 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     }
 
     /**
-     * Information: 
-     * 
+     * Information:
+     *
      * If you make changes to the regEx, the examples will help you
      * to adjust it correctly. Always check where and on which side the
      * currency, amount, exchange rate and fees are!
-     *  
+     *
      * Please do not delete these examples!
      */
     private void addDepotStatementTransactions()
@@ -1380,7 +1379,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                 + "(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) "
                                                 + "[\\w]{3} ([\\s]+)?"
                                                 + "(?<shares>[\\-\\.,'\\d]+) "
-                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} " 
+                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} "
                                                 + "(?<currency>[\\w]{3}) (\\-)?(?<amountFx>[\\.,'\\d\\s]+[\\.|,][\\d]{2}) "
                                                 + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} "
                                                 + "(?<exchangeRate>[\\.,'\\d\\s]+[\\.|,][\\d]{1,4}) "
@@ -1405,7 +1404,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                     Money feeAmount = Money.of(asCurrencyCode(v.get("currencyFee")), asAmount(v.get("fee")));
                                     t.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, feeAmount));
 
-                                    long amountFx = asAmount(v.get("amountFx")); 
+                                    long amountFx = asAmount(v.get("amountFx"));
                                     String currencyFx = asCurrencyCode(v.get("currency"));
 
                                     if (currencyFx.equals(t.getPortfolioTransaction().getSecurity().getCurrencyCode()))
@@ -1459,7 +1458,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                         t.setType(PortfolioTransaction.Type.SELL);
                                         t.setShares(asShares(v.get("shares").replaceFirst("-", "")));
                                     }
-                                    else 
+                                    else
                                     {
                                         t.setShares(asShares(v.get("shares")));
                                     }
@@ -1513,7 +1512,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                     {
                                         t.setType(PortfolioTransaction.Type.SELL);
                                         t.setShares(asShares(v.get("shares").replaceFirst("-", "")));
-                                    } 
+                                    }
                                     else
                                     {
                                         t.setShares(asShares(v.get("shares")));
@@ -1576,7 +1575,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                         t.setType(PortfolioTransaction.Type.SELL);
                                         t.setShares(asShares(v.get("shares").replaceFirst("-", "")));
                                     }
-                                    else 
+                                    else
                                     {
                                         t.setShares(asShares(v.get("shares")));
                                     }
@@ -1684,7 +1683,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                         t.setType(PortfolioTransaction.Type.SELL);
                                         t.setShares(asShares(v.get("shares").replaceFirst("-", "")));
                                     }
-                                    else 
+                                    else
                                     {
                                         t.setShares(asShares(v.get("shares")));
                                     }
@@ -1720,7 +1719,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                             // -------------------------------------
                             // Formatting:
                             // DateTime | Name | ISIN | Stock Exchange | Shares | Quote | Market value | Local market value | Total amount
-                            // -------------------------------------          
+                            // -------------------------------------
                             // 08-02-2019 13:27 ODX2 C11000.00 08FEB19 DE000C25KFE8 ERX -3 EUR 0,00 EUR 0,00 EUR 0,00 EUR 0,00
                             // 09-07-2019 14:08 VANGUARD FTSE AW IE00B3RBWM25 EAM 3 EUR 77,10 EUR -231,30 EUR -231,30 EUR -231,30
                             // @formatter:on
@@ -1731,9 +1730,9 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                 + "(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) "
                                                 + "[\\w]{3} ([\\s]+)?"
                                                 + "(?<shares>[\\-\\.,'\\d]+) "
-                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} " 
-                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} " 
-                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} " 
+                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} "
+                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} "
+                                                + "[\\w]{3} (\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} "
                                                 + "([\\s]+)?(?<currency>[\\w]{3}) (\\-)?(?<amount>[\\.,'\\d\\s]+[\\.|,][\\d]{2})([\\s]+)?$")
                                 .assign((t, v) -> {
                                     t.setSecurity(getOrCreateSecurity(v));
@@ -1759,7 +1758,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                             // -------------------------------------
                             // Formatting:
                             // DateTime | Name | ISIN | Stock Exchange | Shares | Quote | Market value | Local market value | Total amount
-                            // -------------------------------------     
+                            // -------------------------------------
                             // 13-03-2018 00:00 BAUMOT GROUP AG O.N DE000A2DAM11 XET -350 1,84 EUR 644,00 EUR 644,00 EUR 644,00 EUR
                             // 22-07-2020 00:00 PHARMA MAR SA ES0169501022 MAD 21 114,66 EUR -2 407,86 EUR -2 407,86 EUR -2 407,86 EUR
                             // @formatter:on
@@ -1798,7 +1797,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                             // -------------------------------------
                             // Formatting:
                             // DateTime | Name | ISIN | Stock Exchange | Shares | Quote | Market value | Local market value | Fee | Total amount
-                            // -------------------------------------  
+                            // -------------------------------------
                             // 07-02-2019 12:22 ODX2 C11200.00 08FEB19 DE000C25KFN9 ERX 1 EUR 30,00 EUR -150,00 EUR -150,00 EUR -0,90 EUR -150,90
                             // 01-04-2019 15:35 DEUTSCHE BANK AG NA O.N DE0005140008 XET -136 EUR 7,45 EUR 1.013,20 EUR 1.013,20 EUR -2,26 EUR 1.010,94
                             // 01-04-2019 12:20 DEUTSCHE BANK AG NA O.N DE0005140008 XET 18 EUR 7,353 EUR -132,35 EUR -132,35 EUR -0,03 EUR -132,38
@@ -1828,7 +1827,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                     {
                                         t.setType(PortfolioTransaction.Type.SELL);
                                         t.setShares(asShares(v.get("shares").replaceFirst("-", "")));
-                                    } 
+                                    }
                                     else
                                     {
                                         t.setShares(asShares(v.get("shares")));
@@ -1852,16 +1851,16 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                 + "(?<name>.*) "
                                                 + "(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) "
                                                 + "[\\w]{3} ([\\s]+)?"
-                                                + "(?<shares>[\\-\\.,'\\d]+) "  
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} [\\w]{3} " 
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} " 
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} " 
+                                                + "(?<shares>[\\-\\.,'\\d]+) "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} [\\w]{3} "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} "
                                                 + "(\\-)?(?<fee>[\\.,'\\d\\s]+[\\.|,][\\d]{2}) (?<currencyFee>[\\w]{3}) "
                                                 + "([\\s]+)?(\\-)?(?<amount>[\\.,'\\d\\s]+[\\.|,][\\d]{2}) (?<currency>[\\w]{3})([\\s]+)?$")
                                 .assign((t, v) -> {
                                     t.setSecurity(getOrCreateSecurity(v));
                                     t.setDate(asDate(v.get("date"), v.get("time")));
-                                    t.setCurrencyCode(asCurrencyCode(v.get("currency"))); 
+                                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                     t.setAmount(asAmount(v.get("amount")));
 
                                     if (v.get("shares").startsWith("-"))
@@ -1897,16 +1896,16 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
                                                 + "(?<name>.*) "
                                                 + "(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) "
                                                 + "[\\w]{3} [\\w]{4} ([\\s]+)?"
-                                                + "(?<shares>[\\-\\.,'\\d]+) "  
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} [\\w]{3} " 
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} " 
-                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} " 
+                                                + "(?<shares>[\\-\\.,'\\d]+) "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2,6} [\\w]{3} "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} "
+                                                + "(\\-)?[\\.,'\\d\\s]+[\\.|,][\\d]{2} [\\w]{3} "
                                                 + "(\\-)?(?<fee>[\\.,'\\d\\s]+[\\.|,][\\d]{2}) (?<currencyFee>[\\w]{3}) "
                                                 + "([\\s]+)?(\\-)?(?<amount>[\\.,'\\d\\s]+[\\.|,][\\d]{2}) (?<currency>[\\w]{3})([\\s]+)?$")
                                 .assign((t, v) -> {
                                     t.setSecurity(getOrCreateSecurity(v));
                                     t.setDate(asDate(v.get("date"), v.get("time")));
-                                    t.setCurrencyCode(asCurrencyCode(v.get("currency"))); 
+                                    t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                     t.setAmount(asAmount(v.get("amount")));
 
                                     if (v.get("shares").startsWith("-"))
@@ -2016,10 +2015,8 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
             // Search date and time of dividend transaction using date+time and
             // ISIN.
 
-            for (int i = 0; i < items.size(); i++) // NOSONAR
+            for (DividendeTransactionsItem item : items)
             {
-                DividendeTransactionsItem item = items.get(i);
-
                 if (item.dateTime.equals(dateTime) && item.isin.equals(isin))
                     return Optional.of(item);
             }
@@ -2027,11 +2024,11 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
             return Optional.empty();
         }
     }
-    
+
     /**
      * Represents two lines in the account statement for a currency exchange
      * ("Währungswechsel" or "FX Debit").
-     * 
+     *
      * <pre>
      *  amount in base currency x exchange rate = amount in term currency
      * </pre>
@@ -2072,25 +2069,25 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 
@@ -2100,25 +2097,25 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 
@@ -2128,25 +2125,25 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
-
 import static name.abuchen.portfolio.util.TextUtil.replaceMultipleBlanks;
 import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
@@ -40,7 +39,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("DekaBank"); //$NON-NLS-1$
+        addBankIdentifier("DekaBank");
 
         addBuySellTransaction();
         addSwapBuyTransaction();
@@ -54,7 +53,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "DekaBank Deutsche Girozentrale"; //$NON-NLS-1$
+        return "DekaBank Deutsche Girozentrale";
     }
 
     private void addBuySellTransaction()
@@ -88,7 +87,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                 // ISIN: DE000DK0ECT0 Unterdepot: 00 Auftragsnummer: 8103 1017
                                 // =Abrechnungsbetrag EUR 4.000,00 EUR 4.000,00 EUR 494,260000 Anteilumsatz: 8,093
                                 //
-                                // Fondsbezeichnung: Deka-GeldmarktPlan TF 
+                                // Fondsbezeichnung: Deka-GeldmarktPlan TF
                                 // ISIN: LU0268059614 Unterkonto: 00 Auftragsnummer: 8101 2521
                                 // = Abrechnungsbetrag EUR 400,00 EUR 400,00 EUR 996,160000 Anteilumsatz: 0,402
                                 // @formatter:on
@@ -383,7 +382,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
                                 ,
                                 // @formatter:off
-                                // Fondsbezeichnung: AriDeka CF 
+                                // Fondsbezeichnung: AriDeka CF
                                 // ISIN: DE0008474511 Unterkonto: 00 Auftragsnummer: 9387 9103
                                 // +Verrechnete Steuern EUR 1,43 EUR 29,15 EUR 33,420000 Anteilumsatz: 0,872
                                 // @formatter:on
@@ -473,7 +472,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
                                 ,
                                 // @formatter:off
-                                // Fondsbezeichnung: AriDeka CF 
+                                // Fondsbezeichnung: AriDeka CF
                                 // ISIN: DE0008474511 Unterkonto: 00 Auftragsnummer: 9387 9103
                                 // +Verrechnete Steuern EUR 1,43 EUR 29,15 EUR 33,420000 Anteilumsatz: 0,872
                                 // @formatter:on
@@ -547,7 +546,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 // @formatter:on
                 .section("noTax").optional()
                 .match("^(?<noTax>\\+).*Verrechnete Steuern [\\w]{3} [\\.,\\d]+.*$")
-                .assign((t, v) -> type.getCurrentContext().put("noTax", "X"))
+                .assign((t, v) -> type.getCurrentContext().putBoolean("noTax", true))
 
                 .wrap(t -> {
                     // If we have multiple entries in the document, then
@@ -656,7 +655,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 if (mContractFeeDate.matches())
                     context.put("contractFeeDate", mContractFeeDate.group("contractFeeDate"));
             }
-                            
+
             // Create a helper to store the list of security items found in the document
             SecurityListHelper securityListHelper = new SecurityListHelper();
             context.putType(securityListHelper);
@@ -1401,9 +1400,9 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
                 .oneOf(
                                 // @formatter:off
-                                // Vertragspreis (zu Lasten Girokonto) -10,00  
+                                // Vertragspreis (zu Lasten Girokonto) -10,00
                                 // Vertragspreis (zu Lasten Vertrag)  0,00
-                                // Weitere Preise (zu Lasten Girokonto) 0,00  
+                                // Weitere Preise (zu Lasten Girokonto) 0,00
                                 // Weitere Preise (zu Lasten Vertrag)  0,00
                                 // Vertragspreis -10,00
                                 // Abschluss- und Vertriebskosten (Ausgabeaufschlag) -21,06
@@ -1427,7 +1426,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                             // Formatting some notes
                                             if (t.getNote().startsWith("Abschluss"))
                                                 t.setNote("Abschluss-/ Vertriebskosten");
-                                            
+
                                             t.setNote(t.getNote() + " " + t.getDateTime().getYear());
                                         })
                                 ,
@@ -1518,15 +1517,15 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         })
                                 ,
                                 // @formatter:off
-                                // Depotpreis inkl. 19% Mehrwertsteuer (MwSt): 
+                                // Depotpreis inkl. 19% Mehrwertsteuer (MwSt):
                                 // 12,50 EUR inkl. 2,00 EUR MwSt wurden für 2019 belastet
                                 // per 31.12.2019
                                 //
-                                // D epotpreis inkl. 19% MwSt: 
+                                // D epotpreis inkl. 19% MwSt:
                                 // 10,00 EUR wurden für 2012 belastet
                                 // Jahresdepotauszug per 31.12.2012
                                 //
-                                // Depotpreis inkl. Mehrwertsteuer (MwSt): 
+                                // Depotpreis inkl. Mehrwertsteuer (MwSt):
                                 // 0,00 EUR
                                 // @formatter:on
                                 section -> section
@@ -1579,7 +1578,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                     .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
                             ,
                             // @formatter:off
-                            // Fondsbezeichnung: AriDeka CF 
+                            // Fondsbezeichnung: AriDeka CF
                             // ISIN: DE0008474511 Unterkonto: 00 Auftragsnummer: 9387 9103
                             // +Verrechnete Steuern EUR 1,43 EUR 29,15 EUR 33,420000 Anteilumsatz: 0,872
                             // @formatter:on
@@ -1651,7 +1650,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^([\\-|\\+]).*Verrechnete Steuern (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 });
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -25,7 +25,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("1822direkt"); //$NON-NLS-1$
+        addBankIdentifier("1822direkt");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -34,7 +34,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "1822direkt"; //$NON-NLS-1$
+        return "1822direkt";
     }
 
     private void addBuySellTransaction()
@@ -58,7 +58,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds)).*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Rücknahme Investmentfonds"))
+                    if ("Verkauf".equals(v.get("type")) || "Rücknahme Investmentfonds".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -26,35 +26,28 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class DkbPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String IS_JOINT_ACCOUNT = "isJointAccount"; //$NON-NLS-1$
+    private static final String IS_JOINT_ACCOUNT = "isJointAccount";
 
     BiConsumer<DocumentContext, String[]> isJointAccount = (context, lines) -> {
-        Pattern pJointAccount = Pattern.compile("^Anteilige Berechnungsgrundlage f.r \\(50,00([\\s]+)?%\\).*$"); //$NON-NLS-1$
-        Boolean bJointAccount = Boolean.FALSE;
-        
+        Pattern pJointAccount = Pattern.compile("^Anteilige Berechnungsgrundlage f.r \\(50,00([\\s]+)?%\\).*$");
+
         for (String line : lines)
         {
-            Matcher m = pJointAccount.matcher(line);
-            if (m.matches())
+            if (pJointAccount.matcher(line).matches())
             {
-                context.put(IS_JOINT_ACCOUNT, Boolean.TRUE.toString());
-                bJointAccount = Boolean.TRUE;
+                context.putBoolean(IS_JOINT_ACCOUNT, true);
                 break;
             }
         }
-
-        if (!bJointAccount)
-            context.put(IS_JOINT_ACCOUNT, Boolean.FALSE.toString());
-
     };
 
     public DkbPDFExtractor(Client client)
     {
         super(client);
 
-        addBankIdentifier("DKB"); //$NON-NLS-1$
-        addBankIdentifier("Deutsche Kreditbank"); //$NON-NLS-1$
-        addBankIdentifier("10919 Berlin"); //$NON-NLS-1$
+        addBankIdentifier("DKB");
+        addBankIdentifier("Deutsche Kreditbank");
+        addBankIdentifier("10919 Berlin");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -68,7 +61,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Deutsche Kreditbank AG"; //$NON-NLS-1$
+        return "Deutsche Kreditbank AG";
     }
 
     private void addBuySellTransaction()
@@ -120,10 +113,10 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                 + "Verkauf aus Kapitalmaßnahme|"
                                 + "R.cknahme Investmentfonds))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") 
-                                    || v.get("type").equals("Verkauf Direkthandel")
-                                    || v.get("type").equals("Verkauf aus Kapitalmaßnahme")
-                                    || v.get("type").equals("Rücknahme Investmentfonds"))
+                    if ("Verkauf".equals(v.get("type"))
+                                    || "Verkauf Direkthandel".equals(v.get("type"))
+                                    || "Verkauf aus Kapitalmaßnahme".equals(v.get("type"))
+                                    || "Rücknahme Investmentfonds".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -131,9 +124,9 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Gesamtk.ndigung|Teilr.ckzahlung mit Nennwert.nderung|Teilliquidation mit Nennwertreduzierung))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Gesamtkündigung")
-                                    || v.get("type").equals("Teilrückzahlung mit Nennwertänderung")
-                                    || v.get("type").equals("Teilliquidation mit Nennwertreduzierung"))
+                    if ("Gesamtkündigung".equals(v.get("type"))
+                                    || "Teilrückzahlung mit Nennwertänderung".equals(v.get("type"))
+                                    || "Teilliquidation mit Nennwertreduzierung".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -169,7 +162,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<notation>(St.ck|[\\w]{3})) (?<shares>[\\.,\\d]+) .*$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stück"))
+                    if (v.get("notation") != null && !"Stück".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -312,7 +305,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<notation>(St.ck|[\\w]{3})) (?<shares>[\\.,\\d]+) .*$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stück"))
+                    if (v.get("notation") != null && !"Stück".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -323,7 +316,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     }
                 })
 
-                // Den Betrag buchen wir mit Wertstellung 04.01.2016 zu Gunsten des Kontos 12345678 (IBAN DE30 1203 0000 0012 3456 
+                // Den Betrag buchen wir mit Wertstellung 04.01.2016 zu Gunsten des Kontos 12345678 (IBAN DE30 1203 0000 0012 3456
                 .section("date")
                 .match("^Den Betrag buchen wir mit Wertstellung (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
@@ -454,7 +447,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<notation>St.ck|[\\w]{3}) (?<shares>[\\.,\\d]+) .*$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stück"))
+                    if (v.get("notation") != null && !"Stück".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -486,7 +479,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         final DocumentType type = new DocumentType("Halbjahresabrechnung Sparplan", (context, lines) -> {
             Pattern pSecurity = Pattern.compile("^(?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (\\((?<wkn>.*)\\).*)$");
             Pattern pCurrency = Pattern.compile("^(?<currency>[\\w]{3}) in .*$");
-            // read the current context here
+
             for (String line : lines)
             {
                 Matcher m = pSecurity.matcher(line);
@@ -561,7 +554,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
             Pattern pCurrency = Pattern.compile("^Bu.Tag Wert Wir haben f.r Sie gebucht Belastung in (?<currency>[\\w]{3}).*$");
             Pattern pYear = Pattern.compile("^Kontoauszug Nummer (?<nr>[\\d]+) \\/ (?<year>[\\d]{4}) vom [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$");
             Pattern pAccountingBillDate = Pattern.compile("^Abrechnung (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
-            // read the current context here
+
             for (String line : lines)
             {
                 Matcher m = pCurrency.matcher(line);
@@ -599,7 +592,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^Zinsen f.r (einger.umte Konto.berziehung|Guthaben) ([\\s]+)?(?<amount>[\\.,\\d]+)(?<type>([\\-|\\+]))$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
-                    if (v.get("type").equals("-"))
+                    if ("-".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.INTEREST_CHARGE);
 
                     t.setDateTime(asDate(context.get("accountingBillDate")));
@@ -628,7 +621,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<note>Zinsen f.r Dispositionskredit) ([\\s]+)?(?<amount>[\\.,\\d]+)(?<type>(([\\-|\\+])))$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
-                    if (v.get("type").equals("-"))
+                    if ("-".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.INTEREST_CHARGE);
 
                     t.setDateTime(asDate(context.get("accountingBillDate")));
@@ -657,7 +650,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<note>Kapitalertragsteuer) ([\\s]+)?(?<amount>[\\.,\\d]+)(?<type>(([\\-|\\+])))$")
                 .assign((t, v) -> {
                     Map<String, String> context = type.getCurrentContext();
-                    if (v.get("type").equals("+"))
+                    if ("+".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.TAX_REFUND);
 
                     t.setDateTime(asDate(context.get("accountingBillDate")));
@@ -710,8 +703,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     // necessary in first receipt of year
                     if (context.get("nr").compareTo("1") == 0 && Integer.parseInt(v.get("month1")) != Integer.parseInt(v.get("month2")))
                     {
-                        Integer year = Integer.parseInt(context.get("year")) - 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year.toString()));
+                        int year = Integer.parseInt(context.get("year")) - 1;
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year));
                     }
                     else
                     {
@@ -722,22 +715,22 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("Kreditkartenabr."))
+                    if ("Kreditkartenabr.".equals(v.get("note")))
                         v.put("note", "Kreditkartenabrechnung");
 
-                    if (v.get("note").equals("Verfügung Geldautomat"))
+                    if ("Verfügung Geldautomat".equals(v.get("note")))
                         v.put("note", "Geldautomat");
 
-                    if (v.get("note").equals("Verfüg. Geldautom. FW"))
+                    if ("Verfüg. Geldautom. FW".equals(v.get("note")))
                         v.put("note", "Geldautomat (Fremdwährung)");
 
-                    if (v.get("note").equals("Kartenzahlung onl"))
+                    if ("Kartenzahlung onl".equals(v.get("note")))
                         v.put("note", "Kartenzahlung online");
 
-                    if (v.get("note").equals("Überweis. entgeltfr."))
+                    if ("Überweis. entgeltfr.".equals(v.get("note")))
                         v.put("note", "Überweisung entgeltfrei");
 
-                    if (v.get("note").equals("Kartenzahlung FW"))
+                    if ("Kartenzahlung FW".equals(v.get("note")))
                         v.put("note", "Kartenzahlung (Fremdwährung)");
 
                     t.setNote(v.get("note"));
@@ -779,8 +772,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     // necessary in first receipt of year
                     if (context.get("nr").compareTo("1") == 0 && Integer.parseInt(v.get("month1")) != Integer.parseInt(v.get("month2")))
                     {
-                        Integer year = Integer.parseInt(context.get("year")) - 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year.toString()));
+                        int year = Integer.parseInt(context.get("year")) - 1;
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year));
                     }
                     else
                     {
@@ -791,10 +784,10 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("Eingang Echtzeitüberw"))
+                    if ("Eingang Echtzeitüberw".equals(v.get("note")))
                         v.put("note", "Eingang Echtzeitüberweisung");
 
-                    if (v.get("note").equals("Bareinzahlung am GA"))
+                    if ("Bareinzahlung am GA".equals(v.get("note")))
                         v.put("note", "Bareinzahlung am Geldautomat");
 
                     t.setNote(v.get("note"));
@@ -822,8 +815,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     // necessary in first receipt of year
                     if (context.get("nr").compareTo("1") == 0 && Integer.parseInt(v.get("month1")) != Integer.parseInt(v.get("month2")))
                     {
-                        Integer year = Integer.parseInt(context.get("year")) - 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year.toString()));
+                        int year = Integer.parseInt(context.get("year")) - 1;
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year));
                     }
                     else
                     {
@@ -869,14 +862,14 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     // necessary in first receipt of year
                     if (context.get("nr").compareTo("1") == 0 && Integer.parseInt(v.get("month1")) != Integer.parseInt(v.get("month2")))
                     {
-                        Integer year = Integer.parseInt(context.get("year")) - 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year.toString()));
+                        int year = Integer.parseInt(context.get("year")) - 1;
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + year));
                     }
                     else
                     {
                         t.setDateTime(asDate(v.get("day") + "." + v.get("month2") + "." + context.get("year")));
                     }
-                    if (v.get("note2").equals("Stornorechnung"))
+                    if ("Stornorechnung".equals(v.get("note2")))
                     {
                         t.setType(AccountTransaction.Type.FEES_REFUND);
                     }
@@ -885,7 +878,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                     t.setNote(v.get("note1") + " " + v.get("note2"));
 
                     // Formatting some notes
-                    if (t.getNote().equals("BUCHUNG IDENTIFIKATIONSCODE"))
+                    if ("BUCHUNG IDENTIFIKATIONSCODE".equals(t.getNote()))
                         t.setNote("Buchung Identifikationscode");
                 })
 
@@ -897,7 +890,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Ihre Abrechnung vom ", (context, lines) -> {
             Pattern pCurrency = Pattern.compile("^Beleg BuchungVerwendungszweck (?<currency>[\\w]{3})$");
             Pattern pcentury = Pattern.compile("^.*Abrechnungsdatum: [\\d]{2}\\. .*(?<year>[\\d]{2})[\\d]{2}$");
-            // read the current context here
+
             for (String line : lines)
             {
                 Matcher m = pCurrency.matcher(line);
@@ -951,7 +944,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
-                                            // Deletes characters that occur during 
+                                            // Deletes characters that occur during
                                             // withdrawals from foreign banks
                                             v.put("note", trim(v.get("note")));
                                             if (v.get("note").startsWith("*"))
@@ -976,7 +969,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
-                                            // Deletes characters that occur during 
+                                            // Deletes characters that occur during
                                             // withdrawals from foreign banks
                                             v.put("note", trim(v.get("note")));
                                             if (v.get("note").startsWith("*"))
@@ -1072,7 +1065,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
-                                            // Deletes characters that occur during 
+                                            // Deletes characters that occur during
                                             // withdrawals from foreign banks
                                             v.put("note", trim(v.get("note")));
                                             if (v.get("note").startsWith("*"))
@@ -1098,7 +1091,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
-                                            // Deletes characters that occur during 
+                                            // Deletes characters that occur during
                                             // withdrawals from foreign banks
                                             v.put("note", trim(v.get("note")));
                                             if (v.get("note").startsWith("*"))
@@ -1182,7 +1175,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1193,7 +1186,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax1>[\\.,\\d]+)\\- (?<currency1>[\\w]{3})$")
                 .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax2>[\\.,\\d]+)\\- (?<currency2>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));
@@ -1213,7 +1206,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1224,7 +1217,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax1>[\\.,\\d]+)\\- (?<currency1>[\\w]{3})$")
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax2>[\\.,\\d]+)\\- (?<currency2>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));
@@ -1244,7 +1237,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1255,7 +1248,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax1>[\\.,\\d]+)\\- (?<currency1>[\\w]{3})$")
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% .* [\\.,\\d]+ [\\w]{3} (?<tax2>[\\.,\\d]+)\\- (?<currency2>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(IS_JOINT_ACCOUNT)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
@@ -20,7 +20,7 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("91810s/Klagenfurt"); //$NON-NLS-1$
+        addBankIdentifier("91810s/Klagenfurt");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -29,7 +29,7 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "3BankenEDV"; //$NON-NLS-1$
+        return "3BankenEDV";
     }
 
     private void addBuySellTransaction()
@@ -52,7 +52,7 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
                 // Is type --> "Verkauf" change from BUY to SELL
                 .section("type").optional().match("Wertpapier\\-.* (?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EasyBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EasyBankAGPDFExtractor.java
@@ -26,7 +26,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("easybank Service Center"); //$NON-NLS-1$
+        addBankIdentifier("easybank Service Center");
 
         addBuySellTransaction();
         addDividendTransaction();
@@ -36,7 +36,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Easybank AG"; //$NON-NLS-1$
+        return "Easybank AG";
     }
 
     private void addBuySellTransaction()
@@ -60,13 +60,13 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Gesch.ftsart: (?<type>(Kauf|Verkauf|Kauf aus Dauerauftrag)).*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
-                // Titel: DE000A0F5UK5  i S h . S T . E u . 6 00 Bas.Res.U.ETF DE 
-                // Inhaber-Anlageaktien               
-                // Kurs: 66,88 EUR 
+                // Titel: DE000A0F5UK5  i S h . S T . E u . 6 00 Bas.Res.U.ETF DE
+                // Inhaber-Anlageaktien
+                // Kurs: 66,88 EUR
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
@@ -112,7 +112,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
                         )
 
-                // Zu Lasten IBAN AT00 0000 0000 0000 0000 -468,43 EUR 
+                // Zu Lasten IBAN AT00 0000 0000 0000 0000 -468,43 EUR
                 .section("amount", "currency")
                 .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
@@ -157,7 +157,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                                             if (t.getPortfolioTransaction().getNote() == null)
                                                 t.setNote(trim(v.get("note")));
                                             else
-                                                t.setNote(t.getPortfolioTransaction().getNote() + " | " + trim(v.get("note"))); //$NON-NLS-1$
+                                                t.setNote(t.getPortfolioTransaction().getNote() + " | " + trim(v.get("note")));
                                         })
                                 ,
                                 // Limit: 42,500000
@@ -168,7 +168,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                                             if (t.getPortfolioTransaction().getNote() == null)
                                                 t.setNote(trim(v.get("note")));
                                             else
-                                                t.setNote(t.getPortfolioTransaction().getNote() + " | " + trim(v.get("note"))); //$NON-NLS-1$
+                                                t.setNote(t.getPortfolioTransaction().getNote() + " | " + trim(v.get("note")));
                                         })
                         )
 
@@ -192,9 +192,9 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
         });
 
         pdfTransaction
-                // Titel: AT0000APOST4  O E S T E R R E I C H ISCHE POST AG  
+                // Titel: AT0000APOST4  O E S T E R R E I C H ISCHE POST AG
                 // AKTIEN O.N.
-                // Dividende: 1,9 EUR 
+                // Dividende: 1,9 EUR
                 .section("isin", "name", "name1", "currency").optional()
                 .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
@@ -206,10 +206,10 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
-                // Titel: DE000A14J587  t h y s s e n k r u p p AG                    
+                // Titel: DE000A14J587  t h y s s e n k r u p p AG
                 // Medium Term Notes v.15(25)
                 // Kup. 25.2.2023/GZJ Endfälligkeit 25.2.2025
-                // Zinsertrag für 365 Tage: 50,-- EUR 
+                // Zinsertrag für 365 Tage: 50,-- EUR
                 .section("isin", "name", "name1", "currency").optional()
                 .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
@@ -235,7 +235,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                                         .match("^(?<shares>[\\.,\\d]+) (?<notation>[\\w]{3}).*$")
                                         .assign((t, v) -> {
                                             // Percentage quotation, workaround for bonds
-                                            if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("Stk"))
+                                            if (v.get("notation") != null && !"Stk".equalsIgnoreCase(v.get("notation")))
                                             {
                                                 BigDecimal shares = asBigDecimal(v.get("shares"));
                                                 t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -261,7 +261,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
                         )
 
-                // Zu Gunsten IBAN AT12 1234 1234 1234 1234 123,75 EUR 
+                // Zu Gunsten IBAN AT12 1234 1234 1234 1234 123,75 EUR
                 .section("amount", "currency")
                 .match("^Zu Gunsten .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
@@ -270,8 +270,8 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .optionalOneOf(
-                                // Ertrag: 0,279 USD 
-                                // Bruttoertrag: 336,16 USD 
+                                // Ertrag: 0,279 USD
+                                // Bruttoertrag: 336,16 USD
                                 // Devisenkurs: 1,06145 (11.5.2022) 316,70 EUR
                                 section -> section
                                         .attributes("termCurrency","fxGross", "fxCurrency", "exchangeRate", "currency")
@@ -415,7 +415,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                // Kapitalertragsteuer: -52,25 EUR 
+                // Kapitalertragsteuer: -52,25 EUR
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
@@ -434,17 +434,17 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                 .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
-                // Quellensteuer: -327,58 EUR 
+                // Quellensteuer: -327,58 EUR
                 .section("withHoldingTax", "currency").optional()
                 .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
-                // Quellensteuer US-Emittent: -54,80 USD 
+                // Quellensteuer US-Emittent: -54,80 USD
                 .section("withHoldingTax", "currency").optional()
                 .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
-                // Umsatzsteuer: -0,62 EUR 
+                // Umsatzsteuer: -0,62 EUR
                 .section("tax", "currency").optional()
                 .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
@@ -463,12 +463,12 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                 .match("^Fremde Settlementspesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Fremde Spesen: -2,86 EUR 
+                // Fremde Spesen: -2,86 EUR
                 .section("fee", "currency").optional()
                 .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Eigene Spesen: -1,28 EUR 
+                // Eigene Spesen: -1,28 EUR
                 .section("fee", "currency").optional()
                 .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
@@ -478,8 +478,8 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
                 .match("^Devisenprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Grundgebühr: -3,-- EUR 
-                // Grundgebühr: -7,95 EUR 
+                // Grundgebühr: -3,-- EUR
+                // Grundgebühr: -7,95 EUR
                 .section("fee", "currency").optional()
                 .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
@@ -19,7 +19,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("European Bank for Financial Services GmbH"); //$NON-NLS-1$
+        addBankIdentifier("European Bank for Financial Services GmbH");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -32,7 +32,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "European Bank for Financial Services GmbH"; //$NON-NLS-1$
+        return "European Bank for Financial Services GmbH";
     }
 
     private void addBuySellTransaction()
@@ -90,25 +90,25 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                                 + "|Wiederanlage Fondsertrag"
                                 + "|Wiederanlage Ertragsaussch.ttung)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf")
-                                    || v.get("type").equals("Entgelt Verkauf")
-                                    || v.get("type").equals("Entgeltbelastung Verkauf")
-                                    || v.get("type").equals("Entnahmeplan")
-                                    || v.get("type").equals("Fondsumschichtung (Abgang)"))
+                    if ("Verkauf".equals(v.get("type"))
+                                    || "Entgelt Verkauf".equals(v.get("type"))
+                                    || "Entgeltbelastung Verkauf".equals(v.get("type"))
+                                    || "Entnahmeplan".equals(v.get("type"))
+                                    || "Fondsumschichtung (Abgang)".equals(v.get("type")))
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }
                 })
 
-                // Here we set a flag for all entries 
+                // Here we set a flag for all entries
                 // which should be skipped.
-                // If this is not done, it can happen that taxes and fees 
+                // If this is not done, it can happen that taxes and fees
                 // are included from the following entries
                 .section("type").optional()
                 .match("^(?<type>Fondsertrag) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Fondsertrag"))
-                        type.getCurrentContext().put("skipTransaction", Boolean.TRUE.toString());
+                    if ("Fondsertrag".equals(v.get("type")))
+                        type.getCurrentContext().putBoolean("skipTransaction", true);
                 })
 
                 // Kauf 300,00 EUR mit Kursdatum 20.11.2019 in Depotposition 1234567890.01
@@ -327,8 +327,8 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                 .match("^(?<note>Entgeltbelastung Verkauf) .*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
 
-                .wrap(t -> {                   
-                    if (type.getCurrentContext().get("skipTransaction") == null)
+                .wrap(t -> {
+                    if (!type.getCurrentContext().getBoolean("skipTransaction"))
                         return new BuySellEntryItem(t);
 
                     // If we have multiple entries in the document,
@@ -500,7 +500,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         // The advance tax payment is always paid in local currency.
         // If the security is in foreign currency,
         // the exchange rate is missing in the document for posting.
-        // 
+        //
         // Vorabpauschale zum Stichtag 31.12.2020 aus Depotposition xxx.21
         // Mor.St.Inv.-Global Opportunity Actions Nominatives A USD o.N.
         // Ref. Nr. 000/22012021, Buchungsdatum 22.01.2021
@@ -510,9 +510,9 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         // 0,03 EUR 0,00 EUR 0,00 EUR
         // Belastung der angefallenen Steuern in Höhe von 0,03 EUR erfolgt durch Verkauf aus Depotposition xxx.21 mit Ref. Nr.
         // 000/22012021
-        // 
+        //
         // --------------------------------------------------------
-        // 
+        //
         // Verkauf wegen Vorabpauschale 0,03 EUR mit Kursdatum 25.01.2021 aus Depotposition xxx.21
         // Mor.St.Inv.-Global Opportunity Actions Nominatives A USD o.N.
         // Ref. Nr. 000/22012021, Buchungsdatum 26.01.2021
@@ -667,7 +667,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>Eingang) externer .bertrag .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Eingang"))
+                    if ("Eingang".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -26,13 +26,13 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("BROKERJET"); //$NON-NLS-1$
-        addBankIdentifier("Brokerjet Bank AG"); //$NON-NLS-1$
-        addBankIdentifier("ERSTE BANK"); //$NON-NLS-1$
-        addBankIdentifier("FB-Nr."); //$NON-NLS-1$
-        addBankIdentifier("Sparkasse Bank AG"); //$NON-NLS-1$
-        addBankIdentifier("www.sparkasse.at"); //$NON-NLS-1$
-        addBankIdentifier("www.erstebank.at"); //$NON-NLS-1$
+        addBankIdentifier("BROKERJET");
+        addBankIdentifier("Brokerjet Bank AG");
+        addBankIdentifier("ERSTE BANK");
+        addBankIdentifier("FB-Nr.");
+        addBankIdentifier("Sparkasse Bank AG");
+        addBankIdentifier("www.sparkasse.at");
+        addBankIdentifier("www.erstebank.at");
 
         addBuySellTransaction_DocFormat01();
         addBuySellTransaction_DocFormat02();
@@ -44,7 +44,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Erste Bank Gruppe / Österreichischen Sparkassenverbands / BrokerJet"; //$NON-NLS-1$
+        return "Erste Bank Gruppe / Österreichischen Sparkassenverbands / BrokerJet";
     }
 
     private void addBuySellTransaction_DocFormat01()
@@ -68,7 +68,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(IHR )?(?<type>(KAUF|VERKAUF))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("VERKAUF"))
+                    if ("VERKAUF".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -356,7 +356,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^.*(?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -1086,25 +1086,25 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 
@@ -1114,25 +1114,25 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 
@@ -1142,25 +1142,25 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -32,10 +32,10 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("biw AG"); //$NON-NLS-1$
-        addBankIdentifier("FinTech Group Bank AG"); //$NON-NLS-1$
-        addBankIdentifier("flatex Bank AG"); //$NON-NLS-1$
-        addBankIdentifier("flatexDEGIRO Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("biw AG");
+        addBankIdentifier("FinTech Group Bank AG");
+        addBankIdentifier("flatex Bank AG");
+        addBankIdentifier("flatexDEGIRO Bank AG");
 
         addBuySellTransaction();
         addSummaryStatementBuySellTransaction();
@@ -53,7 +53,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "flatexDEGIRO Bank AG / FinTech Group Bank AG / biw AG"; //$NON-NLS-1$
+        return "flatexDEGIRO Bank AG / FinTech Group Bank AG / biw AG";
     }
 
     private void addBuySellTransaction()
@@ -136,7 +136,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
 
                         if (t.getPortfolioTransaction().getType().isPurchase())
-                            type.getCurrentContext().put("isPurchaseBonds", "X");
+                            type.getCurrentContext().putBoolean("isPurchaseBonds", true);
                     }
                     else
                     {
@@ -246,7 +246,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
                                                 t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
@@ -268,7 +268,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && !t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
 
@@ -294,7 +294,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
                                                 t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
@@ -316,7 +316,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && !t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
 
@@ -485,7 +485,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && !t.getPortfolioTransaction().getCurrencyCode().equals(v.get("fxCurrency")))
                                             {
-                                                type.getCurrentContext().put("negative", "X");
+                                                type.getCurrentContext().putBoolean("negative", true);
 
                                                 Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("gross")));
 
@@ -499,7 +499,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                             }
                                             else if (t.getPortfolioTransaction().getType().isLiquidation() && t.getPortfolioTransaction().getCurrencyCode().equals(v.get("fxCurrency")))
                                             {
-                                                type.getCurrentContext().put("negative", "X");
+                                                type.getCurrentContext().putBoolean("negative", true);
 
                                                 t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
                                                 t.setAmount(asAmount(v.get("gross")));
@@ -518,7 +518,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && t.getPortfolioTransaction().getCurrencyCode().equals(v.get("fxCurrency")))
                                             {
-                                                type.getCurrentContext().put("negative", "X");
+                                                type.getCurrentContext().putBoolean("negative", true);
 
                                                 t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
                                                 t.setAmount(asAmount(v.get("gross")));
@@ -543,7 +543,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && !t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money fxTaxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
 
@@ -566,7 +566,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             if (t.getPortfolioTransaction().getType().isLiquidation() && t.getPortfolioTransaction().getCurrencyCode().equals(v.get("currency")))
                                             {
-                                                type.getCurrentContext().put("negativeTax", "X");
+                                                type.getCurrentContext().putBoolean("negativeTax", true);
 
                                                 Money taxRefund = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxRefund")));
                                                 t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(taxRefund));
@@ -765,7 +765,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^(.* )?Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* Endbetrag([:\\s]+)? \\-[\\.,\\d]+ (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negative", "X");
+                                            type.getCurrentContext().putBoolean("negative", true);
 
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
@@ -804,7 +804,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^.* (?<type>(Bruttodividende|Bruttoaussch.ttung|Bruttothesaurierung))([:\\s]+)? (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .match("^.* Endbetrag([:\\s]+)? \\-[\\.,\\d]+ [\\w]{3}$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negative", "X");
+                                            type.getCurrentContext().putBoolean("negative", true);
 
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
@@ -952,7 +952,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* [\\*]+Einbeh\\. Steuer([:\\s]+)? (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .match("^.* Endbetrag([:\\s]+)? \\-[\\.,\\d]+ [\\w]{3}$")
                 .assign((t, v) -> {
-                    type.getCurrentContext().put("negative", "X");
+                    type.getCurrentContext().putBoolean("negative", true);
 
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                     t.setAmount(asAmount(v.get("amount")));
@@ -1574,6 +1574,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     {
         final DocumentType type = new DocumentType("(Depotausgang|Gutschrifts\\- \\/ Belastungsanzeige)", (context, lines) -> {
             Pattern pDate = Pattern.compile("^([\\s]+)?Frankfurt( am Main)?, ([\\s]+)?(den )?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
+
             for (String line : lines)
             {
                 Matcher mDate = pDate.matcher(line);
@@ -1900,6 +1901,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     {
         final DocumentType type = new DocumentType("Wertpapierabrechnung Vorabpauschale", (context, lines) -> {
             Pattern pDate = Pattern.compile("^Buchungsdatum ([\\s]+)?(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$");
+
             for (String line : lines)
             {
                 Matcher m = pDate.matcher(line);
@@ -2158,7 +2160,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* [\\*]+Einbeh\\. Steuer([:\\s]+)? \\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
@@ -2186,7 +2188,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("currency", "amount")
                                         .match("^.* [\\*]+Einbeh\\. Steuer([:\\s]+)? (?<currency>[\\w]{3}) ([\\s]+)?\\-(?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -2205,7 +2207,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* [\\*]+Einbeh\\. (Steuer|KESt)([:\\s]+)? \\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
@@ -2234,7 +2236,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("amount", "currency")
                                         .match("^.* [\\*]+Einbeh\\. (Steuer|KESt)([:\\s]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -2330,7 +2332,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs ([\\s]+)?: (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* [\\*]+Einbeh\\. Steuer([:\\s]+)? \\-(?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             if (!t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
@@ -2358,7 +2360,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("amount", "currency")
                                         .match("^.* [\\*]+Einbeh\\. Steuer([:\\s]+)? \\-(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            type.getCurrentContext().put("negativeTax", "X");
+                                            type.getCurrentContext().putBoolean("negativeTax", true);
 
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -2446,7 +2448,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
 
                     if (v.get("negative").startsWith("-"))
-                        type.getCurrentContext().put("negative", "X");
+                        type.getCurrentContext().putBoolean("negative", true);
                 })
 
                 .optionalOneOf(
@@ -2457,7 +2459,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("exchangeRate", "fxAmount", "fxCurrency")
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).* Provision([:\\s]+)? (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2469,7 +2471,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                                                 t.setMonetaryAmount(amount);
                                             }
-                                            else if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            else if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 t.setCurrencyCode(asCurrencyCode(v.get("fxCurrency")));
                                                 t.setAmount(asAmount(v.get("fxAmount")));
@@ -2483,7 +2485,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("amount", "currency")
                                         .match("^.* Provision([:\\s]+)? (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                 t.setAmount(asAmount(v.get("amount")));
@@ -2499,7 +2501,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("exchangeRate", "fxCurrency", "fxAmount")
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).* Provision([:\\s]+)? (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2520,7 +2522,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("currency", "amount")
                                         .match("^.* Provision([:\\s]+)? (?<currency>[\\w]{3}) ([\\s]+)?(?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                 t.setAmount(asAmount(v.get("amount")));
@@ -2538,7 +2540,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* Eigene Spesen([:\\s]+)? (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2550,7 +2552,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
                                             }
-                                            else if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            else if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2564,7 +2566,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("amount", "currency")
                                         .match("^.* Eigene Spesen([:\\s]+)? (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2582,7 +2584,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* Eigene Spesen([:\\s]+)? (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2594,7 +2596,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
                                             }
-                                            else if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            else if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2608,7 +2610,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("currency", "amount")
                                         .match("^.* Eigene Spesen([:\\s]+)? (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2626,7 +2628,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* \\*Fremde Spesen([:\\s]+)? (?<fxAmount>[\\.,\\d]+) (?<fxCurrency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2638,7 +2640,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
                                             }
-                                            else if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            else if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2652,7 +2654,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("amount", "currency")
                                         .match("^.* \\*Fremde Spesen([:\\s]+)? (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2670,7 +2672,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^Devisenkurs([:\\s]+)? (?<exchangeRate>[\\.,\\d]+).*$")
                                         .match("^.* \\*Fremde Spesen([:\\s]+)? (?<fxCurrency>[\\w]{3}) (?<fxAmount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && !t.getCurrencyCode().contentEquals(v.get("fxCurrency")))
                                             {
                                                 Money fxAmount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
 
@@ -2682,7 +2684,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
                                             }
-                                            else if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            else if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxAmount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2696,7 +2698,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                         .attributes("currency", "amount")
                                         .match("^.* \\*Fremde Spesen([:\\s]+)? (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if ("X".equals(type.getCurrentContext().get("negative")) && t.getCurrencyCode().contentEquals(v.get("currency")))
+                                            if (type.getCurrentContext().getBoolean("negative") && t.getCurrencyCode().contentEquals(v.get("currency")))
                                             {
                                                 Money amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
                                                 t.setMonetaryAmount(t.getMonetaryAmount().add(amount));
@@ -2880,7 +2882,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("withHoldingTax", "currency").optional()
                 .match("^.* Gez\\. (Quellenst\\.|Quellensteuer)([:\\s]+)? (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
@@ -2892,7 +2894,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* \\*\\*Einbeh\\. (Steuer|KESt)([:\\s]+)? (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                     {
                         Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
@@ -2918,7 +2920,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^.* \\*\\*Einbeh\\. (Steuer|KESt)([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                     {
                         Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
@@ -2943,7 +2945,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^.* \\*\\*\\*Einbeh\\. SichSt([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                     {
                         Money tax = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("tax")));
 
@@ -2968,7 +2970,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* \\*Einbeh\\. Steuer([:\\s]+)? (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -2978,7 +2980,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^.* Einbeh\\. Steuer\\*([:\\s]+)? (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -2988,7 +2990,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Steuerbetrag\\*\\* .* (?<tax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negativeTax")) && !"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negativeTax") && !type.getCurrentContext().getBoolean("negative"))
                         processTaxEntries(t, v, type);
                 });
     }
@@ -3005,7 +3007,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Provision([:\\s]+)? (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                     {
                         Money fee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
 
@@ -3030,7 +3032,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "fee").optional()
                 .match("^.* Provision([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                     {
                         Money fee = Money.of(asCurrencyCode(v.get("currency")),asAmount(v.get("fee")));
 
@@ -3056,7 +3058,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Eigene Spesen([:\\s]+)? (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3066,7 +3068,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "fee").optional()
                 .match("^.* Eigene Spesen([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3077,7 +3079,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* \\*Fremde Spesen([:\\s]+)? (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3087,7 +3089,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "fee").optional()
                 .match("^.* \\*Fremde Spesen([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3097,7 +3099,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Gesamtgeb.hr([:\\s]+)? (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")))
+                    if (!type.getCurrentContext().getBoolean("negative"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3107,7 +3109,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Zinsbetrag([:\\s]+)? (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && "X".equals(type.getCurrentContext().get("isPurchaseBonds")))
+                    if (!type.getCurrentContext().getBoolean("negative") && type.getCurrentContext().getBoolean("isPurchaseBonds"))
                         processFeeEntries(t, v, type);
                 })
 
@@ -3117,7 +3119,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                 .section("fee", "currency").optional()
                 .match("^.* Zinsbetrag([:\\s]+)? (?<currency>[\\w]{3})([\\s]+)? (?<fee>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && "X".equals(type.getCurrentContext().get("isPurchaseBonds")))
+                    if (!type.getCurrentContext().getBoolean("negative") && type.getCurrentContext().getBoolean("isPurchaseBonds"))
                         processFeeEntries(t, v, type);
                 });
     }
@@ -3125,17 +3127,17 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HargreavesLansdownPlcExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HargreavesLansdownPlcExtractor.java
@@ -30,7 +30,7 @@ public class HargreavesLansdownPlcExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Hargreaves Lansdown Asset Management Limited"); //$NON-NLS-1$
+        addBankIdentifier("Hargreaves Lansdown Asset Management Limited");
 
         addBuySellTransaction();
     }
@@ -38,7 +38,7 @@ public class HargreavesLansdownPlcExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Hargreaves Lansdown Asset Management Limited"; //$NON-NLS-1$
+        return "Hargreaves Lansdown Asset Management Limited";
     }
 
     private void addBuySellTransaction()
@@ -65,7 +65,7 @@ public class HargreavesLansdownPlcExtractor extends AbstractPDFExtractor
                                 + "S([\\s]+)?O([\\s]+)?L([\\s]+)?D))"
                                 + "([\\s]+)?\\*\\* ([\\s]+)?the security detailed below\\.$")
                 .assign((t, v) -> {
-                    if (stripBlanks(v.get("type")).equals("SOLD"))
+                    if ("SOLD".equals(stripBlanks(v.get("type"))))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -13,14 +13,15 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.Money;
 
+@SuppressWarnings("nls")
 public class HelloBankPDFExtractor extends AbstractPDFExtractor
 {
     public HelloBankPDFExtractor(Client client)
     {
         super(client);
 
-        addBankIdentifier("Hellobank"); //$NON-NLS-1$
-        addBankIdentifier("Hello bank!"); //$NON-NLS-1$
+        addBankIdentifier("Hellobank");
+        addBankIdentifier("Hello bank!");
 
         addBuySellTransaction();
         addDividendTransaction();
@@ -30,10 +31,9 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Hello Bank"; //$NON-NLS-1$
+        return "Hello Bank";
     }
 
-    @SuppressWarnings("nls")
     private void addBuySellTransaction()
     {
         DocumentType type = new DocumentType("Gesch.ftsart: (Kauf|Verkauf|Kauf aus Dauerauftrag)");
@@ -55,12 +55,12 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Gesch.ftsart: (?<type>(Kauf|Verkauf|Kauf aus Dauerauftrag))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
-                // Titel: NO0003054108  M a r i n e  H a r v est ASA   
-                // Kurs: 140 NOK 
+                // Titel: NO0003054108  M a r i n e  H a r v est ASA
+                // Kurs: 140 NOK
                 .section("isin", "name", "nameContinued", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<nameContinued>.*)$")
@@ -88,7 +88,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .match("^(Zugang|Abgang): (?<shares>[\\.,\\d]+) Stk.*$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                // Zu Lasten IBAN AT44 1925 0654 0668 9002 -1.118,80 EUR 
+                // Zu Lasten IBAN AT44 1925 0654 0668 9002 -1.118,80 EUR
                 .section("amount", "currency")
                 .match("^(Zu Lasten|Zu Gunsten) .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
@@ -96,9 +96,9 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                 })
 
-                // Kurswert: -10.360,-- NOK 
-                // -10.360,-- NOK 
-                // Devisenkurs: 9,486 (3.7.2017) -1.092,14 EUR 
+                // Kurswert: -10.360,-- NOK
+                // -10.360,-- NOK
+                // Devisenkurs: 9,486 (3.7.2017) -1.092,14 EUR
                 .section("termCurrency", "fxGross", "fxCurrency", "exchangeRate", "baseCurrency").optional()
                 .match("^Kurs: [\\-\\.,\\d]+ (?<termCurrency>[\\w]{3}).*$")
                 .match("^Kurswert: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
@@ -119,7 +119,6 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    @SuppressWarnings("nls")
     private void addDividendTransaction()
     {
         DocumentType type = new DocumentType("Gesch.ftsart: Ertrag");
@@ -134,9 +133,9 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         });
 
         pdfTransaction
-                // Titel: NO0003054108  M a r i n e  H a r v est ASA                 
-                // Navne-Aksjer NK 7,50               
-                // Dividende: 3,2 NOK 
+                // Titel: NO0003054108  M a r i n e  H a r v est ASA
+                // Navne-Aksjer NK 7,50
+                // Dividende: 3,2 NOK
                 .section("isin", "name", "nameContinued", "currency")
                 .match("^Titel: (?<isin>[\\w]{12}) (?<name>.*)$")
                 .match("^(?<nameContinued>.*)$")
@@ -153,7 +152,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .match("^Valuta (?<date>[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                // Zu Gunsten IBAN AT44 1925 0654 0668 9002 48,71 EUR 
+                // Zu Gunsten IBAN AT44 1925 0654 0668 9002 48,71 EUR
                 .section("amount", "currency")
                 .match("^Zu Gunsten .* (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
@@ -161,9 +160,9 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                 })
 
-                // Dividende: 3,2 NOK 
-                // Bruttoertrag: 640,-- NOK 
-                // Devisenkurs: 9,308 (5.9.2017) 49,85 EUR 
+                // Dividende: 3,2 NOK
+                // Bruttoertrag: 640,-- NOK
+                // Devisenkurs: 9,308 (5.9.2017) 49,85 EUR
                 .section("termCurrency","fxGross", "fxCurrency", "exchangeRate", "baseCurrency").optional()
                 .match("^(Dividende|Ertrag): [\\.,\\d]+ (?<termCurrency>[\\w]{3}).*$")
                 .match("^Bruttoertrag: (?<fxGross>[\\-\\.,\\d]+) (?<fxCurrency>[\\w]{3}).*$")
@@ -186,7 +185,6 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
         block.set(pdfTransaction);
     }
 
-    @SuppressWarnings("nls")
     private void addInboundDelivery()
     {
         DocumentType type = new DocumentType("Freier Erhalt");
@@ -202,9 +200,9 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                     return transaction;
                 })
 
-                // Titel: DK0060534915  N o v o - N o r d i s k AS                    
-                // Navne-Aktier B DK -,20             
-                // Lieferpflichtiger: Depotnummer: 99147 
+                // Titel: DK0060534915  N o v o - N o r d i s k AS
+                // Navne-Aktier B DK -,20
+                // Lieferpflichtiger: Depotnummer: 99147
                 .section("isin", "name", "name1", "currency")
                 .match("^Titel: (?<isin>\\S*) (?<name>.*)$")
                 .match("^(?<name1>.*)$")
@@ -212,7 +210,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (!v.get("name1").startsWith("Kurs") || !v.get("name1").startsWith("Verwahrart"))
                         v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
-                    
+
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -237,56 +235,54 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
                 .wrap(TransactionItem::new));
     }
 
-    @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                // Kapitalertragsteuer: -254,10 AUD 
+                // Kapitalertragsteuer: -254,10 AUD
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
-                // KESt Ausländische Dividende: -176,01 NOK 
+                // KESt Ausländische Dividende: -176,01 NOK
                 .section("tax", "currency").optional()
                 .match("^KESt Ausl.ndische Dividende: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type))
 
-                // Quellensteuer US-Emittent: -3,05 USD 
+                // Quellensteuer US-Emittent: -3,05 USD
                 .section("withHoldingTax", "currency").optional()
                 .match("^Quellensteuer US\\-Emittent: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
-                // Quellensteuer: -8,81 EUR 
+                // Quellensteuer: -8,81 EUR
                 .section("withHoldingTax", "currency").optional()
                 .match("^Quellensteuer: \\-(?<withHoldingTax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
-                // Umsatzsteuer: -0,19 EUR 
+                // Umsatzsteuer: -0,19 EUR
                 .section("tax", "currency").optional()
                 .match("^Umsatzsteuer: \\-(?<tax>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
-    @SuppressWarnings("nls")
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction
-                // Fremde Spesen: -25,20 EUR 
+                // Fremde Spesen: -25,20 EUR
                 .section("fee", "currency").optional()
                 .match("^Fremde Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Eigene Spesen: -6,42 EUR 
+                // Eigene Spesen: -6,42 EUR
                 .section("fee", "currency").optional()
                 .match("^Eigene Spesen: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Inkassoprovision: -0,95 EUR 
+                // Inkassoprovision: -0,95 EUR
                 .section("fee", "currency").optional()
                 .match("^Inkassoprovision: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Grundgebühr: -1,46 EUR 
+                // Grundgebühr: -1,46 EUR
                 .section("fee", "currency").optional()
                 .match("^Grundgeb.hr: \\-(?<fee>[\\-\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> processFeeEntries(t, v, type));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
-
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -28,33 +27,26 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 {
-    private static final String isJointAccount = "isJointAccount"; //$NON-NLS-1$
+    private static final String IS_JOINT_ACCOUNT = "isJointAccount";
 
     BiConsumer<DocumentContext, String[]> jointAccount = (context, lines) -> {
-        Pattern pJointAccount = Pattern.compile("KapSt anteilig 50,00 %.*"); //$NON-NLS-1$
-        Boolean bJointAccount = false;
+        Pattern pJointAccount = Pattern.compile("KapSt anteilig 50,00 %.*");
 
         for (String line : lines)
         {
-            Matcher m = pJointAccount.matcher(line);
-            if (m.matches())
+            if (pJointAccount.matcher(line).matches())
             {
-                context.put(isJointAccount, Boolean.TRUE.toString());
-                bJointAccount = true;
+                context.putBoolean(IS_JOINT_ACCOUNT, true);
                 break;
             }
         }
-
-        if (!bJointAccount)
-            context.put(isJointAccount, Boolean.FALSE.toString());
-
     };
 
     public INGDiBaPDFExtractor(Client client)
     {
         super(client);
 
-        addBankIdentifier("ING-DiBa AG"); //$NON-NLS-1$
+        addBankIdentifier("ING-DiBa AG");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -65,7 +57,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "ING-DiBa AG"; //$NON-NLS-1$
+        return "ING-DiBa AG";
     }
 
     private void addBuySellTransaction()
@@ -110,7 +102,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                 + "Verk. Teil\\-\\/Bezugsr\\.)|"
                                 + "R.ckzahlung|"
                                 + "Einl.sung)$")
-                .assign((t, v) -> {                    
+                .assign((t, v) -> {
                     if ("Verkauf".equals(v.get("type"))
                             || "Verk. Teil-/Bezugsr.".equals(v.get("type"))
                             || "Rückzahlung".equals(v.get("type"))
@@ -471,9 +463,9 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
             for (String line : lines)
             {
-                Matcher m = pCurrency.matcher(line);
-                if (m.matches())
-                    context.put("currency", m.group("currency"));
+                Matcher mCurrency = pCurrency.matcher(line);
+                if (mCurrency.matches())
+                    context.put("currency", mCurrency.group("currency"));
             }
         });
         this.addDocumentTyp(type);
@@ -628,7 +620,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -641,7 +633,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .match("^KapSt anteilig [\\.,\\d]+([\\s]+)?% [\\.,\\d]+([\\s]+)?% (?<currency1>[\\w]{3}) (?<tax1>[\\.,\\d]+)$")
                 .match("^KapSt anteilig [\\.,\\d]+([\\s]+)?% [\\.,\\d]+([\\s]+)?% (?<currency2>[\\w]{3}) (?<tax2>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));
@@ -663,7 +655,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -676,7 +668,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% (?<currency1>[\\w]{3}) (?<tax1>[\\.,\\d]+)$")
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% (?<currency2>[\\w]{3}) (?<tax2>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));
@@ -698,7 +690,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (!type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                         processTaxEntries(t, v, type);
                 })
 
@@ -711,7 +703,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% (?<currency1>[\\w]{3}) (?<tax1>[\\.,\\d]+)$")
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% (?<currency2>[\\w]{3}) (?<tax2>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (Boolean.parseBoolean(type.getCurrentContext().get(isJointAccount)))
+                    if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                     {
                         // Account 1
                         v.put("currency", v.get("currency1"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JustTradePDFExtractor.java
@@ -14,7 +14,7 @@ import name.abuchen.portfolio.money.CurrencyUnit;
 public class JustTradePDFExtractor extends AbstractPDFExtractor
 {
     /***
-     * Information: 
+     * Information:
      * Sutor always provides the amount in EUR, column "Betrag in EUR"
      */
 
@@ -22,9 +22,9 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("justTRADE"); //$NON-NLS-1$
-        addBankIdentifier("Sutor"); //$NON-NLS-1$
-        addBankIdentifier("SUTOR BANK"); //$NON-NLS-1$
+        addBankIdentifier("justTRADE");
+        addBankIdentifier("Sutor");
+        addBankIdentifier("SUTOR BANK");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -34,7 +34,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Sutor Bank / justTRADE"; //$NON-NLS-1$
+        return "Sutor Bank / justTRADE";
     }
 
     private void addBuySellTransaction()
@@ -58,7 +58,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(Transaktionsart: |Wertpapier Abrechnung )?(?<type>(Kauf|Verkauf|F.lligkeit\\/Verfall))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Fälligkeit/Verfall"))
+                    if ("Verkauf".equals(v.get("type")) || "Fälligkeit/Verfall".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -100,7 +100,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (v.get("name").endsWith(":"))
                         v.put("name", v.get("name").substring(0, v.get("name").length()-1));
-                    
+
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -143,11 +143,11 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                                         .attributes("currency", "amount")
                                         .match("^Ausmachender Betrag: (?<currency>\\p{Sc})(?<amount>[\\.,\\d]+)$")
                                         .assign((t, v) -> {
-                                            if (v.get("currency").equals("€"))
+                                            if ("€".equals(v.get("currency")))
                                                 v.put("currency", CurrencyUnit.EUR);
                                             else
                                                 v.put("currency", CurrencyUnit.USD);
-                                                
+
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
                                         })
@@ -199,7 +199,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     if (v.get("name").endsWith(":"))
                         v.put("name", v.get("name").substring(0, v.get("name").length()-1));
-                    
+
                     t.setSecurity(getOrCreateSecurity(v));
                 })
 
@@ -254,7 +254,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^.* (?<type>(Kauf|Verkauf|Geb.hrentilgung)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Gebührentilgung"))
+                    if ("Verkauf".equals(v.get("type")) || "Gebührentilgung".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -640,7 +640,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("Kapitalertragssteuer: (?<currency>\\p{Sc})(?<tax>[\\.,\\d]+)")
                 .assign((t, v) -> {
-                    if (v.get("currency").equals("€"))
+                    if ("€".equals(v.get("currency")))
                         v.put("currency", CurrencyUnit.EUR);
                     else
                         v.put("currency", CurrencyUnit.USD);
@@ -657,7 +657,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("Solidarit.tszuschlag: (?<currency>\\p{Sc})(?<tax>[\\.,\\d]+)")
                 .assign((t, v) -> {
-                    if (v.get("currency").equals("€"))
+                    if ("€".equals(v.get("currency")))
                         v.put("currency", CurrencyUnit.EUR);
                     else
                         v.put("currency", CurrencyUnit.USD);
@@ -674,7 +674,7 @@ public class JustTradePDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("Kirchensteuer: (?<currency>\\p{Sc})(?<tax>[\\.,\\d]+)")
                 .assign((t, v) -> {
-                    if (v.get("currency").equals("€"))
+                    if ("€".equals(v.get("currency")))
                         v.put("currency", CurrencyUnit.EUR);
                     else
                         v.put("currency", CurrencyUnit.USD);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
@@ -16,7 +16,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("KBC BANK NV"); //$NON-NLS-1$
+        addBankIdentifier("KBC BANK NV");
 
         addBuySellTransaction();
     }
@@ -24,7 +24,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "KBC Group NV"; //$NON-NLS-1$
+        return "KBC Group NV";
     }
 
     private void addBuySellTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -26,7 +26,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Keytrade Bank"); //$NON-NLS-1$
+        addBankIdentifier("Keytrade Bank");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -35,7 +35,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Keytrade Bank"; //$NON-NLS-1$
+        return "Keytrade Bank";
     }
 
     private void addBuySellTransaction()
@@ -49,13 +49,13 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
             // are outside the block.
             for (String line : lines)
             {
-                Matcher m = pTransaction.matcher(line);
-                if (m.matches())
+                Matcher mTransaction = pTransaction.matcher(line);
+                if (mTransaction.matches())
                 {
-                    context.put("shares", m.group("shares"));
-                    context.put("name", m.group("name"));
-                    context.put("isin", m.group("isin"));
-                    context.put("currency", m.group("currency"));
+                    context.put("shares", mTransaction.group("shares"));
+                    context.put("name", mTransaction.group("name"));
+                    context.put("isin", mTransaction.group("isin"));
+                    context.put("currency", mTransaction.group("currency"));
                 }
             }
         });
@@ -77,7 +77,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(Num.ro.*)?(?<type>(Kauf|Achat|Vente|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Vente"))
+                    if ("Verkauf".equals(v.get("type")) || "Vente".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -114,7 +114,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
                 .oneOf(
                                 // Ausführungsdatum und -zeit : 15/03/2021 12:31:50 CET
-                                // Date et heure d'exécution : 19/10/2020 11:53:03 CET 
+                                // Date et heure d'exécution : 19/10/2020 11:53:03 CET
                                 section -> section
                                         .attributes("date", "time")
                                         .match("^(Ausf.hrungsdatum und \\-zeit|Date et heure d.ex.cution)([\\s]+)?: (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$")
@@ -365,17 +365,17 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
@@ -384,17 +384,17 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
@@ -403,17 +403,17 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-        int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+        int lastDot = value.lastIndexOf(".");
+        int lastComma = value.lastIndexOf(",");
 
         // returns the greater of two int values
         if (Math.max(lastDot, lastComma) == lastDot)
         {
-            language = "en"; //$NON-NLS-1$
-            country = "US"; //$NON-NLS-1$
+            language = "en";
+            country = "US";
         }
 
         return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -21,7 +21,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("LGT Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("LGT Bank AG");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -30,7 +30,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "LGT Bank AG"; //$NON-NLS-1$
+        return "LGT Bank AG";
     }
 
     private void addBuySellTransaction()
@@ -194,6 +194,6 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH"); //$NON-NLS-1$ //$NON-NLS-2$
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
@@ -26,7 +26,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Lime Trading Corp"); //$NON-NLS-1$
+        addBankIdentifier("Lime Trading Corp");
 
         addAccountStatementTransaction();
     }
@@ -34,19 +34,19 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Lime Trading Corp."; //$NON-NLS-1$
+        return "Lime Trading Corp.";
     }
 
     /***
      * Information:
      * Lime Trading Corp. is a US-based financial services company.
      * The currency is US$.
-     * 
+     *
      * All security currencies are USD.
-     * 
+     *
      * CUSIP Number:
      * The CUSIP number is the WKN number.
-     * 
+     *
      * Dividend transactions:
      * The amount of dividends is reported in gross.
      */
@@ -54,14 +54,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
     {
         final DocumentType type = new DocumentType("ACCOUNT STATEMENT", (context, lines) -> {
             Pattern pYear = Pattern.compile("^.* STATEMENT PERIOD: .*, (?<year>[\\d]{4})$");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pYear.matcher(line);
-                if (m.matches())
-                {
-                    context.put("year", m.group("year"));
-                }
+                Matcher mYear = pYear.matcher(line);
+                if (mYear.matches())
+                    context.put("year", mYear.group("year"));
             }
         });
         this.addDocumentTyp(type);
@@ -90,7 +88,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)")
                         .assign((t, v) -> {
                             // Is type --> "Sell" change from BUY to SELL
-                            if (v.get("type").equals("Sell"))
+                            if ("Sell".equals(v.get("type")))
                             {
                                 t.setType(PortfolioTransaction.Type.SELL);
                             }
@@ -113,13 +111,13 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         // Date | Effective Description | CUSIP | Type of Activity | Quantity Market Price | Net Settlement Amount
         // -------------------------------------
         // Sep 16 Barrick Gold Co             14 067901108 Dividend 1.97
-        // 
+        //
         // Sep 17 Barrick Gold Co             14 067901108 Dividend 1.26
         // Sep 17 For Sec Withhold: Div   .25000 067901108 Foreign Withholding (0.31)
-        //  
+        //
         // Sep 15 Realty Income C             22 756109104 Dividend 5.18
         // Sep 15 Nra Withhold: Dividend 756109104 NRA Withhold (1.55)
-        //  
+        //
         // Sep 15 Tyson Foods Inc              6 902494103 Qualified Dividend 2.67
         // Sep 15 Nra Withhold: Dividend 902494103 NRA Withhold (0.80)
         // @formatter:on

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -24,8 +24,8 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("MLP Banking AG"); //$NON-NLS-1$
-        addBankIdentifier("MLP FDL AG"); //$NON-NLS-1$
+        addBankIdentifier("MLP Banking AG");
+        addBankIdentifier("MLP FDL AG");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -35,7 +35,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "MLP Banking AG"; //$NON-NLS-1$
+        return "MLP Banking AG";
     }
 
     private void addBuySellTransaction()
@@ -62,7 +62,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -92,7 +92,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                     t.setShares(asShares(v.get("shares")));
 
                     // Handshake, if there is a tax refund
-                    context.put("shares", v.get("shares"));  
+                    context.put("shares", v.get("shares"));
                 })
 
                 // Schlusstag 14.01.2021
@@ -159,10 +159,10 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                 .match("^.* (?<type>(Aussch.ttung|Dividende|Ertrag|Thesaurierung brutto)) pro (St\\.|St.ck) [\\.,\\d]+ [\\w]{3}$")
                 .match("^Ausmachender Betrag [\\.,\\d]+(?<sign>(\\+|\\-))? (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Thesaurierung brutto") && v.get("sign").equals("+"))
+                    if ("Thesaurierung brutto".equals(v.get("type")) && "+".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.TAX_REFUND);
 
-                    if (v.get("type").equals("Thesaurierung brutto") && v.get("sign").equals("-"))
+                    if ("Thesaurierung brutto".equals(v.get("type")) && "-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.TAXES);
                 })
 
@@ -259,9 +259,9 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                     Map<String, String> context = type.getCurrentContext();
 
                     // Is sign --> "S" change from DEPOSIT to REMOVAL
-                    if (v.get("sign").equals("S"))
+                    if ("S".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.REMOVAL);
-                    
+
                     // create a long date from the year in the context
                     t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + context.get("year")));
 
@@ -269,7 +269,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                     // Formatting some notes
-                    if (v.get("note").equals("LASTSCHRIFTEINR."))
+                    if ("LASTSCHRIFTEINR.".equals(v.get("note")))
                         v.put("note", "Lastschrifteinr.");
 
                     t.setNote(v.get("note"));
@@ -300,9 +300,9 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             Map<String, String> context = type.getCurrentContext();
 
                                             // Is sign --> "S" change from FEES_REFUND to FEES
-                                            if (v.get("sign").equals("S"))
+                                            if ("S".equals(v.get("sign")))
                                                 t.setType(AccountTransaction.Type.FEES);
-                                            
+
                                             // create a long date from the year in the context
                                             t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + context.get("year")));
 
@@ -310,16 +310,16 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                                             // Formatting some notes
-                                            if (v.get("note1").equals("DEPOTPREIS"))
+                                            if ("DEPOTPREIS".equals(v.get("note1")))
                                                 v.put("note1", "Depotpreis");
 
-                                            if (v.get("note1").equals("DEPOTENTGELT"))
+                                            if ("DEPOTENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Depotentgelt");
 
-                                            if (v.get("note1").equals("VERWALTUNGSENTGELT"))
+                                            if ("VERWALTUNGSENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Verwaltungsentgeld");
 
-                                            if (v.get("note1").equals("VERMOEGENSDEPOT"))
+                                            if ("VERMOEGENSDEPOT".equals(v.get("note1")))
                                                 v.put("note1", "Vermögensdepot");
 
                                             t.setNote(v.get("note1") + " " + v.get("note2"));
@@ -333,9 +333,9 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             Map<String, String> context = type.getCurrentContext();
 
                                             // Is sign --> "S" change from FEES_REFUND to FEES
-                                            if (v.get("sign").equals("S"))
+                                            if ("S".equals(v.get("sign")))
                                                 t.setType(AccountTransaction.Type.FEES);
-                                            
+
                                             // create a long date from the year in the context
                                             t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + context.get("year")));
 
@@ -343,28 +343,28 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                                             // Formatting some notes
-                                            if (v.get("note1").equals("DEPOTPREIS"))
+                                            if ("DEPOTPREIS".equals(v.get("note1")))
                                                 v.put("note1", "Depotpreis");
 
-                                            if (v.get("note1").equals("DEPOTENTGELT"))
+                                            if ("DEPOTENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Depotentgelt");
 
-                                            if (v.get("note1").equals("VERWALTUNGSENTGELT"))
+                                            if ("VERWALTUNGSENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Verwaltungsentgeld");
 
-                                            if (v.get("note1").equals("VERMOEGENSDEPOT"))
+                                            if ("VERMOEGENSDEPOT".equals(v.get("note1")))
                                                 v.put("note1", "Vermögensdepot");
 
-                                            if (v.get("note3").equals("QUARTAL I"))
+                                            if ("QUARTAL I".equals(v.get("note3")))
                                                 v.put("note3", "Q1/");
 
-                                            if (v.get("note3").equals("QUARTAL II"))
+                                            if ("QUARTAL II".equals(v.get("note3")))
                                                 v.put("note3", "Q2/");
 
-                                            if (v.get("note3").equals("QUARTAL III"))
+                                            if ("QUARTAL III".equals(v.get("note3")))
                                                 v.put("note3", "Q3/");
 
-                                            if (v.get("note3").equals("QUARTAL IV"))
+                                            if ("QUARTAL IV".equals(v.get("note3")))
                                                 v.put("note3", "Q4/");
 
                                             t.setNote(v.get("note1") + " " + v.get("note3") + v.get("note2"));
@@ -378,9 +378,9 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             Map<String, String> context = type.getCurrentContext();
 
                                             // Is sign --> "S" change from FEES_REFUND to FEES
-                                            if (v.get("sign").equals("S"))
+                                            if ("S".equals(v.get("sign")))
                                                 t.setType(AccountTransaction.Type.FEES);
-                                            
+
                                             // create a long date from the year in the context
                                             t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + context.get("year")));
 
@@ -388,28 +388,28 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                                             // Formatting some notes
-                                            if (v.get("note1").equals("DEPOTPREIS"))
+                                            if ("DEPOTPREIS".equals(v.get("note1")))
                                                 v.put("note1", "Depotpreis");
 
-                                            if (v.get("note1").equals("DEPOTENTGELT"))
+                                            if ("DEPOTENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Depotentgelt");
 
-                                            if (v.get("note1").equals("VERWALTUNGSENTGELT"))
+                                            if ("VERWALTUNGSENTGELT".equals(v.get("note1")))
                                                 v.put("note1", "Verwaltungsentgeld");
 
-                                            if (v.get("note1").equals("VERMOEGENSDEPOT"))
+                                            if ("VERMOEGENSDEPOT".equals(v.get("note1")))
                                                 v.put("note1", "Vermögensdepot");
 
-                                            if (v.get("note3").equals("QUARTAL I"))
+                                            if ("QUARTAL I".equals(v.get("note3")))
                                                 v.put("note3", "Q1/");
 
-                                            if (v.get("note3").equals("QUARTAL II"))
+                                            if ("QUARTAL II".equals(v.get("note3")))
                                                 v.put("note3", "Q2/");
 
-                                            if (v.get("note3").equals("QUARTAL III"))
+                                            if ("QUARTAL III".equals(v.get("note3")))
                                                 v.put("note3", "Q3/");
 
-                                            if (v.get("note3").equals("QUARTAL IV"))
+                                            if ("QUARTAL IV".equals(v.get("note3")))
                                                 v.put("note3", "Q4/");
 
                                             t.setNote(v.get("note1") + " " + v.get("note3") + v.get("note2"));
@@ -424,9 +424,9 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             Map<String, String> context = type.getCurrentContext();
 
                                             // Is sign --> "S" change from FEES_REFUND to FEES
-                                            if (v.get("sign").equals("S"))
+                                            if ("S".equals(v.get("sign")))
                                                 t.setType(AccountTransaction.Type.FEES);
-                                            
+
                                             // create a long date from the year in the context
                                             t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + context.get("year")));
 
@@ -434,7 +434,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                             t.setCurrencyCode(asCurrencyCode(context.get("currency")));
 
                                             // Formatting some notes
-                                            if (v.get("note1").equals("ERSTATTUNG VERTRIEBSFOLGEPROVISION"))
+                                            if ("ERSTATTUNG VERTRIEBSFOLGEPROVISION".equals(v.get("note1")))
                                                 v.put("note1", "Erstattung Vertriebsfolgeprovision");
 
                                             t.setNote(v.get("note1") + " " + v.get("note2"));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
@@ -17,7 +17,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Umsatzsteuer-ID DE198159260"); //$NON-NLS-1$
+        addBankIdentifier("Umsatzsteuer-ID DE198159260");
 
         addBuySellTransaction();
     }
@@ -25,7 +25,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "MERKUR PRIVATBANK KGaA"; //$NON-NLS-1$
+        return "MERKUR PRIVATBANK KGaA";
     }
 
     private void addBuySellTransaction()
@@ -41,25 +41,25 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
         });
 
         // @formatter:off
-        // Wertpapier Abrechnung Kauf 
+        // Wertpapier Abrechnung Kauf
         // @formatter:on
         Block firstRelevantLine = new Block("^Am Marktplatz.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction // @formatter:off
-                        // Wertpapier Abrechnung Verkauf 
+                        // Wertpapier Abrechnung Verkauf
                         // or
-                        // Wertpapier Abrechnung Kauf 
+                        // Wertpapier Abrechnung Kauf
                         // @formatter:on
                         .section("type").match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf)).*").assign((t, v) -> {
-                            if (v.get("type").equals("Verkauf"))
+                            if ("Verkauf".equals(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
 
                         // @formatter:off
                         // Stück 600 XTR.(IE) - MSCI WORLD              IE00BJ0KDQ92 (A1XB5U)
-                        // REGISTERED SHARES 1C O.N.     
+                        // REGISTERED SHARES 1C O.N.
                         // @formatter:on
                         .section("name", "name1", "isin", "wkn", "currency")
                         .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
@@ -22,7 +22,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("NIBC Direct"); //$NON-NLS-1$
+        addBankIdentifier("NIBC Direct");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -31,7 +31,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "NIBC Bank N.V."; //$NON-NLS-1$
+        return "NIBC Bank N.V.";
     }
 
     private void addBuySellTransaction()
@@ -58,12 +58,12 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("Wertpapier Abrechnung (?<type>(Kauf|Verkauf)).*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
                 // Stück 13 VANGUARD FTSE ALL-WORLD U.ETF      IE00B3RBWM25 (A1JX52)
-                // REGISTERED SHARES USD DIS.ON       
+                // REGISTERED SHARES USD DIS.ON
                 // ACCIONES NOM. EO -,10
                 // Handels-/Ausführungsplatz Quotrix (gemäß Weisung)
                 // Kurswert 1.029,99- EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -28,10 +28,10 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("onvista bank"); //$NON-NLS-1$
-        addBankIdentifier("OnVista Bank"); //$NON-NLS-1$
-        addBankIdentifier("onvist a bank"); //$NON-NLS-1$
-        addBankIdentifier("Frankfurt am Main"); //$NON-NLS-1$
+        addBankIdentifier("onvista bank");
+        addBankIdentifier("OnVista Bank");
+        addBankIdentifier("onvist a bank");
+        addBankIdentifier("Frankfurt am Main");
 
         addBuySellTransaction();
         addReinvestTransaction();
@@ -46,7 +46,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "OnVista Bank GmbH"; //$NON-NLS-1$
+        return "OnVista Bank GmbH";
     }
 
     private void addBuySellTransaction()
@@ -70,9 +70,9 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("(^|Wir haben für Sie )(?<type>verkauft|Gesamtf.lligkeit|Ausbuchung:)( .*)?$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("verkauft")
-                                    || v.get("type").equals("Gesamtfälligkeit")
-                                    || v.get("type").equals("Ausbuchung:"))
+                    if ("verkauft".equals(v.get("type"))
+                                    || "Gesamtfälligkeit".equals(v.get("type"))
+                                    || "Ausbuchung:".equals(v.get("type")))
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }
@@ -338,7 +338,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                 + "|[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\w]{3} [\\.,\\d]+)$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("STK"))
+                    if (v.get("notation") != null && !"STK".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -394,7 +394,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
             entry.setType(AccountTransaction.Type.DIVIDENDS);
             return entry;
         });
-        
+
         pdfTransaction
                 // If we have a gross reinvestment, then it is taxes.
 
@@ -494,7 +494,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                                     .match("^(?<notation>[\\w]{3}) (?<shares>[\\.,\\d]+)( [\\d]{2}\\.[\\d]{2}\\.[\\d]{4})? [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\w]{3} [\\.,\\d]+$")
                                     .assign((t, v) -> {
                                         // Percentage quotation, workaround for bonds
-                                        if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("STK"))
+                                        if (v.get("notation") != null && !"STK".equalsIgnoreCase(v.get("notation")))
                                         {
                                             BigDecimal shares = asBigDecimal(v.get("shares"));
                                             t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -756,7 +756,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupported);
                     return item;
                 });
-        
+
         block.set(pdfTransaction);
     }
 
@@ -768,17 +768,15 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         + "|Wertlose Ausbuchung"
                         + "|Kapitalerh.hung"
                         + "|Kapitalherabsetzung"
-                        + "|Umtausch" 
+                        + "|Umtausch"
                         + "|Ausbuchung der Rechte", (context, lines) -> {
             Pattern pDate = Pattern.compile("(^|^[\\s]+).*, (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pDate.matcher(line);
-                if (m.matches())
-                {
-                    context.put("date", m.group("date"));
-                }
+                Matcher mDate = pDate.matcher(line);
+                if (mDate.matches())
+                    context.put("date", mDate.group("date"));
             }
         });
         this.addDocumentTyp(type);
@@ -848,7 +846,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("note").optional()
                 .match("^(?<note>Einbuchung der Rechte zur Dividende wahlweise\\.) .*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
-                
+
                 // Im Zuge der Geldzahlung erfolgt die Ausbuchung der Rechte. Ein separater Beleg wird nicht erstellt.
                 .section("note").optional()
                 .match("^(?<note>Im Zuge der Geldzahlung erfolgt die Ausbuchung der Rechte\\. Ein separater Beleg wird nicht erstellt\\.).*$")
@@ -901,7 +899,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<notation>[\\w]{3}) (?<shares>[\\.,\\d]+) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("STK"))
+                    if (v.get("notation") != null && !"STK".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -925,7 +923,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setAmount(asAmount(v.get("amount")));
                 })
 
-                // Für die Registrierung der Namens-Aktien (auf Ihren Namen) im Aktionärs-Register belasten wir Ihrem Konto vorstehenden 
+                // Für die Registrierung der Namens-Aktien (auf Ihren Namen) im Aktionärs-Register belasten wir Ihrem Konto vorstehenden
                 .section("note").optional()
                 .match("^F.r die (?<note>Registrierung der Namens\\-Aktien) .*$")
                 .assign((t, v) -> t.setNote(v.get("note")))
@@ -953,28 +951,22 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 // EUR - Verrechnungskonto: 0 111111 222
                 Matcher m = pCurrency.matcher(line);
                 if (m.matches())
-                {
                     context.put("currency", m.group("currency"));
-                }
+
                 // Ihre Kontonummer : 172306238 : Customer Cash Account  EUR
                 m = pCurrency2.matcher(line);
                 if (m.matches())
-                {
                     context.put("currency", m.group("currency2"));
-                }
 
                 // Kontoauszug Nr. 2017 / 2 und Rechnungsabschluss zum 30.06.2017
                 m = pYear.matcher(line);
                 if (m.matches())
-                {
                     context.put("year", m.group("year"));
-                }
+
                 // KONTOAUSZUG Nr. 2 per 30.06.2015
                 m = pYear2.matcher(line);
                 if (m.matches())
-                {
                     context.put("year", m.group("year2"));
-                }
             }
         });
         this.addDocumentTyp(type);
@@ -999,7 +991,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<note>.berweisung(seingang|ausgang) SEPA)( .*)?$")
                 .assign((t, v) -> {
                     // Is sign is negative change to REMOVAL
-                    if (v.get("sign").equals("-"))
+                    if ("-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.REMOVAL);
 
                     t.setDateTime(asDate(v.get("date") + type.getCurrentContext().get("year")));
@@ -1031,7 +1023,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("^(Portogebuehren )?(?<note2>([\\d]{2}\\/[\\d]{2}|[\\d]{1}\\. Quartal [\\d]{4}))$")
                 .assign((t, v) -> {
                     // Is sign is positiv change to FEES_REFUND
-                    if (v.get("sign").equals("-"))
+                    if ("-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.FEES);
                     else
                         t.setType(AccountTransaction.Type.FEES_REFUND);
@@ -1049,7 +1041,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<note>.berziehungszinsen)$")
                 .assign((t, v) -> {
                     // Is sign is positiv change to INTEREST
-                    if (v.get("sign").equals("-"))
+                    if ("-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.INTEREST_CHARGE);
                     else
                         t.setType(AccountTransaction.Type.INTEREST);
@@ -1284,7 +1276,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                 })
 
-                // Handelstag 15.12.2020 Kurswert USD 4.872,01 
+                // Handelstag 15.12.2020 Kurswert USD 4.872,01
                 // 17.12.2020 241462046 EUR/USD 1,2239 EUR 3.965,72
                 .section("fxCurrency", "baseCurrency", "termCurrency", "exchangeRate").optional()
                 .match("^.* Kurswert (?<fxCurrency>[\\w]{3}) [\\.,\\d]+([-\\s])?$")
@@ -1318,14 +1310,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
     {
         DocumentType type = new DocumentType("Umtausch", (context, lines) -> {
             Pattern pDate = Pattern.compile("(^|^[\\s]+).*, (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pDate.matcher(line);
-                if (m.matches())
-                {
-                    context.put("date", m.group("date"));
-                }
+                Matcher mDate = pDate.matcher(line);
+                if (mDate.matches())
+                    context.put("date", mDate.group("date"));
             }
         });
         this.addDocumentTyp(type);
@@ -1375,7 +1365,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("^(?<notation>[\\w]{3}) (?<shares>[\\.,\\d]+)( [\\d]{2}\\.[\\d]{2}\\.[\\d]{4})?$")
                 .assign((t, v) -> {
                     // Percentage quotation, workaround for bonds
-                    if (v.get("notation") != null && !v.get("notation").equalsIgnoreCase("STK"))
+                    if (v.get("notation") != null && !"STK".equalsIgnoreCase(v.get("notation")))
                     {
                         BigDecimal shares = asBigDecimal(v.get("shares"));
                         t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
@@ -1441,7 +1431,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
         transaction
                 .section("n").optional()
                 .match("zu versteuern \\(negativ\\) (?<n>.*)")
-                .assign((t, v) -> type.getCurrentContext().put("negative", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("negative", true));
 
         // If we have a gross reinvestment, we set a flag and don't book tax
         // below.
@@ -1449,14 +1439,14 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("n").optional()
                 .match("^Ertragsthesaurierung .*$")
                 .match("Steuerliquidit.t (?<n>.*)")
-                .assign((t, v) -> type.getCurrentContext().put("noTax", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("noTax", true));
 
         transaction
                 // Handelsplatz außerbörslich Lang & Schwarz Frz. Finanztrans. Steuer EUR 11,19-
                 .section("currency", "tax").optional()
                 .match("^.* Finanztrans\\. Steuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
@@ -1466,7 +1456,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("(^|^.* )Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
@@ -1477,7 +1467,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("(^|^.* )Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
@@ -1487,12 +1477,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("(^|^.* )Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)\\-$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
                 })
-                
+
                 // ausländische Dividende EUR 4,13
                 // ausländische Quellensteuer 27% DKK 8,34
                 // anrechenbare Quellensteuer 15% DKK 4,64
@@ -1500,7 +1490,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("ausländische Quellensteuer( [\\.,\\d]+%|.*)? (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
@@ -1513,12 +1503,12 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("(^.* davon |^davon )anrechenbare US-Quellensteuer( [\\.,\\d]+%|.*)? (?<currency>[\\w]{3}) (?<creditableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                     }
                 })
-                
+
                 // ausl. Dividendenanteil (Ausschüttung) EUR 0,98
                 // anrechenbare Quellensteuer EUR 0,03
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 0,03
@@ -1526,40 +1516,40 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .match("anrechenbare Quellensteuer (?<currency>[\\w]{3}) (?<creditableWithHoldingTax>[\\.,\\d]+)$")
                 .match(".* davon anrechenbare Quellensteuer Fondseingangsseite [\\w]{3} [\\.,\\d]+$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                     }
                 })
 
                 // einbehaltene Kapitalertragsteuer EUR 1,81
-                // einbehaltene Kapitalertragsteuer EUR              0,39     
+                // einbehaltene Kapitalertragsteuer EUR              0,39
                 .section("tax", "currency").optional()
                 .match("^einbehaltene Kapitalertragsteuer ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
                 })
 
                 // einbehaltener Solidaritätszuschlag EUR 0,10
-                // einbehaltener Solidaritätszuschlag  EUR              0,02     
+                // einbehaltener Solidaritätszuschlag  EUR              0,02
                 .section("tax", "currency").optional()
                 .match("^einbehaltener Solidarit.tszuschlag ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
                 })
 
                 // einbehaltene Kirchensteuer EUR 5,86
-                // einbehaltener Kirchensteuer  EUR              0,02 
+                // einbehaltener Kirchensteuer  EUR              0,02
                 .section("tax", "currency").optional()
                 .match("^einbehaltene Kirchensteuer(  Ehegatte\\/Lebenspartner)? ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }
@@ -1569,7 +1559,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^einbehaltene Kirchensteuer Ehegatte\\/Lebenspartner ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                     {
                         processTaxEntries(t, v, type);
                     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OpenBankSAPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OpenBankSAPDFExtractor.java
@@ -16,7 +16,7 @@ public class OpenBankSAPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("OPEN BANK"); //$NON-NLS-1$
+        addBankIdentifier("OPEN BANK");
 
         addBuySellTransaction();
     }
@@ -24,7 +24,7 @@ public class OpenBankSAPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Open Bank S.A."; //$NON-NLS-1$
+        return "Open Bank S.A.";
     }
 
     private void addBuySellTransaction()
@@ -48,7 +48,7 @@ public class OpenBankSAPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^.* TRANSAKTION .* (?<type>(ZEICHNUNG|R.CKERSTATTUNG|MAXIMAL VERF.GBARE ERSTATTUNG))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("RÜCKERSTATTUNG") || v.get("type").equals("MAXIMAL VERFÜGBARE ERSTATTUNG"))
+                    if ("RÜCKERSTATTUNG".equals(v.get("type")) || "MAXIMAL VERFÜGBARE ERSTATTUNG".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PictetCieGruppeSAPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PictetCieGruppeSAPDFExtractor.java
@@ -21,7 +21,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Banque Pictet & Cie SA"); //$NON-NLS-1$
+        addBankIdentifier("Banque Pictet & Cie SA");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -30,7 +30,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Banque Pictet & Cie SA"; //$NON-NLS-1$
+        return "Banque Pictet & Cie SA";
     }
 
     private void addBuySellTransaction()
@@ -54,7 +54,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Purchase|Sale)) (\\-)?[\\.'\\d]+ .* [\\w]{3} [\\.'\\d]+$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Sale"))
+                    if ("Sale".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -62,7 +62,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Purchase|Sale)) [\\w]{3} (\\-)?[\\.'\\d]+ .* [\\.'\\d]+%$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Sale"))
+                    if ("Sale".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -117,7 +117,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
                                 section -> section
                                         .attributes("currency", "amount")
                                         .match("^Net amount (?<currency>[\\w]{3}) (\\-)?(?<amount>[\\.'\\d]+).*$")
-                                        .assign((t, v) -> {                                                
+                                        .assign((t, v) -> {
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
                                         })
@@ -245,6 +245,6 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH"); //$NON-NLS-1$ //$NON-NLS-2$
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
@@ -22,8 +22,8 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("quirin bank AG"); //$NON-NLS-1$
-        addBankIdentifier("Quirin Privatbank AG"); //$NON-NLS-1$
+        addBankIdentifier("quirin bank AG");
+        addBankIdentifier("Quirin Privatbank AG");
 
         addBuySellTransaction_Format01();
         addBuySellTransaction_Format02();
@@ -35,7 +35,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Quirin Privatbank AG"; //$NON-NLS-1$
+        return "Quirin Privatbank AG";
     }
 
     private void addBuySellTransaction_Format01()
@@ -59,7 +59,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -127,7 +127,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -138,7 +138,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 //
                 // Nominal/Stück Hewlett-Packard Co. Registered Shares DL -,01
                 // ST 150 ISIN US4282361033
-                // Kurs 39,99667 USD Kurswert -5.999,50 USD -4.734,08 EUR 
+                // Kurs 39,99667 USD Kurswert -5.999,50 USD -4.734,08 EUR
                 .section("name", "isin", "currency")
                 .match("^Nominal\\/St.ck (?<name>.*)$")
                 .match("^ST [\\.,\\d]+ ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$")
@@ -191,7 +191,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                                         })
                         )
 
-                // Kurs 39,99667 USD Kurswert -5.999,50 USD -4.734,08 EUR 
+                // Kurs 39,99667 USD Kurswert -5.999,50 USD -4.734,08 EUR
                 // Devisenkurs  1,267300
                 .section("fxGross", "fxCurrency", "gross", "currency", "exchangeRate").optional()
                 .match("^.* Kurswert ([\\-\\s])?(?<fxGross>[\\.,\\d]+) (?<fxCurrency>[\\w]{3}) ([\\-\\s])?(?<gross>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
@@ -268,7 +268,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 })
 
                 // Dividenden für 01.01.2009-31.12.2009 Bruttobetrag  163,08 USD  124,50 EUR
-                // Devisenkurs  1,309900  
+                // Devisenkurs  1,309900
                 .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "fxCurrency", "gross", "currency").optional()
                 .match("^(Umrechnungskurs|Exchange Rate): (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$")
                 .match("^(Bruttobetrag|Gross Amount) (?<fxCurrency>[\\w]{3}) (?<fxGross>[\\.,\\d]+)$")
@@ -328,7 +328,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 .match("^ST (?<shares>[\\.,\\d]+) ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$")
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                // Zahlungstag 27.01.2010  
+                // Zahlungstag 27.01.2010
                 .section("date")
                 .match("^Zahlungstag (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
                 .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
@@ -340,7 +340,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
                 // The net amount is determined on the taxes and
                 // withholding taxes.
                 // formatter:on
-                
+
                 // Dividenden für 01.10.2008-30.09.2009 Bruttobetrag  83,20 EUR
                 // Dividenden für 01.01.2009-31.12.2009 Bruttobetrag  163,08 USD  124,50 EUR
                 .section("amount", "currency")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -28,11 +28,11 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Raiffeisenbank"); //$NON-NLS-1$
-        addBankIdentifier("RB Augsburger Land West eG"); //$NON-NLS-1$
-        addBankIdentifier("Raiffeisenlandesbank"); //$NON-NLS-1$
-        addBankIdentifier("Freisinger Bank eG"); //$NON-NLS-1$
-        addBankIdentifier("VR Bank"); //$NON-NLS-1$
+        addBankIdentifier("Raiffeisenbank");
+        addBankIdentifier("RB Augsburger Land West eG");
+        addBankIdentifier("Raiffeisenlandesbank");
+        addBankIdentifier("Freisinger Bank eG");
+        addBankIdentifier("VR Bank");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -43,7 +43,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Raiffeisenbank Bankgruppe"; //$NON-NLS-1$
+        return "Raiffeisenbank Bankgruppe";
     }
 
     private void addBuySellTransaction()
@@ -68,7 +68,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(Gesch.ftsart:|Wertpapier Abrechnung) (?<type>(Kauf|Verkauf|R.cknahme Fonds)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Rücknahme Fonds"))
+                    if ("Verkauf".equals(v.get("type")) || "Rücknahme Fonds".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -558,7 +558,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. .* [\\.,\\d]+ (?<type>[S|H])$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("H"))
+                    if ("H".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.DEPOSIT);
                 })
 
@@ -594,7 +594,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                     if (context.get("nr").compareTo("01") == 0  && Integer.parseInt(v.get("month")) < 3)
                     {
                         int year = Integer.parseInt(context.get("year")) + 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + Integer.toString(year)));
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + year));
                     }
                     else
                     {
@@ -643,7 +643,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. .* [.,\\d]+ (?<type>[S|H])$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("S"))
+                    if ("S".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.INTEREST_CHARGE);
                 })
 
@@ -663,7 +663,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                     if (context.get("nr").compareTo("01") == 0  && Integer.parseInt(v.get("month")) < 3)
                     {
                         int year = Integer.parseInt(context.get("year")) + 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + Integer.toString(year)));
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + year));
                     }
                     else
                     {
@@ -695,7 +695,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. .* [\\.,\\d]+ (?<type>[S|H])$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("H"))
+                    if ("H".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.FEES_REFUND);
                 })
 
@@ -721,7 +721,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                     if (context.get("nr").compareTo("01") == 0  && Integer.parseInt(v.get("month")) < 3)
                     {
                         int year = Integer.parseInt(context.get("year")) + 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + Integer.toString(year)));
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + year));
                     }
                     else
                     {
@@ -750,7 +750,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                     if (context.get("nr").compareTo("01") == 0  && Integer.parseInt(v.get("month")) < 3)
                     {
                         int year = Integer.parseInt(context.get("year")) + 1;
-                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + Integer.toString(year)));
+                        t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + year));
                     }
                     else
                     {
@@ -777,7 +777,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("n").optional()
                 .match("^Zu (?<n>Lasten) .* \\-[\\.,\\d]+ [\\w]{3}.*$")
                 .match("^Belastung KESt bei aussch.ttungsgleichen Erträgen .*$")
-                .assign((t, v) -> type.getCurrentContext().put("noTax", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("noTax", true));
 
         transaction
                 // @formatter:off
@@ -786,7 +786,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -796,7 +796,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -806,7 +806,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kirchensteuer [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\d.]+,\\d+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -816,7 +816,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Quellensteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -826,7 +826,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Auslands\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -836,7 +836,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^KESt ausl.ndische Dividende: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -846,7 +846,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -856,7 +856,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Umsatzsteuer: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -866,7 +866,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kursgewinn\\-KESt: \\-(?<tax>[\\.,\\d]+) (?<currency>[\\w]{3}).*$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -876,7 +876,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("withHoldingTax", "currency").optional()
                 .match("^Einbehaltene Quellensteuer [\\.,\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
@@ -886,7 +886,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("^Anrechenbare Quellensteuer [\\.,\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                 });
     }
@@ -961,25 +961,25 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de"; //$NON-NLS-1$
-        String country = "DE"; //$NON-NLS-1$
+        String language = "de";
+        String country = "DE";
 
-        int apostrophe = value.indexOf("\'"); //$NON-NLS-1$
+        int apostrophe = value.indexOf("\'");
         if (apostrophe >= 0)
         {
-            language = "de"; //$NON-NLS-1$
-            country = "CH"; //$NON-NLS-1$
+            language = "de";
+            country = "CH";
         }
         else
         {
-            int lastDot = value.lastIndexOf("."); //$NON-NLS-1$
-            int lastComma = value.lastIndexOf(","); //$NON-NLS-1$
+            int lastDot = value.lastIndexOf(".");
+            int lastComma = value.lastIndexOf(",");
 
             // returns the greater of two int values
             if (Math.max(lastDot, lastComma) == lastDot)
             {
-                language = "en"; //$NON-NLS-1$
-                country = "US"; //$NON-NLS-1$
+                language = "en";
+                country = "US";
             }
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
@@ -19,16 +19,16 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
     private static final String DEPOSIT_2019 = "^(?<date>\\d+.\\d+.)  (.*-Gutschrift)(\\s*)(?<amount>[\\d\\s,.]*)(\\+$)";
     private static final String REMOVAL_2019 = "^(?<date>\\d+.\\d+.)  (Internet-Euro-Überweisung)(\\s*)(?<amount>[\\d\\s,.]*)(\\-)(.*)";
     private static final String INTEREST_2019 = "^(?<date>\\d+.\\d+.)  (.*)(Zinsen\\/Kontoführung)(\\s*)(?<amount>[\\d\\s,.]*)(\\+$)";
-    
+
     private static final String DEPOSIT_2021 = "^(?<date>\\d+.\\d+.) (\\d+.\\d+.) (.*gutschr\\.?)(\\s*)(?<amount>[\\d\\s,.]*) [H]";
     private static final String REMOVAL_2021 = "^(?<date>\\d+.\\d+.) (\\d+.\\d+.) (Umbuchung)(\\s*)(?<amount>[\\d\\s,.]*) [S]";
     private static final String INTEREST_2021 = "^(?<date>\\d+.\\d+.) (\\d+.\\d+.) (Abschluss)(\\s*)(?<amount>[\\d\\s,.]*) [H]";
-    
+
     private static final String DEPOSIT_2022 = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Zahlungseingang) (\\w+) (?<amount>[\\d\\s,.]*?) (.*)";
     private static final String REMOVAL_2022 = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (.berweisung) (\\w+) (\\-)(?<amount>[\\d\\s,.]*?) (.*)";
     private static final String INTEREST_2022 = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (\\w+zinsen) (\\w+) (?<amount>[\\d\\s,.]*?) (.*)";
     private static final String TAXES_2022 = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Kapitalertragsteuer) (\\w+) (\\-)(?<amount>[\\d\\s,.]*?) (.*)";
-    
+
     private static final String CONTEXT_KEY_YEAR = "year";
     private static final String CONTEXT_KEY_CURRENCY = "currency";
     private static final String CONTEXT_KEY_TRANSACTIONS_HAVE_FULL_DATE = "transactions_full_date";
@@ -38,9 +38,9 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("305 200 37"); //$NON-NLS-1$
-        addBankIdentifier("Renault Bank direkt"); //$NON-NLS-1$
-        
+        addBankIdentifier("305 200 37");
+        addBankIdentifier("Renault Bank direkt");
+
         addTransactionWith2019Format();
         addTransactionWith2021Format();
         addTransactionWith2022Format();
@@ -49,7 +49,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Renault Bank direkt"; //$NON-NLS-1$
+        return "Renault Bank direkt";
     }
 
     private void addTransactionWith2019Format()
@@ -64,12 +64,12 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         Block removalBlock = new Block(REMOVAL_2019);
         removalBlock.set(removalTransaction(type, REMOVAL_2019));
         type.addBlock(removalBlock);
-        
+
         Block interestBlock = new Block(INTEREST_2019);
         interestBlock.set(interestTransaction(type, INTEREST_2019));
         type.addBlock(interestBlock);
     }
-    
+
     private void addTransactionWith2021Format()
     {
         DocumentType type = new DocumentType("Renault Bank direkt", contextProvider2021());
@@ -82,12 +82,12 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         Block removalBlock = new Block(REMOVAL_2021);
         removalBlock.set(removalTransaction(type, REMOVAL_2021));
         type.addBlock(removalBlock);
-        
+
         Block interestBlock = new Block(INTEREST_2021);
         interestBlock.set(interestTransaction(type, INTEREST_2021));
         type.addBlock(interestBlock);
     }
-    
+
     private void addTransactionWith2022Format()
     {
         DocumentType type = new DocumentType("Renault Bank direkt", contextProvider2022());
@@ -100,11 +100,11 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         Block removalBlock = new Block(REMOVAL_2022);
         removalBlock.set(removalTransaction(type, REMOVAL_2022));
         type.addBlock(removalBlock);
-        
+
         Block interestBlock = new Block(INTEREST_2022);
         interestBlock.set(interestTransaction(type, INTEREST_2022));
         type.addBlock(interestBlock);
-        
+
         Block taxesBlock = new Block(TAXES_2022);
         taxesBlock.set(taxesTransaction(type, TAXES_2022));
         type.addBlock(taxesBlock);
@@ -145,7 +145,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
                         .assign(assignmentsProvider(type))
                         .wrap(TransactionItem::new);
     }
-    
+
     private Transaction<AccountTransaction> taxesTransaction(DocumentType type, String regex)
     {
         return new Transaction<AccountTransaction>().subject(() -> {
@@ -164,14 +164,14 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
             Map<String, String> context = type.getCurrentContext();
 
             boolean transactionsHaveFullDate = CONTEXT_VALUE_TRUE.equals(context.get(CONTEXT_KEY_TRANSACTIONS_HAVE_FULL_DATE));
-            
+
             String date = matcherMap.get("date");
-            
+
             if (!transactionsHaveFullDate)
             {
                 date += context.get(CONTEXT_KEY_YEAR);
             }
-            
+
             transaction.setDateTime(asDate(date));
             transaction.setAmount(asAmount(matcherMap.get("amount")));
             transaction.setCurrencyCode(context.get(RenaultBankDirektPDFExtractor.CONTEXT_KEY_CURRENCY));
@@ -184,7 +184,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
             Pattern yearPattern = Pattern.compile("(.*)(KONTOAUSZUG  Nr. )(\\d+)\\/(?<year>\\d{4})");
             Pattern currencyPattern = Pattern
                             .compile("(.*)(Summe Zinsen\\/Kontoführung)(\\s*)                (?<currency>[\\w]{3})(.*)");
-            
+
             contextProviderCommon(context, lines, yearPattern, currencyPattern);
         };
     }
@@ -208,9 +208,9 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
             contextProviderCommon(context, lines, null, currencyPattern);
         };
     }
-    
+
     private void contextProviderCommon(Map<String, String> context,
-                    String[] lines, 
+                    String[] lines,
                     Pattern yearPattern,
                     Pattern currencyPattern)
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
@@ -26,7 +26,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Revolut Trading Ltd"); //$NON-NLS-1$
+        addBankIdentifier("Revolut Trading Ltd");
 
         addBuySellTransaction();
         addAccountStatementTransaction();
@@ -35,7 +35,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Revolut Trading Ltd."; //$NON-NLS-1$
+        return "Revolut Trading Ltd.";
     }
 
     private void addBuySellTransaction()
@@ -49,7 +49,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
             entry.setType(PortfolioTransaction.Type.BUY);
             return entry;
         });
-        
+
         Block firstRelevantLine = new Block("^Order details$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
@@ -59,7 +59,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^.* (?<type>Sell) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Sell"))
+                    if ("Sell".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -91,8 +91,8 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
 
     /***
      * Information:
-     * We cannot import in the bank statement the purchases, 
-     * sales, dividends, etc. because the amounts of price and 
+     * We cannot import in the bank statement the purchases,
+     * sales, dividends, etc. because the amounts of price and
      * number of shares are not correctly reported.
      */
     private void addAccountStatementTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -30,9 +30,9 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("S Broker AG & Co. KG"); //$NON-NLS-1$
-        addBankIdentifier("Sparkasse"); //$NON-NLS-1$
-        addBankIdentifier("Stadtsparkasse"); //$NON-NLS-1$
+        addBankIdentifier("S Broker AG & Co. KG");
+        addBankIdentifier("Sparkasse");
+        addBankIdentifier("Stadtsparkasse");
 
         addBuySellTransaction();
         addDividendTransaction();
@@ -43,7 +43,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "S Broker AG & Co. KG / Sparkasse / StarMoney"; //$NON-NLS-1$
+        return "S Broker AG & Co. KG / Sparkasse / StarMoney";
     }
 
     private void addBuySellTransaction()
@@ -1363,14 +1363,14 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         transaction
                 .section("n").optional()
                 .match("^zu versteuern \\(negativ\\) (?<n>.*)$")
-                .assign((t, v) -> type.getCurrentContext().put("negative", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("negative", true));
 
         // If we have a gross reinvestment,
         // we set a flag and don't book tax below.
         transaction
                 .section("n").optional()
                 .match("^(?<n>Ertragsthesaurierung)$")
-                .assign((t, v) -> type.getCurrentContext().put("noTax", "X"));
+                .assign((t, v) -> type.getCurrentContext().putBoolean("noTax", true));
 
         transaction
                 // @formatter:off
@@ -1379,7 +1379,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^einbehaltene Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1389,7 +1389,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kapitalertragsteuer [\\.,\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1399,7 +1399,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Kapitalertragsteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1409,7 +1409,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^einbehaltener Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1419,7 +1419,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Solidarit.tszuschlag (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1429,7 +1429,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Solidarit.tszuschlag [\\.,\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1439,7 +1439,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^einbehaltener Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1449,7 +1449,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^Kirchensteuer (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1459,7 +1459,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("tax", "currency").optional()
                 .match("^Kirchensteuer [\\.,\\d]+ % .* [\\.,\\d]+ [\\w]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processTaxEntries(t, v, type);
                 })
 
@@ -1469,7 +1469,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("withHoldingTax", "currency").optional()
                 .match("^Einbehaltene Quellensteuer .* (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
                 })
 
@@ -1478,7 +1478,10 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 // @formatter:on
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("^Anrechenbare Quellensteuer .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
+                .assign((t, v) -> {
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
+                        processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
+                })
 
                 // @formatter:off
                 // davon anrechenbare Quellensteuer Fondseingangsseite EUR 0,04
@@ -1486,7 +1489,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("creditableWithHoldingTax", "currency").optional()
                 .match("^davon anrechenbare Quellensteuer Fondseingangsseite (?<currency>[\\w]{3}) (?<creditableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                 })
 
@@ -1496,7 +1499,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "creditableWithHoldingTax").optional()
                 .match("^davon anrechenbare US\\-Quellensteuer [\\.,\\d]+% (?<currency>[\\w]{3}) (?<creditableWithHoldingTax>[\\.,\\d]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("negative")) && !"X".equals(type.getCurrentContext().get("noTax")))
+                    if (!type.getCurrentContext().getBoolean("negative") && !type.getCurrentContext().getBoolean("noTax"))
                         processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
                 });
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankAGPDFExtractor.java
@@ -20,7 +20,7 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Santander Consumer Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("Santander Consumer Bank AG");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -29,7 +29,7 @@ public class SantanderConsumerBankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Santander Consumer Bank AG"; //$NON-NLS-1$
+        return "Santander Consumer Bank AG";
     }
 
     private void addBuySellTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
@@ -29,12 +29,12 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
      * Information:
      * Score Priority is a US-based financial services company.
      * The currency is US$.
-     * 
+     *
      * All security currencies are USD.
-     * 
+     *
      * CUSIP Number:
      * The CUSIP number is the WKN number.
-     * 
+     *
      * Dividend transactions:
      * The amount of dividends is reported in gross.
      */
@@ -43,7 +43,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Score Priority"); //$NON-NLS-1$
+        addBankIdentifier("Score Priority");
 
         addAccountStatementTransaction();
     }
@@ -51,19 +51,19 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Score Priority Corp. / Just2Trade US"; //$NON-NLS-1$
+        return "Score Priority Corp. / Just2Trade US";
     }
 
     private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType("ACCOUNT STATEMENT", (context, lines) -> {
             Pattern pYear = Pattern.compile("^.* STATEMENT PERIOD: .*, (?<year>[\\d]{4})$");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pYear.matcher(line);
-                if (m.matches())
-                    context.put("year", m.group("year"));
+                Matcher mYear = pYear.matcher(line);
+                if (mYear.matches())
+                    context.put("year", mYear.group("year"));
             }
         });
         this.addDocumentTyp(type);
@@ -92,7 +92,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)")
                         .assign((t, v) -> {
                             // Is type --> "Sell" change from BUY to SELL
-                            if (v.get("type").equals("Sell"))
+                            if ("Sell".equals(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);
 
                             Map<String, String> context = type.getCurrentContext();
@@ -113,13 +113,13 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         // Date | Effective Description | CUSIP | Type of Activity | Quantity Market Price | Net Settlement Amount
         // -------------------------------------
         // Sep 16 Barrick Gold Co             14 067901108 Dividend 1.97
-        //  
+        //
         // Sep 17 Barrick Gold Co             14 067901108 Dividend 1.26
         // Sep 17 For Sec Withhold: Div   .25000 067901108 Foreign Withholding (0.31)
-        //  
+        //
         // Sep 15 Realty Income C             22 756109104 Dividend 5.18
         //  Sep 15 Nra Withhold: Dividend 756109104 NRA Withhold (1.55)
-        // 
+        //
         // Sep 15 Tyson Foods Inc              6 902494103 Qualified Dividend 2.67
         // Sep 15 Nra Withhold: Dividend 902494103 NRA Withhold (0.80)
         // @formatter:on

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
@@ -20,8 +20,8 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("SelfWealth"); //$NON-NLS-1$
-        addBankIdentifier("Selfwealth"); //$NON-NLS-1$
+        addBankIdentifier("SelfWealth");
+        addBankIdentifier("Selfwealth");
 
         addBuySellTransaction();
     }
@@ -29,7 +29,7 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "SelfWealth Ltd"; //$NON-NLS-1$
+        return "SelfWealth Ltd";
     }
 
     private void addBuySellTransaction()
@@ -54,7 +54,7 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>(Buy|Sell)) Confirmation$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Sell"))
+                    if ("Sell".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
@@ -61,7 +61,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^([\\s]+)?(?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
@@ -14,10 +14,10 @@ import name.abuchen.portfolio.model.Client;
 @SuppressWarnings("nls")
 public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
 {
-    
+
     private static final String DEPOSIT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*(SEPA\\-.berweisung|.berweisung|Kartenvorgang)(?<note>.*) (?<amount>[\\.,\\d]+) (?<currency>\\w{3})$";
     private static final String REMOVAL = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*(Kartenzahlung|.berweisung|SEPA-Lastschrift|SEPA\\-.berweisung)(?<note>.*) (?<amount>\\-[\\.,\\d]+) (?<currency>\\w{3})$";
-    
+
     private static final String CONTEXT_KEY_DATE = "date";
     private static final String CONTEXT_KEY_AMOUNT = "amount";
     private static final String CONTEXT_KEY_CURRENCY = "currency";
@@ -26,8 +26,8 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
     public SolarisbankAGPDFExtractor(Client client)
     {
         super(client);
-        
-        addBankIdentifier("Solarisbank"); //$NON-NLS-1$
+
+        addBankIdentifier("Solarisbank");
 
         addAccountStatementTransaction();
     }
@@ -35,9 +35,9 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Solarisbank AG"; //$NON-NLS-1$
+        return "Solarisbank AG";
     }
-    
+
     private void addAccountStatementTransaction()
     {
         DocumentType type = new DocumentType("Rechnungsabschluss");
@@ -52,7 +52,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
     }
 
-    
+
     private Transaction<AccountTransaction> depositTransaction(String regex)
     {
         return new Transaction<AccountTransaction>().subject(() -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
@@ -17,7 +17,7 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Suresse"); //$NON-NLS-1$
+        addBankIdentifier("Suresse");
 
         addAccountStatementTransaction();
     }
@@ -25,19 +25,19 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Suresse Direkt Bank"; //$NON-NLS-1$
+        return "Suresse Direkt Bank";
     }
 
     private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType("Auszug [\\d]+([\\s]+)\\/[\\d]+", (context, lines) -> {
             Pattern pYear = Pattern.compile("^.* [\\d]{2}\\-[\\d]{2}\\-(?<year>[\\d]{4}) : ([\\-])?[\\.,\\d]+ [\\w]{3}$");
-            // read the current context here
+
             for (String line : lines)
             {
-                Matcher m = pYear.matcher(line);
-                if (m.matches())
-                    context.put("year", m.group("year"));
+                Matcher mYear = pYear.matcher(line);
+                if (mYear.matches())
+                    context.put("year", mYear.group("year"));
             }
         });
         this.addDocumentTyp(type);
@@ -61,9 +61,9 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
                     Map<String, String> context = type.getCurrentContext();
 
                     // Is sign --> "-" change from DEPOSIT to REMOVAL
-                    if (v.get("sign").equals("-"))
+                    if ("-".equals(v.get("sign")))
                         t.setType(AccountTransaction.Type.REMOVAL);
-                    
+
                     t.setDateTime(asDate(v.get("date") + "-" + context.get("year")));
                     t.setAmount(asAmount(v.get("amount")));
                     t.setCurrencyCode(asCurrencyCode(v.get("currency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
@@ -24,7 +24,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Swissquote Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("Swissquote Bank AG");
 
         addBuySellTransaction();
         addDividendsTransaction();
@@ -35,7 +35,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Swissquote Bank AG / Yuh (powerd by Swissquote Bank AG)"; //$NON-NLS-1$
+        return "Swissquote Bank AG / Yuh (powerd by Swissquote Bank AG)";
     }
 
     private void addBuySellTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -30,31 +30,31 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
      * @formatter:off
      * Information:
      * Targobank AG always creates two documents per transaction.
-     * 
+     *
      * 1. Transaction, e.g. sale or dividend
-     * 2. tax statement 
-     * 
-     * To offset the taxes due with the transaction, we use the ex-tag as a 
+     * 2. tax statement
+     *
+     * To offset the taxes due with the transaction, we use the ex-tag as a
      * transaction date, which we later replace again with the payment date in
      * postProcessing().
-     * 
+     *
      * The reason for this is that sometimes the transaction
      * date is different between the taxes document and the transaction.
-     * 
+     *
      * @Override public List<Item> postProcessing(List<Item> items)
      * @formatter:on
      */
 
-    private static final String TO_BE_DELETED = "to_be_deleted"; //$NON-NLS-1$
-    private static final String ATTRIBUTE_PAY_DATE = "pay_date"; //$NON-NLS-1$
+    private static final String TO_BE_DELETED = "to_be_deleted";
+    private static final String ATTRIBUTE_PAY_DATE = "pay_date";
 
     public TargobankPDFExtractor(Client client)
     {
         super(client);
 
-        addBankIdentifier("TARGO"); //$NON-NLS-1$
-        addBankIdentifier("Targobank"); //$NON-NLS-1$
-        addBankIdentifier("TARGOBANK AG"); //$NON-NLS-1$
+        addBankIdentifier("TARGO");
+        addBankIdentifier("Targobank");
+        addBankIdentifier("TARGOBANK AG");
 
         addBuySellTransaction();
         addTaxTreatmentForBuySellTransaction();
@@ -65,7 +65,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Targobank AG"; //$NON-NLS-1$
+        return "Targobank AG";
     }
 
     private void addBuySellTransaction()
@@ -89,7 +89,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Transaktionstyp (?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -149,7 +149,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Effektenabrechnung \\(Steuerbeilage\\) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>();
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
         pdfTransaction.subject(() -> {
             AccountTransaction entry = new AccountTransaction();
             entry.setType(AccountTransaction.Type.TAXES);
@@ -243,8 +243,8 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // @formatter:of
-                // Temporarily set the ex-day as the transaction day 
-                // and will be corrected to the payDay in the postProcessing(). 
+                // Temporarily set the ex-day as the transaction day
+                // and will be corrected to the payDay in the postProcessing().
                 // (See information on top)
                 // @formatter:on
 
@@ -334,8 +334,8 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                 // @formatter:of
-                // Temporarily set the ex-day as the transaction day 
-                // and will be corrected to the payDay in the postProcessing(). 
+                // Temporarily set the ex-day as the transaction day
+                // and will be corrected to the payDay in the postProcessing().
                 // (See information on top)
                 // @Formatter:on
 
@@ -371,7 +371,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 // @formatter:on
                 .section("amount", "currency").optional()
                 .match("^Anrechenbare ausl.ndische Quellensteuer (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$")
-                .assign((t, v) -> { 
+                .assign((t, v) -> {
                     if (t.getMonetaryAmount().isZero())
                     {
                         t.setAmount(asAmount(v.get("amount")));
@@ -464,7 +464,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 // @formatter:off
                 // It is possible that several sell transactions exist on
                 // the same day without one or with several taxes transactions.
-                // 
+                //
                 // We simplify here only one sell transaction with one
                 // related taxes transaction.
                 // @formatter:on
@@ -526,7 +526,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                 // @formatter:off
                 // It is possible that several dividend transactions exist on
                 // the same day without one or with several taxes transactions.
-                // 
+                //
                 // We simplify here only one dividend transaction with one
                 // related taxes transaction.
                 // @formatter:on
@@ -619,6 +619,6 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         if (first != null && second == null)
             return first;
 
-        return first == null ? second : first + "; " + second; //$NON-NLS-1$
+        return first == null ? second : first + "; " + second;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
@@ -27,7 +27,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Tiger Brokers (Singapore) PTE.LTD."); //$NON-NLS-1$
+        addBankIdentifier("Tiger Brokers (Singapore) PTE.LTD.");
 
         addAccountStatementTransaction();
     }
@@ -35,7 +35,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Tiger Brokers (Singapore) Pte. Ltd."; //$NON-NLS-1$
+        return "Tiger Brokers (Singapore) Pte. Ltd.";
     }
 
     private void addAccountStatementTransaction()
@@ -92,7 +92,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
                 m = pSecurityDividendTaxEnd.matcher(lines[i]);
                 if (m.matches())
-                    endBlockDividendTaxList = i;   
+                    endBlockDividendTaxList = i;
 
                 m = pSecurityDividendSharesStart.matcher(lines[i]);
                 if (m.matches())
@@ -111,7 +111,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                     // @formatter:off
                     // Stringbuilder:
                     // security_(security name)_(security currency) = tickerSymbol
-                    // 
+                    //
                     // Example:
                     // Stock
                     // Symbol Issuer Description Multiplier Expiry Strike Right
@@ -132,7 +132,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                     // @formatter:off
                     // Stringbuilder:
                     // pSecurityDividendShares_(shares) = tickerSymbol
-                    // 
+                    //
                     // Example:
                     // Change in Dividend Accruals
                     // Symbol Date Ex Date Pay Date Quantity Tax GST Fee(include ADR) Gross Rate Gross Amount Net Amount Code
@@ -149,14 +149,14 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                 Matcher m = pCurrency.matcher(lines[i]);
                 if (m.matches())
                     baseCurrency = m.group("currency");
-                
+
                 m = pSecurityDividendTax.matcher(lines[i]);
                 if (m.matches())
                 {
                     // @formatter:off
                     // Stringbuilder:
                     // pSecurityDividendTax_(tax)_(security currency) = tickerSymbol
-                    // 
+                    //
                     // Example:
                     // Withholding Tax
                     // Date Description Amount
@@ -458,8 +458,8 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     {
         for (String key : context.keySet())
         {
-            String[] parts = key.split("_"); //$NON-NLS-1$
-            if (parts[0].equalsIgnoreCase("security")) //$NON-NLS-1$
+            String[] parts = key.split("_");
+            if ("security".equalsIgnoreCase(parts[0]))
             {
                 if (context.get(key).equals(tickerSymbol))
                 {
@@ -519,8 +519,8 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     {
         for (String key : context.keySet())
         {
-            String[] parts = key.split("_"); //$NON-NLS-1$
-            if (parts[0].equalsIgnoreCase("securityDividendShares")) //$NON-NLS-1$
+            String[] parts = key.split("_");
+            if ("securityDividendShares".equalsIgnoreCase(parts[0]))
             {
                 if (context.get(key).equals(tickerSymbol))
                 {
@@ -558,8 +558,8 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     {
         for (String key : context.keySet())
         {
-            String[] parts = key.split("_"); //$NON-NLS-1$
-            if (parts[0].equalsIgnoreCase("securityDividendTax")) //$NON-NLS-1$
+            String[] parts = key.split("_");
+            if ("securityDividendTax".equalsIgnoreCase(parts[0]))
             {
                 if (context.get(key).equals(tickerSymbol))
                 {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
@@ -24,9 +24,9 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("UBS"); //$NON-NLS-1$
-        addBankIdentifier("UBS Switzerland AG"); //$NON-NLS-1$
-        addBankIdentifier("www.ubs.com"); //$NON-NLS-1$
+        addBankIdentifier("UBS");
+        addBankIdentifier("UBS Switzerland AG");
+        addBankIdentifier("www.ubs.com");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -36,7 +36,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "UBS AG"; //$NON-NLS-1$
+        return "UBS AG";
     }
 
     private void addBuySellTransaction()
@@ -68,7 +68,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^.* B.rse (?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -76,7 +76,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Ihr (?<type>(Kauf|Verkauf))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -86,9 +86,9 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                                 + "|FUSION"
                                 + "|FRAKTIONS\\-ABRECHNUNG))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("RÜCKZAHLUNG RESERVEN AUS KAPITALEINLAGEN")
-                                    || v.get("type").equals("FUSION")
-                                    || v.get("type").equals("FRAKTIONS-ABRECHNUNG"))
+                    if ("RÜCKZAHLUNG RESERVEN AUS KAPITALEINLAGEN".equals(v.get("type"))
+                                    || "FUSION".equals(v.get("type"))
+                                    || "FRAKTIONS-ABRECHNUNG".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -489,7 +489,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                         checkAndSetFee(fee, t, type.getCurrentContext());
                     }
 
-                    type.getCurrentContext().put("noProvision", "X");
+                    type.getCurrentContext().putBoolean("noProvision", true);
                 })
 
                 // Courtage USD -22.01
@@ -497,7 +497,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "fee").optional()
                 .match("^Courtage (?<currency>[\\w]{3}) (\\-)?(?<fee>[\\.,'\\d\\s]+)$")
                 .assign((t, v) -> {
-                    if (!"X".equals(type.getCurrentContext().get("noProvision")))
+                    if (!type.getCurrentContext().getBoolean("noProvision"))
                         processFeeEntries(t, v, type);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -19,7 +19,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("UniCredit Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("UniCredit Bank AG");
 
         addBuySellTransaction();
         addDividendTransaction();
@@ -28,7 +28,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "UniCredit Bank AG / HypoVereinsbank (HVB)"; //$NON-NLS-1$
+        return "UniCredit Bank AG / HypoVereinsbank (HVB)";
     }
 
     private void addBuySellTransaction()
@@ -52,7 +52,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^W e r t p a p i e r \\- A b r e c h n u n g ([\\s]+)?(?<type>(K a u f| V e r k a u f))( .*)?$")
                 .assign((t, v) -> {
-                    if (stripBlanks(v.get("type")).equals("Verkauf"))
+                    if ("Verkauf".equals(stripBlanks(v.get("type"))))
                     {
                         t.setType(PortfolioTransaction.Type.SELL);
                     }
@@ -232,7 +232,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
                 .match("^Provision (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)(\\-)?( .*)?$")
                 .assign((t, v) -> processFeeEntries(t, v, type))
 
-                // Wertpapierprovision* EUR 41,09- 
+                // Wertpapierprovision* EUR 41,09-
                 .section("currency", "fee").optional()
                 .match("^Wertpapierprovision\\* (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)(\\-)?( .*)?$")
                 .assign((t, v) -> processFeeEntries(t, v, type));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
@@ -19,7 +19,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("V-Bank AG"); //$NON-NLS-1$
+        addBankIdentifier("V-Bank AG");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -28,7 +28,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "V-Bank AG"; //$NON-NLS-1$
+        return "V-Bank AG";
     }
 
     private void addBuySellTransaction()
@@ -52,7 +52,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(?<type>Verkauf)$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VanguardGroupEuropePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VanguardGroupEuropePDFExtractor.java
@@ -16,7 +16,7 @@ public class VanguardGroupEuropePDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Vanguard Group Europe GmbH"); //$NON-NLS-1$^
+        addBankIdentifier("Vanguard Group Europe GmbH");
 
         addBuySellTransaction();
     }
@@ -24,7 +24,7 @@ public class VanguardGroupEuropePDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Vanguard Group Europe GmbH"; //$NON-NLS-1$
+        return "Vanguard Group Europe GmbH";
     }
 
     private void addBuySellTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
@@ -32,11 +32,11 @@ import name.abuchen.portfolio.money.Values;
 public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
 {
     /**
-     * Information: 
+     * Information:
      * Wealthsimple Investments Inc. is a CAD-based financial
      * services company. The currency is $CAD.
-     * 
-     * All securities are specified in $CAD. 
+     *
+     * All securities are specified in $CAD.
      * However, there is an exchange rate in $USD.
      */
 
@@ -44,7 +44,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("Wealthsimple Inc."); //$NON-NLS-1$
+        addBankIdentifier("Wealthsimple Inc.");
 
         addDepotStatementTransaction();
     }
@@ -52,7 +52,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Wealthsimple Investments Inc."; //$NON-NLS-1$
+        return "Wealthsimple Investments Inc.";
     }
 
     private void addDepotStatementTransaction()
@@ -157,7 +157,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                     Map<String, String> context = type.getCurrentContext();
 
                     // Is type --> "Out" change from DEPOSIT to REMOVAL
-                    if (v.get("type").equals("Out"))
+                    if ("Out".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.REMOVAL);
 
                     t.setDateTime(asDate(v.get("day") + " " + v.get("month") + " " + context.get("year")));
@@ -203,7 +203,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                     DocumentContext context = type.getCurrentContext();
 
                     // Is type --> "Out" change from BUY to SELL
-                    if (v.get("type").equals("Sold"))
+                    if ("Sold".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
 
                     t.setSecurity(getOrCreateSecurity(v));
@@ -531,10 +531,8 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         {
             // Search date of dividend transaction using date and tickerSymbol.
 
-            for (int i = 0; i < items.size(); i++) // NOSONAR
+            for (DividendTaxTransactionsItem item : items)
             {
-                DividendTaxTransactionsItem item = items.get(i);
-
                 if (item.dateTime.equals(dateTime) && item.tickerSymbol.equals(tickerSymbol))
                     return Optional.of(item);
             }
@@ -567,10 +565,8 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         {
             // Search for date of fee tax by date.
 
-            for (int i = 0; i < items.size(); i++) // NOSONAR
+            for (FeeTaxTransactionsItem item : items)
             {
-                FeeTaxTransactionsItem item = items.get(i);
-
                 if (item.dateTime.equals(dateTime))
                     return Optional.of(item);
             }
@@ -599,10 +595,8 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         {
             // Search by date of fee refund by date.
 
-            for (int i = 0; i < items.size(); i++) // NOSONAR
+            for (FeeRefundTransactionsItem item : items)
             {
-                FeeRefundTransactionsItem item = items.get(i);
-
                 if (item.dateTime.equals(dateTime))
                     return Optional.of(item);
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -19,9 +19,9 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("BLZ 101 201 00"); //$NON-NLS-1$
-        addBankIdentifier("BLZ 10120100"); //$NON-NLS-1$
-        addBankIdentifier("BIC WELADED1WBB"); //$NON-NLS-1$
+        addBankIdentifier("BLZ 101 201 00");
+        addBankIdentifier("BLZ 10120100");
+        addBankIdentifier("BIC WELADED1WBB");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -30,7 +30,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Weberbank AG"; //$NON-NLS-1$
+        return "Weberbank AG";
     }
 
     private void addBuySellTransaction()
@@ -54,7 +54,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^Wertpapier Abrechnung (?<type>(Kauf|Verkauf)) .*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf"))
+                    if ("Verkauf".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -25,7 +25,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
     {
         super(client);
 
-        addBankIdentifier("WIR Bank"); //$NON-NLS-1$
+        addBankIdentifier("WIR Bank");
 
         addDepositTransaction();
         addBuySellTransaction();
@@ -37,7 +37,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "WIR Bank Genossenschaft"; //$NON-NLS-1$
+        return "WIR Bank Genossenschaft";
     }
 
     private void addDepositTransaction()
@@ -90,7 +90,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(B.rsenabrechnung|Exchange Settlement) \\- (?<type>(Kauf|Verkauf|Buy|Sell)).*$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Verkauf") || v.get("type").equals("Sell"))
+                    if ("Verkauf".equals(v.get("type")) || "Sell".equals(v.get("type")))
                         t.setType(PortfolioTransaction.Type.SELL);
                 })
 
@@ -230,7 +230,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                 .section("type").optional()
                 .match("^(Dividendenart|Type of dividend): (?<type>(R.ckerstattung Quellensteuer|Refund withholding tax))$")
                 .assign((t, v) -> {
-                    if (v.get("type").equals("Rückerstattung Quellensteuer") || v.get("type").equals("Refund withholding tax"))
+                    if ("Rückerstattung Quellensteuer".equals(v.get("type")) || "Refund withholding tax".equals(v.get("type")))
                         t.setType(AccountTransaction.Type.TAX_REFUND);
                 })
 
@@ -285,7 +285,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                                         })
                                 ,
                                 // Betrag USD 34.26
-                                // Umrechnungskurs CHF/USD 
+                                // Umrechnungskurs CHF/USD
                                 // 0.91759 CHF 31.44
                                 section -> section
                                         .attributes("fxCurrency", "fxGross", "termCurrency", "baseCurrency", "exchangeRate", "currency", "gross")
@@ -333,18 +333,18 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH"); //$NON-NLS-1$ //$NON-NLS-2$
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
     }
 
     @Override
     protected long asShares(String value)
     {
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH"); //$NON-NLS-1$ //$NON-NLS-2$
+        return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH"); //$NON-NLS-1$ //$NON-NLS-2$
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 }


### PR DESCRIPTION
I noticed that we already have 61 PDF importers... OMG. 
No tests have been changed!

**Cleanup of importers:**
- removed unnecessary spaces
- remove the "equal" checks to "getCurrentContext()" and replaced by a primitive data type boolean
- replace various variables with primitive data types
- simplification of various pattern matches (e. g. isJointAccount)
- avoid Object.equals() or Object.equalsIgnoreCase() on null objects
- remove unnecessary $NON-NLS tags (all use @SuppressWarnings("nls"))