### PR TITLE
Improve DEKA PDF-Importer to simplified fallback calculation of shares

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
@@ -1056,10 +1056,8 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                             BigDecimal amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
                                             BigDecimal amount = BigDecimal.valueOf(asAmount(v.get("amount")));
 
-                                            int sharesPrecision = Values.Share.precision() * 2;
-                                            BigDecimal shares = amount.divide(amountPerShare, sharesPrecision, RoundingMode.HALF_UP);
-
-                                            t.setShares(Math.round(shares.doubleValue() * Values.Share.factor()));
+                                            BigDecimal shares = amount.divide(amountPerShare, Values.Share.precision(), RoundingMode.HALF_UP);
+                                            t.setShares(shares.movePointRight(Values.Share.precision()).longValue());
                                         }
 
                                         // Formatting some notes


### PR DESCRIPTION
Improve DEKA PDF-Importer to simplified fallback calculation of shares
Example: [here](https://github.com/buchen/portfolio/blob/e716242a51e0f7126a4f989476bc4b5cc1d3c0eb/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dekabank/DekaBankPDFExtractorTest.java#L20892:L20905)