### PR TITLE
fix for #3452: add check in SECURITY_CREATED subscriber method to determine if security was created in current file/client or not

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/NewDomainElementHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/NewDomainElementHandler.java
@@ -60,6 +60,7 @@ import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.FormDataFactory;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityDialog;
 import name.abuchen.portfolio.ui.wizards.security.SearchSecurityWizardDialog;
+import name.abuchen.portfolio.util.Pair;
 import name.abuchen.portfolio.util.TradeCalendarManager;
 
 public class NewDomainElementHandler
@@ -126,8 +127,13 @@ public class NewDomainElementHandler
             view.getClient().markDirty();
             new UpdateQuotesJob(view.getClient(), newSecurity).schedule();
 
-            broker.post(UIConstants.Event.Domain.SECURITY_CREATED, newSecurity);
+            postSecurityCreatedEvent(newSecurity, view.getClient());
         }
+    }
+
+    private void postSecurityCreatedEvent(Security security, Client client)
+    {
+        broker.post(UIConstants.Event.Domain.SECURITY_CREATED, new Pair<Security, Client>(security, client));
     }
 
     private void createNewCryptocurrency(AbstractFinanceView view)
@@ -226,7 +232,7 @@ public class NewDomainElementHandler
                 view.getClient().addSecurity(newSecurity);
                 view.getClient().markDirty();
                 new UpdateQuotesJob(view.getClient(), newSecurity).schedule();
-                broker.post(UIConstants.Event.Domain.SECURITY_CREATED, newSecurity);
+                postSecurityCreatedEvent(newSecurity, view.getClient());
             }
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -383,12 +383,6 @@ public class SecurityListView extends AbstractFinanceView
     @Optional
     public void onSecurityCreated(@UIEventTopic(UIConstants.Event.Domain.SECURITY_CREATED) Security newSecurity)
     {
-        if (watchlist != null)
-        {
-            watchlist.addSecurity(newSecurity);
-            getClient().touch();
-        }
-
         setSecurityTableInput();
         securities.getTableViewer().setSelection(new StructuredSelection(newSecurity), true);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -62,6 +62,7 @@ import name.abuchen.portfolio.ui.views.panes.TradesPane;
 import name.abuchen.portfolio.ui.views.panes.TransactionsPane;
 import name.abuchen.portfolio.ui.wizards.datatransfer.CSVImportWizard;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityDialog;
+import name.abuchen.portfolio.util.Pair;
 
 public class SecurityListView extends AbstractFinanceView
 {
@@ -381,10 +382,20 @@ public class SecurityListView extends AbstractFinanceView
 
     @Inject
     @Optional
-    public void onSecurityCreated(@UIEventTopic(UIConstants.Event.Domain.SECURITY_CREATED) Security newSecurity)
+    public void onSecurityCreated(
+                    @UIEventTopic(UIConstants.Event.Domain.SECURITY_CREATED) Pair<Security, Client> data)
     {
+        if (data.getRight() != getClient())
+            return; // if security was created by other client, ignore event
+
+        if (watchlist != null)
+        {
+            watchlist.addSecurity(data.getLeft());
+            getClient().touch();
+        }
+
         setSecurityTableInput();
-        securities.getTableViewer().setSelection(new StructuredSelection(newSecurity), true);
+        securities.getTableViewer().setSelection(new StructuredSelection(data.getLeft()), true);
     }
 
     @Override


### PR DESCRIPTION
With this the issue in  #3452 is fixed. ~~But additionally the functionality  is lost that when on the **active** file a watchlist is selected when creating a new security, then the new security is not automatically inserted to this watchlist.~~ *Update: no, it's not. See https://github.com/buchen/portfolio/pull/3453#issuecomment-1645712619*

dbeda8c60a4a0de7871fb34e02333009ddb5554b was just the first solution that comes in my mind.
Maybe better solutions would be (to preserve the automatic insertion into watchlist):
* Fire the event ``SECURITY_CREATED`` only in the active file (don't know if this kind of filtering is possible)
* Or detect in the event handler ``onSecurityCreated`` [method](https://github.com/buchen/portfolio/blob/044c24f049189aadfa413ea77b6765578a55ec71/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java#L384) if the file is active or not
    * maybe there the ``MenuHelper.getActiveClientInput`` is accessible
    * or when firing the event the current client will also passed (additionally to the new security) then in the ``onSecurityCreated`` method we can check if this passed client is the client of the current file (itself)

*UPDATE: I have chosen the last listed option.*