### PR TITLE
remove wrongly added securities (due to #3452) at startup

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -29,7 +29,7 @@ public class Client
         String WATCHLISTS = "watchlists"; //$NON-NLS-1$
     }
 
-    public static final int CURRENT_VERSION = 57;
+    public static final int CURRENT_VERSION = 58;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
     public static final int VERSION_WITH_UNIQUE_FILTER_KEY = 57;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -828,6 +828,10 @@ public class ClientFactory
 
                 // remove obsolete MARKET properties
                 removeMarketSecurityProperty(client);
+            case 57:
+                // remove securities in watchlists which are not present in "all
+                // securities", see #3452
+                removeWronglyAddedSecurities(client);
 
                 client.setVersion(Client.CURRENT_VERSION);
                 break;
@@ -836,6 +840,16 @@ public class ClientFactory
             default:
                 break;
         }
+    }
+
+    private static void removeWronglyAddedSecurities(Client client)
+    {
+        client.getWatchlists().forEach(w -> new ArrayList<>(w.getSecurities()).forEach(s -> {
+            if (!client.getSecurities().contains(s))
+            {
+                w.getSecurities().remove(s);
+            }
+        }));
     }
 
     private static void fixAssetClassTypes(Client client)


### PR DESCRIPTION
I wonder if it would be necessary to automatically delete wrongly added securities in watchlist due to #3452 on startup. What do you think?