### PR TITLE
tests: Create test securities with explicit currency set

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractorTest.java
@@ -108,7 +108,7 @@ public class CSVAccountTransactionExtractorTest
     public void testDividendTransaction()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
 
@@ -154,10 +154,10 @@ public class CSVAccountTransactionExtractorTest
     public void testIfMultipleSecuritiesWithSameISINExist()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
-        Security security2 = new Security();
+        Security security2 = new Security("", "EUR");
         security2.setIsin("DE0007164600");
         client.addSecurity(security2);
 
@@ -227,7 +227,7 @@ public class CSVAccountTransactionExtractorTest
     public void testTypeIsDeterminedByUnaryMinusOperatorAndSecurity()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
 
@@ -267,7 +267,7 @@ public class CSVAccountTransactionExtractorTest
     public void testBuyTransaction()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
 
@@ -295,7 +295,7 @@ public class CSVAccountTransactionExtractorTest
     public void testBuyTransactionFailsWhenSharesAreMissing()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
 
@@ -314,7 +314,7 @@ public class CSVAccountTransactionExtractorTest
     public void testBuyTransactionFailsWhenSecurityIsMissing()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setIsin("DE0007164600");
         client.addSecurity(security);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractorTest.java
@@ -74,7 +74,7 @@ public class CSVPortfolioTransactionExtractorTest
     public void testTransferTransaction()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setTickerSymbol("SAP.DE");
         client.addSecurity(security);
 
@@ -115,7 +115,7 @@ public class CSVPortfolioTransactionExtractorTest
     public void testBuyTransaction()
     {
         Client client = new Client();
-        Security security = new Security();
+        Security security = new Security("", "EUR");
         security.setTickerSymbol("SAP.DE");
         client.addSecurity(security);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
@@ -172,7 +172,7 @@ public class ClientPerformanceSnapshotTest
     {
         Client client = new Client();
 
-        Security security = new Security();
+        Security security = new Security("", CurrencyUnit.EUR);
         security.addPrice(new SecurityPrice(LocalDate.of(2010, Month.JANUARY, 1), Values.Quote.factorize(100)));
         security.addPrice(new SecurityPrice(LocalDate.of(2011, Month.JUNE, 1), Values.Quote.factorize(110)));
         client.addSecurity(security);
@@ -203,7 +203,7 @@ public class ClientPerformanceSnapshotTest
     {
         Client client = new Client();
 
-        Security security = new Security();
+        Security security = new Security("", CurrencyUnit.EUR);
         security.addPrice(new SecurityPrice(LocalDate.of(2010, Month.JANUARY, 1), Values.Quote.factorize(100)));
         security.addPrice(new SecurityPrice(LocalDate.of(2011, Month.JUNE, 1), Values.Quote.factorize(110)));
         client.addSecurity(security);

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PortfolioMergeTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PortfolioMergeTest.java
@@ -39,15 +39,15 @@ public class PortfolioMergeTest
 
         client = new Client();
 
-        securityA = new Security();
+        securityA = new Security("", CurrencyUnit.EUR);
         securityA.addPrice(new SecurityPrice(LocalDate.of(2010, Month.JANUARY, 1), Values.Quote.factorize(10)));
         client.addSecurity(securityA);
 
-        securityB = new Security();
+        securityB = new Security("", CurrencyUnit.EUR);
         securityB.addPrice(new SecurityPrice(LocalDate.of(2010, Month.JANUARY, 1), Values.Quote.factorize(11)));
         client.addSecurity(securityB);
 
-        securityX = new Security();
+        securityX = new Security("", CurrencyUnit.EUR);
         securityX.addPrice(new SecurityPrice(LocalDate.of(2010, Month.JANUARY, 1), Values.Quote.factorize(12)));
         client.addSecurity(securityX);
 


### PR DESCRIPTION
Don't rely on a particular curreny to be "hardcoded" in a generic security create for a test. These cases where identified by setting Security.currencyCode to a different currency and seeing what tests break.